### PR TITLE
chore(deps): switch fluidaudio-rs to upstream, retire the fork

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -677,7 +677,7 @@ dependencies = [
 [[package]]
 name = "fluidaudio-rs"
 version = "0.14.8"
-source = "git+https://github.com/drakulavich/fluidaudio-rs?branch=forked-main#74fa3dc52af6571c9ac6b73a8c2b013717d18d70"
+source = "git+https://github.com/FluidInference/fluidaudio-rs?rev=2d8e6b6891ccaf0807f8b6562893b24e5e1ec0f4#2d8e6b6891ccaf0807f8b6562893b24e5e1ec0f4"
 dependencies = [
  "thiserror 1.0.69",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -68,13 +68,13 @@ ort = { version = "2.0.0-rc.12" }
 ndarray = { version = "0.17" }
 
 # FluidAudio (macOS): ASR (CoreML/ANE), native Kokoro TTS, and model-path
-# diarization. Forked to add the Kokoro binding + `diarize_file_with_models`
-# (upstream PR pending; retire the fork once merged).
-# Tracks `forked-main`, which carries FluidAudio 0.14.8 + per-language KokoroAne
-# variant selection (fork PRs #2 + #3, both merged): `init_kokoro` takes a `lang`
-# arg → `zh` selects the `.mandarin` variant (tone-aware Mandarin G2P), else
-# `.english` (#492). Retains the `--rate` model-native speed (#475).
-fluidaudio-rs = { git = "https://github.com/drakulavich/fluidaudio-rs", branch = "forked-main", optional = true }
+# diarization. Now on upstream `FluidInference/fluidaudio-rs` — the Kokoro
+# binding (upstream PR #19) and `diarize_file_with_models` both landed there, so
+# the fork is retired. Pinned to a rev for reproducible builds. API is unchanged
+# from the fork: `init_kokoro` takes a `lang` arg → `zh` selects the `.mandarin`
+# variant (tone-aware Mandarin G2P), else `.english` (#492); retains the `--rate`
+# model-native speed (#475).
+fluidaudio-rs = { git = "https://github.com/FluidInference/fluidaudio-rs", rev = "2d8e6b6891ccaf0807f8b6562893b24e5e1ec0f4", optional = true }
 audioadapter-buffers = "3.0.0"
 
 # TTS (Kokoro + SSML parser; G2P via ONNX ByT5 at runtime, see #123)

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -65,5 +65,7 @@ allow-wildcard-paths = true
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-# First-party fork consumed by the `coreml`/`system_*` features (#199, #259).
-allow-git = ["https://github.com/drakulavich/fluidaudio-rs"]
+# Upstream FluidAudio Rust bindings, consumed by the `coreml`/`system_*`
+# features (#199, #259). Was the personal fork until the Kokoro binding landed
+# upstream (FluidInference/fluidaudio-rs#19); fork now retired.
+allow-git = ["https://github.com/FluidInference/fluidaudio-rs"]

--- a/rust/src/tts/fluid_kokoro.rs
+++ b/rust/src/tts/fluid_kokoro.rs
@@ -1,6 +1,6 @@
 //! FluidAudio Kokoro backend — macOS arm64, behind `system_kokoro`.
 //!
-//! Uses the forked `fluidaudio-rs` crate's native Kokoro binding (in-process),
+//! Uses the `fluidaudio-rs` crate's native Kokoro binding (in-process),
 //! replacing the previous Swift sidecar. Non-Darwin builds stay on the existing
 //! ONNX Kokoro implementation.
 
@@ -31,9 +31,9 @@ pub struct VoiceSpec {
     pub lang: &'static str,
 }
 
-// FluidAudio 0.14.5 voice snapshot plus the multilingual Kokoro voice packs
+// FluidAudio 0.14.8 voice snapshot plus the multilingual Kokoro voice packs
 // validated against the ANE cache. Keep this list in sync with the FluidAudio
-// pin in the fluidaudio-rs fork whenever it changes.
+// pin in the fluidaudio-rs git rev (rust/Cargo.toml) whenever it changes.
 const VOICES: &[VoiceSpec] = &[
     VoiceSpec {
         public_id: "en-af_alloy",


### PR DESCRIPTION
## What

Points the `fluidaudio-rs` dependency at **upstream** `FluidInference/fluidaudio-rs` instead of the personal fork `drakulavich/fluidaudio-rs@forked-main`, pinned to the merge commit `2d8e6b6` for reproducible builds.

The fork existed only to carry two things that have now both landed upstream:
- **Kokoro TTS binding** — merged as [FluidInference/fluidaudio-rs#19](https://github.com/FluidInference/fluidaudio-rs/pull/19)
- `diarize_file_with_models` + CoreML ASR — already upstream (#17)

So the fork is retired.

## No code changes

The public API is identical to `forked-main` — `init_kokoro(voice, lang)`, `synthesize_kokoro(text, voice, speed)`, and `diarize_file_with_models(audio, model)` signatures are unchanged (PR #19 was derived from the fork without altering the public surface). Every call site in `backend/fluidaudio.rs`, `tts/fluid_kokoro.rs`, and `transcribe/diarize.rs` compiles untouched. Diff is just `rust/Cargo.toml` (dep line + refreshed comment) and `rust/Cargo.lock` (source).

## Verification (macOS, `MACOSX_DEPLOYMENT_TARGET=14.0`)

- `cargo check --no-default-features --features coreml,system_kokoro,system_diarize` — clean (compiles all three FluidAudio-backed backends against the upstream rev)
- `cargo clippy --all-targets` (same features) `-D warnings` — clean