### PR TITLE
feat(tts): add Chatterbox ONNX backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 <p align="center"><b>Open-source voice toolkit.</b> Optimized for Apple Silicon (CoreML), works on any platform (ONNX fallback).<br>A collection of small, fast, open-source audio models — packaged as CLI tools and an <a href="https://github.com/openclaw/openclaw">OpenClaw</a> skill for LLM agents.</p>
 
 - **Speech-to-text** — 25 languages, ~15x faster than Whisper on Apple Silicon, ~2.5x on CPU
-- **Text-to-speech** — Kokoro (EN) + Vosk-TTS (RU) + macOS system voices, SSML preview
+- **Text-to-speech** — Kokoro (EN) + Chatterbox (RU) + macOS system voices, SSML preview
 - **Rust engine** — single 20MB binary, no ffmpeg, no Python, no native Node addons
 - **OpenClaw-ready** — plug into your LLM agent as a voice processing skill
 
@@ -100,12 +100,12 @@ Each segment gets a `speaker` integer (cluster ID, stable within one file). Linu
 
 ## Text-to-speech
 
-Kesha speaks back via Kokoro-82M (English) and Vosk-TTS (Russian) — voice auto-picks from the text's language:
+Kesha speaks back via Kokoro-82M (English) and Chatterbox Multilingual ONNX (Russian on Linux/Windows) — voice auto-picks from the text's language:
 
 ```bash
-kesha install --tts                      # ~990MB (Kokoro + Vosk-TTS RU, opt-in)
+kesha install --tts                      # ~3.3GB (Kokoro + Chatterbox, opt-in)
 kesha say "Hello, world" > hello.wav
-kesha say "Привет, мир" > privet.wav     # auto-routes (Milena on darwin, ru-vosk-m02 elsewhere)
+kesha say "Привет, мир" > privet.wav     # auto-routes (Milena on darwin, ru-chatterbox-m01 elsewhere)
 ```
 
 **Russian abbreviations** (`ru-vosk-*`): all-uppercase Cyrillic 2-5-char tokens auto-expand letter-by-letter when not pronounceable as a Russian syllable (ФСБ → "эф-эс-бэ", ВОЗ → "воз"). Disable with `--no-expand-abbrev`. See [docs/tts.md#russian-abbreviation-auto-expansion](docs/tts.md#russian-abbreviation-auto-expansion).
@@ -158,7 +158,7 @@ See [BENCHMARK.md](BENCHMARK.md) for the full per-file breakdown (Russian + Engl
 | SpeechBrain ECAPA-TDNN | Audio language detection | ~86MB | [HuggingFace](https://huggingface.co/speechbrain/lang-id-voxlingua107-ecapa) |
 | Apple NLLanguageRecognizer | Text language detection | built-in | macOS system framework |
 | Silero VAD v5 (opt-in) | Voice activity detection | ~2.3MB | [snakers4/silero-vad](https://github.com/snakers4/silero-vad) |
-| Kokoro-82M / Vosk-TTS (opt-in) | Text-to-speech | ~990MB | [Kokoro](https://huggingface.co/hexgrad/Kokoro-82M) · [Vosk-TTS](https://github.com/alphacep/vosk-tts) |
+| Kokoro-82M / Chatterbox (opt-in) | Text-to-speech | ~3.3GB | [Kokoro](https://huggingface.co/hexgrad/Kokoro-82M) · [Chatterbox](https://huggingface.co/onnx-community/chatterbox-multilingual-ONNX) |
 
 All models run through `kesha-engine` — a Rust binary using [FluidAudio](https://github.com/FluidInference/FluidAudio) (CoreML) on Apple Silicon and [ort](https://github.com/pykeio/ort) (ONNX Runtime) on other platforms.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 <p align="center"><b>Open-source voice toolkit.</b> Optimized for Apple Silicon (CoreML), works on any platform (ONNX fallback).<br>A collection of small, fast, open-source audio models — packaged as CLI tools and an <a href="https://github.com/openclaw/openclaw">OpenClaw</a> skill for LLM agents.</p>
 
 - **Speech-to-text** — 25 languages, ~15x faster than Whisper on Apple Silicon, ~2.5x on CPU
-- **Text-to-speech** — Kokoro (EN) + Chatterbox (RU) + macOS system voices, SSML preview
+- **Text-to-speech** — Kokoro (EN) + Chatterbox (23 languages) + macOS system voices, SSML preview
 - **Rust engine** — single 20MB binary, no ffmpeg, no Python, no native Node addons
 - **OpenClaw-ready** — plug into your LLM agent as a voice processing skill
 
@@ -100,13 +100,15 @@ Each segment gets a `speaker` integer (cluster ID, stable within one file). Linu
 
 ## Text-to-speech
 
-Kesha speaks back via Kokoro-82M (English) and Chatterbox Multilingual ONNX (Russian on Linux/Windows) — voice auto-picks from the text's language:
+Kesha speaks back via Kokoro-82M (English) and Chatterbox Multilingual ONNX (23 languages) — voice auto-picks from the text's language:
 
 ```bash
 kesha install --tts                      # ~3.3GB (Kokoro + Chatterbox, opt-in)
 kesha say "Hello, world" > hello.wav
 kesha say "Привет, мир" > privet.wav     # auto-routes (Milena on darwin, ru-chatterbox-m01 elsewhere)
 ```
+
+Chatterbox voice ids use `<lang>-chatterbox-m01` for `ar`, `da`, `de`, `el`, `en`, `es`, `fi`, `fr`, `he`, `hi`, `it`, `ja`, `ko`, `ms`, `nl`, `no`, `pl`, `pt`, `ru`, `sv`, `sw`, `tr`, `zh`.
 
 **Russian abbreviations** (`ru-vosk-*`): all-uppercase Cyrillic 2-5-char tokens auto-expand letter-by-letter when not pronounceable as a Russian syllable (ФСБ → "эф-эс-бэ", ВОЗ → "воз"). Disable with `--no-expand-abbrev`. See [docs/tts.md#russian-abbreviation-auto-expansion](docs/tts.md#russian-abbreviation-auto-expansion).
 

--- a/README.md
+++ b/README.md
@@ -100,12 +100,13 @@ Each segment gets a `speaker` integer (cluster ID, stable within one file). Linu
 
 ## Text-to-speech
 
-Kesha speaks back via Kokoro-82M (English) and Chatterbox Multilingual ONNX (23 languages) — voice auto-picks from the text's language:
+Kesha speaks back via Kokoro-82M (English) and Chatterbox Multilingual ONNX (23 languages) — voice auto-picks from the text's language. Use `--lang <tag>` to choose a language's default voice, or `--voice <id>` for an exact voice:
 
 ```bash
 kesha install --tts                      # ~3.3GB (Kokoro + Chatterbox, opt-in)
 kesha say "Hello, world" > hello.wav
-kesha say "Привет, мир" > privet.wav     # auto-routes (Milena on darwin, ru-chatterbox-m01 elsewhere)
+kesha say "Привет, мир" > privet.wav     # Chatterbox if installed; Milena fallback on darwin
+kesha say --lang de "Hallo"              # picks de-chatterbox-m01
 ```
 
 Chatterbox voice ids use `<lang>-chatterbox-m01` for `ar`, `da`, `de`, `el`, `en`, `es`, `fi`, `fr`, `he`, `hi`, `it`, `ja`, `ko`, `ms`, `nl`, `no`, `pl`, `pt`, `ru`, `sv`, `sw`, `tr`, `zh`.

--- a/docs/tts.md
+++ b/docs/tts.md
@@ -1,29 +1,29 @@
 # Text-to-Speech
 
-Kesha speaks back via Kokoro-82M (English) and Vosk-TTS (Russian). Voice is auto-picked from the input text's language — `en` routes to Kokoro, `ru` to Vosk. Pass `--voice` to override.
+Kesha speaks back via Kokoro-82M (English) and Chatterbox Multilingual ONNX (Russian on Linux/Windows). Voice is auto-picked from the input text's language — `en` routes to Kokoro, `ru` routes to macOS AVSpeech on darwin and Chatterbox elsewhere. Pass `--voice` to override.
 
 ```bash
-kesha install --tts                 # ~990MB (Kokoro + Vosk-TTS RU, opt-in)
+kesha install --tts                 # ~3.3GB (Kokoro + Chatterbox, opt-in)
 kesha say "Hello, world" > hello.wav
-kesha say "Привет, мир" > privet.wav    # auto-routes (Milena on darwin, ru-vosk-m02 elsewhere)
+kesha say "Привет, мир" > privet.wav    # auto-routes (Milena on darwin, ru-chatterbox-m01 elsewhere)
 echo "long text" | kesha say > reply.wav
 kesha say --out reply.wav "text"
 kesha say --voice en-am_michael "text"    # explicit voice overrides auto-routing
 kesha say --list-voices
 ```
 
-Output format: WAV mono float32 (24 kHz for Kokoro, 22.05 kHz for Vosk). OGG/Opus and MP3 are tracked in follow-up issues.
+Output format: WAV mono float32 (24 kHz for Kokoro and Chatterbox, 22.05 kHz for legacy Vosk). OGG/Opus is available via `--format ogg-opus`.
 
 Grapheme-to-phoneme:
 - **English** uses [misaki-rs](https://github.com/MicheleYin/misaki-rs) — a self-contained Rust port of [hexgrad/misaki](https://github.com/hexgrad/misaki) (the G2P Kokoro was trained against). Lexicon and POS-tagger weights are embedded at compile time, no system deps. Out-of-vocabulary words spell letter-by-letter — proper-noun fallback is tracked as a follow-up.
-- **Russian** is handled internally by [Vosk-TTS](https://github.com/alphacep/vosk-tts) — text normalisation, stress, palatalisation, and a BERT prosody model all run inside the bundled ONNX (no separate G2P pass, no system `espeak-ng` dependency).
+- **Russian** on Linux/Windows is handled by [Chatterbox Multilingual ONNX](https://huggingface.co/onnx-community/chatterbox-multilingual-ONNX) from raw text plus a language tag and reference WAV. No separate G2P pass, no system `espeak-ng`, no Python.
 - **Other languages**: not supported by the on-disk engines we ship today — tracked per-language in [#212](https://github.com/drakulavich/kesha-voice-kit/issues/212).
 
-Default voices are **male** per CLAUDE.md "DEFAULT TTS VOICES MUST BE MALE": `am_michael` for English Kokoro, `ru-vosk-m02` for Russian Vosk on Linux/Windows. The darwin Russian fallback uses `Milena` (AVSpeech, female) for the zero-install path; pass `--voice ru-vosk-m02` to opt into Vosk on macOS too.
+Default voices are **male** per CLAUDE.md "DEFAULT TTS VOICES MUST BE MALE": `am_michael` for English Kokoro, `ru-chatterbox-m01` for Russian Chatterbox on Linux/Windows. The darwin Russian fallback uses `Milena` (AVSpeech) for the zero-install path.
 
 **Supported voices:**
 - English: `en-am_michael` (default), plus any Kokoro voice you download into `~/.cache/kesha/models/kokoro-82m/voices/` (`am_*`/`bm_*` male, `af_*`/`bf_*` female).
-- Russian: 5 Vosk-TTS speakers baked into the multi-speaker model — `ru-vosk-m02` (default, male), `ru-vosk-m01` (male), `ru-vosk-f01`/`f02`/`f03` (female).
+- Russian: `ru-chatterbox-m01` (Chatterbox default reference voice). Legacy cached Vosk installs may still expose `ru-vosk-m02`, `ru-vosk-m01`, and `ru-vosk-f01`/`f02`/`f03`, but fresh `kesha install --tts` no longer downloads Vosk.
 - macOS system voices: `macos-<identifier-or-language>` routes to `AVSpeechSynthesizer`. Zero install, any of the 180+ voices already on your Mac.
 
 ## macOS system voices
@@ -38,7 +38,7 @@ kesha say --voice macos-ru-RU "Привет, мир" > hello-ru.wav             
 
 Voice id format: `macos-<id>` where `<id>` is either a full Apple identifier (`com.apple.voice.compact.en-US.Samantha`) or a language code (`en-US`, `ru-RU`) — the Swift helper tries the identifier first and falls back to the language. Output is mono float32 @ 22050 Hz, structurally identical to Vosk.
 
-Quality tradeoff is honest: macOS system voices are notification-grade. Use them when you want zero-install TTS on macOS; keep Kokoro/Vosk for anything that needs to sound good.
+Quality tradeoff is honest: macOS system voices are notification-grade. Use them when you want zero-install TTS on macOS; keep Kokoro/Chatterbox for anything that needs to sound good.
 
 ## English acronym auto-expansion
 

--- a/docs/tts.md
+++ b/docs/tts.md
@@ -1,6 +1,6 @@
 # Text-to-Speech
 
-Kesha speaks back via Kokoro-82M (English) and Chatterbox Multilingual ONNX (Russian on Linux/Windows). Voice is auto-picked from the input text's language — `en` routes to Kokoro, `ru` routes to macOS AVSpeech on darwin and Chatterbox elsewhere. Pass `--voice` to override.
+Kesha speaks back via Kokoro-82M (English) and Chatterbox Multilingual ONNX. Voice is auto-picked from the input text's language — `en` routes to Kokoro, `ru` routes to macOS AVSpeech on darwin and Chatterbox elsewhere, and other Chatterbox languages route to Chatterbox. Pass `--voice` to override.
 
 ```bash
 kesha install --tts                 # ~3.3GB (Kokoro + Chatterbox, opt-in)
@@ -16,14 +16,17 @@ Output format: WAV mono float32 (24 kHz for Kokoro and Chatterbox, 22.05 kHz for
 
 Grapheme-to-phoneme:
 - **English** uses [misaki-rs](https://github.com/MicheleYin/misaki-rs) — a self-contained Rust port of [hexgrad/misaki](https://github.com/hexgrad/misaki) (the G2P Kokoro was trained against). Lexicon and POS-tagger weights are embedded at compile time, no system deps. Out-of-vocabulary words spell letter-by-letter — proper-noun fallback is tracked as a follow-up.
-- **Russian** on Linux/Windows is handled by [Chatterbox Multilingual ONNX](https://huggingface.co/onnx-community/chatterbox-multilingual-ONNX) from raw text plus a language tag and reference WAV. No separate G2P pass, no system `espeak-ng`, no Python.
-- **Other languages**: not supported by the on-disk engines we ship today — tracked per-language in [#212](https://github.com/drakulavich/kesha-voice-kit/issues/212).
+- **Chatterbox languages** are handled by [Chatterbox Multilingual ONNX](https://huggingface.co/onnx-community/chatterbox-multilingual-ONNX) from raw text plus a language tag and reference WAV. No separate G2P pass, no system `espeak-ng`, no Python.
+
+Chatterbox voice ids use `<lang>-chatterbox-m01`. Supported language tags:
+
+`ar`, `da`, `de`, `el`, `en`, `es`, `fi`, `fr`, `he`, `hi`, `it`, `ja`, `ko`, `ms`, `nl`, `no`, `pl`, `pt`, `ru`, `sv`, `sw`, `tr`, `zh`
 
 Default voices are **male** per CLAUDE.md "DEFAULT TTS VOICES MUST BE MALE": `am_michael` for English Kokoro, `ru-chatterbox-m01` for Russian Chatterbox on Linux/Windows. The darwin Russian fallback uses `Milena` (AVSpeech) for the zero-install path.
 
 **Supported voices:**
 - English: `en-am_michael` (default), plus any Kokoro voice you download into `~/.cache/kesha/models/kokoro-82m/voices/` (`am_*`/`bm_*` male, `af_*`/`bf_*` female).
-- Russian: `ru-chatterbox-m01` (Chatterbox default reference voice). Legacy cached Vosk installs may still expose `ru-vosk-m02`, `ru-vosk-m01`, and `ru-vosk-f01`/`f02`/`f03`, but fresh `kesha install --tts` no longer downloads Vosk.
+- Chatterbox: `<lang>-chatterbox-m01` for each supported tag above, all using the bundled default reference voice. Legacy cached Vosk installs may still expose `ru-vosk-m02`, `ru-vosk-m01`, and `ru-vosk-f01`/`f02`/`f03`, but fresh `kesha install --tts` no longer downloads Vosk.
 - macOS system voices: `macos-<identifier-or-language>` routes to `AVSpeechSynthesizer`. Zero install, any of the 180+ voices already on your Mac.
 
 ## macOS system voices

--- a/docs/tts.md
+++ b/docs/tts.md
@@ -1,11 +1,12 @@
 # Text-to-Speech
 
-Kesha speaks back via Kokoro-82M (English) and Chatterbox Multilingual ONNX. Voice is auto-picked from the input text's language — `en` routes to Kokoro, `ru` routes to macOS AVSpeech on darwin and Chatterbox elsewhere, and other Chatterbox languages route to Chatterbox. Pass `--voice` to override.
+Kesha speaks back via Kokoro-82M (English) and Chatterbox Multilingual ONNX. Voice is auto-picked from the input text's language — `en` routes to Kokoro, Chatterbox languages route to Chatterbox, and `ru` on darwin uses Milena only as the zero-install fallback when Chatterbox is not installed. Pass `--lang <tag>` to choose a language's default voice, or `--voice <id>` to pick an exact voice.
 
 ```bash
 kesha install --tts                 # ~3.3GB (Kokoro + Chatterbox, opt-in)
 kesha say "Hello, world" > hello.wav
-kesha say "Привет, мир" > privet.wav    # auto-routes (Milena on darwin, ru-chatterbox-m01 elsewhere)
+kesha say "Привет, мир" > privet.wav    # auto-routes (Chatterbox if installed; Milena fallback on darwin)
+kesha say --lang de "Hallo"             # picks de-chatterbox-m01
 echo "long text" | kesha say > reply.wav
 kesha say --out reply.wav "text"
 kesha say --voice en-am_michael "text"    # explicit voice overrides auto-routing
@@ -22,7 +23,7 @@ Chatterbox voice ids use `<lang>-chatterbox-m01`. Supported language tags:
 
 `ar`, `da`, `de`, `el`, `en`, `es`, `fi`, `fr`, `he`, `hi`, `it`, `ja`, `ko`, `ms`, `nl`, `no`, `pl`, `pt`, `ru`, `sv`, `sw`, `tr`, `zh`
 
-Default voices are **male** per CLAUDE.md "DEFAULT TTS VOICES MUST BE MALE": `am_michael` for English Kokoro, `ru-chatterbox-m01` for Russian Chatterbox on Linux/Windows. The darwin Russian fallback uses `Milena` (AVSpeech) for the zero-install path.
+Default voices are **male** per CLAUDE.md "DEFAULT TTS VOICES MUST BE MALE": `am_michael` for English Kokoro, `ru-chatterbox-m01` for Russian Chatterbox. The darwin Russian fallback uses `Milena` (AVSpeech) only for the zero-install path before `kesha install --tts`.
 
 **Supported voices:**
 - English: `en-am_michael` (default), plus any Kokoro voice you download into `~/.cache/kesha/models/kokoro-82m/voices/` (`am_*`/`bm_*` male, `af_*`/`bf_*` female).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
   "version": "1.17.0",
-  "description": "Open-source voice toolkit. Speech-to-text (25 langs, ~19x faster than Whisper on Apple Silicon, ONNX fallback on CPU), text-to-speech (Kokoro + Chatterbox + ~180 macOS system voices, SSML), voice-activity detection, language detection (107 langs). Rust engine, OpenClaw skill.",
+  "description": "Open-source voice toolkit. Speech-to-text (25 langs, ~19x faster than Whisper on Apple Silicon, ONNX fallback on CPU), text-to-speech (Kokoro + Chatterbox 23 langs + ~180 macOS system voices, SSML), voice-activity detection, language detection (107 langs). Rust engine, OpenClaw skill.",
   "type": "module",
   "bin": {
     "kesha": "bin/kesha.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
   "version": "1.17.0",
-  "description": "Open-source voice toolkit. Speech-to-text (25 langs, ~19x faster than Whisper on Apple Silicon, ONNX fallback on CPU), text-to-speech (Kokoro + Vosk-TTS + ~180 macOS system voices, SSML), voice-activity detection, language detection (107 langs). Rust engine, OpenClaw skill.",
+  "description": "Open-source voice toolkit. Speech-to-text (25 langs, ~19x faster than Whisper on Apple Silicon, ONNX fallback on CPU), text-to-speech (Kokoro + Chatterbox + ~180 macOS system voices, SSML), voice-activity detection, language detection (107 langs). Rust engine, OpenClaw skill.",
   "type": "module",
   "bin": {
     "kesha": "bin/kesha.js",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -9,6 +9,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,6 +149,12 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -151,7 +171,16 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -159,6 +188,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -198,6 +233,15 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -271,6 +315,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "compact_str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
+ "static_assertions",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,13 +399,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "daachorse"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f55d7153ba3b507595872a3874803f07a8a81d1e888abed8e5db7da0597d6e2"
+
+[[package]]
 name = "darling"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.14.4",
+ "darling_macro 0.14.4",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
 ]
 
 [[package]]
@@ -364,14 +439,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
- "darling_core",
+ "darling_core 0.14.4",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "dary_heap"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -390,7 +499,16 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
 dependencies = [
- "derive_builder_macro",
+ "derive_builder_macro 0.12.0",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro 0.20.2",
 ]
 
 [[package]]
@@ -399,10 +517,22 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
 dependencies = [
- "darling",
+ "darling 0.14.4",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -411,8 +541,18 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
 dependencies = [
- "derive_builder_core",
+ "derive_builder_core 0.12.0",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core 0.20.2",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -474,8 +614,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "esaxx-rs"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
 
 [[package]]
 name = "extended"
@@ -489,7 +635,18 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
 dependencies = [
- "bit-set",
+ "bit-set 0.5.3",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+dependencies = [
+ "bit-set 0.8.0",
  "regex-automata",
  "regex-syntax",
 ]
@@ -575,13 +732,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -693,6 +862,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -724,6 +902,7 @@ dependencies = [
  "symphonia-adapter-libopus",
  "tempfile",
  "thiserror 1.0.69",
+ "tokenizers",
  "ureq",
  "vosk_tts",
 ]
@@ -790,6 +969,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1670343e58806300d87950e3401e820b519b9384281bbabfb15e3636689ffd69"
 
 [[package]]
+name = "macro_rules_attribute"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65049d7923698040cd0b1ddcced9b0eb14dd22c5f86ae59c3740eab64a676520"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "paste",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
+
+[[package]]
 name = "matrixmultiply"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -812,6 +1007,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -827,7 +1028,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e93650257ef50ccc74057b6248912e844b8874d9c7dfdd145d91f65deef095e"
 dependencies = [
- "fancy-regex",
+ "fancy-regex 0.13.0",
  "language-tokenizer",
  "log",
  "num2words",
@@ -835,6 +1036,28 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "monostate"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3341a273f6c9d5bef1908f17b7267bbab0e95c9bf69a0d4dcf8e9e1b2c76ef67"
+dependencies = [
+ "monostate-impl",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "monostate-impl"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -867,6 +1090,16 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "rawpointer",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1037,6 +1270,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pem-rfc7468"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1076,6 +1315,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]
@@ -1135,9 +1383,44 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "rawpointer"
@@ -1153,6 +1436,17 @@ checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
+]
+
+[[package]]
+name = "rayon-cond"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
+dependencies = [
+ "either",
+ "itertools",
+ "rayon",
 ]
 
 [[package]]
@@ -1268,7 +1562,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1311,6 +1605,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "schannel"
@@ -1434,13 +1734,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "spm_precompiled"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
+dependencies = [
+ "base64 0.13.1",
+ "nom",
+ "serde",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "ssml-parser"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bad5be8b59c13ef474977a027a3b7f5d5cdc6a2f86630dea4fe82e2628530c49"
 dependencies = [
  "anyhow",
- "derive_builder",
+ "derive_builder 0.12.0",
  "http 0.2.12",
  "indexmap 1.9.3",
  "lazy_static",
@@ -1448,6 +1760,12 @@ dependencies = [
  "quick-xml",
  "regex",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strength_reduce"
@@ -1709,7 +2027,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1766,6 +2084,39 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokenizers"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44e5bea67576e04b6ff8564c5d9e09c2ef0cf476502245f2f120e497769d3112"
+dependencies = [
+ "ahash",
+ "compact_str",
+ "daachorse",
+ "dary_heap",
+ "derive_builder 0.20.2",
+ "esaxx-rs",
+ "fancy-regex 0.17.0",
+ "getrandom 0.3.4",
+ "itertools",
+ "log",
+ "macro_rules_attribute",
+ "monostate",
+ "paste",
+ "rand",
+ "rayon",
+ "rayon-cond",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "spm_precompiled",
+ "thiserror 2.0.18",
+ "unicode-normalization-alignments",
+ "unicode-segmentation",
+ "unicode_categories",
+]
 
 [[package]]
 name = "toml_datetime"
@@ -1848,6 +2199,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-normalization-alignments"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1858,6 +2218,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "untrusted"
@@ -1871,7 +2237,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "der",
  "flate2",
  "log",
@@ -1892,7 +2258,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "http 1.4.0",
  "httparse",
  "log",
@@ -2247,6 +2613,26 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -26,7 +26,7 @@ default = ["onnx", "tts"]
 # invalidAudioData")` (see #259) interleaves with kesha-engine's JSON output.
 coreml = ["dep:fluidaudio-rs", "dep:tempfile", "dep:libc"]
 onnx = []
-tts = ["dep:hound", "dep:thiserror", "dep:ssml-parser", "dep:opus", "dep:ogg"]
+tts = ["dep:hound", "dep:thiserror", "dep:ssml-parser", "dep:opus", "dep:ogg", "dep:tokenizers"]
 # macOS-only AVSpeechSynthesizer backend for `macos-*` voices (#141).
 # Opt-in — builds a Swift sidecar via swiftc in build.rs. Silently no-op on
 # non-macOS targets even when enabled.
@@ -79,6 +79,7 @@ ssml-parser = { version = "0.1", optional = true }
 # is a pure-Rust container muxer. Both are MIT/Apache-2.0 — license-compatible.
 opus = { version = "0.3", optional = true }
 ogg = { version = "0.9", optional = true }
+tokenizers = { version = "0.23.1", default-features = false, features = ["fancy-regex"], optional = true }
 
 tempfile = { version = "3", optional = true }
 libc = { version = "0.2", optional = true }

--- a/rust/src/cli/say.rs
+++ b/rust/src/cli/say.rs
@@ -116,6 +116,14 @@ fn list_vosk_ru_voices(cache: &std::path::Path) -> Vec<String> {
     ]
 }
 
+fn list_chatterbox_voices(cache: &std::path::Path) -> Vec<String> {
+    let dir = models::model_dir_at(models::ModelKind::Chatterbox, cache);
+    if !models::is_cached_in(models::ModelKind::Chatterbox, &dir) {
+        return Vec::new();
+    }
+    vec!["ru-chatterbox-m01".into()]
+}
+
 /// Map a TTS error to the documented exit code for `kesha say`.
 /// 2 = bad input, 4 = synthesis failure, 5 = text too long.
 /// (Voice-not-installed exits 1 directly from the resolver path.)
@@ -134,6 +142,7 @@ pub fn run(a: SayArgs) -> i32 {
         let cache = models::cache_dir();
         let mut voice_ids: Vec<String> = list_kokoro_voices(&cache)
             .into_iter()
+            .chain(list_chatterbox_voices(&cache))
             .chain(list_vosk_ru_voices(&cache))
             .collect();
         // macos-* voices live in the OS, not the cache — enumerate them via
@@ -213,6 +222,15 @@ pub fn run(a: SayArgs) -> i32 {
             model_dir,
             speaker_id: *speaker_id,
             speed: a.rate,
+        },
+        tts::voices::ResolvedVoice::Chatterbox {
+            model_dir,
+            voice_path,
+            lang: _,
+        } => tts::EngineChoice::Chatterbox {
+            model_dir,
+            voice_path,
+            lang: &espeak_lang,
         },
         #[cfg(all(feature = "system_tts", target_os = "macos"))]
         tts::voices::ResolvedVoice::AVSpeech { voice_id } => {

--- a/rust/src/cli/say.rs
+++ b/rust/src/cli/say.rs
@@ -121,7 +121,10 @@ fn list_chatterbox_voices(cache: &std::path::Path) -> Vec<String> {
     if !models::is_cached_in(models::ModelKind::Chatterbox, &dir) {
         return Vec::new();
     }
-    vec!["ru-chatterbox-m01".into()]
+    tts::chatterbox::SUPPORTED_LANGS
+        .iter()
+        .map(|lang| format!("{lang}-{}", tts::voices::CHATTERBOX_DEFAULT_VOICE))
+        .collect()
 }
 
 /// Map a TTS error to the documented exit code for `kesha say`.

--- a/rust/src/cli/say.rs
+++ b/rust/src/cli/say.rs
@@ -156,6 +156,9 @@ pub fn run(a: SayArgs) -> i32 {
         voice_ids.sort();
         if voice_ids.is_empty() {
             println!("No voices installed. Run: kesha install --tts");
+            println!(
+                "Chatterbox languages install together in one bundle; use <lang>-chatterbox-m01 after install."
+            );
         } else {
             for id in voice_ids {
                 println!("{id}");

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -66,7 +66,7 @@ enum Commands {
         /// Re-download even if cached
         #[arg(long)]
         no_cache: bool,
-        /// Also install TTS models (Kokoro EN + Vosk RU, ~990MB).
+        /// Also install TTS models (Kokoro EN + Chatterbox multilingual, ~3.3GB).
         #[cfg(feature = "tts")]
         #[arg(long)]
         tts: bool,

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -66,7 +66,8 @@ enum Commands {
         /// Re-download even if cached
         #[arg(long)]
         no_cache: bool,
-        /// Also install TTS models (Kokoro EN + Chatterbox multilingual, ~3.3GB).
+        /// Also install TTS models (Kokoro EN + Chatterbox 23 languages,
+        /// one bundled download, ~3.3GB).
         #[cfg(feature = "tts")]
         #[arg(long)]
         tts: bool,

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -141,43 +141,62 @@ pub fn kokoro_manifest() -> Vec<ModelFile> {
     ]
 }
 
-/// Vosk-TTS multi-speaker Russian model, mirrored to HF at
-/// `drakulavich/vosk-tts-ru-0.9-multi`. Replaces Piper-ru per
-/// `docs/superpowers/specs/2026-04-27-vosk-ru-replacement-design.md`.
-/// SHA-256 pins computed from the HF mirror — see CLAUDE.md MODEL HASHES
-/// ARE PINNED rule.
+/// Chatterbox Multilingual ONNX. Pinned to HF revision
+/// `452d3f434aa592098f1eedac9099f33642ab2da5` so fresh installs do not
+/// silently pick up a republished 3+ GB model bundle.
 #[cfg(feature = "tts")]
-pub fn vosk_ru_manifest() -> Vec<ModelFile> {
+pub fn chatterbox_manifest() -> Vec<ModelFile> {
     vec![
         ModelFile {
-            rel_path: "models/vosk-ru/model.onnx",
-            url: "https://huggingface.co/drakulavich/vosk-tts-ru-0.9-multi/resolve/main/model.onnx",
-            sha256: "0fa5a36b22a8bf7fe7179a3882c6371d2c01e5317019e717516f892d329c24b9",
+            rel_path: "models/chatterbox/onnx/speech_encoder.onnx",
+            url: "https://huggingface.co/onnx-community/chatterbox-multilingual-ONNX/resolve/452d3f434aa592098f1eedac9099f33642ab2da5/onnx/speech_encoder.onnx",
+            sha256: "8f1c8a0f89b77bf9cd5dd8f2e034eb2c79dc00fe70d41196b28c257643b00ccb",
         },
         ModelFile {
-            rel_path: "models/vosk-ru/dictionary",
-            url: "https://huggingface.co/drakulavich/vosk-tts-ru-0.9-multi/resolve/main/dictionary",
-            sha256: "2939e72c170bb41ac8e256828cca1c5fac4db1e36717f9f53fde843b00a220ba",
+            rel_path: "models/chatterbox/onnx/speech_encoder.onnx_data",
+            url: "https://huggingface.co/onnx-community/chatterbox-multilingual-ONNX/resolve/452d3f434aa592098f1eedac9099f33642ab2da5/onnx/speech_encoder.onnx_data",
+            sha256: "92f8f290fc9720e169bc2412c507209e20b03f6564bc3243739e25c56f7dfb8f",
         },
         ModelFile {
-            rel_path: "models/vosk-ru/config.json",
-            url: "https://huggingface.co/drakulavich/vosk-tts-ru-0.9-multi/resolve/main/config.json",
-            sha256: "e155fb266a730e1858a2420442b465acf08a3236dffad7d1a507bf155b213d50",
+            rel_path: "models/chatterbox/onnx/embed_tokens.onnx",
+            url: "https://huggingface.co/onnx-community/chatterbox-multilingual-ONNX/resolve/452d3f434aa592098f1eedac9099f33642ab2da5/onnx/embed_tokens.onnx",
+            sha256: "f785819ca4f6271262d5bb8971d62796c3a909e3b031982c113dbe83a4c3b854",
         },
         ModelFile {
-            rel_path: "models/vosk-ru/bert/model.onnx",
-            url: "https://huggingface.co/drakulavich/vosk-tts-ru-0.9-multi/resolve/main/bert/model.onnx",
-            sha256: "2e2f1740eaae5e29c2b4844625cbb01ff644b2b5fb0560bd34374c35d8a092c1",
+            rel_path: "models/chatterbox/onnx/embed_tokens.onnx_data",
+            url: "https://huggingface.co/onnx-community/chatterbox-multilingual-ONNX/resolve/452d3f434aa592098f1eedac9099f33642ab2da5/onnx/embed_tokens.onnx_data",
+            sha256: "2a15f7dd73b2ee47f6edf87740324011594b5a528ed6471ae55e327ed6cad68c",
         },
         ModelFile {
-            rel_path: "models/vosk-ru/bert/vocab.txt",
-            url: "https://huggingface.co/drakulavich/vosk-tts-ru-0.9-multi/resolve/main/bert/vocab.txt",
-            sha256: "bbe5063cc3d7a314effd90e9c5099cf493b81f2b9552c155264e16eeab074237",
+            rel_path: "models/chatterbox/onnx/language_model.onnx",
+            url: "https://huggingface.co/onnx-community/chatterbox-multilingual-ONNX/resolve/452d3f434aa592098f1eedac9099f33642ab2da5/onnx/language_model.onnx",
+            sha256: "861a34585605e8ad671051788afc495dcbeaee833a41523a1b33aded9c3babc7",
         },
-        // removed: README.md (drakulavich/vosk-tts-ru-0.9-multi) — not opened at
-        // runtime; pinning its SHA forced a manifest bump on every upstream
-        // doc copy-edit. CharsiuG2P entries (3 byt5-tiny ONNX) were also
-        // removed in PR #213 — Russian uses vosk-tts internal G2P now.
+        ModelFile {
+            rel_path: "models/chatterbox/onnx/language_model.onnx_data",
+            url: "https://huggingface.co/onnx-community/chatterbox-multilingual-ONNX/resolve/452d3f434aa592098f1eedac9099f33642ab2da5/onnx/language_model.onnx_data",
+            sha256: "b3556d41085196c122b7197e4d44ec4475b6d7cfe0971a70faa95caa38ad787a",
+        },
+        ModelFile {
+            rel_path: "models/chatterbox/onnx/conditional_decoder.onnx",
+            url: "https://huggingface.co/onnx-community/chatterbox-multilingual-ONNX/resolve/452d3f434aa592098f1eedac9099f33642ab2da5/onnx/conditional_decoder.onnx",
+            sha256: "1656d0d31332bae1854839959a3139300ebb67c178651dfa3f8c5fbfa5351351",
+        },
+        ModelFile {
+            rel_path: "models/chatterbox/onnx/conditional_decoder.onnx_data",
+            url: "https://huggingface.co/onnx-community/chatterbox-multilingual-ONNX/resolve/452d3f434aa592098f1eedac9099f33642ab2da5/onnx/conditional_decoder.onnx_data",
+            sha256: "51d58345a272747665ec9d5bb61e01835258a940e321a288582ac4c18cf01b5a",
+        },
+        ModelFile {
+            rel_path: "models/chatterbox/tokenizer.json",
+            url: "https://huggingface.co/onnx-community/chatterbox-multilingual-ONNX/resolve/452d3f434aa592098f1eedac9099f33642ab2da5/tokenizer.json",
+            sha256: "29d48c4a178f6af3ad5130097c34744639e9294847b38a7b912c8c68027cb819",
+        },
+        ModelFile {
+            rel_path: "models/chatterbox/default_voice.wav",
+            url: "https://huggingface.co/onnx-community/chatterbox-multilingual-ONNX/resolve/452d3f434aa592098f1eedac9099f33642ab2da5/default_voice.wav",
+            sha256: "3ebc531cdaba358a327099c1c4f0448026719957bcf4d8e9868767f227e02f4e",
+        },
     ]
 }
 
@@ -258,6 +277,9 @@ pub enum ModelKind {
     /// Vosk-TTS multi-speaker Russian model (model + dictionary + BERT).
     #[cfg(feature = "tts")]
     VoskRu,
+    /// Chatterbox Multilingual ONNX TTS model bundle.
+    #[cfg(feature = "tts")]
+    Chatterbox,
     /// FluidAudio Sortformer streaming diarizer (`.mlpackage`).
     #[cfg(feature = "system_diarize")]
     Diarize,
@@ -272,6 +294,8 @@ impl ModelKind {
             ModelKind::Vad => "models/silero-vad",
             #[cfg(feature = "tts")]
             ModelKind::VoskRu => "models/vosk-ru",
+            #[cfg(feature = "tts")]
+            ModelKind::Chatterbox => "models/chatterbox",
             #[cfg(feature = "system_diarize")]
             ModelKind::Diarize => "models/diarize/SortformerNvidiaLow_v2.mlpackage",
         }
@@ -307,6 +331,8 @@ pub fn is_cached_in(kind: ModelKind, dir: &Path) -> bool {
         ModelKind::Vad => has_all_files(dir, VAD_FILES),
         #[cfg(feature = "tts")]
         ModelKind::VoskRu => has_vosk_ru_layout(dir),
+        #[cfg(feature = "tts")]
+        ModelKind::Chatterbox => has_chatterbox_layout(dir),
         #[cfg(feature = "system_diarize")]
         ModelKind::Diarize => has_diarize_layout(dir),
     }
@@ -321,6 +347,20 @@ fn has_vosk_ru_layout(dir: &Path) -> bool {
     dir.join("model.onnx").exists()
         && dir.join("dictionary").exists()
         && dir.join("bert/model.onnx").exists()
+}
+
+#[cfg(feature = "tts")]
+fn has_chatterbox_layout(dir: &Path) -> bool {
+    dir.join("onnx/speech_encoder.onnx").exists()
+        && dir.join("onnx/speech_encoder.onnx_data").exists()
+        && dir.join("onnx/embed_tokens.onnx").exists()
+        && dir.join("onnx/embed_tokens.onnx_data").exists()
+        && dir.join("onnx/language_model.onnx").exists()
+        && dir.join("onnx/language_model.onnx_data").exists()
+        && dir.join("onnx/conditional_decoder.onnx").exists()
+        && dir.join("onnx/conditional_decoder.onnx_data").exists()
+        && dir.join("tokenizer.json").exists()
+        && dir.join("default_voice.wav").exists()
 }
 
 /// `.mlpackage` is a directory tree — the runtime-required files live at
@@ -582,24 +622,27 @@ mod tts_tests {
     }
 
     #[test]
-    fn vosk_ru_manifest_has_expected_files() {
-        let m = vosk_ru_manifest();
-        assert_eq!(m.len(), 5);
+    fn chatterbox_manifest_has_expected_files() {
+        let m = chatterbox_manifest();
+        assert_eq!(m.len(), 10);
         let names: std::collections::HashSet<&str> = m.iter().map(|f| f.rel_path).collect();
         for f in [
-            "models/vosk-ru/model.onnx",
-            "models/vosk-ru/dictionary",
-            "models/vosk-ru/config.json",
-            "models/vosk-ru/bert/model.onnx",
-            "models/vosk-ru/bert/vocab.txt",
+            "models/chatterbox/onnx/speech_encoder.onnx",
+            "models/chatterbox/onnx/speech_encoder.onnx_data",
+            "models/chatterbox/onnx/embed_tokens.onnx",
+            "models/chatterbox/onnx/embed_tokens.onnx_data",
+            "models/chatterbox/onnx/language_model.onnx",
+            "models/chatterbox/onnx/language_model.onnx_data",
+            "models/chatterbox/onnx/conditional_decoder.onnx",
+            "models/chatterbox/onnx/conditional_decoder.onnx_data",
+            "models/chatterbox/tokenizer.json",
+            "models/chatterbox/default_voice.wav",
         ] {
             assert!(names.contains(f), "missing {f}");
         }
         for f in &m {
             assert!(f.sha256.len() == 64, "sha256 must be 64 hex chars");
-            assert!(f.url.starts_with(
-                "https://huggingface.co/drakulavich/vosk-tts-ru-0.9-multi/resolve/main/"
-            ));
+            assert!(f.url.starts_with("https://huggingface.co/onnx-community/chatterbox-multilingual-ONNX/resolve/452d3f434aa592098f1eedac9099f33642ab2da5/"));
         }
     }
 
@@ -661,14 +704,14 @@ pub fn download_vad(no_cache: bool) -> Result<()> {
     parallel_download(&cache, &refs, no_cache)
 }
 
-/// Download every TTS model file: Kokoro English + Vosk Russian.
+/// Download every TTS model file: Kokoro English + Chatterbox multilingual.
 /// Each file is streamed to disk, then SHA256-verified. 4 concurrent
 /// downloads (#178).
 #[cfg(feature = "tts")]
 pub fn download_tts(no_cache: bool) -> Result<()> {
     let cache = cache_dir();
     let mut manifest = kokoro_manifest();
-    manifest.extend(vosk_ru_manifest());
+    manifest.extend(chatterbox_manifest());
     let refs: Vec<&ModelFile> = manifest.iter().collect();
     parallel_download(&cache, &refs, no_cache)
 }

--- a/rust/src/say_loop.rs
+++ b/rust/src/say_loop.rs
@@ -305,6 +305,28 @@ fn handle(req: &LoopRequest, state: &mut LoopState) -> Result<Vec<u8>, String> {
                 tts::encode::encode(&audio, sample_rate, format).map_err(|e| format!("encode: {e}"))
             }
         }
+        tts::voices::ResolvedVoice::Chatterbox {
+            model_dir,
+            voice_path,
+            lang: _,
+        } => {
+            if req.ssml {
+                return Err("SSML is not yet supported with Chatterbox voices".into());
+            }
+            tts::say(tts::SayOptions {
+                text: &req.text,
+                lang: espeak_lang,
+                engine: tts::EngineChoice::Chatterbox {
+                    model_dir: &model_dir,
+                    voice_path: &voice_path,
+                    lang: espeak_lang,
+                },
+                ssml: false,
+                format,
+                expand_abbrev: req.expand_abbrev,
+            })
+            .map_err(|e| e.to_string())
+        }
         #[cfg(all(feature = "system_tts", target_os = "macos"))]
         tts::voices::ResolvedVoice::AVSpeech { voice_id } => {
             // AVSpeech is a Swift sidecar — no in-process state to cache.

--- a/rust/src/tts/chatterbox.rs
+++ b/rust/src/tts/chatterbox.rs
@@ -1,0 +1,461 @@
+//! Chatterbox Multilingual ONNX inference.
+//!
+//! Pipeline:
+//! reference WAV -> speech_encoder -> text token embeddings -> autoregressive
+//! language_model -> conditional_decoder -> 24 kHz mono f32 PCM.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use ndarray::{ArrayD, IxDyn};
+use ort::session::Session;
+use ort::value::Value;
+use tokenizers::Tokenizer;
+
+pub const SAMPLE_RATE: u32 = 24_000;
+
+const EXAGGERATION_TOKEN: i64 = 6563;
+const BOS_TOKEN: i64 = 255;
+const EOS_TOKEN: i64 = 0;
+const START_SPEECH_TOKEN: i64 = 6561;
+const STOP_SPEECH_TOKEN: i64 = 6562;
+const SPEECH_VOCAB_SIZE: usize = 6564;
+const NUM_LAYERS: usize = 30;
+const NUM_KV_HEADS: usize = 16;
+const HEAD_DIM: usize = 64;
+const MAX_NEW_TOKENS: usize = 4096;
+const REPETITION_PENALTY: f32 = 1.2;
+
+pub const SUPPORTED_LANGS: &[&str] = &[
+    "ar", "da", "de", "el", "en", "es", "fi", "fr", "hi", "it", "ms", "nl", "no", "pl", "pt", "ru",
+    "sv", "sw", "tr",
+];
+
+const PREPROCESSING_LANGS: &[&str] = &["zh", "ja", "he", "ko"];
+
+#[derive(Clone)]
+struct TensorF32 {
+    shape: Vec<usize>,
+    data: Vec<f32>,
+}
+
+#[derive(Clone)]
+struct TensorI64 {
+    shape: Vec<usize>,
+    data: Vec<i64>,
+}
+
+pub struct Chatterbox {
+    speech_encoder: Session,
+    embed_tokens: Session,
+    language_model: Session,
+    conditional_decoder: Session,
+    tokenizer: Tokenizer,
+}
+
+struct SpeechEncoderOutput {
+    cond_emb: TensorF32,
+    prompt_token: TensorI64,
+    ref_xvector: TensorF32,
+    prompt_feat: TensorF32,
+}
+
+impl Chatterbox {
+    pub fn load(model_dir: &Path) -> Result<Self> {
+        let onnx = model_dir.join("onnx");
+        Ok(Self {
+            speech_encoder: Session::builder()?
+                .commit_from_file(onnx.join("speech_encoder.onnx"))
+                .with_context(|| format!("load {}", onnx.join("speech_encoder.onnx").display()))?,
+            embed_tokens: Session::builder()?
+                .commit_from_file(onnx.join("embed_tokens.onnx"))
+                .with_context(|| format!("load {}", onnx.join("embed_tokens.onnx").display()))?,
+            language_model: Session::builder()?
+                .commit_from_file(onnx.join("language_model.onnx"))
+                .with_context(|| format!("load {}", onnx.join("language_model.onnx").display()))?,
+            conditional_decoder: Session::builder()?
+                .commit_from_file(onnx.join("conditional_decoder.onnx"))
+                .with_context(|| {
+                    format!("load {}", onnx.join("conditional_decoder.onnx").display())
+                })?,
+            tokenizer: Tokenizer::from_file(model_dir.join("tokenizer.json"))
+                .map_err(|e| anyhow::anyhow!("load tokenizer.json: {e}"))?,
+        })
+    }
+
+    pub fn infer(&mut self, text: &str, lang: &str, voice_path: &Path) -> Result<Vec<f32>> {
+        validate_lang(lang)?;
+        let reference = load_reference_wav(voice_path)?;
+        let encoded = self.encode_speech(&reference)?;
+        let input_ids = self.prepare_input_ids(text, lang)?;
+        let position_ids = build_position_ids(&input_ids);
+        let text_embeds = self.embed(&input_ids, &position_ids, 0.5)?;
+        let combined = concat_embeddings(&encoded.cond_emb, &text_embeds)?;
+        let speech_tokens = self.generate_speech_tokens(&combined, 0.5)?;
+        let all_tokens = concat_i64(&encoded.prompt_token.data, &speech_tokens);
+        self.decode_speech(
+            &TensorI64 {
+                shape: vec![1, all_tokens.len()],
+                data: all_tokens,
+            },
+            &encoded.ref_xvector,
+            &encoded.prompt_feat,
+        )
+    }
+
+    fn encode_speech(&mut self, audio: &[f32]) -> Result<SpeechEncoderOutput> {
+        let audio_values = f32_value(vec![1, audio.len()], audio.to_vec())?;
+        let outputs = self
+            .speech_encoder
+            .run(ort::inputs!["audio_values" => audio_values])?;
+        Ok(SpeechEncoderOutput {
+            cond_emb: extract_f32(&outputs["audio_features"])?,
+            prompt_token: extract_i64(&outputs["audio_tokens"])?,
+            ref_xvector: extract_f32(&outputs["speaker_embeddings"])?,
+            prompt_feat: extract_f32(&outputs["speaker_features"])?,
+        })
+    }
+
+    fn prepare_input_ids(&self, text: &str, lang: &str) -> Result<Vec<i64>> {
+        let tagged = format!("[{lang}]{}", text.trim());
+        let encoding = self
+            .tokenizer
+            .encode(tagged, false)
+            .map_err(|e| anyhow::anyhow!("tokenize Chatterbox text: {e}"))?;
+        let mut ids = Vec::with_capacity(encoding.len() + 5);
+        ids.push(EXAGGERATION_TOKEN);
+        ids.push(BOS_TOKEN);
+        ids.extend(encoding.get_ids().iter().map(|&id| i64::from(id)));
+        ids.push(EOS_TOKEN);
+        ids.push(START_SPEECH_TOKEN);
+        ids.push(START_SPEECH_TOKEN);
+        Ok(ids)
+    }
+
+    fn embed(
+        &mut self,
+        input_ids: &[i64],
+        position_ids: &[i64],
+        exaggeration: f32,
+    ) -> Result<TensorF32> {
+        let seq_len = input_ids.len();
+        let ids = i64_value(vec![1, seq_len], input_ids.to_vec())?;
+        let pos = i64_value(vec![1, seq_len], position_ids.to_vec())?;
+        let exag = f32_value(vec![1], vec![exaggeration])?;
+        let outputs = self.embed_tokens.run(ort::inputs![
+            "input_ids" => ids,
+            "position_ids" => pos,
+            "exaggeration" => exag,
+        ])?;
+        extract_f32(&outputs["inputs_embeds"])
+    }
+
+    fn generate_speech_tokens(
+        &mut self,
+        combined_embeds: &TensorF32,
+        exaggeration: f32,
+    ) -> Result<Vec<i64>> {
+        let seq_len = combined_embeds
+            .shape
+            .get(1)
+            .copied()
+            .context("combined embeddings must be rank-3")?;
+        let mut kv_cache = empty_kv_cache()?;
+        let mut attention_mask = vec![1_i64; seq_len];
+        let mut generated = Vec::new();
+
+        let mut prefill = ort::inputs![
+            "inputs_embeds" => f32_value(combined_embeds.shape.clone(), combined_embeds.data.clone())?,
+            "attention_mask" => i64_value(vec![1, attention_mask.len()], attention_mask.clone())?,
+        ];
+        push_kv_cache(&mut prefill, kv_cache);
+        let logits = {
+            let outputs = self.language_model.run(prefill)?;
+            kv_cache = extract_kv_cache(&outputs)?;
+            extract_f32(&outputs["logits"])?
+        };
+        let mut next_token = argmax(last_logits(&logits, seq_len)?) as i64;
+        generated.push(next_token);
+
+        for step in 0..MAX_NEW_TOKENS {
+            if next_token == STOP_SPEECH_TOKEN {
+                break;
+            }
+            let next_ids = [next_token];
+            let next_pos = [step as i64];
+            let next_embeds = self.embed(&next_ids, &next_pos, exaggeration)?;
+            attention_mask.push(1);
+
+            let mut feeds = ort::inputs![
+                "inputs_embeds" => f32_value(next_embeds.shape, next_embeds.data)?,
+                "attention_mask" => i64_value(vec![1, attention_mask.len()], attention_mask.clone())?,
+            ];
+            push_kv_cache(&mut feeds, kv_cache);
+            let logits = {
+                let outputs = self.language_model.run(feeds)?;
+                kv_cache = extract_kv_cache(&outputs)?;
+                extract_f32(&outputs["logits"])?
+            };
+            let mut step_logits = logits.data[..SPEECH_VOCAB_SIZE.min(logits.data.len())].to_vec();
+            apply_repetition_penalty(&mut step_logits, &generated, REPETITION_PENALTY);
+            next_token = argmax(&step_logits) as i64;
+            generated.push(next_token);
+        }
+
+        Ok(generated
+            .into_iter()
+            .filter(|&t| t != START_SPEECH_TOKEN && t != STOP_SPEECH_TOKEN)
+            .collect())
+    }
+
+    fn decode_speech(
+        &mut self,
+        speech_tokens: &TensorI64,
+        speaker_embeddings: &TensorF32,
+        speaker_features: &TensorF32,
+    ) -> Result<Vec<f32>> {
+        let outputs = self.conditional_decoder.run(ort::inputs![
+            "speech_tokens" => i64_value(speech_tokens.shape.clone(), speech_tokens.data.clone())?,
+            "speaker_embeddings" => f32_value(speaker_embeddings.shape.clone(), speaker_embeddings.data.clone())?,
+            "speaker_features" => f32_value(speaker_features.shape.clone(), speaker_features.data.clone())?,
+        ])?;
+        Ok(extract_f32(&outputs["waveform"])?.data)
+    }
+}
+
+pub fn validate_lang(lang: &str) -> Result<()> {
+    if SUPPORTED_LANGS.contains(&lang) {
+        return Ok(());
+    }
+    if PREPROCESSING_LANGS.contains(&lang) {
+        anyhow::bail!(
+            "language '{lang}' requires Chatterbox text preprocessing that is not implemented yet"
+        );
+    }
+    anyhow::bail!(
+        "unsupported Chatterbox language '{lang}'. supported: {}",
+        SUPPORTED_LANGS.join(", ")
+    )
+}
+
+fn build_position_ids(input_ids: &[i64]) -> Vec<i64> {
+    input_ids
+        .iter()
+        .enumerate()
+        .map(|(i, &id)| {
+            if id >= START_SPEECH_TOKEN {
+                0
+            } else {
+                i as i64 - 1
+            }
+        })
+        .collect()
+}
+
+fn load_reference_wav(path: &Path) -> Result<Vec<f32>> {
+    let mut reader = hound::WavReader::open(path)
+        .with_context(|| format!("open Chatterbox reference WAV {}", path.display()))?;
+    let spec = reader.spec();
+    anyhow::ensure!(
+        spec.sample_rate == SAMPLE_RATE,
+        "Chatterbox reference WAV must be 24 kHz, got {} Hz ({})",
+        spec.sample_rate,
+        path.display()
+    );
+    anyhow::ensure!(
+        spec.channels == 1,
+        "Chatterbox reference WAV must be mono, got {} channels ({})",
+        spec.channels,
+        path.display()
+    );
+    match spec.sample_format {
+        hound::SampleFormat::Float => Ok(reader.samples::<f32>().collect::<Result<Vec<_>, _>>()?),
+        hound::SampleFormat::Int => {
+            if spec.bits_per_sample <= 16 {
+                Ok(reader
+                    .samples::<i16>()
+                    .map(|s| s.map(|v| v as f32 / 32768.0))
+                    .collect::<Result<Vec<_>, _>>()?)
+            } else {
+                let denom = ((1_i64 << (spec.bits_per_sample - 1)) - 1) as f32;
+                Ok(reader
+                    .samples::<i32>()
+                    .map(|s| s.map(|v| v as f32 / denom))
+                    .collect::<Result<Vec<_>, _>>()?)
+            }
+        }
+    }
+}
+
+fn f32_value(shape: Vec<usize>, data: Vec<f32>) -> Result<Value> {
+    Ok(Value::from_array(ArrayD::<f32>::from_shape_vec(IxDyn(&shape), data)?)?.into())
+}
+
+fn i64_value(shape: Vec<usize>, data: Vec<i64>) -> Result<Value> {
+    Ok(Value::from_array(ArrayD::<i64>::from_shape_vec(IxDyn(&shape), data)?)?.into())
+}
+
+fn extract_f32(value: &Value) -> Result<TensorF32> {
+    let (shape, data) = value.try_extract_tensor::<f32>()?;
+    Ok(TensorF32 {
+        shape: shape.iter().map(|&d| d as usize).collect(),
+        data: data.to_vec(),
+    })
+}
+
+fn extract_i64(value: &Value) -> Result<TensorI64> {
+    let (shape, data) = value.try_extract_tensor::<i64>()?;
+    Ok(TensorI64 {
+        shape: shape.iter().map(|&d| d as usize).collect(),
+        data: data.to_vec(),
+    })
+}
+
+fn concat_embeddings(cond: &TensorF32, text: &TensorF32) -> Result<TensorF32> {
+    anyhow::ensure!(cond.shape.len() == 3, "cond embeddings must be rank-3");
+    anyhow::ensure!(text.shape.len() == 3, "text embeddings must be rank-3");
+    anyhow::ensure!(cond.shape[0] == 1 && text.shape[0] == 1, "batch must be 1");
+    anyhow::ensure!(
+        cond.shape[2] == text.shape[2],
+        "embedding width mismatch: {} vs {}",
+        cond.shape[2],
+        text.shape[2]
+    );
+    let mut data = Vec::with_capacity(cond.data.len() + text.data.len());
+    data.extend_from_slice(&cond.data);
+    data.extend_from_slice(&text.data);
+    Ok(TensorF32 {
+        shape: vec![1, cond.shape[1] + text.shape[1], cond.shape[2]],
+        data,
+    })
+}
+
+fn concat_i64(prefix: &[i64], suffix: &[i64]) -> Vec<i64> {
+    let mut out = Vec::with_capacity(prefix.len() + suffix.len());
+    out.extend_from_slice(prefix);
+    out.extend_from_slice(suffix);
+    out
+}
+
+fn empty_kv_cache() -> Result<Vec<(String, Value)>> {
+    let mut cache = Vec::with_capacity(NUM_LAYERS * 2);
+    for i in 0..NUM_LAYERS {
+        cache.push((
+            format!("past_key_values.{i}.key"),
+            f32_value(vec![1, NUM_KV_HEADS, 0, HEAD_DIM], Vec::new())?,
+        ));
+        cache.push((
+            format!("past_key_values.{i}.value"),
+            f32_value(vec![1, NUM_KV_HEADS, 0, HEAD_DIM], Vec::new())?,
+        ));
+    }
+    Ok(cache)
+}
+
+fn push_kv_cache(
+    inputs: &mut Vec<(
+        std::borrow::Cow<'_, str>,
+        ort::session::SessionInputValue<'_>,
+    )>,
+    cache: Vec<(String, Value)>,
+) {
+    for (name, value) in cache {
+        inputs.push((name.into(), value.into()));
+    }
+}
+
+fn extract_kv_cache(outputs: &ort::session::SessionOutputs<'_>) -> Result<Vec<(String, Value)>> {
+    let mut cache = Vec::with_capacity(NUM_LAYERS * 2);
+    for i in 0..NUM_LAYERS {
+        let key_name = if outputs.contains_key(format!("present.{i}.key").as_str()) {
+            format!("present.{i}.key")
+        } else {
+            format!("present_key_values.{i}.key")
+        };
+        let value_name = if outputs.contains_key(format!("present.{i}.value").as_str()) {
+            format!("present.{i}.value")
+        } else {
+            format!("present_key_values.{i}.value")
+        };
+        let key = extract_f32(&outputs[key_name.as_str()])
+            .with_context(|| format!("extract KV key layer {i}"))?;
+        let value = extract_f32(&outputs[value_name.as_str()])
+            .with_context(|| format!("extract KV value layer {i}"))?;
+        cache.push((
+            format!("past_key_values.{i}.key"),
+            f32_value(key.shape, key.data)?,
+        ));
+        cache.push((
+            format!("past_key_values.{i}.value"),
+            f32_value(value.shape, value.data)?,
+        ));
+    }
+    Ok(cache)
+}
+
+fn last_logits(logits: &TensorF32, seq_len: usize) -> Result<&[f32]> {
+    let vocab = *logits.shape.get(2).context("logits must be rank-3")?;
+    let start = (seq_len - 1)
+        .checked_mul(vocab)
+        .context("logits offset overflow")?;
+    let end = start + SPEECH_VOCAB_SIZE.min(vocab);
+    logits
+        .data
+        .get(start..end)
+        .with_context(|| format!("logits slice out of bounds: {start}..{end}"))
+}
+
+fn apply_repetition_penalty(logits: &mut [f32], generated: &[i64], penalty: f32) {
+    for &token in generated {
+        let Ok(idx) = usize::try_from(token) else {
+            continue;
+        };
+        if let Some(score) = logits.get_mut(idx) {
+            if *score > 0.0 {
+                *score /= penalty;
+            } else {
+                *score *= penalty;
+            }
+        }
+    }
+}
+
+fn argmax(values: &[f32]) -> usize {
+    values
+        .iter()
+        .enumerate()
+        .max_by(|a, b| a.1.total_cmp(b.1))
+        .map(|(idx, _)| idx)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_position_ids_zeroes_speech_tokens() {
+        let ids = [
+            EXAGGERATION_TOKEN,
+            BOS_TOKEN,
+            100,
+            101,
+            EOS_TOKEN,
+            START_SPEECH_TOKEN,
+        ];
+        assert_eq!(build_position_ids(&ids), vec![0, 0, 1, 2, 3, 0]);
+    }
+
+    #[test]
+    fn unsupported_preprocessing_languages_error_clearly() {
+        let err = validate_lang("ja").unwrap_err().to_string();
+        assert!(err.contains("requires Chatterbox text preprocessing"));
+    }
+
+    #[test]
+    fn repetition_penalty_penalizes_seen_tokens() {
+        let mut logits = vec![2.0, -2.0, 4.0];
+        apply_repetition_penalty(&mut logits, &[0, 1], 2.0);
+        assert_eq!(logits, vec![1.0, -4.0, 4.0]);
+    }
+}

--- a/rust/src/tts/chatterbox.rs
+++ b/rust/src/tts/chatterbox.rs
@@ -27,11 +27,9 @@ const MAX_NEW_TOKENS: usize = 4096;
 const REPETITION_PENALTY: f32 = 1.2;
 
 pub const SUPPORTED_LANGS: &[&str] = &[
-    "ar", "da", "de", "el", "en", "es", "fi", "fr", "hi", "it", "ms", "nl", "no", "pl", "pt", "ru",
-    "sv", "sw", "tr",
+    "ar", "da", "de", "el", "en", "es", "fi", "fr", "he", "hi", "it", "ja", "ko", "ms", "nl", "no",
+    "pl", "pt", "ru", "sv", "sw", "tr", "zh",
 ];
-
-const PREPROCESSING_LANGS: &[&str] = &["zh", "ja", "he", "ko"];
 
 #[derive(Clone)]
 struct TensorF32 {
@@ -226,11 +224,6 @@ impl Chatterbox {
 pub fn validate_lang(lang: &str) -> Result<()> {
     if SUPPORTED_LANGS.contains(&lang) {
         return Ok(());
-    }
-    if PREPROCESSING_LANGS.contains(&lang) {
-        anyhow::bail!(
-            "language '{lang}' requires Chatterbox text preprocessing that is not implemented yet"
-        );
     }
     anyhow::bail!(
         "unsupported Chatterbox language '{lang}'. supported: {}",
@@ -447,9 +440,16 @@ mod tests {
     }
 
     #[test]
-    fn unsupported_preprocessing_languages_error_clearly() {
-        let err = validate_lang("ja").unwrap_err().to_string();
-        assert!(err.contains("requires Chatterbox text preprocessing"));
+    fn validates_all_supported_languages() {
+        for lang in SUPPORTED_LANGS {
+            validate_lang(lang).unwrap_or_else(|e| panic!("{lang}: {e}"));
+        }
+    }
+
+    #[test]
+    fn unsupported_languages_error_clearly() {
+        let err = validate_lang("uk").unwrap_err().to_string();
+        assert!(err.contains("unsupported Chatterbox language"));
     }
 
     #[test]

--- a/rust/src/tts/mod.rs
+++ b/rust/src/tts/mod.rs
@@ -8,6 +8,7 @@
 
 use std::path::Path;
 
+pub mod chatterbox;
 pub mod en;
 pub mod encode;
 pub mod g2p;
@@ -60,6 +61,12 @@ pub enum EngineChoice<'a> {
         speaker_id: u32,
         /// Speaking rate (1.0 = model default); passed to vosk's `speech_rate`.
         speed: f32,
+    },
+    /// Chatterbox Multilingual ONNX: raw text + language tag + reference WAV.
+    Chatterbox {
+        model_dir: &'a Path,
+        voice_path: &'a Path,
+        lang: &'a str,
     },
 }
 

--- a/rust/src/tts/say.rs
+++ b/rust/src/tts/say.rs
@@ -14,7 +14,8 @@ use std::time::Instant;
 
 use super::encode::OutputFormat;
 use super::{
-    en, encode, g2p, kokoro, ru, sessions, ssml, EngineChoice, SayOptions, TtsError, MAX_TEXT_CHARS,
+    chatterbox, en, encode, g2p, kokoro, ru, sessions, ssml, EngineChoice, SayOptions, TtsError,
+    MAX_TEXT_CHARS,
 };
 
 #[cfg(all(feature = "system_tts", target_os = "macos"))]
@@ -89,6 +90,7 @@ pub fn say(opts: SayOptions) -> Result<Vec<u8>, TtsError> {
     let engine_label: &str = match &opts.engine {
         EngineChoice::Kokoro { .. } => "kokoro",
         EngineChoice::Vosk { .. } => "vosk",
+        EngineChoice::Chatterbox { .. } => "chatterbox",
         #[cfg(all(feature = "system_tts", target_os = "macos"))]
         EngineChoice::AVSpeech { .. } => "avspeech",
     };
@@ -141,6 +143,20 @@ pub fn say(opts: SayOptions) -> Result<Vec<u8>, TtsError> {
         );
     }
 
+    if let EngineChoice::Chatterbox {
+        model_dir,
+        voice_path,
+        lang,
+    } = &opts.engine
+    {
+        if opts.ssml {
+            return Err(TtsError::SynthesisFailed(
+                "SSML is not yet supported with Chatterbox voices".into(),
+            ));
+        }
+        return say_with_chatterbox(opts.text, model_dir, voice_path, lang, opts.format);
+    }
+
     if opts.ssml {
         return say_ssml(&opts);
     }
@@ -186,6 +202,7 @@ pub fn say(opts: SayOptions) -> Result<Vec<u8>, TtsError> {
         // Vosk and AVSpeech are handled by early-returns above. Keep guard arms
         // so the match stays exhaustive when those features are enabled.
         EngineChoice::Vosk { .. } => unreachable!("handled by early return above"),
+        EngineChoice::Chatterbox { .. } => unreachable!("handled by early return above"),
         #[cfg(all(feature = "system_tts", target_os = "macos"))]
         EngineChoice::AVSpeech { .. } => unreachable!("handled by early return above"),
     }
@@ -218,6 +235,8 @@ fn say_ssml(opts: &SayOptions) -> Result<Vec<u8>, TtsError> {
         ),
         // Vosk + SSML is handled by the early-return in say(); this arm keeps the match exhaustive.
         EngineChoice::Vosk { .. } => unreachable!("handled by early return in say()"),
+        // Chatterbox + SSML is rejected by the early-return in say().
+        EngineChoice::Chatterbox { .. } => unreachable!("handled by early return in say()"),
         // AVSpeech + SSML is rejected up-front in `say()`; this arm keeps the match exhaustive.
         #[cfg(all(feature = "system_tts", target_os = "macos"))]
         EngineChoice::AVSpeech { .. } => {
@@ -388,6 +407,21 @@ fn say_with_vosk(
         .infer(model_dir, normalized.as_ref(), speaker_id, speed)
         .map_err(|e| TtsError::SynthesisFailed(format!("vosk: {e}")))?;
     encode_or_fail(&audio, sample_rate, format)
+}
+
+fn say_with_chatterbox(
+    text: &str,
+    model_dir: &Path,
+    voice_path: &Path,
+    lang: &str,
+    format: OutputFormat,
+) -> Result<Vec<u8>, TtsError> {
+    let mut engine = chatterbox::Chatterbox::load(model_dir)
+        .map_err(|e| TtsError::SynthesisFailed(format!("chatterbox load: {e}")))?;
+    let samples = engine
+        .infer(text, lang, voice_path)
+        .map_err(|e| TtsError::SynthesisFailed(format!("chatterbox: {e}")))?;
+    encode_or_fail(&samples, chatterbox::SAMPLE_RATE, format)
 }
 
 fn synth_segments_vosk(

--- a/rust/src/tts/voices.rs
+++ b/rust/src/tts/voices.rs
@@ -87,6 +87,16 @@ impl ResolvedVoice {
 /// Voice id is `<lang>-<name>`; lang picks the engine and espeak language code.
 /// The special `macos-*` prefix routes to AVSpeechSynthesizer on supported builds.
 pub fn resolve_voice(cache_dir: &Path, voice_id: &str) -> anyhow::Result<ResolvedVoice> {
+    if let Some((lang, voice_path)) = voice_id.split_once(':') {
+        if let Some(lang) = crate::tts::chatterbox::SUPPORTED_LANGS
+            .iter()
+            .copied()
+            .find(|candidate| *candidate == lang)
+        {
+            return resolve_chatterbox_reference(cache_dir, lang, Path::new(voice_path));
+        }
+    }
+
     let voice_as_path = Path::new(voice_id);
     if voice_as_path.exists() {
         return resolve_chatterbox_reference(cache_dir, "en", voice_as_path);
@@ -330,6 +340,26 @@ mod tests {
             } => {
                 assert!(model_dir.ends_with("models/chatterbox"));
                 assert!(voice_path.ends_with("models/chatterbox/default_voice.wav"));
+                assert_eq!(lang, "ru");
+            }
+            other => panic!("expected Chatterbox, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_chatterbox_reference_path_with_explicit_language() {
+        let tmp = tempfile::tempdir().unwrap();
+        populate_chatterbox(tmp.path());
+        let reference = tmp.path().join("custom-voice.wav");
+        std::fs::write(&reference, b"dummy").unwrap();
+
+        let voice_id = format!("ru:{}", reference.display());
+        let r = resolve_voice(tmp.path(), &voice_id).unwrap();
+        match r {
+            ResolvedVoice::Chatterbox {
+                voice_path, lang, ..
+            } => {
+                assert_eq!(voice_path, reference);
                 assert_eq!(lang, "ru");
             }
             other => panic!("expected Chatterbox, got {other:?}"),

--- a/rust/src/tts/voices.rs
+++ b/rust/src/tts/voices.rs
@@ -54,6 +54,13 @@ pub enum ResolvedVoice {
         model_dir: std::path::PathBuf,
         speaker_id: u32,
     },
+    /// Chatterbox Multilingual ONNX. `lang` is the Chatterbox language tag
+    /// (`ru`, `en`, etc.), and `voice_path` is a 24 kHz mono reference WAV.
+    Chatterbox {
+        model_dir: std::path::PathBuf,
+        voice_path: std::path::PathBuf,
+        lang: &'static str,
+    },
     /// macOS system TTS via AVSpeechSynthesizer (#141). The voice id is
     /// whatever the user passed after the `macos-` prefix — forwarded to the
     /// Swift helper, which tries `AVSpeechSynthesisVoice(identifier:)` first
@@ -67,6 +74,7 @@ impl ResolvedVoice {
         match self {
             Self::Kokoro { espeak_lang, .. } => espeak_lang,
             Self::Vosk { .. } => "",
+            Self::Chatterbox { lang, .. } => lang,
             // AVSpeech does its own G2P; the espeak language tag is unused.
             #[cfg(all(feature = "system_tts", target_os = "macos"))]
             Self::AVSpeech { .. } => "",
@@ -74,16 +82,27 @@ impl ResolvedVoice {
     }
 }
 
-/// Parse a voice id like `en-am_michael` or `ru-ruslan` into engine + paths.
+/// Parse a voice id like `en-am_michael` or `ru-chatterbox-m01` into engine + paths.
 /// Voice id is `<lang>-<name>`; lang picks the engine and espeak language code.
 /// The special `macos-*` prefix routes to AVSpeechSynthesizer on supported builds.
 pub fn resolve_voice(cache_dir: &Path, voice_id: &str) -> anyhow::Result<ResolvedVoice> {
+    let voice_as_path = Path::new(voice_id);
+    if voice_as_path.exists() {
+        return resolve_chatterbox_reference(cache_dir, "en", voice_as_path);
+    }
     let (lang, name) = voice_id.split_once('-').ok_or_else(|| {
         anyhow::anyhow!("voice id must be in 'lang-name' form (got '{voice_id}')")
     })?;
     match lang {
         "en" => resolve_kokoro(cache_dir, voice_id, name),
         "ru" => {
+            if name == "chatterbox-m01" {
+                return resolve_chatterbox_reference(
+                    cache_dir,
+                    "ru",
+                    &cache_dir.join("models/chatterbox/default_voice.wav"),
+                );
+            }
             let suffix = name.strip_prefix("vosk-").unwrap_or(name);
             resolve_vosk_ru(cache_dir, voice_id, suffix)
         }
@@ -106,6 +125,28 @@ pub fn resolve_voice(cache_dir: &Path, voice_id: &str) -> anyhow::Result<Resolve
             anyhow::bail!("language '{other}' not supported (use 'en-*', 'ru-*', or 'macos-*')")
         }
     }
+}
+
+fn resolve_chatterbox_reference(
+    cache_dir: &Path,
+    lang: &'static str,
+    voice_path: &Path,
+) -> anyhow::Result<ResolvedVoice> {
+    let model_dir = crate::models::model_dir_at(crate::models::ModelKind::Chatterbox, cache_dir);
+    if !crate::models::is_cached_in(crate::models::ModelKind::Chatterbox, &model_dir) {
+        anyhow::bail!("Chatterbox TTS model not installed. run: kesha install --tts");
+    }
+    if !voice_path.exists() {
+        anyhow::bail!(
+            "Chatterbox reference voice not found at {}. run: kesha install --tts",
+            voice_path.display()
+        );
+    }
+    Ok(ResolvedVoice::Chatterbox {
+        model_dir,
+        voice_path: voice_path.to_path_buf(),
+        lang,
+    })
 }
 
 fn resolve_kokoro(cache_dir: &Path, voice_id: &str, name: &str) -> anyhow::Result<ResolvedVoice> {
@@ -232,6 +273,41 @@ mod tests {
                 assert_eq!(espeak_lang, "en-us");
             }
             other => panic!("expected Kokoro, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_installed_chatterbox_voice() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("models/chatterbox");
+        std::fs::create_dir_all(dir.join("onnx")).unwrap();
+        for rel in [
+            "onnx/speech_encoder.onnx",
+            "onnx/speech_encoder.onnx_data",
+            "onnx/embed_tokens.onnx",
+            "onnx/embed_tokens.onnx_data",
+            "onnx/language_model.onnx",
+            "onnx/language_model.onnx_data",
+            "onnx/conditional_decoder.onnx",
+            "onnx/conditional_decoder.onnx_data",
+            "tokenizer.json",
+            "default_voice.wav",
+        ] {
+            std::fs::write(dir.join(rel), b"dummy").unwrap();
+        }
+
+        let r = resolve_voice(tmp.path(), "ru-chatterbox-m01").unwrap();
+        match r {
+            ResolvedVoice::Chatterbox {
+                model_dir,
+                voice_path,
+                lang,
+            } => {
+                assert!(model_dir.ends_with("models/chatterbox"));
+                assert!(voice_path.ends_with("models/chatterbox/default_voice.wav"));
+                assert_eq!(lang, "ru");
+            }
+            other => panic!("expected Chatterbox, got {other:?}"),
         }
     }
 

--- a/rust/src/tts/voices.rs
+++ b/rust/src/tts/voices.rs
@@ -40,6 +40,7 @@ pub fn select_style(voice: &[f32], token_count: usize) -> &[f32] {
 
 /// Default voice id used when neither `--voice` nor auto-routing resolves one.
 pub const DEFAULT_VOICE_ID: &str = "en-am_michael";
+pub const CHATTERBOX_DEFAULT_VOICE: &str = "chatterbox-m01";
 
 /// Resolved engine + paths for a given voice id.
 #[derive(Debug)]
@@ -94,9 +95,14 @@ pub fn resolve_voice(cache_dir: &Path, voice_id: &str) -> anyhow::Result<Resolve
         anyhow::anyhow!("voice id must be in 'lang-name' form (got '{voice_id}')")
     })?;
     match lang {
+        "en" if name == CHATTERBOX_DEFAULT_VOICE => resolve_chatterbox_reference(
+            cache_dir,
+            "en",
+            &cache_dir.join("models/chatterbox/default_voice.wav"),
+        ),
         "en" => resolve_kokoro(cache_dir, voice_id, name),
         "ru" => {
-            if name == "chatterbox-m01" {
+            if name == CHATTERBOX_DEFAULT_VOICE {
                 return resolve_chatterbox_reference(
                     cache_dir,
                     "ru",
@@ -122,7 +128,22 @@ pub fn resolve_voice(cache_dir: &Path, voice_id: &str) -> anyhow::Result<Resolve
             "'macos-*' voices require a macOS build with --features system_tts (got '{voice_id}')"
         ),
         other => {
-            anyhow::bail!("language '{other}' not supported (use 'en-*', 'ru-*', or 'macos-*')")
+            if name == CHATTERBOX_DEFAULT_VOICE {
+                if let Some(lang) = crate::tts::chatterbox::SUPPORTED_LANGS
+                    .iter()
+                    .copied()
+                    .find(|candidate| *candidate == other)
+                {
+                    return resolve_chatterbox_reference(
+                        cache_dir,
+                        lang,
+                        &cache_dir.join("models/chatterbox/default_voice.wav"),
+                    );
+                }
+            }
+            anyhow::bail!(
+                "language '{other}' not supported (use 'en-*', 'macos-*', or '<lang>-chatterbox-m01')"
+            )
         }
     }
 }
@@ -257,6 +278,25 @@ mod tests {
         std::fs::write(cache.join("models/kokoro-82m/model.onnx"), b"dummy").unwrap();
     }
 
+    fn populate_chatterbox(cache: &Path) {
+        let dir = cache.join("models/chatterbox");
+        std::fs::create_dir_all(dir.join("onnx")).unwrap();
+        for rel in [
+            "onnx/speech_encoder.onnx",
+            "onnx/speech_encoder.onnx_data",
+            "onnx/embed_tokens.onnx",
+            "onnx/embed_tokens.onnx_data",
+            "onnx/language_model.onnx",
+            "onnx/language_model.onnx_data",
+            "onnx/conditional_decoder.onnx",
+            "onnx/conditional_decoder.onnx_data",
+            "tokenizer.json",
+            "default_voice.wav",
+        ] {
+            std::fs::write(dir.join(rel), b"dummy").unwrap();
+        }
+    }
+
     #[test]
     fn resolve_installed_kokoro_voice() {
         let tmp = tempfile::tempdir().unwrap();
@@ -279,22 +319,7 @@ mod tests {
     #[test]
     fn resolve_installed_chatterbox_voice() {
         let tmp = tempfile::tempdir().unwrap();
-        let dir = tmp.path().join("models/chatterbox");
-        std::fs::create_dir_all(dir.join("onnx")).unwrap();
-        for rel in [
-            "onnx/speech_encoder.onnx",
-            "onnx/speech_encoder.onnx_data",
-            "onnx/embed_tokens.onnx",
-            "onnx/embed_tokens.onnx_data",
-            "onnx/language_model.onnx",
-            "onnx/language_model.onnx_data",
-            "onnx/conditional_decoder.onnx",
-            "onnx/conditional_decoder.onnx_data",
-            "tokenizer.json",
-            "default_voice.wav",
-        ] {
-            std::fs::write(dir.join(rel), b"dummy").unwrap();
-        }
+        populate_chatterbox(tmp.path());
 
         let r = resolve_voice(tmp.path(), "ru-chatterbox-m01").unwrap();
         match r {
@@ -308,6 +333,20 @@ mod tests {
                 assert_eq!(lang, "ru");
             }
             other => panic!("expected Chatterbox, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_all_chatterbox_languages() {
+        let tmp = tempfile::tempdir().unwrap();
+        populate_chatterbox(tmp.path());
+
+        for lang in crate::tts::chatterbox::SUPPORTED_LANGS {
+            let voice = format!("{lang}-chatterbox-m01");
+            match resolve_voice(tmp.path(), &voice).unwrap() {
+                ResolvedVoice::Chatterbox { lang: got, .. } => assert_eq!(got, *lang, "{voice}"),
+                other => panic!("{voice}: expected Chatterbox, got {other:?}"),
+            }
         }
     }
 

--- a/rust/tests/tts_smoke.rs
+++ b/rust/tests/tts_smoke.rs
@@ -30,6 +30,14 @@ fn install_has_tts_flag() {
         stdout.contains("--tts"),
         "install --help missing --tts: {stdout}"
     );
+    assert!(
+        stdout.contains("Chatterbox 23 languages"),
+        "install --help should explain Chatterbox language bundle: {stdout}"
+    );
+    assert!(
+        stdout.contains("one bundled download"),
+        "install --help should say Chatterbox languages install together: {stdout}"
+    );
 }
 
 #[test]
@@ -207,6 +215,10 @@ fn list_voices_empty_on_fresh_cache() {
     assert!(
         stdout.contains("install --tts"),
         "expected install hint, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("Chatterbox languages install together"),
+        "expected bundled-language hint, got: {stdout}"
     );
 }
 

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -73,7 +73,7 @@ export const installCommand = defineCommand({
     },
     tts: {
       type: "boolean",
-      description: "Also install TTS models (Kokoro EN + Vosk-TTS RU, ~990MB)",
+      description: "Also install TTS models (Kokoro EN + Chatterbox multilingual, ~3.3GB)",
       default: false,
     },
     vad: {

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -73,7 +73,7 @@ export const installCommand = defineCommand({
     },
     tts: {
       type: "boolean",
-      description: "Also install TTS models (Kokoro EN + Chatterbox multilingual, ~3.3GB)",
+      description: "Also install TTS models (Kokoro EN + Chatterbox 23 languages, one bundled download, ~3.3GB)",
       default: false,
     },
     vad: {

--- a/src/cli/say.ts
+++ b/src/cli/say.ts
@@ -1,14 +1,44 @@
 import { defineCommand } from "citty";
+import { existsSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
 import { detectTextLanguageEngine, getEngineBinPath } from "../engine";
 import { log } from "../log";
 import { say, SayError, type SayFormat } from "../synth";
-import { pickVoiceForLang } from "../voice-routing";
+import { resolveSayVoice } from "../voice-routing";
+
+function keshaCacheDir(): string {
+  return process.env.KESHA_CACHE_DIR ?? join(homedir(), ".cache", "kesha");
+}
+
+function isChatterboxInstalled(): boolean {
+  const root = join(keshaCacheDir(), "models", "chatterbox");
+  return [
+    "onnx/speech_encoder.onnx",
+    "onnx/speech_encoder.onnx_data",
+    "onnx/embed_tokens.onnx",
+    "onnx/embed_tokens.onnx_data",
+    "onnx/language_model.onnx",
+    "onnx/language_model.onnx_data",
+    "onnx/conditional_decoder.onnx",
+    "onnx/conditional_decoder.onnx_data",
+    "tokenizer.json",
+    "default_voice.wav",
+  ].every((rel) => existsSync(join(root, rel)));
+}
 
 /** Run NLLanguageRecognizer (via engine) on the text and pick a default voice. */
-async function autoRouteVoice(text: string): Promise<string | undefined> {
+async function autoRouteVoice(
+  text: string,
+  chatterboxInstalled: boolean,
+): Promise<string | undefined> {
   if (!text) return undefined;
   const detected = await detectTextLanguageEngine(text);
-  return pickVoiceForLang(detected?.code, detected?.confidence ?? 0);
+  return resolveSayVoice({
+    detectedCode: detected?.code,
+    detectedConfidence: detected?.confidence ?? 0,
+    chatterboxInstalled,
+  });
 }
 
 /** Resolve the text to synthesize: inline positional, else read from stdin. */
@@ -36,8 +66,11 @@ export const sayCommand = defineCommand({
   },
   args: {
     text: { type: "positional", required: false, description: "Text to speak (stdin if omitted)" },
-    voice: { type: "string", description: "Voice id, e.g. en-am_michael" },
-    lang: { type: "string", description: "BCP 47 language code (default en-us)" },
+    voice: { type: "string", description: "Exact voice id, e.g. en-am_michael" },
+    lang: {
+      type: "string",
+      description: "Language tag; picks that language's default voice when --voice is omitted",
+    },
     out: { type: "string", description: "Write audio to file instead of stdout" },
     rate: { type: "string", description: "Speaking rate 0.5–2.0", default: "1.0" },
     "list-voices": { type: "boolean", description: "List installed voices and exit" },
@@ -90,7 +123,11 @@ export const sayCommand = defineCommand({
     const inlineText = typeof args.text === "string" ? args.text : undefined;
     const text = await resolveText(inlineText);
     const explicitVoice = typeof args.voice === "string" ? args.voice : undefined;
-    const voice = explicitVoice ?? (await autoRouteVoice(text));
+    const explicitLang = typeof args.lang === "string" ? args.lang : undefined;
+    const chatterboxInstalled = isChatterboxInstalled();
+    const voice = explicitVoice || explicitLang
+      ? resolveSayVoice({ explicitVoice, explicitLang, chatterboxInstalled })
+      : await autoRouteVoice(text, chatterboxInstalled);
 
     // Validate --format up front so we surface a clear error before spawning
     // the engine subprocess. The engine repeats the check authoritatively, but
@@ -124,7 +161,7 @@ export const sayCommand = defineCommand({
     const opts = {
       text,
       voice,
-      lang: typeof args.lang === "string" ? args.lang : undefined,
+      lang: explicitLang,
       out: typeof args.out === "string" ? args.out : undefined,
       rate: args.rate ? Number(args.rate) : undefined,
       ssml: Boolean(args.ssml),

--- a/src/engine-install.ts
+++ b/src/engine-install.ts
@@ -222,7 +222,7 @@ async function downloadSidecar(
 }
 
 export interface InstallOptions {
-  /** Also install Kokoro + Vosk-TTS models. */
+  /** Also install Kokoro + Chatterbox TTS models. */
   tts?: boolean;
   /** Also install Silero VAD model for long-audio preprocessing. */
   vad?: boolean;

--- a/src/engine-install.ts
+++ b/src/engine-install.ts
@@ -28,10 +28,10 @@ function getEngineBinaryName(): string {
   if (platform === "linux" && arch === "x64") return "kesha-engine-linux-x64";
   if (platform === "win32" && arch === "x64") {
     throw new Error(
-      "Windows x64 is temporarily unsupported in v1.5.0 — the Vosk-TTS engine has " +
-        "native deps that trip MSVC at link time. Tracked at " +
+      "Windows x64 is temporarily unsupported because this release does not ship " +
+        "a kesha-engine-win32-x64 binary. Tracked at " +
         "https://github.com/drakulavich/kesha-voice-kit/issues/216. " +
-        "Use v1.4.x as a workaround until the fix lands.",
+        "Use a supported platform until the Windows release asset lands.",
     );
   }
 

--- a/src/status.ts
+++ b/src/status.ts
@@ -170,6 +170,10 @@ export function activeModelMirror(): string | null {
 function listInstalledVoices(): string[] {
   const cache = kesheCacheDir();
   const voices: string[] = [];
+  const chatterboxLangs = [
+    "ar", "da", "de", "el", "en", "es", "fi", "fr", "he", "hi", "it", "ja",
+    "ko", "ms", "nl", "no", "pl", "pt", "ru", "sv", "sw", "tr", "zh",
+  ];
   try {
     const kokoro = readdirSync(join(cache, "models", "kokoro-82m", "voices"));
     for (const f of kokoro) {
@@ -182,7 +186,7 @@ function listInstalledVoices(): string[] {
     statSync(join(cache, "models", "chatterbox", "onnx", "speech_encoder.onnx"));
     statSync(join(cache, "models", "chatterbox", "onnx", "language_model.onnx"));
     statSync(join(cache, "models", "chatterbox", "default_voice.wav"));
-    voices.push("ru-chatterbox-m01");
+    for (const lang of chatterboxLangs) voices.push(`${lang}-chatterbox-m01`);
   } catch {
     /* Chatterbox not installed */
   }

--- a/src/status.ts
+++ b/src/status.ts
@@ -110,7 +110,8 @@ function showDiskUsage(binPath: string): void {
     { label: "Language ID", path: join(cache, "models/lang-id-ecapa") },
     { label: "VAD (Silero)", path: join(cache, "models/silero-vad") },
     { label: "TTS (Kokoro)", path: join(cache, "models/kokoro-82m") },
-    { label: "TTS (Vosk)", path: join(cache, "models/vosk-ru") },
+    { label: "TTS (Chatterbox)", path: join(cache, "models/chatterbox") },
+    { label: "TTS (Vosk legacy)", path: join(cache, "models/vosk-ru") },
   ];
 
   const rows: Array<{ label: string; size: number }> = [];
@@ -178,16 +179,21 @@ function listInstalledVoices(): string[] {
     /* Kokoro not installed */
   }
   try {
-    // Vosk-TTS Russian is a single multi-speaker model. Mirror the Rust-side
-    // gate (models::is_vosk_ru_cached) — checking model.onnx + bert/model.onnx
-    // avoids advertising voices that would fail to load on a partial install.
+    statSync(join(cache, "models", "chatterbox", "onnx", "speech_encoder.onnx"));
+    statSync(join(cache, "models", "chatterbox", "onnx", "language_model.onnx"));
+    statSync(join(cache, "models", "chatterbox", "default_voice.wav"));
+    voices.push("ru-chatterbox-m01");
+  } catch {
+    /* Chatterbox not installed */
+  }
+  try {
+    // Legacy installs may still have Vosk cached; keep explicit voices
+    // discoverable even though new `kesha install --tts` no longer fetches it.
     statSync(join(cache, "models", "vosk-ru", "model.onnx"));
     statSync(join(cache, "models", "vosk-ru", "bert", "model.onnx"));
-    for (const id of ["f01", "f02", "f03", "m01", "m02"]) {
-      voices.push(`ru-vosk-${id}`);
-    }
+    for (const id of ["f01", "f02", "f03", "m01", "m02"]) voices.push(`ru-vosk-${id}`);
   } catch {
-    /* Vosk not installed */
+    /* Legacy Vosk not installed */
   }
   return voices.sort();
 }

--- a/src/voice-routing.ts
+++ b/src/voice-routing.ts
@@ -1,7 +1,6 @@
 /**
  * Darwin defaults to AVSpeech Milena — zero install, no model download required.
- * Linux/Windows fall through to Vosk-TTS `ru-vosk-m02` (male, per CLAUDE.md
- * "DEFAULT TTS VOICES MUST BE MALE"; replaces Piper-ruslan as of #213).
+ * Linux/Windows fall through to Chatterbox `ru-chatterbox-m01`.
  */
 const RU_DARWIN_FALLBACK_VOICE = "macos-com.apple.voice.compact.ru-RU.Milena";
 
@@ -16,7 +15,7 @@ export function pickVoiceForLang(
     case "en":
       return "en-am_michael";
     case "ru":
-      return platform === "darwin" ? RU_DARWIN_FALLBACK_VOICE : "ru-vosk-m02";
+      return platform === "darwin" ? RU_DARWIN_FALLBACK_VOICE : "ru-chatterbox-m01";
     default:
       return undefined;
   }

--- a/src/voice-routing.ts
+++ b/src/voice-routing.ts
@@ -1,8 +1,12 @@
 /**
- * Darwin defaults to AVSpeech Milena — zero install, no model download required.
- * Linux/Windows fall through to Chatterbox `ru-chatterbox-m01`.
+ * Darwin keeps Russian on AVSpeech Milena for the zero-install path.
+ * Other Chatterbox-supported languages route to `<lang>-chatterbox-m01`.
  */
 const RU_DARWIN_FALLBACK_VOICE = "macos-com.apple.voice.compact.ru-RU.Milena";
+const CHATTERBOX_LANGS = new Set([
+  "ar", "da", "de", "el", "es", "fi", "fr", "he", "hi", "it", "ja", "ko",
+  "ms", "nl", "no", "pl", "pt", "ru", "sv", "sw", "tr", "zh",
+]);
 
 /** Map a detected language code to a default voice id. Unknown / low-confidence → undefined. */
 export function pickVoiceForLang(
@@ -17,6 +21,9 @@ export function pickVoiceForLang(
     case "ru":
       return platform === "darwin" ? RU_DARWIN_FALLBACK_VOICE : "ru-chatterbox-m01";
     default:
+      if (CHATTERBOX_LANGS.has(code)) {
+        return `${code}-chatterbox-m01`;
+      }
       return undefined;
   }
 }

--- a/src/voice-routing.ts
+++ b/src/voice-routing.ts
@@ -3,10 +3,32 @@
  * Other Chatterbox-supported languages route to `<lang>-chatterbox-m01`.
  */
 const RU_DARWIN_FALLBACK_VOICE = "macos-com.apple.voice.compact.ru-RU.Milena";
-const CHATTERBOX_LANGS = new Set([
-  "ar", "da", "de", "el", "es", "fi", "fr", "he", "hi", "it", "ja", "ko",
-  "ms", "nl", "no", "pl", "pt", "ru", "sv", "sw", "tr", "zh",
-]);
+
+export const AUTO_VOICE_BY_LANG: Readonly<Record<string, string>> = Object.freeze({
+  en: "en-am_michael",
+  ar: "ar-chatterbox-m01",
+  da: "da-chatterbox-m01",
+  de: "de-chatterbox-m01",
+  el: "el-chatterbox-m01",
+  es: "es-chatterbox-m01",
+  fi: "fi-chatterbox-m01",
+  fr: "fr-chatterbox-m01",
+  he: "he-chatterbox-m01",
+  hi: "hi-chatterbox-m01",
+  it: "it-chatterbox-m01",
+  ja: "ja-chatterbox-m01",
+  ko: "ko-chatterbox-m01",
+  ms: "ms-chatterbox-m01",
+  nl: "nl-chatterbox-m01",
+  no: "no-chatterbox-m01",
+  pl: "pl-chatterbox-m01",
+  pt: "pt-chatterbox-m01",
+  ru: "ru-chatterbox-m01",
+  sv: "sv-chatterbox-m01",
+  sw: "sw-chatterbox-m01",
+  tr: "tr-chatterbox-m01",
+  zh: "zh-chatterbox-m01",
+});
 
 /** Map a detected language code to a default voice id. Unknown / low-confidence → undefined. */
 export function pickVoiceForLang(
@@ -15,15 +37,8 @@ export function pickVoiceForLang(
   platform: NodeJS.Platform = process.platform,
 ): string | undefined {
   if (!code || confidence < 0.5) return undefined;
-  switch (code) {
-    case "en":
-      return "en-am_michael";
-    case "ru":
-      return platform === "darwin" ? RU_DARWIN_FALLBACK_VOICE : "ru-chatterbox-m01";
-    default:
-      if (CHATTERBOX_LANGS.has(code)) {
-        return `${code}-chatterbox-m01`;
-      }
-      return undefined;
+  if (code === "ru" && platform === "darwin") {
+    return RU_DARWIN_FALLBACK_VOICE;
   }
+  return AUTO_VOICE_BY_LANG[code];
 }

--- a/src/voice-routing.ts
+++ b/src/voice-routing.ts
@@ -35,10 +35,33 @@ export function pickVoiceForLang(
   code: string | undefined,
   confidence: number,
   platform: NodeJS.Platform = process.platform,
+  opts: { chatterboxInstalled?: boolean } = {},
 ): string | undefined {
   if (!code || confidence < 0.5) return undefined;
-  if (code === "ru" && platform === "darwin") {
+  if (code === "ru" && platform === "darwin" && !opts.chatterboxInstalled) {
     return RU_DARWIN_FALLBACK_VOICE;
   }
   return AUTO_VOICE_BY_LANG[code];
+}
+
+export function resolveSayVoice(options: {
+  explicitVoice?: string;
+  explicitLang?: string;
+  detectedCode?: string;
+  detectedConfidence?: number;
+  platform?: NodeJS.Platform;
+  chatterboxInstalled?: boolean;
+}): string | undefined {
+  if (options.explicitVoice) return options.explicitVoice;
+  const platform = options.platform ?? process.platform;
+  const routeOptions = { chatterboxInstalled: options.chatterboxInstalled };
+  if (options.explicitLang) {
+    return pickVoiceForLang(options.explicitLang, 1.0, platform, routeOptions);
+  }
+  return pickVoiceForLang(
+    options.detectedCode,
+    options.detectedConfidence ?? 0,
+    platform,
+    routeOptions,
+  );
 }

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -17,6 +17,12 @@ describe("CLI help", () => {
     expect(usage).toContain("--no-cache");
   });
 
+  test("install help explains Chatterbox languages install as one bundle", async () => {
+    const usage = await renderUsage(installCommand);
+    expect(usage).toContain("Chatterbox 23 languages");
+    expect(usage).toContain("one bundled download");
+  });
+
   test("main help contains --json flag", async () => {
     const usage = await renderUsage(mainCommand);
     expect(usage).toContain("--json");

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -240,6 +240,12 @@ describe("say --verbose (TTS time, parallel to #139)", () => {
     const usage = await renderUsage(sayCommand);
     expect(usage).toMatch(/TTS|synthesis time/i);
   });
+
+  test("say help explains --lang picks a default voice", async () => {
+    const usage = await renderUsage(sayCommand);
+    expect(usage).toContain("--lang");
+    expect(usage).toMatch(/default voice/i);
+  });
 });
 
 describe("sttTimeMs field (#139)", () => {

--- a/tests/unit/voice-routing.test.ts
+++ b/tests/unit/voice-routing.test.ts
@@ -17,13 +17,20 @@ describe("pickVoiceForLang (auto-routing)", () => {
     expect(pickVoiceForLang("ru", 0.95, "win32")).toBe("ru-chatterbox-m01");
   });
 
+  it("routes Chatterbox-supported languages", () => {
+    expect(pickVoiceForLang("de", 0.95, "linux")).toBe("de-chatterbox-m01");
+    expect(pickVoiceForLang("fr", 0.95, "linux")).toBe("fr-chatterbox-m01");
+    expect(pickVoiceForLang("zh", 0.95, "linux")).toBe("zh-chatterbox-m01");
+    expect(pickVoiceForLang("de", 0.95, "darwin")).toBe("de-chatterbox-m01");
+  });
+
   it("returns undefined below 0.5 confidence (too ambiguous)", () => {
     expect(pickVoiceForLang("ru", 0.3)).toBeUndefined();
   });
 
   it("returns undefined for unsupported languages", () => {
-    expect(pickVoiceForLang("fr", 0.95)).toBeUndefined();
-    expect(pickVoiceForLang("de", 0.95)).toBeUndefined();
+    expect(pickVoiceForLang("uk", 0.95)).toBeUndefined();
+    expect(pickVoiceForLang("cs", 0.95)).toBeUndefined();
   });
 
   it("returns undefined when code is missing", () => {

--- a/tests/unit/voice-routing.test.ts
+++ b/tests/unit/voice-routing.test.ts
@@ -12,9 +12,9 @@ describe("pickVoiceForLang (auto-routing)", () => {
     );
   });
 
-  it("falls back to ru-vosk-m02 for Russian on non-darwin (Vosk replaces Piper-ruslan, #213)", () => {
-    expect(pickVoiceForLang("ru", 0.95, "linux")).toBe("ru-vosk-m02");
-    expect(pickVoiceForLang("ru", 0.95, "win32")).toBe("ru-vosk-m02");
+  it("falls back to Chatterbox for Russian on non-darwin", () => {
+    expect(pickVoiceForLang("ru", 0.95, "linux")).toBe("ru-chatterbox-m01");
+    expect(pickVoiceForLang("ru", 0.95, "win32")).toBe("ru-chatterbox-m01");
   });
 
   it("returns undefined below 0.5 confidence (too ambiguous)", () => {

--- a/tests/unit/voice-routing.test.ts
+++ b/tests/unit/voice-routing.test.ts
@@ -1,7 +1,19 @@
 import { describe, it, expect } from "bun:test";
-import { pickVoiceForLang } from "../../src/voice-routing";
+import { AUTO_VOICE_BY_LANG, pickVoiceForLang } from "../../src/voice-routing";
+
+const CHATTERBOX_LANGS_EXCEPT_EN = [
+  "ar", "da", "de", "el", "es", "fi", "fr", "he", "hi", "it", "ja", "ko",
+  "ms", "nl", "no", "pl", "pt", "ru", "sv", "sw", "tr", "zh",
+];
 
 describe("pickVoiceForLang (auto-routing)", () => {
+  it("keeps an explicit auto-routing dictionary", () => {
+    expect(AUTO_VOICE_BY_LANG.en).toBe("en-am_michael");
+    for (const lang of CHATTERBOX_LANGS_EXCEPT_EN) {
+      expect(AUTO_VOICE_BY_LANG[lang]).toBe(`${lang}-chatterbox-m01`);
+    }
+  });
+
   it("returns en-am_michael for English with high confidence", () => {
     expect(pickVoiceForLang("en", 0.95)).toBe("en-am_michael");
   });

--- a/tests/unit/voice-routing.test.ts
+++ b/tests/unit/voice-routing.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import { AUTO_VOICE_BY_LANG, pickVoiceForLang } from "../../src/voice-routing";
+import { AUTO_VOICE_BY_LANG, pickVoiceForLang, resolveSayVoice } from "../../src/voice-routing";
 
 const CHATTERBOX_LANGS_EXCEPT_EN = [
   "ar", "da", "de", "el", "es", "fi", "fr", "he", "hi", "it", "ja", "ko",
@@ -48,5 +48,47 @@ describe("pickVoiceForLang (auto-routing)", () => {
   it("returns undefined when code is missing", () => {
     expect(pickVoiceForLang(undefined, 0.95)).toBeUndefined();
     expect(pickVoiceForLang("", 0.95)).toBeUndefined();
+  });
+});
+
+describe("resolveSayVoice", () => {
+  it("uses --lang as a default voice shortcut when --voice is omitted", () => {
+    expect(resolveSayVoice({ explicitLang: "de", platform: "linux" })).toBe(
+      "de-chatterbox-m01",
+    );
+    expect(resolveSayVoice({ explicitLang: "en", platform: "linux" })).toBe("en-am_michael");
+  });
+
+  it("lets explicit --voice win over --lang", () => {
+    expect(resolveSayVoice({
+      explicitVoice: "fr-chatterbox-m01",
+      explicitLang: "de",
+      platform: "linux",
+    })).toBe("fr-chatterbox-m01");
+  });
+
+  it("does not invent a voice for unsupported --lang values", () => {
+    expect(resolveSayVoice({ explicitLang: "uk", platform: "linux" })).toBeUndefined();
+  });
+
+  it("uses detected language only when neither --voice nor --lang is present", () => {
+    expect(resolveSayVoice({
+      detectedCode: "de",
+      detectedConfidence: 0.95,
+      platform: "linux",
+    })).toBe("de-chatterbox-m01");
+  });
+
+  it("keeps darwin Russian on Milena until Chatterbox is installed", () => {
+    expect(resolveSayVoice({
+      explicitLang: "ru",
+      platform: "darwin",
+      chatterboxInstalled: false,
+    })).toBe("macos-com.apple.voice.compact.ru-RU.Milena");
+    expect(resolveSayVoice({
+      explicitLang: "ru",
+      platform: "darwin",
+      chatterboxInstalled: true,
+    })).toBe("ru-chatterbox-m01");
   });
 });


### PR DESCRIPTION
## Summary
- add a Rust `tts::chatterbox` backend driven by ONNX Runtime (`ort`) and four pinned Chatterbox ONNX sessions
- switch fresh `kesha install --tts` from Vosk RU to Chatterbox multilingual ONNX while keeping legacy cached `ru-vosk-*` voices selectable
- expose Chatterbox voice ids for all 23 supported tags: `ar`, `da`, `de`, `el`, `en`, `es`, `fi`, `fr`, `he`, `hi`, `it`, `ja`, `ko`, `ms`, `nl`, `no`, `pl`, `pt`, `ru`, `sv`, `sw`, `tr`, `zh`
- add an explicit auto-routing dictionary: English routes to Kokoro `en-am_michael`; every other Chatterbox-supported tag routes to `<lang>-chatterbox-m01`
- let `kesha say --lang <tag>` pick that language's default voice when `--voice` is omitted; `--voice` remains the exact override
- on darwin, keep Russian Milena only as the zero-install fallback; once Chatterbox is installed, Russian routes to `ru-chatterbox-m01`
- update install/status/list-voices/docs wording to make clear Chatterbox languages install together in one bundle

## ONNX check
- Chatterbox loads `speech_encoder.onnx`, `embed_tokens.onnx`, `language_model.onnx`, and `conditional_decoder.onnx` via Rust `ort::Session::builder().commit_from_file(...)`
- model manifest pins HF revision `452d3f434aa592098f1eedac9099f33642ab2da5` and SHA-256 for every ONNX/data file
- no `onnxruntime-node`, Python, or CoreML path is used for Chatterbox

## Verification
- `bun test` (194 passed, 4 skipped)
- `bunx tsc --noEmit`
- `bun run check:versions`
- `git diff --check`
- `cd rust && cargo fmt --check`
- `cd rust && cargo clippy --all-targets --features tts -- -D warnings`
- `cd rust && cargo nextest run --features tts` (440 passed, 10 slow)
