### PR TITLE
ci(tts): consolidate model caching into one composite action + shared cache

### DIFF
--- a/.github/actions/setup-kokoro-models/action.yml
+++ b/.github/actions/setup-kokoro-models/action.yml
@@ -1,0 +1,24 @@
+name: Setup Kokoro TTS models
+description: >
+  Restore-or-download the shared Kokoro + Vosk-RU + multilingual CharsiuG2P model
+  cache used by every TTS test lane (rust-test nextest + ci.yml say-e2e). One cache
+  key per OS so the macOS lanes share a single ~1.3 GB cache instead of duplicating it.
+
+inputs:
+  cache-dir:
+    description: Model cache directory (also used as KOKORO_CACHE by callers).
+    required: false
+    default: ${{ github.workspace }}/.kokoro-spike
+
+runs:
+  using: composite
+  steps:
+    - name: Cache TTS models
+      uses: actions/cache@v6
+      with:
+        path: ${{ inputs.cache-dir }}
+        key: kokoro-models-v1-${{ runner.os }}
+
+    - name: Download TTS models (if cache miss)
+      shell: bash
+      run: bash rust/ci/download-kokoro.sh "${{ inputs.cache-dir }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -575,14 +575,8 @@ jobs:
           # this discriminator if the stale path ever resurfaces.
           key: xcode-16.2
 
-      - name: 💾 Cache Kokoro models
-        uses: actions/cache@v6
-        with:
-          path: ${{ env.KOKORO_CACHE }}
-          key: kokoro-spike-v5-${{ runner.os }}
-
-      - name: 📥 Download Kokoro models (if cache miss)
-        run: bash rust/ci/download-kokoro.sh "$KOKORO_CACHE"
+      - name: 🎚️ Setup Kokoro TTS models
+        uses: ./.github/actions/setup-kokoro-models
 
       - name: 🎧 Install system Opus
         # audiopus_sys / opusic-sys fall back to a cmake build of vendored

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -164,15 +164,8 @@ jobs:
             --features coreml,tts,system_tts,system_kokoro,system_diarize,system_text_lang \
             --no-default-features -- -D warnings
 
-      - name: Cache Kokoro spike models
-        uses: actions/cache@v6
-        with:
-          path: ${{ env.KOKORO_CACHE }}
-          key: kokoro-spike-ml-v1-${{ runner.os }}
-
-      - name: Download Kokoro model (if cache miss)
-        shell: bash
-        run: bash rust/ci/download-kokoro.sh "$KOKORO_CACHE" multilang
+      - name: 🎚️ Setup Kokoro TTS models
+        uses: ./.github/actions/setup-kokoro-models
 
       - name: Run tests (with real Kokoro)
         shell: bash
@@ -247,15 +240,8 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends libopus-dev pkg-config
 
-      - name: Cache Kokoro spike models
-        uses: actions/cache@v6
-        with:
-          path: ${{ env.KOKORO_CACHE }}
-          key: kokoro-spike-ml-v1-${{ runner.os }}
-
-      - name: Download Kokoro model (if cache miss)
-        shell: bash
-        run: bash rust/ci/download-kokoro.sh "$KOKORO_CACHE" multilang
+      - name: 🎚️ Setup Kokoro TTS models
+        uses: ./.github/actions/setup-kokoro-models
 
       - name: 📈 Rust coverage
         shell: bash

--- a/rust/ci/download-kokoro.sh
+++ b/rust/ci/download-kokoro.sh
@@ -9,12 +9,7 @@
 # test runner.
 set -euo pipefail
 
-DEST="${1:?usage: download-kokoro.sh <dest_dir> [multilang]}"
-# Pass "multilang" as $2 to also stage the runtime cache layout + es/fr/it/pt
-# voices + CharsiuG2P for tts_multilang_audio. Only rust-test.yml opts in; the
-# ci.yml TTS-e2e cache stays lean so its say-e2e SPIKE_AVAILABLE gate is
-# unaffected (that suite skips without a staged g2p dir).
-STAGE_MULTILANG="${2:-}"
+DEST="${1:?usage: download-kokoro.sh <dest_dir>}"
 mkdir -p "$DEST"
 
 if [[ ! -f "$DEST/model.onnx" ]]; then
@@ -57,46 +52,44 @@ ls -lh "$DEST"
 ls -lh "$VOSK_DIR"
 ls -lh "$VOSK_DIR/bert"
 
