### PR TITLE
docs: refresh ROADMAP to match current issue state

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,31 +10,23 @@ curated lens over them. Suggestions welcome via an issue.
 
 ## Now (in flight)
 
-- **Fix Kokoro `--rate` on CoreML** — speaking-rate currently ignored (silently) for
-- **Raycast integration on macOS** — drive transcription/TTS from Raycast.
+- **Raycast integration on macOS** — drive transcription/TTS from Raycast's launcher
+  without a terminal; extension scaffold lives in `raycast/`.
   ([#145](https://github.com/drakulavich/kesha-voice-kit/issues/145))
-- **Fix Kokoro `--rate` on CoreML** — speaking-rate currently ignored (silently) for
-  `en-*` voices on the Apple Silicon build.
-  ([#475](https://github.com/drakulavich/kesha-voice-kit/issues/475))
 
 ## Next (committed, near-term)
 
-- **Structured error taxonomy** — consistent, machine-readable error kinds across the
-  CLI and engine. ([#462](https://github.com/drakulavich/kesha-voice-kit/issues/462))
-- **Product polish** — benchmark harness, cache backup/restore, release smoke
-  hardening. ([#464](https://github.com/drakulavich/kesha-voice-kit/issues/464))
-- **MCP server follow-ups** — mid-flight cancellation (thread `AbortSignal` into the
-  engine subprocess) and richer voice metadata (macOS voice gender/name via a
-  structured engine `--list-voices`). (follow-ups to
-  [#473](https://github.com/drakulavich/kesha-voice-kit/issues/473))
-- **Dependency maintenance** — routine Cargo/npm bumps.
-  ([#432](https://github.com/drakulavich/kesha-voice-kit/issues/432))
+- **Product polish** — reproducible benchmark harness, cache backup/restore, and
+  Linux/Windows real-synth release smoke.
+  ([#464](https://github.com/drakulavich/kesha-voice-kit/issues/464))
 
 ## Later (planned, unscheduled)
 
-- **Serve mode + observability** — long-running server interface with metrics/tracing.
+- **Serve mode + observability** — long-running `kesha serve` with warmed model state,
+  a Prometheus/OpenMetrics endpoint, and `/healthz`.
   ([#460](https://github.com/drakulavich/kesha-voice-kit/issues/460))
-- **Multi-language Kokoro (fr/it/es/pt)** — blocked: the originally-planned espeak-ng
-  G2P was removed (see the [decision log](docs/decision-log.md)), so this needs a new
-  no-system-deps G2P path before it can proceed.
-  ([#212](https://github.com/drakulavich/kesha-voice-kit/issues/212))
+- **Native-script multilingual TTS (hi/ja)** — es/fr/it/pt landed
+  ([#212](https://github.com/drakulavich/kesha-voice-kit/issues/212)) and Chinese is
+  supported natively, but Hindi and Japanese still fail fast on native-script input;
+  they need a transliteration (Devanagari→IAST, kana→romaji) G2P path.
+  ([#492](https://github.com/drakulavich/kesha-voice-kit/issues/492))


### PR DESCRIPTION
## What

Refreshes `ROADMAP.md` to reflect the current state of the issue tracker, and fixes a rendering defect in the previous version: the **Now** section duplicated the Kokoro `--rate` entry and left a truncated, dangling first line (`…ignored (silently) for` with no continuation).

## Changes

**Dropped — shipped since the last roadmap:**
- #475 Kokoro `--rate` on CoreML
- #462 structured error taxonomy
- #473 MCP server (+ its follow-ups)
- #432 dependency maintenance (routine/recurring)
- #212 es/fr/it/pt Kokoro

**Current horizons:**
| Horizon | Item | Issue |
|---|---|---|
| Now | Raycast integration on macOS (scaffold now in `raycast/`) | #145 |
| Next | Product polish (benchmark, backup/restore, real-synth release smoke) | #464 |
| Later | Serve mode + observability | #460 |
| Later | Native-script hi/ja TTS (es/fr/it/pt done, zh native) | #492 |

## Verification

Cross-checked every claim against the tree with `ccc`:
- No `serve`/daemon mode is implemented (only `--stdin-loop` session warming) → #460 correctly in Later.
- The `raycast/` extension scaffold is present in-tree → #145 correctly in Now.
- `hi`/`ja` reject native-script input with `E_SCRIPT_UNSUPPORTED`; `docs/languages.md` already cites #492.

Docs-only change — no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DHQ2d5oTrL8dLi6qXq4zC