### PR TITLE
ci(security): scope the concurrency group per ref

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,7 +18,11 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}
+  # Must include the ref: a workflow-wide group serialises every PR into one
+  # queue, and GitHub evicts the pending run when a third arrives — the evicted
+  # run reports nothing, so the required "🛡️ Security Audit" check never lands
+  # and the PR is BLOCKED forever (#597, evicted by #596/#598 in the same second).
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Problem

`security.yml` used a workflow-wide concurrency group:

```yaml
concurrency:
  group: ${{ github.workflow }}
  cancel-in-progress: false
```

Every PR in the repo lands in **one** queue. GitHub keeps at most one *pending* run per group — when a third concurrent run arrives, the queued one is **cancelled**. A cancelled run reports no check at all, and `🛡️ Security Audit` is a required status context, so the PR is left `BLOCKED` with no failing check to point at.

## Evidence

Dependabot opened #596, #597 and #598 within the same second on 2026-07-21. #597's audit run ([29813164023](https://github.com/drakulavich/kesha-voice-kit/actions/runs/29813164023)) came back `cancelled`, and the PR sat un-mergeable for four days:

```
$ gh pr checks 597 --required
🧪 CI            pass
🧪 Rust Tests    pass
                          ← 🛡️ Security Audit never reported

$ gh pr checks 596 --required
🛡️ Security Audit  pass
🧪 CI              pass
🧪 Rust Tests      pass
```

It merged only after the cancelled run was re-triggered by hand.

## Fix

Add `-${{ github.ref }}` so each PR gets its own queue. `cancel-in-progress` stays `false`: within a single ref the only run that can be evicted is one for a superseded SHA, which no longer gates anything.

`ci.yml`, `docker.yml` and `linux-packages.yml` already scope per ref. `cargo-dependency-maintenance.yml` keeps its workflow-wide group deliberately — it is `schedule` + `workflow_dispatch` only, never PR-gating, and the global group is what serialises its monthly runs.