-if [[ "$STAGE_MULTILANG" == "multilang" ]]; then
-  # Runtime cache layout (models/kokoro-82m/...) for tests that resolve Kokoro
-  # via KESHA_CACHE_DIR instead of the flat KOKORO_MODEL env — tts_multilang_audio.
-  # Hardlink the 310 MB model rather than copy (same filesystem; `ln` falls back
-  # to a copy on Windows git-bash).
-  KOKORO_DIR="$DEST/models/kokoro-82m"
-  mkdir -p "$KOKORO_DIR/voices"
-  if [[ ! -f "$KOKORO_DIR/model.onnx" ]]; then
-    ln -f "$DEST/model.onnx" "$KOKORO_DIR/model.onnx" 2>/dev/null \
-      || cp "$DEST/model.onnx" "$KOKORO_DIR/model.onnx"
-  fi
-  if [[ ! -f "$KOKORO_DIR/voices/am_michael.bin" ]]; then
-    ln -f "$DEST/am_michael.bin" "$KOKORO_DIR/voices/am_michael.bin" 2>/dev/null \
-      || cp "$DEST/am_michael.bin" "$KOKORO_DIR/voices/am_michael.bin"
-  fi
-
-  # Multilingual voices (es/fr/it/pt) — URLs mirror rust/src/models.rs multilang
-  # voice manifest. em_alex/im_nicola/pm_alex are male; ff_siwis is the documented
-  # French brand-rule exception (Kokoro v1.0 ships no male French voice).
-  VOICE_BASE="https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices"
-  for v in em_alex ff_siwis im_nicola pm_alex; do
-    if [[ ! -f "$KOKORO_DIR/voices/$v.bin" ]]; then
-      echo "Downloading Kokoro voice $v.bin..."
-      curl -fL -o "$KOKORO_DIR/voices/$v.bin" "$VOICE_BASE/$v.bin"
-    fi
-  done
-
-  # CharsiuG2P byt5-tiny ONNX (es/fr/it/pt phonemisation). URLs mirror
-  # rust/src/models.rs; the loader (charsiu::load) opens exactly these three.
-  # run-cargo-test.sh exports CHARSIU_ONNX pointing at this dir.
-  G2P_DIR="$DEST/models/g2p/byt5-tiny"
-  mkdir -p "$G2P_DIR"
-  G2P_BASE="https://huggingface.co/klebster/g2p_multilingual_byT5_tiny_onnx/resolve/main"
-  for f in encoder_model decoder_model decoder_with_past_model; do
-    if [[ ! -f "$G2P_DIR/$f.onnx" ]]; then
-      echo "Downloading CharsiuG2P $f.onnx..."
-      curl -fL -o "$G2P_DIR/$f.onnx" "$G2P_BASE/$f.onnx"
-    fi
-  done
-
-  ls -lh "$KOKORO_DIR/voices"
-  ls -lh "$G2P_DIR"
+# Runtime cache layout (models/kokoro-82m/...) for tests that resolve Kokoro via
+# KESHA_CACHE_DIR instead of the flat KOKORO_MODEL env — tts_multilang_audio.
+# Hardlink the 310 MB model rather than copy (same filesystem; `ln` falls back to
+# a copy on Windows git-bash).
+KOKORO_DIR="$DEST/models/kokoro-82m"
+mkdir -p "$KOKORO_DIR/voices"
+if [[ ! -f "$KOKORO_DIR/model.onnx" ]]; then
+  ln -f "$DEST/model.onnx" "$KOKORO_DIR/model.onnx" 2>/dev/null \
+    || cp "$DEST/model.onnx" "$KOKORO_DIR/model.onnx"
 fi
