### PR TITLE
ci(homebrew): trust oven-sh/bun tap for Tap-Trust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,12 @@ jobs:
         uses: actions/checkout@v7
 
       - name: 🍞 Tap Bun formula
-        run: brew tap oven-sh/bun
+        run: |
+          brew tap oven-sh/bun
+          # Homebrew Tap-Trust now refuses to load formulae from untrusted
+          # taps (the kesha-voice-kit formula depends on oven-sh/bun/bun).
+          # Trust the tap so the formula can be loaded below.
+          brew trust oven-sh/bun
 
       - name: 🧪 Create local test tap
         run: |

--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -77,6 +77,9 @@ jobs:
         if: steps.tag.outputs.skip != 'true'
         run: |
           brew tap oven-sh/bun
+          # Homebrew Tap-Trust refuses to load formulae from untrusted taps;
+          # the kesha-voice-kit formula depends on oven-sh/bun/bun.
+          brew trust oven-sh/bun
           brew tap-new local/tap
           cp tap/Formula/kesha-voice-kit.rb "$(brew --repository local/tap)/Formula/kesha-voice-kit.rb"
           brew install --build-from-source local/tap/kesha-voice-kit

--- a/packaging/homebrew/Formula/kesha-voice-kit.rb
+++ b/packaging/homebrew/Formula/kesha-voice-kit.rb
@@ -18,7 +18,7 @@ class KeshaVoiceKit < Formula
 
     (bin/"kesha").write <<~EOS
       #!/bin/bash
-      exec "#{Formula["oven-sh/bun/bun"].opt_bin}/bun" "#{libexec}/bin/kesha.js" "$@"
+      exec "#{formula_opt_bin("oven-sh/bun/bun")}/bun" "#{libexec}/bin/kesha.js" "$@"
     EOS
   end
 


### PR DESCRIPTION
## Why

Main CI has been red because the `homebrew-formula` job fails at `📦 Install formula`:

```
Refusing to load formula oven-sh/bun/bun from untrusted tap oven-sh/bun.
Run `brew trust --formula oven-sh/bun/bun` or `brew trust oven-sh/bun` to trust it.
```

Homebrew introduced **Tap-Trust**: it refuses to load formulae from taps that haven't been explicitly trusted. The `kesha-voice-kit` formula depends on `oven-sh/bun/bun`, so the install (and subsequent `audit`/`test`) abort.

## Fix

Add `brew trust oven-sh/bun` immediately after `brew tap oven-sh/bun` in:
- `ci.yml` `homebrew-formula` job (the one blocking main)
- `homebrew-tap.yml` release validation (same pattern — would break the next release)

This is the canonical fix the Homebrew error message itself recommends (`HOMEBREW_NO_REQUIRE_TAP_TRUST=1` also works but Homebrew marks it for removal).