### PR TITLE
fix(asr): reset TDT decoder state per one-shot CoreML call (engine 1.24.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ binary.
 
 ## [Unreleased]
 
+## [1.24.5] — 2026-07-19
+
+Engine release. Fixes corrupted multi-segment transcription on the CoreML (Apple Silicon) backend by picking up the FluidAudio TDT stateless-reset fix in `fluidaudio-rs`.
+
+### Fixed
+- **ASR (CoreML / Apple Silicon):** one-shot `transcribe_samples` calls no longer leak decoder state across calls. The VAD and long-audio chunked paths transcribe each speech segment on a single backend instance; before this fix the shared `TdtDecoderState` primed every segment after the first with the previous utterance's terminal token, prepending a spurious `.` — and collapsing short segments to just `.`. Picks up `fluidaudio-rs` `forked-main` (merged upstream [FluidInference/fluidaudio-rs#15](https://github.com/FluidInference/fluidaudio-rs/pull/15)) and adds an on-device (`#[ignore]`) regression test that runs `transcribe_samples` twice and asserts the second call is byte-identical to the first.
+
 ## [1.24.2] — 2026-06-12
 
 Engine release. Ships the [#539](https://github.com/drakulavich/kesha-voice-kit/pull/539) Rust refactors in isolation — binaries are intended to be functionally identical to v1.23.0, so any future regression bisects cleanly to this refactor set. CLI and engine versions move together to 1.24.2.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.24.4",
+  "version": "1.24.5",
   "description": "Give your tools a voice — speech to text and back, 25 languages, up to ~19× faster than Whisper. On your machine.",
   "type": "module",
   "bin": {
@@ -38,7 +38,7 @@
     }
   },
   "keshaEngine": {
-    "version": "1.24.4"
+    "version": "1.24.5"
   },
   "scripts": {
     "test": "bun test",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -688,7 +688,7 @@ dependencies = [
 [[package]]
 name = "fluidaudio-rs"
 version = "0.14.8"
-source = "git+https://github.com/drakulavich/fluidaudio-rs?branch=forked-main#8081ac65aa8d1efc906a4aed43884afa4b61a8b1"
+source = "git+https://github.com/drakulavich/fluidaudio-rs?branch=forked-main#74fa3dc52af6571c9ac6b73a8c2b013717d18d70"
 dependencies = [
  "thiserror 1.0.69",
 ]
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "kesha-engine"
-version = "1.24.4"
+version = "1.24.5"
 dependencies = [
  "anyhow",
  "audioadapter-buffers",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesha-engine"
-version = "1.24.4"
+version = "1.24.5"
 edition = "2021"
 description = "Inference engine for Kesha Voice Kit: ASR + language detection"
 # Not for crates.io. The library target (`src/lib.rs`) exists only for the

--- a/rust/src/backend/fluidaudio.rs
+++ b/rust/src/backend/fluidaudio.rs
@@ -98,4 +98,41 @@ mod tests {
         assert_eq!(out.len(), MIN_SAMPLES);
         assert!(out.iter().all(|&v| v == 0.0));
     }
+
+    // Regression: the VAD/chunked paths call `transcribe_samples` once per
+    // segment on a single backend instance. Before fluidaudio-rs carried the
+    // upstream TDT stateless-reset fix (FluidInference/fluidaudio-rs#15), the
+    // shared TdtDecoderState leaked the previous utterance's terminal token, so
+    // the 2nd+ one-shot call collapsed to a degenerate prefix (usually "."). A
+    // one-shot call must be independent of prior calls.
+    #[test]
+    #[ignore = "needs cached CoreML Parakeet models + Apple Neural Engine; run with --run-ignored on macOS arm64"]
+    fn transcribe_samples_is_stateless_across_calls() {
+        let wav = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../tests/fixtures/benchmark-en/03-review-pull-request.ogg"
+        );
+        let samples = crate::audio::load_audio(wav).expect("load sentence fixture");
+
+        let mut be = FluidAudioBackend::new().expect("init FluidAudio CoreML backend");
+        let first = be
+            .transcribe_samples(&samples)
+            .expect("first transcribe_samples");
+        let second = be
+            .transcribe_samples(&samples)
+            .expect("second transcribe_samples");
+
+        assert!(
+            !first.trim().is_empty(),
+            "sanity: first call should transcribe speech, got {first:?}"
+        );
+        assert_eq!(
+            first, second,
+            "second one-shot call diverged — decoder state leaked across calls (got {second:?})"
+        );
+        assert!(
+            !second.trim().trim_matches('.').trim().is_empty(),
+            "second call collapsed to a degenerate prefix: {second:?}"
+        );
+    }
 }


### PR DESCRIPTION
## What

On the **CoreML (Apple Silicon)** backend, multi-segment transcription was corrupting every segment after the first.

The VAD path (`transcribe_via_vad`) and long-audio chunking (`transcribe_chunked`) call `transcribe_samples` **once per segment on a single `FluidAudioBackend` instance**. In `fluidaudio-rs` before this bump, the Swift bridge threaded one shared `TdtDecoderState` across those calls, so each segment after the first was primed with the previous utterance's terminal token — prepending a spurious `.`, and collapsing short segments to just `.`.

Observed on-device (live ANE, one backend, same clip twice):

```
first  = "I need you to review the pull request before we can merge it into the main branch."
second = ". I need you to review the pull request before we can merge it into the main branch."   ← bug
```

## Fix

- Bump `fluidaudio-rs` to `forked-main`, which merges the upstream stateless-reset fix ([FluidInference/fluidaudio-rs#15](https://github.com/FluidInference/fluidaudio-rs/pull/15)) — each one-shot `transcribe`/`transcribe_samples` now allocates a fresh `TdtDecoderState`. `Cargo.lock`: `8081ac6` → `74fa3dc`.
- Add an `#[ignore]` on-device regression test (`transcribe_samples_is_stateless_across_calls`) that runs `transcribe_samples` twice and asserts the second call is byte-identical to the first.
- Engine release bump `1.24.4` → `1.24.5` (`package.json` version + `keshaEngine.version`, `rust/Cargo.toml`, `rust/Cargo.lock`); drift gate green.

## Test plan

- `cargo fmt` — clean
- `cargo clippy --all-targets -- -D warnings` (default) — clean
- `cargo clippy --no-default-features --features coreml --all-targets -- -D warnings` — clean
- `cargo check --no-default-features --features coreml` — ok
- `make rust-test` — **386/386 passed**
- Regression test against the pushed git dep (`--run-ignored`, macOS arm64): **PASS after / FAIL before** the bump

Not linked to an existing issue — surfaced while reviewing the `fluidaudio-rs` fork. The `#[ignore]` test needs cached CoreML Parakeet models + ANE, so it doesn't run in CI (coreml is compile-only there); it's a local/manual guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114aNzwPaegRuvVrGSxNcTH