+if [[ ! -f "$KOKORO_DIR/voices/am_michael.bin" ]]; then
+  ln -f "$DEST/am_michael.bin" "$KOKORO_DIR/voices/am_michael.bin" 2>/dev/null \
+    || cp "$DEST/am_michael.bin" "$KOKORO_DIR/voices/am_michael.bin"
+fi
+
+# Multilingual voices (es/fr/it/pt) — URLs mirror rust/src/models.rs multilang
+# voice manifest. em_alex/im_nicola/pm_alex are male; ff_siwis is the documented
+# French brand-rule exception (Kokoro v1.0 ships no male French voice).
+VOICE_BASE="https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices"
+for v in em_alex ff_siwis im_nicola pm_alex; do
+  if [[ ! -f "$KOKORO_DIR/voices/$v.bin" ]]; then
+    echo "Downloading Kokoro voice $v.bin..."
+    curl -fL -o "$KOKORO_DIR/voices/$v.bin" "$VOICE_BASE/$v.bin"
+  fi
+done
+
+# CharsiuG2P byt5-tiny ONNX (es/fr/it/pt phonemisation). URLs mirror
+# rust/src/models.rs; the loader (charsiu::load) opens exactly these three.
+# run-cargo-test.sh exports CHARSIU_ONNX pointing at this dir.
+G2P_DIR="$DEST/models/g2p/byt5-tiny"
+mkdir -p "$G2P_DIR"
+G2P_BASE="https://huggingface.co/klebster/g2p_multilingual_byT5_tiny_onnx/resolve/main"
+for f in encoder_model decoder_model decoder_with_past_model; do
+  if [[ ! -f "$G2P_DIR/$f.onnx" ]]; then
+    echo "Downloading CharsiuG2P $f.onnx..."
+    curl -fL -o "$G2P_DIR/$f.onnx" "$G2P_BASE/$f.onnx"
+  fi
+done
+
+ls -lh "$KOKORO_DIR/voices"
+ls -lh "$G2P_DIR"

--- a/tests/integration/say-e2e.test.ts
+++ b/tests/integration/say-e2e.test.ts
@@ -5,35 +5,28 @@ import { existsSync, mkdirSync, symlinkSync } from "fs";
 const CLI_PATH = new URL("../../bin/kesha.js", import.meta.url).pathname;
 
 /**
- * End-to-end: run the full `kesha say` CLI with a populated cache that points
- * at the spike-downloaded Kokoro model + af_heart voice. Skipped if the spike
- * artifacts are missing (set up with `cd rust/spike-kokoro && ...` from Task 0.2).
+ * End-to-end: run the full `kesha say` CLI with a populated cache pointing at the
+ * Kokoro model + the male default voice `am_michael`. Skipped only when the model
+ * artifacts are missing (CI stages them via KOKORO_MODEL / KOKORO_VOICE).
+ *
+ * English Kokoro phonemises through the embedded misaki lexicon (#207), NOT the
+ * byt5 CharsiuG2P ONNX pack — so no g2p artifact is needed here.
  */
 const SPIKE_MODEL = process.env.KOKORO_MODEL ?? "/tmp/kokoro-spike/model.onnx";
-const SPIKE_VOICE = process.env.KOKORO_VOICE ?? "/tmp/kokoro-spike/af_heart.bin";
-// G2P source dir lives under the inherited KESHA_CACHE_DIR (CI runner
-// layout). Required since #123 Phase 2a — Kokoro pipes through ONNX G2P.
-const G2P_SRC_DIR = process.env.KESHA_CACHE_DIR
-  ? `${process.env.KESHA_CACHE_DIR}/models/g2p/byt5-tiny`
-  : "";
-const G2P_AVAILABLE =
-  G2P_SRC_DIR !== "" && existsSync(`${G2P_SRC_DIR}/encoder_model.onnx`);
-const SPIKE_AVAILABLE = existsSync(SPIKE_MODEL) && existsSync(SPIKE_VOICE) && G2P_AVAILABLE;
+const SPIKE_VOICE = process.env.KOKORO_VOICE ?? "/tmp/kokoro-spike/am_michael.bin";
+const SPIKE_AVAILABLE = existsSync(SPIKE_MODEL) && existsSync(SPIKE_VOICE);
 
 const CACHE_DIR = `/tmp/kesha-e2e-${Date.now()}`;
 const MODEL_DIR = `${CACHE_DIR}/models/kokoro-82m`;
