### PR TITLE
refactor(cli): make command handlers testable without process.exit

### DIFF
--- a/src/cli/command-session.ts
+++ b/src/cli/command-session.ts
@@ -1,0 +1,72 @@
+import { createDiagnosticLogSession } from "../diagnostic-log";
+import type {
+  DiagnosticLogFields,
+  DiagnosticLogSession,
+  DiagnosticSessionStatus,
+} from "../diagnostic-log";
+import { createStatsRecorder } from "../stats";
+import type { StatsCommandName, StatsRecorder } from "../stats";
+
+export interface CommandSession {
+  readonly stats: StatsRecorder;
+  readonly diagnosticLog: DiagnosticLogSession;
+}
+
+export interface CommandOutcome {
+  status: DiagnosticSessionStatus;
+  itemCount: number;
+  /** Merged into the `command.finish` event alongside `command` and `status`. */
+  finishFields?: DiagnosticLogFields;
+  /** Exit code the caller should terminate with; omitted means "don't exit". */
+  exitCode?: number;
+}
+
+export interface CommandSessionFactories {
+  createStats: (command: StatsCommandName) => StatsRecorder;
+  createDiagnosticLog: () => DiagnosticLogSession;
+}
+
+const defaultFactories: CommandSessionFactories = {
+  createStats: createStatsRecorder,
+  createDiagnosticLog: createDiagnosticLogSession,
+};
+
+/**
+ * Owns the stats + diagnostic-log lifecycle for one CLI command: opens both
+ * recorders, brackets `body` with `command.start` / `command.finish`, and closes
+ * them exactly once. `body` reports what happened by returning a
+ * {@link CommandOutcome} instead of calling `process.exit` itself.
+ */
+export async function runCommandSession(
+  command: StatsCommandName,
+  startFields: DiagnosticLogFields,
+  body: (session: CommandSession) => Promise<CommandOutcome>,
+  factories: CommandSessionFactories = defaultFactories,
+): Promise<CommandOutcome> {
+  const session: CommandSession = {
+    stats: factories.createStats(command),
+    diagnosticLog: factories.createDiagnosticLog(),
+  };
+  session.diagnosticLog.event("command.start", { command, ...startFields });
+
+  let outcome: CommandOutcome;
+  try {
+    outcome = await body(session);
+  } catch (err) {
+    closeSession(session, command, { status: "failed", itemCount: 0 });
+    throw err;
+  }
+
+  closeSession(session, command, outcome);
+  return outcome;
+}
+
+function closeSession(session: CommandSession, command: StatsCommandName, outcome: CommandOutcome): void {
+  session.diagnosticLog.event("command.finish", {
+    command,
+    status: outcome.status,
+    ...outcome.finishFields,
+  });
+  session.stats.finish(outcome.status, outcome.itemCount);
+  session.diagnosticLog.finish(outcome.status);
+}

--- a/src/cli/command-session.ts
+++ b/src/cli/command-session.ts
@@ -1,11 +1,11 @@
 import { createDiagnosticLogSession } from "../diagnostic-log";
-import { errorMessage } from "../error-utils";
-import { log } from "../log";
 import type {
   DiagnosticLogFields,
   DiagnosticLogSession,
   DiagnosticSessionStatus,
 } from "../diagnostic-log";
+import { errorMessage } from "../error-utils";
+import { log } from "../log";
 import { createStatsRecorder } from "../stats";
 import type { StatsCommandName, StatsRecorder } from "../stats";
 
@@ -33,12 +33,7 @@ const defaultFactories: CommandSessionFactories = {
   createDiagnosticLog: createDiagnosticLogSession,
 };
 
