### PR TITLE
ci(npm-publish): switch to npm Trusted Publishing (tokenless OIDC)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -52,14 +52,19 @@ jobs:
         with:
           ref: ${{ steps.tag.outputs.tag }}
 
-      # npm provenance requires npm CLI ≥ 9.5. Node 22 (LTS) ships with
-      # npm 10.x. `registry-url` configures the auth token line that
-      # `NODE_AUTH_TOKEN` consumes via `npm publish`.
+      # Trusted Publishing (tokenless OIDC) requires Node >=22.14.0 and
+      # npm >=11.5.1. `registry-url` keeps the publish target; no
+      # NODE_AUTH_TOKEN is set — npm exchanges the GitHub OIDC token for a
+      # short-lived publish credential when the package is configured as a
+      # Trusted Publisher on npmjs.com.
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "lts/*"
           registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
+      - name: Ensure npm supports Trusted Publishing
+        run: npm install -g npm@latest && npm --version
 
       # Guard: refuse to publish if `package.json#version` doesn't match
       # the release tag. Catches an accidental release of a tag that
@@ -112,4 +117,3 @@ jobs:
         run: npm publish --provenance --access public --tag "$NPM_DIST_TAG"
         env:
           NPM_DIST_TAG: ${{ steps.dist_tag.outputs.tag }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Same change applied to oura-cli (PR drakulavich/oura-cli#18 + #19), now ported here.

## Change
- Drop `NODE_AUTH_TOKEN: secrets.NPM_TOKEN` from the publish step; rely on npm **Trusted Publishing** (tokenless OIDC) with `--provenance`. No expiring token to rotate, ever.
- Bump `node-version` from `22` → `lts/*` and pin the newest npm via `npm install -g npm@latest`. Trusted Publishing requires **Node >=22.14.0** and **npm >=11.5.1** ([npm docs](https://docs.npmjs.com/trusted-publishers)); node 22 ships npm 10.x, which does not support OIDC publish auth and returns `404 Not Found` on the package PUT (provenance still signs fine via the older path — that's the trap).
- `package-manager-cache: false` per the npm release-build guidance.

## What stays
- `on: release.published` + `workflow_dispatch` triggers — unchanged.
- Version-match guard, idempotent already-published guard, latest/beta dist-tag logic — unchanged. `npm view` reads work unauthenticated for public packages.
- `package.json repository.url` already matches `github.com/drakulavich/kesha-voice-kit` (case-sensitive) — required by Trusted Publishing.

## One-time npm-side setup (required before this can publish)

On npmjs.com → `@drakulavich/kesha-voice-kit` → **Settings → Trusted Publisher**:
- Publisher: **GitHub Actions**
- Repository: `drakulavich/kesha-voice-kit`
- Workflow filename: `npm-publish.yml` (in `.github/workflows/`)
- Allowed action: `npm publish`

Once a release publishes successfully via OIDC, the `NPM_TOKEN` repo secret can be deleted (it's no longer referenced).