-const G2P_DIR = `${CACHE_DIR}/models/g2p/byt5-tiny`;
 const BUILT_ENGINE = `${new URL("../..", import.meta.url).pathname}rust/target/release/kesha-engine`;
 
 beforeAll(() => {
   if (!SPIKE_AVAILABLE) return;
+  // Stage the voice under the brand-default name so bare `kesha say` (which
+  // resolves en-am_michael) finds it without an explicit --voice.
   mkdirSync(`${MODEL_DIR}/voices`, { recursive: true });
   symlinkSync(SPIKE_MODEL, `${MODEL_DIR}/model.onnx`);
-  symlinkSync(SPIKE_VOICE, `${MODEL_DIR}/voices/af_heart.bin`);
-  mkdirSync(G2P_DIR, { recursive: true });
-  for (const f of ["encoder_model.onnx", "decoder_model.onnx", "decoder_with_past_model.onnx"]) {
-    symlinkSync(`${G2P_SRC_DIR}/${f}`, `${G2P_DIR}/${f}`);
-  }
+  symlinkSync(SPIKE_VOICE, `${MODEL_DIR}/voices/am_michael.bin`);
 });
 
 function spawnCli(args: string[], extraEnv: Record<string, string> = {}) {

--- a/tests/integration/say-e2e.test.ts
+++ b/tests/integration/say-e2e.test.ts
@@ -82,7 +82,9 @@ describe("kesha say e2e", () => {
       const proc = spawnCli(["say", "Hi", "--out", outPath], { KESHA_DEBUG: "1" });
       expect(await proc.exited).toBe(0);
       const stderr = await new Response(proc.stderr).text();
-      expect(stderr).toContain("[debug]");
+      // Markers are `[debug +Nms]` / `[debug/engine …]` — match the prefix,
+      // not a literal `[debug]` (the trailing-bracket form drifted away).
+      expect(stderr).toContain("[debug");
     },
     60_000,
   );
@@ -94,7 +96,7 @@ describe("kesha say e2e", () => {
       const proc = spawnCli(["say", "Hi", "--out", outPath], { KESHA_DEBUG: "" });
       expect(await proc.exited).toBe(0);
       const stderr = await new Response(proc.stderr).text();
-      expect(stderr).not.toContain("[debug]");
+      expect(stderr).not.toContain("[debug");
     },
     60_000,
   );


### PR DESCRIPTION
## What

Removes the model-cache duplication that the multilang-CI work (#590) exposed, as a follow-up CI-efficiency pass.

Before: each TTS lane kept its **own** Kokoro cache under a different key — ci.yml `tts-e2e` used `kokoro-spike-v5`, rust-test used `kokoro-spike-ml-v1` — so the two **macOS** lanes cached the same ~1.3 GB models **twice**.

## Change

- **New composite action** `.github/actions/setup-kokoro-models`: one cache key (`kokoro-models-v1-<os>`) + download, used by all three TTS lanes (rust-test `test` + `coverage`, ci.yml `tts-e2e`). The macOS lanes now **share one cache**.
- **`download-kokoro.sh`** always stages the full set (runtime layout + es/fr/it/pt voices + CharsiuG2P); the per-caller `multilang` flag is gone.
- **`say-e2e.test.ts`**: drop the **stale byt5-G2P skip gate** — English Kokoro phonemises via the embedded **misaki** lexicon (#207), not the CharsiuG2P ONNX pack — and stage the voice under the brand-default name **`am_michael`** (bare `kesha say` resolves `en-am_michael`). It previously staged `af_heart` and **only ever passed by being skipped**; now it runs for real.

Net: **−10 lines**, one shared cache instead of a per-lane duplicate, and a previously-dead say-e2e suite that actually executes.

## Why (not touching the "over-broad" triggers)

The other half of the proposed cleanup — tightening `published-engine-smoke` / `integration-tests-full` triggers — was **deliberately not done**: their breadth is intentional and incident-documented (inline comments cite `#274` "rust-only PR yet the real-engine e2e must still run" and `#315` version-drift). The one safe refinement (excluding `rust/ci/**` from `heavy_e2e`) isn't cleanly expressible because `dorny/paths-filter` `!`-negation doesn't mean "exclude." Not worth risking a documented regression for marginal savings.

## Verification

- `bash -n` on `download-kokoro.sh` — clean; 0 leftover flag refs
- `bunx tsc --noEmit` — clean (say-e2e compiles)
- All 3 workflow YAMLs parse; single cache key confirmed
- CI proof: `multilang_audio_regression_*` still run (CHARSIU_ONNX exported by `run-cargo-test.sh` + coverage step), and `say-e2e` now **runs instead of skipping** on the `tts-e2e` lane.

Refs #212, #464.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DHQ2d5oTrL8dLi6qXq4zC