-/**
- * Owns the stats + diagnostic-log lifecycle for one CLI command: opens both
- * recorders, brackets `body` with `command.start` / `command.finish`, and closes
- * them exactly once. `body` reports what happened by returning a
- * {@link CommandOutcome} instead of calling `process.exit` itself.
- */
+/** Runs one CLI command's body between `command.start` / `command.finish`, closing both recorders exactly once; `body` reports failure by returning a {@link CommandOutcome}, never by exiting. */
 export async function runCommandSession(
   command: StatsCommandName,
   startFields: DiagnosticLogFields,
@@ -55,18 +50,29 @@ export async function runCommandSession(
   try {
     outcome = await body(session);
   } catch (err) {
-    // A failing retain-on-failure flush must not replace the command error the
-    // user actually needs to see (Greptile P2 on #607).
-    try {
-      closeSession(session, command, { status: "failed", itemCount: 0 });
-    } catch (cleanupErr) {
-      log.debug(`command session cleanup failed: ${errorMessage(cleanupErr)}`);
-    }
+    closeSessionQuietly(session, command, { status: "failed", itemCount: 0 });
     throw err;
   }
 
-  closeSession(session, command, outcome);
+  // A flush error must not displace a failure the command already has to report (Greptile P1/P2 on #607).
+  if (outcome.status === "failed") {
+    closeSessionQuietly(session, command, outcome);
+  } else {
+    closeSession(session, command, outcome);
+  }
   return outcome;
+}
+
+function closeSessionQuietly(
+  session: CommandSession,
+  command: StatsCommandName,
+  outcome: CommandOutcome,
+): void {
+  try {
+    closeSession(session, command, outcome);
+  } catch (err) {
+    log.debug(`command session cleanup failed: ${errorMessage(err)}`);
+  }
 }
 
 function closeSession(session: CommandSession, command: StatsCommandName, outcome: CommandOutcome): void {

--- a/src/cli/command-session.ts
+++ b/src/cli/command-session.ts
@@ -1,4 +1,6 @@
 import { createDiagnosticLogSession } from "../diagnostic-log";
+import { errorMessage } from "../error-utils";
+import { log } from "../log";
 import type {
   DiagnosticLogFields,
   DiagnosticLogSession,
@@ -53,7 +55,13 @@ export async function runCommandSession(
   try {
     outcome = await body(session);
   } catch (err) {
-    closeSession(session, command, { status: "failed", itemCount: 0 });
+    // A failing retain-on-failure flush must not replace the command error the
+    // user actually needs to see (Greptile P2 on #607).
+    try {
+      closeSession(session, command, { status: "failed", itemCount: 0 });
+    } catch (cleanupErr) {
+      log.debug(`command session cleanup failed: ${errorMessage(cleanupErr)}`);
+    }
     throw err;
   }
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -15,12 +15,12 @@ import {
 } from "../format";
 import { packageVersion } from "../package-info";
 import { formatToonOutput } from "../toon";
-import { artifactFromFile, createStatsRecorder } from "../stats";
+import { artifactFromFile, type StatsRecorder } from "../stats";
 import { createPercentProgress } from "../progress";
 import { getPendingSignalExitCode, waitForPendingSignalCleanup } from "../process-tree";
 import type { TranscriptionSegment } from "../types";
-import { createDiagnosticLogSession } from "../diagnostic-log";
 import { diagnosticSizeBucket } from "../diagnostic-events";
+import { runCommandSession, type CommandSession } from "./command-session";
 import { ENGINE_CODES, extractEngineErrorCode, TS_NATIVE_CODES } from "../error-codes";
 
 interface MainCommandArgs {
@@ -139,14 +139,16 @@ export type ValidatedTranscribeArgs = {
   outputFormat: "json" | "toon" | "transcript" | "text";
 };
 
-/**
- * Validates cross-flag consistency that citty can't express; exits 2 on violation.
- */
+export type TranscribeArgsValidation =
+  | ({ ok: true } & ValidatedTranscribeArgs)
+  | { ok: false; error: string };
+
+/** Validates cross-flag consistency that citty can't express. */
 export function validateTranscribeArgs(
   args: MainCommandArgs,
   rawArgs: string[],
   fmt: ResolvedOutputFormat & { ok: true },
-): ValidatedTranscribeArgs {
+): TranscribeArgsValidation {
   const { wantsJson, wantsToon, wantsTranscript } = fmt;
 
   // citty treats --no-vad as the negated form of --vad, so read rawArgs
@@ -155,20 +157,16 @@ export function validateTranscribeArgs(
   const noVad = rawArgs.includes("--no-vad") || Boolean(args["no-vad"] ?? args.noVad ?? args.no_vad);
 
   if (vad && noVad) {
-    log.error("--vad and --no-vad are mutually exclusive.");
-    process.exit(2);
+    return { ok: false, error: "--vad and --no-vad are mutually exclusive." };
   }
   if (args.timestamps && !(wantsJson || wantsToon)) {
-    log.error("--timestamps requires --json, --toon, or --format {json,toon}.");
-    process.exit(2);
+    return { ok: false, error: "--timestamps requires --json, --toon, or --format {json,toon}." };
   }
   if (args.speakers && !(wantsJson || wantsToon)) {
-    log.error("--speakers requires --json, --toon, or --format {json,toon}.");
-    process.exit(2);
+    return { ok: false, error: "--speakers requires --json, --toon, or --format {json,toon}." };
   }
   if (args["include-errors"] && !wantsJson) {
-    log.error("--include-errors requires --json or --format json.");
-    process.exit(2);
+    return { ok: false, error: "--include-errors requires --json or --format json." };
   }
 
   const vadMode: ValidatedTranscribeArgs["vadMode"] = vad ? "on" : noVad ? "off" : "auto";
@@ -180,7 +178,7 @@ export function validateTranscribeArgs(
         ? "transcript"
         : "text";
 
-  return { vadMode, outputFormat };
+  return { ok: true, vadMode, outputFormat };
 }
 
 async function detectLanguages(
@@ -190,7 +188,7 @@ async function detectLanguages(
     wantsLangId: boolean;
     expectedLang?: string;
     progress: ReturnType<typeof createPercentProgress> | null;
-    stats: ReturnType<typeof createStatsRecorder>;
+    stats: StatsRecorder;
     transcriptDurationSeconds: number | null;
   },
 ): Promise<{
@@ -257,18 +255,13 @@ type ProcessFileOptions = {
   reportProgress: boolean;
 };
 
-type ProcessFileRecorders = {
-  stats: ReturnType<typeof createStatsRecorder>;
-  diagnosticLog: ReturnType<typeof createDiagnosticLogSession>;
-};
-
 type ProcessFileSuccess = { ok: true; result: TranscribeResult };
 type ProcessFileFailure = { ok: false; error: TranscribeErrorRecord };
 
 async function processFile(
   file: string,
   options: ProcessFileOptions,
-  recorders: ProcessFileRecorders,
+  recorders: CommandSession,
 ): Promise<ProcessFileSuccess | ProcessFileFailure> {
   const { vadMode, timestamps, speakers, wantsLangId, expectedLang, reportProgress } = options;
   const { stats, diagnosticLog } = recorders;
@@ -486,7 +479,12 @@ export const mainCommand = defineCommand({
       process.exit(2);
     }
 
-    const { vadMode, outputFormat } = validateTranscribeArgs(args, rawArgs, fmt);
+    const validated = validateTranscribeArgs(args, rawArgs, fmt);
+    if (!validated.ok) {
+      log.error(validated.error);
+      process.exit(2);
+    }
+    const { vadMode, outputFormat } = validated;
 
     if (files.length === 0) {
       log.info(
@@ -505,22 +503,6 @@ export const mainCommand = defineCommand({
       process.exit(1);
     }
 
-    let hasError = false;
-    const results: TranscribeResult[] = [];
-    const errors: TranscribeErrorRecord[] = [];
-    const stats = createStatsRecorder("transcribe");
-    const diagnosticLog = createDiagnosticLogSession();
-    diagnosticLog.event("command.start", {
-      command: "transcribe",
-      itemCount: files.length,
-      outputFormat,
-      vadMode,
-      timestamps: args.timestamps,
-      speakers: args.speakers,
-      includeErrors: args["include-errors"],
-      hasExpectedLang: Boolean(args.lang),
-    });
-
     const wantsLangId = !!(args.lang || args.verbose || outputFormat !== "text");
     const reportProgress = shouldReportTranscribeProgress({
       stderrIsTty: process.stderr.isTTY === true,
@@ -529,43 +511,59 @@ export const mainCommand = defineCommand({
       quiet: log.quietEnabled,
     });
 
-    for (const file of files) {
-      const outcome = await processFile(
-        file,
-        {
-          vadMode,
-          timestamps: args.timestamps,
-          speakers: args.speakers,
-          wantsLangId,
-          expectedLang: args.lang,
-          reportProgress,
-        },
-        { stats, diagnosticLog },
-      );
-      if (outcome.ok) {
-        results.push(outcome.result);
-      } else {
-        hasError = true;
-        errors.push(outcome.error);
-      }
-    }
+    const { status } = await runCommandSession(
+      "transcribe",
+      {
+        itemCount: files.length,
+        outputFormat,
+        vadMode,
+        timestamps: args.timestamps,
+        speakers: args.speakers,
+        includeErrors: args["include-errors"],
+        hasExpectedLang: Boolean(args.lang),
+      },
+      async (session) => {
+        const results: TranscribeResult[] = [];
+        const errors: TranscribeErrorRecord[] = [];
 
-    writeOutput(results, errors, outputFormat, {
-      includeErrors: args["include-errors"],
-      verbose: args.verbose,
-    });
+        for (const file of files) {
+          const outcome = await processFile(
+            file,
+            {
+              vadMode,
+              timestamps: args.timestamps,
+              speakers: args.speakers,
+              wantsLangId,
+              expectedLang: args.lang,
+              reportProgress,
+            },
+            session,
+          );
+          if (outcome.ok) {
+            results.push(outcome.result);
+          } else {
+            errors.push(outcome.error);
+          }
+        }
 
-    stats.finish(hasError ? "failed" : "success", files.length);
-    diagnosticLog.event("command.finish", {
-      command: "transcribe",
-      status: hasError ? "failed" : "success",
-      itemCount: files.length,
-      resultCount: results.length,
-      errorCount: errors.length,
-    });
-    diagnosticLog.finish(hasError ? "failed" : "success");
+        writeOutput(results, errors, outputFormat, {
+          includeErrors: args["include-errors"],
+          verbose: args.verbose,
+        });
 
-    if (hasError) {
+        return {
+          status: errors.length > 0 ? "failed" : "success",
+          itemCount: files.length,
+          finishFields: {
+            itemCount: files.length,
+            resultCount: results.length,
+            errorCount: errors.length,
+          },
+        };
+      },
+    );
+
+    if (status === "failed") {
       const signalExitCode = getPendingSignalExitCode();
       if (signalExitCode !== null) {
         await waitForPendingSignalCleanup();

--- a/src/cli/say.ts
+++ b/src/cli/say.ts
@@ -3,10 +3,10 @@ import { errorMessage } from "../error-utils";
 import { detectTextLanguageEngine, getEngineBinPath } from "../engine";
 import { log } from "../log";
 import { say, SayError, type SayFormat } from "../synth";
-import { artifactFromBytes, artifactFromFile, createStatsRecorder } from "../stats";
+import { artifactFromBytes, artifactFromFile, type StatsRecorder } from "../stats";
 import { pickVoiceForLang } from "../voice-routing";
-import { createDiagnosticLogSession } from "../diagnostic-log";
 import { diagnosticCharBucket, diagnosticSizeBucket } from "../diagnostic-events";
+import { runCommandSession, type CommandOutcome, type CommandSession } from "./command-session";
 
 async function autoRouteVoice(text: string): Promise<string | undefined> {
   if (!text) return undefined;
@@ -56,72 +56,116 @@ export function shouldRejectMissingSayText(
   return (inlineText === undefined || inlineText.length === 0) && stdinIsTty === true;
 }
 
-function parseFiniteNumberFlag(name: string, value: unknown): number | undefined {
-  if (value === undefined || value === null || value === false) return undefined;
+type Parsed<T> = { ok: true; value: T | undefined } | { ok: false; error: string };
+
+function parseFiniteNumberFlag(name: string, value: unknown): Parsed<number> {
+  if (value === undefined || value === null || value === false) return { ok: true, value: undefined };
   const raw = String(value).trim();
   const parsed = Number(raw);
   if (raw === "" || !Number.isFinite(parsed)) {
-    log.error(`${name} must be a finite number.`);
-    process.exit(2);
+    return { ok: false, error: `${name} must be a finite number.` };
   }
-  return parsed;
+  return { ok: true, value: parsed };
 }
 
-function parseRateFlag(value: unknown): number | undefined {
+function parseRateFlag(value: unknown): Parsed<number> {
   const rate = parseFiniteNumberFlag("--rate", value);
-  if (rate === undefined) return undefined;
-  if (rate < 0.5 || rate > 2.0) {
-    log.error("--rate must be between 0.5 and 2.0.");
-    process.exit(2);
+  if (!rate.ok || rate.value === undefined) return rate;
+  if (rate.value < 0.5 || rate.value > 2.0) {
+    return { ok: false, error: "--rate must be between 0.5 and 2.0." };
   }
   return rate;
 }
 
-function parseBitrateFlag(value: unknown): number | undefined {
+function parseBitrateFlag(value: unknown): Parsed<number> {
   const bitrate = parseFiniteNumberFlag("--bitrate", value);
-  if (bitrate === undefined) return undefined;
-  if (!Number.isInteger(bitrate) || bitrate <= 0) {
-    log.error("--bitrate must be a positive integer.");
-    process.exit(2);
+  if (!bitrate.ok || bitrate.value === undefined) return bitrate;
+  if (!Number.isInteger(bitrate.value) || bitrate.value <= 0) {
+    return { ok: false, error: "--bitrate must be a positive integer." };
   }
   return bitrate;
 }
 
-function parseSampleRateFlag(value: unknown): number | undefined {
+const SUPPORTED_SAMPLE_RATES = [8000, 12000, 16000, 24000, 48000];
+
+function parseSampleRateFlag(value: unknown): Parsed<number> {
   const sampleRate = parseFiniteNumberFlag("--sample-rate", value);
-  if (sampleRate === undefined) return undefined;
-  const supported = [8000, 12000, 16000, 24000, 48000];
-  if (!Number.isInteger(sampleRate) || !supported.includes(sampleRate)) {
-    log.error("--sample-rate must be one of 8000, 12000, 16000, 24000, 48000.");
-    process.exit(2);
+  if (!sampleRate.ok || sampleRate.value === undefined) return sampleRate;
+  if (!Number.isInteger(sampleRate.value) || !SUPPORTED_SAMPLE_RATES.includes(sampleRate.value)) {
+    return {
+      ok: false,
+      error: `--sample-rate must be one of ${SUPPORTED_SAMPLE_RATES.join(", ")}.`,
+    };
   }
   return sampleRate;
 }
 
-function parseFormatFlag(raw: string | undefined): SayFormat | undefined {
-  if (!raw) return undefined;
+function parseFormatFlag(raw: unknown): Parsed<SayFormat> {
+  if (typeof raw !== "string" || raw === "") return { ok: true, value: undefined };
   const lower = raw.toLowerCase();
-  if (lower === "wav" || lower === "ogg-opus" || lower === "flac") return lower;
-  if (lower === "opus" || lower === "ogg") return "ogg-opus";
-  log.error(`unknown --format '${raw}'. supported: wav, ogg-opus, flac`);
-  process.exit(2);
+  if (lower === "wav" || lower === "ogg-opus" || lower === "flac") return { ok: true, value: lower };
+  if (lower === "opus" || lower === "ogg") return { ok: true, value: "ogg-opus" };
+  return { ok: false, error: `unknown --format '${raw}'. supported: wav, ogg-opus, flac` };
 }
 
-function assertOpusOnlyFlags(
+function checkOpusOnlyFlags(
   bitrate: number | undefined,
   sampleRate: number | undefined,
   format: SayFormat | undefined,
   outArg: string | undefined,
-): void {
-  if (bitrate === undefined && sampleRate === undefined) return;
+): string | null {
+  if (bitrate === undefined && sampleRate === undefined) return null;
   const outExt = outArg?.split(".").pop()?.toLowerCase();
-  const impliesOpus = outExt && ["ogg", "opus", "oga"].includes(outExt);
+  const impliesOpus = outExt !== undefined && ["ogg", "opus", "oga"].includes(outExt);
   // --bitrate / --sample-rate are Opus-only (wav/flac are lossless, no encoder knobs).
   const resolvesToOpus = format === "ogg-opus" || (format === undefined && impliesOpus);
-  if (!resolvesToOpus) {
-    log.error("--bitrate and --sample-rate are only valid with --format ogg-opus");
-    process.exit(2);
-  }
+  if (resolvesToOpus) return null;
+  return "--bitrate and --sample-rate are only valid with --format ogg-opus";
+}
+
+export type SayFlagArgs = {
+  format?: unknown;
+  rate?: unknown;
+  bitrate?: unknown;
+  "sample-rate"?: unknown;
+  out?: unknown;
+};
+
+export type ResolvedSayFlags =
+  | {
+      ok: true;
+      format: SayFormat | undefined;
+      rate: number | undefined;
+      bitrate: number | undefined;
+      sampleRate: number | undefined;
+    }
+  | { ok: false; error: string };
+
+/**
+ * Validates the encoder-related `kesha say` flags up front — before the engine is
+ * spawned — so scripts fail fast. The engine repeats these checks authoritatively.
+ */
+export function resolveSayFlags(args: SayFlagArgs): ResolvedSayFlags {
+  const format = parseFormatFlag(args.format);
+  if (!format.ok) return format;
+  const rate = parseRateFlag(args.rate);
+  if (!rate.ok) return rate;
+  const bitrate = parseBitrateFlag(args.bitrate);
+  if (!bitrate.ok) return bitrate;
+  const sampleRate = parseSampleRateFlag(args["sample-rate"]);
+  if (!sampleRate.ok) return sampleRate;
+
+  const out = typeof args.out === "string" ? args.out : undefined;
+  const opusOnlyError = checkOpusOnlyFlags(bitrate.value, sampleRate.value, format.value, out);
+  if (opusOnlyError) return { ok: false, error: opusOnlyError };
+
+  return {
+    ok: true,
+    format: format.value,
+    rate: rate.value,
+    bitrate: bitrate.value,
+    sampleRate: sampleRate.value,
+  };
 }
 
 type SayOpts = {
@@ -138,7 +182,7 @@ type SayOpts = {
 };
 
 function recordOutputArtifact(
-  stats: ReturnType<typeof createStatsRecorder>,
+  stats: StatsRecorder,
   audio: Uint8Array,
   opts: SayOpts,
 ): { outputFormat: string; outputSizeBytes: number | null | undefined } {
@@ -157,9 +201,9 @@ function recordOutputArtifact(
 async function synthesizeAndEmit(
   opts: SayOpts,
   verbose: boolean,
-  stats: ReturnType<typeof createStatsRecorder>,
-  diagnosticLog: ReturnType<typeof createDiagnosticLogSession>,
-): Promise<void> {
+  session: CommandSession,
+): Promise<CommandOutcome> {
+  const { stats } = session;
   try {
     const startedAt = performance.now();
     if (opts.out) {
@@ -174,35 +218,32 @@ async function synthesizeAndEmit(
     // stderr — stdout may carry raw audio bytes when --out is omitted.
     if (verbose && !opts.out) log.status(`TTS time: ${ttsTimeMs}ms`);
     const { outputFormat, outputSizeBytes } = recordOutputArtifact(stats, audio, opts);
-    diagnosticLog.event("command.finish", {
-      command: "say",
-      status: "success",
-      durationMs: ttsTimeMs,
-      hasOut: Boolean(opts.out),
-      outputFormat,
-      outputSizeBucket: diagnosticSizeBucket(outputSizeBytes),
-    });
     if (!opts.out) process.stdout.write(audio);
-    stats.finish("success", 1);
-    diagnosticLog.finish("success");
+    return {
+      status: "success",
+      itemCount: 1,
+      finishFields: {
+        durationMs: ttsTimeMs,
+        hasOut: Boolean(opts.out),
+        outputFormat,
+        outputSizeBucket: diagnosticSizeBucket(outputSizeBytes),
+      },
+    };
   } catch (err) {
     const code = err instanceof SayError ? err.code : "E_INTERNAL";
+    const exitCode = err instanceof SayError ? err.exitCode : 4;
     stats.recordError("tts", err, code);
-    stats.finish("failed", 1);
-    diagnosticLog.event("command.finish", {
-      command: "say",
+    log.error(err instanceof SayError ? err.stderr.trim() || err.message : errorMessage(err));
+    return {
       status: "failed",
-      errorKind: err instanceof SayError ? "say_error" : "error",
-      exitCode: err instanceof SayError ? err.exitCode : 4,
-      error_code: code,
-    });
-    diagnosticLog.finish("failed");
-    if (err instanceof SayError) {
-      log.error(err.stderr.trim() || err.message);
-      process.exit(err.exitCode);
-    }
-    log.error(errorMessage(err));
-    process.exit(4);
+      itemCount: 1,
+      exitCode,
+      finishFields: {
+        errorKind: err instanceof SayError ? "say_error" : "error",
+        exitCode,
+        error_code: code,
+      },
+    };
   }
 }
 
@@ -269,14 +310,11 @@ export const sayCommand = defineCommand({
       process.exit(await proc.exited);
     }
 
-    // Validate --format before spawning the engine: faster failure in scripts (engine repeats authoritatively).
-    const format = parseFormatFlag(typeof args.format === "string" ? args.format : undefined);
-    const rate = parseRateFlag(args.rate);
-    const bitrate = parseBitrateFlag(args.bitrate);
-    const sampleRate = parseSampleRateFlag(args["sample-rate"]);
-
-    // Reject --bitrate / --sample-rate with WAV up front to surface the error fast.
-    assertOpusOnlyFlags(bitrate, sampleRate, format, typeof args.out === "string" ? args.out : undefined);
+    const flags = resolveSayFlags(args);
+    if (!flags.ok) {
+      log.error(flags.error);
+      process.exit(2);
+    }
 
     const inlineText = typeof args.text === "string" ? args.text : undefined;
     const stdinIsTty = (process.stdin as { isTTY?: boolean }).isTTY;
@@ -294,27 +332,29 @@ export const sayCommand = defineCommand({
       voice,
       lang: langHint,
       out: typeof args.out === "string" ? args.out : undefined,
-      rate,
+      rate: flags.rate,
       ssml: Boolean(args.ssml),
-      format,
-      bitrate,
-      sampleRate,
+      format: flags.format,
+      bitrate: flags.bitrate,
+      sampleRate: flags.sampleRate,
       noExpandAbbrev: Boolean(args["no-expand-abbrev"]),
     };
-    const stats = createStatsRecorder("say");
-    const diagnosticLog = createDiagnosticLogSession();
-    diagnosticLog.event("command.start", {
-      command: "say",
-      charBucket: diagnosticCharBucket(Array.from(text).length),
-      hasInlineInput: inlineText !== undefined,
-      hasVoice: explicitVoice !== undefined,
-      autoVoice: explicitVoice === undefined && voice !== undefined,
-      hasOut: typeof opts.out === "string",
-      outputFormat: opts.format ?? "auto",
-      ssml: opts.ssml,
-      noExpandAbbrev: opts.noExpandAbbrev,
-    });
 
-    await synthesizeAndEmit(opts, Boolean(args.verbose), stats, diagnosticLog);
+    const outcome = await runCommandSession(
+      "say",
+      {
+        charBucket: diagnosticCharBucket(Array.from(text).length),
+        hasInlineInput: inlineText !== undefined,
+        hasVoice: explicitVoice !== undefined,
+        autoVoice: explicitVoice === undefined && voice !== undefined,
+        hasOut: typeof opts.out === "string",
+        outputFormat: opts.format ?? "auto",
+        ssml: opts.ssml,
+        noExpandAbbrev: opts.noExpandAbbrev,
+      },
+      (session) => synthesizeAndEmit(opts, Boolean(args.verbose), session),
+    );
+
+    if (outcome.exitCode !== undefined) process.exit(outcome.exitCode);
   },
 });

--- a/src/cli/say.ts
+++ b/src/cli/say.ts
@@ -141,10 +141,7 @@ export type ResolvedSayFlags =
     }
   | { ok: false; error: string };
 
-/**
- * Validates the encoder-related `kesha say` flags up front — before the engine is
- * spawned — so scripts fail fast. The engine repeats these checks authoritatively.
- */
+/** Validates the encoder flags before the engine is spawned: faster failure in scripts (the engine repeats them authoritatively). */
 export function resolveSayFlags(args: SayFlagArgs): ResolvedSayFlags {
   const format = parseFormatFlag(args.format);
   if (!format.ok) return format;

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -796,86 +796,84 @@ function okFmt(json = false, toon = false, transcript = false): ResolvedOutputFo
 }
 
 describe("validateTranscribeArgs guards", () => {
-  // log.error uses process.stderr.write (src/log.ts), not console.error — stub the former.
-  function expectValidateExit(
+  function validate(
     argsOverrides: Partial<ReturnType<typeof defaultMainArgs>>,
     rawArgs: string[],
     fmt: ResolvedOutputFormat & { ok: true },
-  ): number {
-    const savedExit = process.exit;
-    const savedWrite = process.stderr.write;
-    try {
-      process.stderr.write = (() => true) as typeof process.stderr.write;
-      process.exit = ((code?: string | number | null | undefined) => {
-        throw new Error(`exit:${code ?? 0}`);
-      }) as typeof process.exit;
-      validateTranscribeArgs(defaultMainArgs(argsOverrides) as never, rawArgs, fmt);
-      throw new Error("validateTranscribeArgs did not exit");
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      expect(message.startsWith("exit:")).toBe(true);
-      return Number(message.slice("exit:".length));
-    } finally {
-      process.exit = savedExit;
-      process.stderr.write = savedWrite;
-    }
+  ) {
+    return validateTranscribeArgs(defaultMainArgs(argsOverrides) as never, rawArgs, fmt);
   }
 
-  test("--timestamps without machine-readable output exits 2", () => {
-    expect(expectValidateExit({ timestamps: true }, ["--timestamps"], okFmt())).toBe(2);
-  });
+  function expectRejected(
+    argsOverrides: Partial<ReturnType<typeof defaultMainArgs>>,
+    rawArgs: string[],
+    fmt: ResolvedOutputFormat & { ok: true },
+  ): string {
+    const result = validate(argsOverrides, rawArgs, fmt);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected validateTranscribeArgs to reject");
+    return result.error;
+  }
 
-  test("--timestamps with --json does not exit", () => {
-    const result = validateTranscribeArgs(
-      defaultMainArgs({ timestamps: true, json: true }) as never,
-      ["--timestamps", "--json"],
-      okFmt(true),
+  function expectAccepted(
+    argsOverrides: Partial<ReturnType<typeof defaultMainArgs>>,
+    rawArgs: string[],
+    fmt: ResolvedOutputFormat & { ok: true },
+  ) {
+    const result = validate(argsOverrides, rawArgs, fmt);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(`expected acceptance, got: ${result.error}`);
+    return result;
+  }
+
+  test("--timestamps without machine-readable output is rejected", () => {
+    expect(expectRejected({ timestamps: true }, ["--timestamps"], okFmt())).toContain(
+      "--timestamps requires --json",
     );
-    expect(result.outputFormat).toBe("json");
   });
 
-  test("--speakers without machine-readable output exits 2", () => {
-    expect(expectValidateExit({ speakers: true }, ["--speakers"], okFmt())).toBe(2);
-  });
-
-  test("--speakers with --toon does not exit", () => {
-    const result = validateTranscribeArgs(
-      defaultMainArgs({ speakers: true, toon: true }) as never,
-      ["--speakers", "--toon"],
-      okFmt(false, true),
-    );
-    expect(result.outputFormat).toBe("toon");
-  });
-
-  test("--include-errors without --json exits 2", () => {
+  test("--timestamps with --json is accepted", () => {
     expect(
-      expectValidateExit({ "include-errors": true }, ["--include-errors"], okFmt()),
-    ).toBe(2);
+      expectAccepted({ timestamps: true, json: true }, ["--timestamps", "--json"], okFmt(true))
+        .outputFormat,
+    ).toBe("json");
   });
 
-  test("--include-errors with --json does not exit", () => {
-    const result = validateTranscribeArgs(
-      defaultMainArgs({ "include-errors": true, json: true }) as never,
-      ["--include-errors", "--json"],
-      okFmt(true),
+  test("--speakers without machine-readable output is rejected", () => {
+    expect(expectRejected({ speakers: true }, ["--speakers"], okFmt())).toContain(
+      "--speakers requires --json",
     );
-    expect(result.outputFormat).toBe("json");
   });
 
-  test("--vad and --no-vad mutually exclusive exits 2", () => {
+  test("--speakers with --toon is accepted", () => {
     expect(
-      expectValidateExit({ vad: true }, ["--vad", "--no-vad"], okFmt()),
-    ).toBe(2);
+      expectAccepted({ speakers: true, toon: true }, ["--speakers", "--toon"], okFmt(false, true))
+        .outputFormat,
+    ).toBe("toon");
+  });
+
+  test("--include-errors without --json is rejected", () => {
+    expect(
+      expectRejected({ "include-errors": true }, ["--include-errors"], okFmt()),
+    ).toContain("--include-errors requires --json");
+  });
+
+  test("--include-errors with --json is accepted", () => {
+    expect(
+      expectAccepted({ "include-errors": true, json: true }, ["--include-errors", "--json"], okFmt(true))
+        .outputFormat,
+    ).toBe("json");
+  });
+
+  test("--vad and --no-vad are mutually exclusive", () => {
+    expect(expectRejected({ vad: true }, ["--vad", "--no-vad"], okFmt())).toContain(
+      "mutually exclusive",
+    );
   });
 
   test("vadMode derives correctly from rawArgs", () => {
-    const auto = validateTranscribeArgs(defaultMainArgs() as never, [], okFmt());
-    expect(auto.vadMode).toBe("auto");
-
-    const on = validateTranscribeArgs(defaultMainArgs({ vad: true }) as never, ["--vad"], okFmt());
-    expect(on.vadMode).toBe("on");
-
-    const off = validateTranscribeArgs(defaultMainArgs() as never, ["--no-vad"], okFmt());
-    expect(off.vadMode).toBe("off");
+    expect(expectAccepted({}, [], okFmt()).vadMode).toBe("auto");
+    expect(expectAccepted({ vad: true }, ["--vad"], okFmt()).vadMode).toBe("on");
+    expect(expectAccepted({}, ["--no-vad"], okFmt()).vadMode).toBe("off");
   });
 });

--- a/tests/unit/command-session.test.ts
+++ b/tests/unit/command-session.test.ts
@@ -128,12 +128,11 @@ describe("runCommandSession", () => {
     expect(f.events.map((e) => e.event)).toEqual(["command.start", "engine.exit", "command.finish"]);
   });
 
-  test("a failing diagnostic flush does not mask the command error (Greptile P2 on #607)", async () => {
-    const f = fakeSession();
-    const factories: CommandSessionFactories = {
-      createStats: f.factories.createStats,
+  function withFailingFlush(base: CommandSessionFactories): CommandSessionFactories {
+    return {
+      createStats: base.createStats,
       createDiagnosticLog: () => {
-        const session = f.factories.createDiagnosticLog();
+        const session = base.createDiagnosticLog();
         return {
           event: session.event,
           finish: () => {
@@ -142,12 +141,42 @@ describe("runCommandSession", () => {
         };
       },
     };
+  }
+
+  test("a failing diagnostic flush does not mask a thrown command error (Greptile P2 on #607)", async () => {
+    const f = fakeSession();
 
     await expect(
       runCommandSession("say", {}, async () => {
         throw new Error("engine crashed");
-      }, factories),
+      }, withFailingFlush(f.factories)),
     ).rejects.toThrow("engine crashed");
+  });
+
+  test("a failing diagnostic flush does not swallow a failed outcome's exit code (Greptile P1 on #607)", async () => {
+    const f = fakeSession();
+
+    const outcome = await runCommandSession(
+      "say",
+      {},
+      async () => ({ status: "failed", itemCount: 1, exitCode: 4 }),
+      withFailingFlush(f.factories),
+    );
+
+    expect(outcome.exitCode).toBe(4);
+  });
+
+  test("a cleanup failure on the success path still surfaces", async () => {
+    const f = fakeSession();
+
+    await expect(
+      runCommandSession(
+        "say",
+        {},
+        async () => ({ status: "success", itemCount: 1 }),
+        withFailingFlush(f.factories),
+      ),
+    ).rejects.toThrow("disk full");
   });
 
   test("a throwing body still closes the session as failed, then rethrows", async () => {

--- a/tests/unit/command-session.test.ts
+++ b/tests/unit/command-session.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, test } from "bun:test";
+import { runCommandSession, type CommandSessionFactories } from "../../src/cli/command-session";
+import type { DiagnosticLogFields, DiagnosticLogSession, DiagnosticSessionStatus } from "../../src/diagnostic-log";
+import type { StatsRecorder, StatsRunStatus } from "../../src/stats";
+
+type LoggedEvent = { event: string; fields: DiagnosticLogFields };
+
+function fakeSession(): {
+  factories: CommandSessionFactories;
+  events: LoggedEvent[];
+  finishes: DiagnosticSessionStatus[];
+  statsFinishes: Array<{ status: StatsRunStatus; itemCount: number | undefined }>;
+  statsCommands: string[];
+} {
+  const events: LoggedEvent[] = [];
+  const finishes: DiagnosticSessionStatus[] = [];
+  const statsFinishes: Array<{ status: StatsRunStatus; itemCount: number | undefined }> = [];
+  const statsCommands: string[] = [];
+
+  const diagnosticLog: DiagnosticLogSession = {
+    event(event, fields = {}) {
+      events.push({ event, fields });
+      return true;
+    },
+    finish(status) {
+      finishes.push(status);
+      return true;
+    },
+  };
+
+  const stats: StatsRecorder = {
+    enabled: false,
+    recordArtifact() {},
+    async timeStage(_stage, fn) {
+      return fn();
+    },
+    recordError() {},
+    finish(status, itemCount) {
+      statsFinishes.push({ status, itemCount });
+    },
+  };
+
+  return {
+    factories: {
+      createStats: (command) => {
+        statsCommands.push(command);
+        return stats;
+      },
+      createDiagnosticLog: () => diagnosticLog,
+    },
+    events,
+    finishes,
+    statsFinishes,
+    statsCommands,
+  };
+}
+
+describe("runCommandSession", () => {
+  test("emits command.start with the command name and caller fields", async () => {
+    const f = fakeSession();
+    await runCommandSession(
+      "transcribe",
+      { itemCount: 2, outputFormat: "json" },
+      async () => ({ status: "success", itemCount: 2 }),
+      f.factories,
+    );
+
+    expect(f.statsCommands).toEqual(["transcribe"]);
+    expect(f.events[0]).toEqual({
+      event: "command.start",
+      fields: { command: "transcribe", itemCount: 2, outputFormat: "json" },
+    });
+  });
+
+  test("emits command.finish with status plus the outcome's finish fields", async () => {
+    const f = fakeSession();
+    await runCommandSession(
+      "say",
+      {},
+      async () => ({ status: "success", itemCount: 1, finishFields: { durationMs: 42, hasOut: true } }),
+      f.factories,
+    );
+
+    expect(f.events[1]).toEqual({
+      event: "command.finish",
+      fields: { command: "say", status: "success", durationMs: 42, hasOut: true },
+    });
+  });
+
+  test("closes both recorders with the outcome status", async () => {
+    const f = fakeSession();
+    await runCommandSession(
+      "transcribe",
+      {},
+      async () => ({ status: "failed", itemCount: 3 }),
+      f.factories,
+    );
+
+    expect(f.statsFinishes).toEqual([{ status: "failed", itemCount: 3 }]);
+    expect(f.finishes).toEqual(["failed"]);
+  });
+
+  test("returns the body's outcome to the caller", async () => {
+    const f = fakeSession();
+    const outcome = await runCommandSession(
+      "say",
+      {},
+      async () => ({ status: "failed", itemCount: 1, exitCode: 5 }),
+      f.factories,
+    );
+
+    expect(outcome.exitCode).toBe(5);
+    expect(outcome.status).toBe("failed");
+  });
+
+  test("hands the body a live session so it can record stages and events", async () => {
+    const f = fakeSession();
+    await runCommandSession(
+      "say",
+      {},
+      async (session) => {
+        session.diagnosticLog.event("engine.exit", { status: "success" });
+        return { status: "success", itemCount: 1 };
+      },
+      f.factories,
+    );
+
+    expect(f.events.map((e) => e.event)).toEqual(["command.start", "engine.exit", "command.finish"]);
+  });
+
+  test("a throwing body still closes the session as failed, then rethrows", async () => {
+    const f = fakeSession();
+    const boom = new Error("boom");
+
+    await expect(
+      runCommandSession("transcribe", {}, async () => {
+        throw boom;
+      }, f.factories),
+    ).rejects.toThrow("boom");
+
+    expect(f.events[1]?.event).toBe("command.finish");
+    expect(f.events[1]?.fields.status).toBe("failed");
+    expect(f.statsFinishes).toEqual([{ status: "failed", itemCount: 0 }]);
+    expect(f.finishes).toEqual(["failed"]);
+  });
+});

--- a/tests/unit/command-session.test.ts
+++ b/tests/unit/command-session.test.ts
@@ -128,6 +128,28 @@ describe("runCommandSession", () => {
     expect(f.events.map((e) => e.event)).toEqual(["command.start", "engine.exit", "command.finish"]);
   });
 
+  test("a failing diagnostic flush does not mask the command error (Greptile P2 on #607)", async () => {
+    const f = fakeSession();
+    const factories: CommandSessionFactories = {
+      createStats: f.factories.createStats,
+      createDiagnosticLog: () => {
+        const session = f.factories.createDiagnosticLog();
+        return {
+          event: session.event,
+          finish: () => {
+            throw new Error("disk full");
+          },
+        };
+      },
+    };
+
+    await expect(
+      runCommandSession("say", {}, async () => {
+        throw new Error("engine crashed");
+      }, factories),
+    ).rejects.toThrow("engine crashed");
+  });
+
   test("a throwing body still closes the session as failed, then rethrows", async () => {
     const f = fakeSession();
     const boom = new Error("boom");

--- a/tests/unit/say-flags.test.ts
+++ b/tests/unit/say-flags.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+import { resolveSayFlags } from "../../src/cli/say";
+
+function ok(input: Parameters<typeof resolveSayFlags>[0]) {
+  const r = resolveSayFlags(input);
+  if (!r.ok) throw new Error(`expected ok, got error: ${r.error}`);
+  return r;
+}
+
+function err(input: Parameters<typeof resolveSayFlags>[0]): string {
+  const r = resolveSayFlags(input);
+  if (r.ok) throw new Error("expected an error");
+  return r.error;
+}
+
+describe("resolveSayFlags: --format", () => {
+  test("accepts the three wire formats", () => {
+    expect(ok({ format: "wav" }).format).toBe("wav");
+    expect(ok({ format: "ogg-opus" }).format).toBe("ogg-opus");
+    expect(ok({ format: "flac" }).format).toBe("flac");
+  });
+
+  test("normalizes case and the opus/ogg aliases", () => {
+    expect(ok({ format: "WAV" }).format).toBe("wav");
+    expect(ok({ format: "opus" }).format).toBe("ogg-opus");
+    expect(ok({ format: "ogg" }).format).toBe("ogg-opus");
+  });
+
+  test("omitted format stays undefined so the engine picks the default", () => {
+    expect(ok({}).format).toBeUndefined();
+  });
+
+  test("rejects an unknown format", () => {
+    expect(err({ format: "mp3" })).toBe("unknown --format 'mp3'. supported: wav, ogg-opus, flac");
+  });
+});
+
+describe("resolveSayFlags: --rate", () => {
+  test("accepts the documented 0.5–2.0 range", () => {
+    expect(ok({ rate: "0.5" }).rate).toBe(0.5);
+    expect(ok({ rate: "1.0" }).rate).toBe(1.0);
+    expect(ok({ rate: "2.0" }).rate).toBe(2.0);
+  });
+
+  test("rejects out-of-range values", () => {
+    expect(err({ rate: "0.4" })).toBe("--rate must be between 0.5 and 2.0.");
+    expect(err({ rate: "2.1" })).toBe("--rate must be between 0.5 and 2.0.");
+  });
+
+  test("rejects non-numeric values", () => {
+    expect(err({ rate: "fast" })).toBe("--rate must be a finite number.");
+    expect(err({ rate: "" })).toBe("--rate must be a finite number.");
+    expect(err({ rate: "Infinity" })).toBe("--rate must be a finite number.");
+  });
+});
+
+describe("resolveSayFlags: --bitrate and --sample-rate", () => {
+  test("accepts opus encoder settings when the format resolves to opus", () => {
+    const r = ok({ format: "ogg-opus", bitrate: "32000", "sample-rate": "24000" });
+    expect(r.bitrate).toBe(32000);
+    expect(r.sampleRate).toBe(24000);
+  });
+
+  test("rejects a non-positive or fractional bitrate", () => {
+    expect(err({ format: "ogg-opus", bitrate: "0" })).toBe("--bitrate must be a positive integer.");
+    expect(err({ format: "ogg-opus", bitrate: "-1" })).toBe("--bitrate must be a positive integer.");
+    expect(err({ format: "ogg-opus", bitrate: "1.5" })).toBe("--bitrate must be a positive integer.");
+  });
+
+  test("rejects an unsupported sample rate", () => {
+    expect(err({ format: "ogg-opus", "sample-rate": "44100" })).toBe(
+      "--sample-rate must be one of 8000, 12000, 16000, 24000, 48000.",
+    );
+  });
+
+  test("rejects opus-only flags on lossless formats", () => {
+    const expected = "--bitrate and --sample-rate are only valid with --format ogg-opus";
+    expect(err({ format: "wav", bitrate: "32000" })).toBe(expected);
+    expect(err({ format: "flac", "sample-rate": "24000" })).toBe(expected);
+    expect(err({ bitrate: "32000" })).toBe(expected);
+  });
+
+  test("infers opus from the --out extension when --format is omitted", () => {
+    expect(ok({ out: "note.ogg", bitrate: "32000" }).bitrate).toBe(32000);
+    expect(ok({ out: "note.opus", bitrate: "32000" }).bitrate).toBe(32000);
+    expect(ok({ out: "note.OGA", bitrate: "32000" }).bitrate).toBe(32000);
+    expect(err({ out: "note.wav", bitrate: "32000" })).toBe(
+      "--bitrate and --sample-rate are only valid with --format ogg-opus",
+    );
+  });
+});
+
+describe("resolveSayFlags: validation order", () => {
+  test("an unknown format is reported before a bad rate", () => {
+    expect(err({ format: "mp3", rate: "9" })).toContain("unknown --format");
+  });
+
+  test("a bad rate is reported before a bad bitrate", () => {
+    expect(err({ rate: "9", bitrate: "0" })).toContain("--rate");
+  });
+
+  test("a bad bitrate value is reported before the opus-only mismatch", () => {
+    expect(err({ format: "wav", bitrate: "0" })).toBe("--bitrate must be a positive integer.");
+  });
+});


### PR DESCRIPTION
First slice of the Tier 1 maintainability/testability work identified by a `repowise health` + coverage sweep. `src/cli/say.ts` scored 4.7/10 with 7 bug-fixes in the last 6 months and **29% line / 15% function coverage** — the worst ratio in the TS tree.

## The problem

Every `say` flag validator (`parseRateFlag`, `parseBitrateFlag`, `parseSampleRateFlag`, `parseFormatFlag`, `assertOpusOnlyFlags`) was module-private and called `log.error` + `process.exit(2)` itself. That made them unreachable from unit tests — which is exactly why lines 59–123 were uncovered. `validateTranscribeArgs` (CCN 18, the highest in the tree) had the same shape, and `tests/unit/cli.test.ts` worked around it by stubbing `process.exit` and `process.stderr.write`.

Both handlers also duplicated the stats + diagnostic-log lifecycle verbatim — repowise flagged 16% of `say.ts` as duplicated, worst clone 13 lines against `main.ts`.

## The change

- **`resolveSayFlags()`** — one exported, Result-returning function replaces the six exit-on-failure validators. This is the shape `resolveOutputFormat()` already used in `main.ts`, so it's an existing in-repo idiom rather than a new pattern.
- **`validateTranscribeArgs()`** now returns `{ok, error}`; the `run` handler does the exiting. The `process.exit` stub in `cli.test.ts` is gone.
- **`runCommandSession()`** (new `src/cli/command-session.ts`) owns the recorder lifecycle for both commands: opens stats + diagnostic log, brackets the body with `command.start` / `command.finish`, closes both exactly once — including when the body throws. Handler bodies return a `CommandOutcome`; the citty `run` handler is the only place calling `process.exit`.

`process.exit` calls: `say.ts` 10 → 2, `main.ts` 8 → 3.

## Behaviour

Unchanged. Every error message, validation order, and exit code is preserved. The end-to-end contract tests in `tests/integration/cli-contracts.test.ts` and `tests/integration/say.test.ts` assert those against a spawned CLI and still pass untouched — that's the regression net for this refactor.

## Verification

- `bun test` — 447 pass, 6 skip (diarize model not installed locally), 0 fail
- `bunx tsc --noEmit` — clean
- `src/cli/say.ts`: 29.17% → **52.50%** lines, 15.38% → **64.29%** functions
- `src/cli/command-session.ts`: 100% / 100%
- overall TS line coverage 80.81% → 81.64%
- 21 new unit tests (`say-flags.test.ts`, `command-session.test.ts`)

`main.ts` line coverage is flat (45.7%) — its remaining gap is `processFile` / `detectLanguages` / `writeOutput`, which need I/O seams rather than a Result type. That's deliberately out of scope here.

## Follow-ups (not in this PR)

- `main.ts`: inject the transcribe/detect calls into `processFile` + `detectLanguages` so the 190 uncovered lines become testable
- `engine-install.ts`: 15% coverage, 5 bug-fixes, top-2% churn — split the download plan from the I/O the way `install-plan.ts` already does
- `src/lang-id.ts` is dead (a 2-line re-export shim with zero importers since #63/#65)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DRnTxyiiF3XHiyFqZJ3soz