### PR TITLE
fix(clippy): use `?` operator in find_relative_rate

### DIFF
--- a/rust/src/tts/ssml/rate.rs
+++ b/rust/src/tts/ssml/rate.rs
@@ -79,28 +79,25 @@ pub(super) fn find_relative_rate(input: &str) -> Option<String> {
                 continue;
             }
         };
-        if let Some(close_rel) = bytes[value_start..].iter().position(|&b| b == quote) {
-            let value_bytes = &bytes[value_start..value_start + close_rel];
-            // Skip leading whitespace per SSML/XML normalization.
-            let trimmed_start = value_bytes
-                .iter()
-                .position(|b| !b.is_ascii_whitespace())
-                .unwrap_or(value_bytes.len());
-            let trimmed = &value_bytes[trimmed_start..];
-            if let Some(&first) = trimmed.first() {
-                if (first == b'+' || first == b'-')
-                    && trimmed.get(1).is_some_and(|c| c.is_ascii_digit())
-                {
-                    if let Ok(s) = std::str::from_utf8(value_bytes) {
-                        return Some(s.to_string());
-                    }
+        // Unclosed quote → None (let ssml-parser surface the real error).
+        let close_rel = bytes[value_start..].iter().position(|&b| b == quote)?;
+        let value_bytes = &bytes[value_start..value_start + close_rel];
+        // Skip leading whitespace per SSML/XML normalization.
+        let trimmed_start = value_bytes
+            .iter()
+            .position(|b| !b.is_ascii_whitespace())
+            .unwrap_or(value_bytes.len());
+        let trimmed = &value_bytes[trimmed_start..];
+        if let Some(&first) = trimmed.first() {
+            if (first == b'+' || first == b'-')
+                && trimmed.get(1).is_some_and(|c| c.is_ascii_digit())
+            {
+                if let Ok(s) = std::str::from_utf8(value_bytes) {
+                    return Some(s.to_string());
                 }
             }
-            i = value_start + close_rel + 1;
-        } else {
-            // Unclosed quote — let ssml-parser surface the real error.
-            return None;
         }
+        i = value_start + close_rel + 1;
     }
     None
 }


### PR DESCRIPTION
Rewrites the `if let Some(close_rel) = .. { .. } else { return None; }` block in `find_relative_rate` (`rust/src/tts/ssml/rate.rs`) to use the `?` operator, resolving the clippy `question_mark` lint.

## Why
This lint is **pre-existing on main** but not caught by the regular main CI, because the `lint-ubuntu` (clippy) job is gated by the `changes.lint` filter and is skipped on most pushes. It surfaces whenever a PR touches `rust-test.yml` (or other `lint`-filter paths) — which is why dependabot [#578](https://github.com/drakulavich/kesha-voice-kit/pull/578) (actions bumps in `rust-test.yml`) fails `lint-ubuntu` despite not touching any Rust code.

## Verification
This PR touches Rust code, so `lint-ubuntu` (clippy) will run here. Expecting a green clippy run.