### PR TITLE
fix(tts): route Opus encode through opusic-sys to kill dual-libopus Windows crash (#585)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -139,17 +139,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "audiopus_sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62314a1546a2064e033665d658e88c620a62904be945f8147e6b16c3db9f8651"
-dependencies = [
- "cmake",
- "log",
- "pkg-config",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -980,7 +969,7 @@ dependencies = [
  "misaki-rs",
  "ndarray",
  "ogg",
- "opus",
+ "opusic-sys",
  "ort",
  "rayon",
  "rubato",
@@ -1363,15 +1352,6 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "opus"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d3809943dff6fbad5f0484449ea26bdb9cb7d8efdf26ed50d3c7f227f69eb5c"
-dependencies = [
- "audiopus_sys",
-]
 
 [[package]]
 name = "opusic-sys"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -25,7 +25,7 @@ default = ["onnx", "tts"]
 # invalidAudioData")` (see #259) interleaves with kesha-engine's JSON output.
 coreml = ["dep:fluidaudio-rs", "dep:libc"]
 onnx = []
-tts = ["dep:thiserror", "dep:ssml-parser", "dep:opus", "dep:ogg", "dep:flacenc"]
+tts = ["dep:thiserror", "dep:ssml-parser", "dep:opusic-sys", "dep:ogg", "dep:flacenc"]
 # macOS-only AVSpeechSynthesizer backend for `macos-*` voices (#141).
 # Opt-in — builds a Swift sidecar via swiftc in build.rs. Silently no-op on
 # non-macOS targets even when enabled.
@@ -83,10 +83,12 @@ thiserror = { version = "2", optional = true }
 sha2 = "0.10"
 ssml-parser = { version = "0.1", optional = true }
 
-# Opus encoding for `kesha say --format ogg-opus` (#223). The `opus` crate is
-# safe Rust bindings around libopus (BSD-3, vendored via `audiopus_sys`); `ogg`
-# is a pure-Rust container muxer. Both are MIT/Apache-2.0 — license-compatible.
-opus = { version = "0.3", optional = true }
+# Opus encoding for `kesha say --format ogg-opus` (#223). Encode drives the
+# `opusic-sys` FFI — the SAME libopus `symphonia-adapter-libopus` links for
+# decode — so the binary carries exactly one static libopus (why this isn't the
+# safe `opus`/`audiopus_sys` crate: see the OpusEncoder doc in tts/encode.rs,
+# #585). `ogg` is a pure-Rust container muxer.
+opusic-sys = { version = "0.7", optional = true }
 ogg = { version = "0.9", optional = true }
 
 libc = { version = "0.2", optional = true }

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -7,10 +7,6 @@
 # revisit on every cargo update.
 yanked = "deny"
 ignore = [
-  # audiopus_sys (via opus, for Opus encode/decode) is implicitly unmaintained;
-  # upstream advisory states "No safe upgrade is available!" — transitive, no fix.
-  # https://rustsec.org/advisories/RUSTSEC-2026-0150 — revisit 2026-08-25.
-  "RUSTSEC-2026-0150",
   # quick-xml 0.27.1 (via ssml-parser 0.1.4, the only published version, which
   # pins quick-xml ^0.27). Both advisories are fixed only in quick-xml >=0.41.0,
   # so this is unfixable transitively until ssml-parser ships a release on the

--- a/rust/src/tts/encode.rs
+++ b/rust/src/tts/encode.rs
@@ -182,6 +182,87 @@ const MAX_OPUS_PACKET: usize = 4_000;
 #[cfg(feature = "tts")]
 const PRE_SKIP_48K: u16 = 3_840;
 
+/// RAII wrapper over libopus' encoder FFI (`opusic-sys`).
+///
+/// We bind encode here instead of pulling the safe `opus` crate: that crate's
+/// `audiopus_sys` static-linked a SECOND copy of libopus, whose C symbols
+/// collided with the copy `symphonia-adapter-libopus` (`opusic-sys`) links for
+/// decode. The MSVC linker bound all calls to one copy — an ODR violation that
+/// crashed Windows CI with `0xc0000005` (#585). Driving encode through the same
+/// `opusic-sys` keeps exactly one libopus in the binary.
+#[cfg(feature = "tts")]
+struct OpusEncoder {
+    raw: *mut opusic_sys::OpusEncoder,
+}
+
+#[cfg(feature = "tts")]
+impl OpusEncoder {
+    fn new(sample_rate: u32, bitrate: i32) -> anyhow::Result<Self> {
+        use opusic_sys::{
+            opus_encoder_create, OPUS_APPLICATION_VOIP, OPUS_OK, OPUS_SET_BITRATE_REQUEST,
+            OPUS_SET_SIGNAL_REQUEST, OPUS_SIGNAL_VOICE,
+        };
+        let mut err: core::ffi::c_int = OPUS_OK;
+        // SAFETY: FFI call; on failure `raw` is null and/or `err` is non-OK, both checked below.
+        let raw =
+            unsafe { opus_encoder_create(sample_rate as i32, 1, OPUS_APPLICATION_VOIP, &mut err) };
+        if raw.is_null() || err != OPUS_OK {
+            anyhow::bail!("opus encoder create: {}", opus_err_str(err));
+        }
+        let enc = Self { raw };
+        enc.set_ctl(OPUS_SET_BITRATE_REQUEST, bitrate)
+            .map_err(|e| anyhow::anyhow!("opus set_bitrate: {e}"))?;
+        // Tell libopus this is voice — affects internal mode selection.
+        enc.set_ctl(OPUS_SET_SIGNAL_REQUEST, OPUS_SIGNAL_VOICE)
+            .map_err(|e| anyhow::anyhow!("opus set_signal: {e}"))?;
+        Ok(enc)
+    }
+
+    fn set_ctl(&self, request: core::ffi::c_int, value: i32) -> anyhow::Result<()> {
+        use opusic_sys::{opus_encoder_ctl, OPUS_OK};
+        // SAFETY: variadic ctl setter; every request we issue takes a single opus_int32 argument.
+        let rc = unsafe { opus_encoder_ctl(self.raw, request, value) };
+        if rc != OPUS_OK {
+            anyhow::bail!("{}", opus_err_str(rc));
+        }
+        Ok(())
+    }
+
+    fn encode_float(&mut self, pcm: &[f32], out: &mut [u8]) -> anyhow::Result<usize> {
+        // SAFETY: `pcm`/`out` are valid slices for their lengths; mono, so frame_size == pcm.len().
+        let n = unsafe {
+            opusic_sys::opus_encode_float(
+                self.raw,
+                pcm.as_ptr(),
+                pcm.len() as i32,
+                out.as_mut_ptr(),
+                out.len() as i32,
+            )
+        };
+        if n < 0 {
+            anyhow::bail!("{}", opus_err_str(n));
+        }
+        Ok(n as usize)
+    }
+}
+
+#[cfg(feature = "tts")]
+impl Drop for OpusEncoder {
+    fn drop(&mut self) {
+        // SAFETY: `raw` came from opus_encoder_create and is destroyed exactly once here.
+        unsafe { opusic_sys::opus_encoder_destroy(self.raw) };
+    }
+}
+
+/// Resolve a libopus error code to its static message string.
+#[cfg(feature = "tts")]
+fn opus_err_str(code: core::ffi::c_int) -> String {
+    // SAFETY: opus_strerror returns a non-null static NUL-terminated C string for any code.
+    unsafe { core::ffi::CStr::from_ptr(opusic_sys::opus_strerror(code)) }
+        .to_string_lossy()
+        .into_owned()
+}
+
 #[cfg(feature = "tts")]
 fn encode_ogg_opus(
     samples: &[f32],
@@ -189,8 +270,6 @@ fn encode_ogg_opus(
     target_sr: u32,
     bitrate: i32,
 ) -> anyhow::Result<Vec<u8>> {
-    use opus::{Application, Channels, Encoder};
-
     if !OPUS_VALID_SR.contains(&target_sr) {
         anyhow::bail!(
             "ogg-opus: --sample-rate must be one of {:?}, got {target_sr}",
@@ -209,14 +288,9 @@ fn encode_ogg_opus(
         Cow::Owned(resample_mono(samples, src_rate, target_sr)?)
     };
 
-    // `Application::Voip`: best perceptual quality at low bitrates for speech.
-    let mut enc = Encoder::new(target_sr, Channels::Mono, Application::Voip)
-        .map_err(|e| anyhow::anyhow!("opus encoder: {e}"))?;
-    enc.set_bitrate(opus::Bitrate::Bits(bitrate))
-        .map_err(|e| anyhow::anyhow!("opus set_bitrate: {e}"))?;
-    // Tell libopus this is voice — affects internal mode selection.
-    enc.set_signal(opus::Signal::Voice)
-        .map_err(|e| anyhow::anyhow!("opus set_signal: {e}"))?;
+    // `OPUS_APPLICATION_VOIP` + voice signal: best perceptual quality at low
+    // bitrates for speech.
+    let mut enc = OpusEncoder::new(target_sr, bitrate)?;
 
     let frame_size = (target_sr * FRAME_DURATION_MS / 1_000) as usize;
 
@@ -550,11 +624,6 @@ mod tests {
     }
 
     #[test]
-    // libopus's SIMD intrinsics intermittently fault with 0xc0000005 (access
-    // violation) on the MSVC target, aborting the test process — #585. Skip on
-    // Windows until the native crash is fixed; the encode path itself is
-    // exercised on macOS/Linux.
-    #[cfg_attr(windows, ignore = "libopus SIMD 0xc0000005 on MSVC — #585")]
     fn ogg_opus_produces_valid_oggs_magic() {
         // 1 second of a 440 Hz tone at 24 kHz mono.
         let sr = 24_000u32;
@@ -616,9 +685,6 @@ mod tests {
     }
 
     #[test]
-    // Same libopus MSVC access violation as ogg_opus_produces_valid_oggs_magic
-    // (this test resamples then encodes, hitting the same native path) — #585.
-    #[cfg_attr(windows, ignore = "libopus SIMD 0xc0000005 on MSVC — #585")]
     fn ogg_opus_resamples_when_engine_sr_mismatches() {
         // Vosk-RU runs at 22.05 kHz natively. We can't feed that to libopus
         // directly, so the encoder must resample to a supported rate first.

--- a/rust/tests/tts_opus.rs
+++ b/rust/tests/tts_opus.rs
@@ -5,11 +5,7 @@
 //! ogg-opus | sendVoice`) lives in the manual QA loop documented in #223 and
 //! the smoke-test scripts under `scripts/`.
 
-// Every test here encodes OggOpus, which intermittently faults with 0xc0000005
-// in libopus's SIMD path on the MSVC target (#585). Compile the whole file out
-// on Windows until the native crash is fixed; encoding stays covered on
-// macOS/Linux.
-#![cfg(all(feature = "tts", not(windows)))]
+#![cfg(feature = "tts")]
 
 use kesha_engine::tts::encode::{self, OutputFormat};
 

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -57,14 +57,15 @@ else
   missing_system=1
 fi
 
-# libopus + pkg-config: audiopus_sys / opusic-sys (OGG/Opus output).
-if have pkg-config && pkg-config --exists opus 2>/dev/null; then
-  ok "libopus (via pkg-config)"
+# cmake: opusic-sys builds a vendored libopus from source via cmake for the
+# `tts` feature's OGG/Opus output — no system libopus is used (#585).
+if have cmake; then
+  ok "cmake ($(cmake --version | head -1 | awk '{print $3}'))"
 else
   case "$OS" in
-    macos) todo "libopus/pkg-config missing — brew install opus pkg-config" ;;
-    linux) todo "libopus/pkg-config missing — sudo apt-get install -y libopus-dev pkg-config" ;;
-    *)     todo "libopus + pkg-config missing — install them for your OS" ;;
+    macos) todo "cmake missing — brew install cmake" ;;
+    linux) todo "cmake missing — sudo apt-get install -y cmake" ;;
+    *)     todo "cmake missing — install it for your OS" ;;
   esac
   missing_system=1
 fi


### PR DESCRIPTION
## What

Fixes the Windows-only flaky `0xc0000005` access violation in the OGG/Opus encode path by unifying on a **single** static libopus.

- Drop the `opus`/`audiopus_sys` crate; rewrite `encode_ogg_opus` to drive libopus' encode FFI directly through **`opusic-sys`** — the same libopus already linked for decode via `symphonia-adapter-libopus` — behind a small RAII `OpusEncoder` wrapper.
- Remove the Windows test quarantine (2× `#[cfg_attr(windows, ignore)]` in `encode.rs` + the `not(windows)` gate on `tests/tts_opus.rs`).
- Remove the now-dead `RUSTSEC-2026-0150` ignore from `deny.toml` (dropping `audiopus_sys` eliminates that unmaintained-crate advisory exposure entirely).
- `dev-setup.sh`: check for **cmake** (opusic-sys's real build prerequisite — it vendors libopus and cmake-builds it) instead of the no-longer-needed system libopus.

## Why

Two static libopus copies with colliding C symbols — `audiopus_sys` (via `opus`, encode) and `opusic-sys` (via `symphonia-adapter-libopus`, decode). The MSVC linker bound all `opus_encode_float`/etc. calls into one copy (an ODR violation), whose SIMD intrinsics faulted on MSVC → `0xc0000005`. macOS/Linux tolerate the UB; Windows doesn't. Swapping `audiopus_sys`'s libopus (tried in #586) changed nothing because encode already resolved into the `opusic-sys` copy.

`cargo tree --features tts` now shows exactly one libopus, shared by encode and decode — the collision (and UB) is structurally gone.

Closes #585

## Testing

- **`test (windows-latest)` passed with the un-quarantined Opus tests running — no `0xc0000005`** (the direct proof the crash is fixed).
- `cargo nextest run --features tts` — 386 passed, 0 skipped (encode now runs through `opusic-sys` on macOS too, so this exercises the new FFI wrapper).
- `clippy --all-targets -D warnings`, `cargo fmt --check`, `cargo deny check` — all clean.
- FFI contract cross-checked against the official opus 1.6 encoder docs; two independent Codex reviews + a 4-agent `/simplify` sweep found no P1/P2.

## Notes for reviewer

- **`coreml-regression` is red but unrelated to this change** — it fails on `backend::fluidaudio::tests::transcribe_samples_is_stateless_across_calls` (`Swift bridge error: Transcription failed`), a brand-new (#594) flaky ANE decoder-state test. That job builds `--no-default-features --features coreml` (no `tts`), so the removed `opus`/`audiopus_sys` crates were never in its binary — my change is a **no-op** for it. It fires on this PR only because its paths-filter triggers on any `Cargo.lock` change (the fluidaudio-rs bump detector). The `🧪 Rust Tests` gate rolls up that job.
- Left the CI workflow files (`build-engine.yml`, `ci.yml`, `rust-test.yml`) untouched to keep this focused. Three of their comments still say `audiopus_sys` and their steps `install libopus` — both now redundant (opusic-sys vendors), but harmless; a follow-up can tidy the CI comments/installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BQ3hCqSNhF3j2GWH1aQPX5