### PR TITLE
chore: align TS tooling to stable TypeScript 7, drop native-preview

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,11 +195,6 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: bun run check:versions
 
-      - name: 🔬 Type check (tsgo / TS 7 preview, advisory)
-        if: matrix.os == 'ubuntu-latest'
-        continue-on-error: true
-        run: bunx tsgo --noEmit
-
       - name: 🧪 Unit tests
         run: mkdir -p test-results && bun run test:unit --reporter=junit --reporter-outfile=test-results/unit-${{ matrix.os }}.xml
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev-setup install check cli-fast coverage-ts coverage-rust test unit integration rust-test lint lint-tsgo versions smoke-test smoke-test-tts benchmark release release-preflight release-notes help
+.PHONY: dev-setup install check cli-fast coverage-ts coverage-rust test unit integration rust-test lint versions smoke-test smoke-test-tts benchmark release release-preflight release-notes help
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-15s %s\n", $$1, $$2}'
@@ -35,9 +35,6 @@ rust-test: ## Run Rust tests via nextest (matches CI — rust-test.yml)
 
 lint: ## Type-check with tsc
 	bunx tsc --noEmit
-
-lint-tsgo: ## Type-check with tsgo (TypeScript 7 native preview, advisory)
-	bunx tsgo --noEmit
 
 versions: ## Check version drift between package.json + Cargo.toml (#267 F16)
 	bun .github/scripts/check-versions.ts

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,6 @@
       },
       "devDependencies": {
         "@types/bun": "latest",
-        "@typescript/native-preview": "^7.0.0-dev.20260423.1",
         "fast-xml-parser": "^5.8.0",
         "typescript": "^7.0.2",
         "yaml": "^2.9.0",
@@ -42,22 +41,6 @@
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
     "@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
-
-    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260423.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260423.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260423.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260423.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260423.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260423.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260423.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260423.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-9WD7TJJlGvt9PQqJI/+44dVP4oqGQFIkYrpXt7nlQ0WgNIErN52x/XhxmJ4nWft06qejgPiUbPo4aYRNOmIHXg=="],
-
-    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260423.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wbLr6o5fROaCYt6cOpFhbe92FJAOdhAHwm/s8I/IyN5HbL1ULgel/wHaZiR+ws+27rgruNUiCENzTUg9vSz2bA=="],
-
-    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20260423.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-13MpNT+4MgkgrfiW2u03rnER5aB3yz9fA0bWEYh6IH3rIqA2AR3Dntp3QXW4sQrZf0SriXqHe2R7X3HCT5xmqA=="],
-
-    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20260423.1", "", { "os": "linux", "cpu": "arm" }, "sha512-CxUA15qbPQRvz2nanBpiv1h4tgXTCJJwqOtgKMSdIuPkow8dyYW3ba5oLoH/jZhS4792XislX659hlFrfiU6CQ=="],
-
-    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20260423.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-ICIkJDTqmn0R4Vs811+Ht2RYTk1OCrAhHCu0JthmhR216T1Tqgi5DWRoCprp3RL1qU6fLnxxrIpEbNlNN7XFYA=="],
-
-    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20260423.1", "", { "os": "linux", "cpu": "x64" }, "sha512-cWLFS4R8dOU1YuUJ/2VLeGMVIjgI3GGb/f9rRY5MbWHq5l3NNZh8y1QwAOrTh3+g3q6+znArfxVnD2hZHUz8Mw=="],
-
-    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260423.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-OWaGUI4+dHqYZv+k6sITx9Y27FNy3XzNFk4OrOiYtBkIO/xrb9TPMP4A5XI4n5zwRLIv3xne9g039xgRbaeyoQ=="],
-
-    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260423.1", "", { "os": "win32", "cpu": "x64" }, "sha512-5MQjO/qdLwXpjW7Dy/1lNv7Vtpvo6bhCkbjan4PoRN5/eeyqEqDWxdf8AGE4btLmHqyIjEHRuYf7kp2tlAr6lQ=="],
 
     "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "coverage:check:rust": "bun .github/scripts/check-coverage.ts --preset=rust --lcov=coverage/rust/lcov.info --summary=coverage/rust/summary.md",
     "generate:shell-artifacts": "bun scripts/generate-shell-artifacts.ts",
     "lint": "bunx tsc --noEmit",
-    "lint:tsgo": "bunx tsgo --noEmit",
     "check": "bun run lint && bun run check:versions && bun run test:cli-fast",
     "check:workflows": "bun .github/scripts/check-workflows.ts",
     "check:release-manifest": "bun .github/scripts/release-manifest.mjs --check",
@@ -85,7 +84,6 @@
   },
   "devDependencies": {
     "@types/bun": "latest",
-    "@typescript/native-preview": "^7.0.0-dev.20260423.1",
     "fast-xml-parser": "^5.8.0",
     "typescript": "^7.0.2",
     "yaml": "^2.9.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,8 +7,7 @@
     "types": ["bun-types"],
     "strict": true,
     "skipLibCheck": true,
-    "outDir": "./dist",
-    "rootDir": "."
+    "noEmit": true
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"]
 }


### PR DESCRIPTION
## What
`typescript` is now **7.0.2** (#577). In TS7 the native compiler **is** `tsc` itself, so the separate `@typescript/native-preview` (`tsgo`) preview package and its advisory checks are redundant.

## Changes
- **tsconfig.json**: declare the type-check-only workflow with `noEmit: true`; drop dead `outDir`/`rootDir` (nothing emits — `tsc` runs only `--noEmit`, `dist/` is gitignored).
- Remove `@typescript/native-preview` devDep (+ lockfile) and every `tsgo` reference:
  - `lint:tsgo` script in `package.json`
  - `lint-tsgo` target + `.PHONY` entry in `Makefile`
  - advisory tsgo type-check step in `.github/workflows/ci.yml`

## Verification
- `bunx tsc --noEmit` and `bunx tsgo --noEmit` both exit **0** on the new config.
- `make lint`, `bun run check:versions`, `bun run check:workflows` all pass.
- No remaining `tsgo`/`native-preview` references (excl. historical `docs/plans`).
- Config-only diff — no runtime code touched. The `kesha install --vad` timeout test is a pre-existing environmental flake (fails identically on clean `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BQ3hCqSNhF3j2GWH1aQPX5