### PR TITLE
release: v1.24.6 (engine)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.24.5",
+  "version": "1.24.6",
   "description": "Give your tools a voice — speech to text and back, 25 languages, up to ~19× faster than Whisper. On your machine.",
   "type": "module",
   "bin": {
@@ -38,7 +38,7 @@
     }
   },
   "keshaEngine": {
-    "version": "1.24.5"
+    "version": "1.24.6"
   },
   "scripts": {
     "test": "bun test",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "kesha-engine"
-version = "1.24.5"
+version = "1.24.6"
 dependencies = [
  "anyhow",
  "audioadapter-buffers",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesha-engine"
-version = "1.24.5"
+version = "1.24.6"
 edition = "2021"
 description = "Inference engine for Kesha Voice Kit: ASR + language detection"
 # Not for crates.io. The library target (`src/lib.rs`) exists only for the


### PR DESCRIPTION
Engine release — bumps all four version spots to **1.24.6** (`package.json#version`, `package.json#keshaEngine.version`, `rust/Cargo.toml`, `rust/Cargo.lock`). Cuts the unreleased work on `main` since `v1.24.5`.

## Changes since v1.24.5
- **fix(tts):** route Opus encode through `opusic-sys` to kill the dual-libopus crash (#595)
- **chore(deps):** `fluidaudio-rs` now tracks **upstream** `FluidInference/fluidaudio-rs` (pinned rev) — the Kokoro TTS binding [landed upstream](https://github.com/FluidInference/fluidaudio-rs/pull/19), joining diarization + CoreML ASR; personal fork retired (#600)
- **security:** override `fast-uri` to `^3.1.3` for two high-severity advisories (GHSA-4c8g-83qw-93j6, GHSA-v2hh-gcrm-f6hx) (#601)
- **ci(coreml):** run the ANE decoder-state regression test on macos-14 (#594)

No user-facing API or behavior change beyond the Opus fix; the fluidaudio swap is a dependency-source change (identical binding API).

## Release checklist
- [x] All four version spots bumped to 1.24.6
- [x] `check:versions` clean (exit 0)
- [x] `tsc --noEmit` clean
- [ ] CI green on this PR (`integration-tests` intentionally skips on `release/*` — chicken-and-egg guard)
- [ ] Merge → `git tag v1.24.6 && git push origin v1.24.6` → `build-engine.yml` drafts 3 binaries
- [ ] Validate draft assets with `gh release download` (version + `--capabilities-json` + a real synth/transcribe)
- [ ] `gh release edit v1.24.6 --draft=false` → fires npm publish + Homebrew