### PR TITLE
refactor(cli): pass resolved global flags as an explicit context

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,7 +27,7 @@ export { statusCommand } from "./cli/status";
 export { statsCommand } from "./cli/stats";
 export { supportBundleCommand } from "./cli/support-bundle";
 export {
-  mainCommand,
+  createMainCommand,
   detectLanguage,
   checkLanguageMismatch,
   estimateTranscriptDurationSeconds,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,6 +28,7 @@ export { statsCommand } from "./cli/stats";
 export { supportBundleCommand } from "./cli/support-bundle";
 export {
   createMainCommand,
+  mainCommand,
   detectLanguage,
   checkLanguageMismatch,
   estimateTranscriptDurationSeconds,

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -1,0 +1,108 @@
+import { log, setColorEnabled } from "../log";
+
+/** The global flags resolved before citty, so every command sees the same decision. */
+export interface CliContext {
+  quiet: boolean;
+  disableColor: boolean;
+}
+
+export interface ResolvedCliContext extends CliContext {
+  /** `rawArgs` with the global flag tokens removed, ready to hand to citty. */
+  rawArgs: string[];
+}
+
+// Falsey grammar shared by --no-color, --quiet, and CI. Mirrors KESHA_DEBUG so
+// `CI=false`/`CI=0` and `--no-color=false` opt back in.
+const FALSEY_VALUES = new Set(["", "0", "false", "no", "off"]);
+function isFalsey(v: string): boolean {
+  return FALSEY_VALUES.has(v.trim().toLowerCase());
+}
+
+/** True when NO_COLOR came from the user's environment, so re-enabling colors must not clear it. */
+export const USER_FORCED_NO_COLOR =
+  process.env.NO_COLOR !== undefined && !isFalsey(process.env.NO_COLOR);
+
+/**
+ * Strip a boolean global flag out of rawArgs so citty never sees it. Matches
+ * any of `names` bare (sets the flag) and the `--name=<value>` form for the
+ * long names (`<falsey>` explicitly turns the flag back off).
+ */
+function stripBooleanFlag(
+  rawArgs: string[],
+  names: string[],
+): { value: boolean; rawArgs: string[] } {
+  const valuedPrefixes = names.filter((n) => n.startsWith("--")).map((n) => `${n}=`);
+  let value = false;
+  const cleaned: string[] = [];
+  for (const arg of rawArgs) {
+    if (names.includes(arg)) {
+      value = true;
+    } else if (valuedPrefixes.some((prefix) => arg.startsWith(prefix))) {
+      value = !isFalsey(arg.slice(arg.indexOf("=") + 1));
+    } else {
+      cleaned.push(arg);
+    }
+  }
+  return { value, rawArgs: cleaned };
+}
+
+/**
+ * Decide whether ANSI colors should be disabled (#531) and return rawArgs with
+ * any `--no-color[=value]` token stripped so citty never sees it.
+ *
+ * Colors are disabled when `--no-color` (bare) or `--no-color=<truthy>` is
+ * passed, or when the environment looks like CI (`CI` set to a non-falsey value
+ * — GitHub Actions, GitLab, CircleCI, … export `CI=true`). `--no-color=false`
+ * and `CI=false`/`CI=0` explicitly opt back in.
+ */
+export function resolveColorMode(
+  rawArgs: string[],
+  env: { CI?: string } = process.env as { CI?: string },
+): { disableColor: boolean; rawArgs: string[] } {
+  const { value, rawArgs: cleaned } = stripBooleanFlag(rawArgs, ["--no-color"]);
+  const ci = env.CI !== undefined && !isFalsey(env.CI);
+  return { disableColor: value || ci, rawArgs: cleaned };
+}
+
+/**
+ * Detect `--quiet`/`-q` (and `--quiet=<value>`) and return rawArgs with the
+ * token stripped (#526). Resolved before citty — like `--no-color` — so quiet
+ * is global: it works for every command, not just the transcribe path, and a
+ * subcommand that doesn't declare it never sees the flag.
+ */
+export function resolveQuietMode(rawArgs: string[]): { quiet: boolean; rawArgs: string[] } {
+  const { value, rawArgs: cleaned } = stripBooleanFlag(rawArgs, ["--quiet", "-q"]);
+  return { quiet: value, rawArgs: cleaned };
+}
+
+/** Resolves every pre-citty global flag into one value, with the tokens stripped from rawArgs. */
+export function resolveCliContext(
+  rawArgs: string[],
+  env: { CI?: string } = process.env as { CI?: string },
+): ResolvedCliContext {
+  const color = resolveColorMode(rawArgs, env);
+  const quiet = resolveQuietMode(color.rawArgs);
+  return { quiet: quiet.quiet, disableColor: color.disableColor, rawArgs: quiet.rawArgs };
+}
+
+/**
+ * Sync NO_COLOR with the resolved color decision so engine subprocesses inherit
+ * the right value. Separated from setColorEnabled so it can be tested without
+ * picocolors side-effects.
+ *
+ * Never clears a NO_COLOR the user exported before this process started.
+ */
+export function applyColorEnv(disableColor: boolean): void {
+  if (disableColor) {
+    process.env.NO_COLOR = "1";
+  } else if (!USER_FORCED_NO_COLOR) {
+    delete process.env.NO_COLOR;
+  }
+}
+
+/** Applies the context to the process-wide output sinks, writing every value so an earlier in-process run (unit tests, `kesha mcp`) can't leak its settings into a later one. */
+export function applyCliContext(context: CliContext): void {
+  setColorEnabled(!context.disableColor);
+  applyColorEnv(context.disableColor);
+  log.quietEnabled = context.quiet;
+}

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -1,7 +1,8 @@
 import { runMain, type CommandDef } from "citty";
 import { existsSync } from "fs";
-import { log, setColorEnabled } from "../log";
+import { log } from "../log";
 import { suggestCommand } from "../suggest-command";
+import { applyCliContext, resolveCliContext } from "./context";
 
 // Lazy loaders so a cold CLI spawn transpiles only the invoked command, not the whole graph (#568).
 // `CommandDef<any>`: citty's generic is invariant in the arg shape and each command has its own schema.
@@ -25,86 +26,6 @@ function isPathLike(arg: string): boolean {
   return arg.includes(".") || arg.includes("/") || existsSync(arg);
 }
 
-// Falsey grammar shared by --no-color and CI. Mirrors KESHA_DEBUG so
-// `CI=false`/`CI=0` and `--no-color=false` opt back in to colors.
-const FALSEY_VALUES = new Set(["", "0", "false", "no", "off"]);
-function isFalsey(v: string): boolean {
-  return FALSEY_VALUES.has(v.trim().toLowerCase());
-}
-
-// Captured at import so re-enabling colors never clobbers a user-exported NO_COLOR.
-const USER_FORCED_NO_COLOR =
-  process.env.NO_COLOR !== undefined && !isFalsey(process.env.NO_COLOR);
-
-/**
- * Strip a boolean global flag out of rawArgs so citty never sees it. Matches
- * any of `names` bare (sets the flag) and the `--name=<value>` form for the
- * long names (`<falsey>` explicitly turns the flag back off).
- */
-function stripBooleanFlag(
-  rawArgs: string[],
-  names: string[],
-): { value: boolean; rawArgs: string[] } {
-  const valuedPrefixes = names.filter((n) => n.startsWith("--")).map((n) => `${n}=`);
-  let value = false;
-  const cleaned: string[] = [];
-  for (const arg of rawArgs) {
-    if (names.includes(arg)) {
-      value = true;
-    } else if (valuedPrefixes.some((prefix) => arg.startsWith(prefix))) {
-      value = !isFalsey(arg.slice(arg.indexOf("=") + 1));
-    } else {
-      cleaned.push(arg);
-    }
-  }
-  return { value, rawArgs: cleaned };
-}
-
-/**
- * Decide whether ANSI colors should be disabled (#531) and return rawArgs with
- * any `--no-color[=value]` token stripped so citty never sees it.
- *
- * Colors are disabled when `--no-color` (bare) or `--no-color=<truthy>` is
- * passed, or when the environment looks like CI (`CI` set to a non-falsey value
- * — GitHub Actions, GitLab, CircleCI, … export `CI=true`). `--no-color=false`
- * and `CI=false`/`CI=0` explicitly opt back in.
- */
-export function resolveColorMode(
-  rawArgs: string[],
-  env: { CI?: string } = process.env as { CI?: string },
-): { disableColor: boolean; rawArgs: string[] } {
-  const { value, rawArgs: cleaned } = stripBooleanFlag(rawArgs, ["--no-color"]);
-  const ci = env.CI !== undefined && !isFalsey(env.CI);
-  return { disableColor: value || ci, rawArgs: cleaned };
-}
-
-/**
- * Detect `--quiet`/`-q` (and `--quiet=<value>`) and return rawArgs with the
- * token stripped (#526). Resolved before citty — like `--no-color` — so quiet
- * is global: it works for every command, not just the transcribe path, and a
- * subcommand that doesn't declare it never sees the flag.
- */
-export function resolveQuietMode(rawArgs: string[]): { quiet: boolean; rawArgs: string[] } {
-  const { value, rawArgs: cleaned } = stripBooleanFlag(rawArgs, ["--quiet", "-q"]);
-  return { quiet: value, rawArgs: cleaned };
-}
-
-/**
- * Sync NO_COLOR with the resolved color decision so engine subprocesses inherit
- * the right value. Separated from setColorEnabled so it can be tested without
- * picocolors side-effects.
- *
- * Never clears a NO_COLOR the user exported before this process started
- * (USER_FORCED_NO_COLOR guard).
- */
-export function applyColorEnv(disableColor: boolean): void {
-  if (disableColor) {
-    process.env.NO_COLOR = "1";
-  } else if (!USER_FORCED_NO_COLOR) {
-    delete process.env.NO_COLOR;
-  }
-}
-
 /**
  * Classify the first positional arg for routing.
  *
@@ -123,18 +44,11 @@ export function classifyFirstArg(
   return "unknown";
 }
 
-export async function runCli(rawArgs = process.argv.slice(2)): Promise<void> {
-  // Global flags resolved before citty so they apply to every command and never reach a subcommand's arg schema.
-  const color = resolveColorMode(rawArgs);
-  // Reset on every invocation so an earlier --no-color/CI call doesn't leave colors off for later in-process calls (unit tests, `kesha mcp`).
-  setColorEnabled(!color.disableColor);
-  applyColorEnv(color.disableColor);
+export async function runCli(argv = process.argv.slice(2)): Promise<void> {
+  const context = resolveCliContext(argv);
+  applyCliContext(context);
 
-  const quiet = resolveQuietMode(color.rawArgs);
-  log.quietEnabled = quiet.quiet;
-
-  rawArgs = quiet.rawArgs;
-  const [firstArg, ...restArgs] = rawArgs;
+  const [firstArg, ...restArgs] = context.rawArgs;
   const subcommandKeys = Object.keys(SUBCOMMANDS);
 
   switch (classifyFirstArg(firstArg, subcommandKeys)) {
@@ -154,7 +68,9 @@ export async function runCli(rawArgs = process.argv.slice(2)): Promise<void> {
       break;
     }
 
-    default:
-      await runMain((await import("./main")).mainCommand, { rawArgs });
+    default: {
+      const { createMainCommand } = await import("./main");
+      await runMain(createMainCommand(context), { rawArgs: context.rawArgs });
+    }
   }
 }

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -21,6 +21,7 @@ import { getPendingSignalExitCode, waitForPendingSignalCleanup } from "../proces
 import type { TranscriptionSegment } from "../types";
 import { diagnosticSizeBucket } from "../diagnostic-events";
 import { runCommandSession, type CommandSession } from "./command-session";
+import type { CliContext } from "./context";
 import { ENGINE_CODES, extractEngineErrorCode, TS_NATIVE_CODES } from "../error-codes";
 
 interface MainCommandArgs {
@@ -368,208 +369,209 @@ function writeOutput(
   }
 }
 
-export const mainCommand = defineCommand({
-  meta: {
-    name: "kesha",
-    version: packageVersion,
-    description:
-      "Kesha Voice Kit — open-source voice toolkit for Apple Silicon.\n" +
-      "\n" +
-      "Examples:\n" +
-      "  kesha audio.ogg          Transcribe an audio file.\n" +
-      "  kesha --json audio.ogg   Transcribe with machine-readable output.\n" +
-      "  kesha say \"hello\"        Speak text (text-to-speech).\n" +
-      "  kesha init               Guided first-time setup.\n" +
-      "\n" +
-      "Commands:\n" +
-      "  completions  Print shell completion script.\n" +
-      "  doctor     Collect support diagnostics.\n" +
-      "  init       Interactive setup guide for Kesha features.\n" +
-      "  install    Download engine and models.\n" +
-      "  logs       Manage local privacy-safe diagnostic logs.\n" +
-      "  manpage    Print the kesha(1) manpage.\n" +
-      "  record     Record microphone audio to a WAV file.\n" +
-      "  status     Inspect installed backend.\n" +
-      "  say        Synthesize speech from text.\n" +
-      "  stats      Manage local anonymous performance stats.\n" +
-      "  support-bundle  Create a redacted diagnostics archive.",
-  },
-  args: {
-    json: {
-      type: "boolean",
-      description: "Output results as JSON",
-      default: false,
+/** The transcribe command, bound to the global flags dispatch resolved before citty. */
+export function createMainCommand(context: CliContext = { quiet: false, disableColor: false }) {
+  return defineCommand({
+    meta: {
+      name: "kesha",
+      version: packageVersion,
+      description:
+        "Kesha Voice Kit — open-source voice toolkit for Apple Silicon.\n" +
+        "\n" +
+        "Examples:\n" +
+        "  kesha audio.ogg          Transcribe an audio file.\n" +
+        "  kesha --json audio.ogg   Transcribe with machine-readable output.\n" +
+        "  kesha say \"hello\"        Speak text (text-to-speech).\n" +
+        "  kesha init               Guided first-time setup.\n" +
+        "\n" +
+        "Commands:\n" +
+        "  completions  Print shell completion script.\n" +
+        "  doctor     Collect support diagnostics.\n" +
+        "  init       Interactive setup guide for Kesha features.\n" +
+        "  install    Download engine and models.\n" +
+        "  logs       Manage local privacy-safe diagnostic logs.\n" +
+        "  manpage    Print the kesha(1) manpage.\n" +
+        "  record     Record microphone audio to a WAV file.\n" +
+        "  status     Inspect installed backend.\n" +
+        "  say        Synthesize speech from text.\n" +
+        "  stats      Manage local anonymous performance stats.\n" +
+        "  support-bundle  Create a redacted diagnostics archive.",
     },
-    toon: {
-      type: "boolean",
-      description: "Output results as TOON (compact, LLM-friendly encoding of the same data as --json)",
-      default: false,
-    },
-    timestamps: {
-      type: "boolean",
-      description: "Include timestamped transcript segments in JSON/TOON output",
-      default: false,
-    },
-    speakers: {
-      type: "boolean",
-      description: "Include speaker labels in segments. Needs --json/--toon and darwin-arm64; run `kesha install --diarize` first. Implies --timestamps.",
-      default: false,
-    },
-    "include-errors": {
-      type: "boolean",
-      description: "With --json, output { results, errors } so scripts can read per-file failures without parsing stderr",
-      default: false,
-    },
-    verbose: {
-      type: "boolean",
-      description: "Show language detection details",
-      default: false,
-    },
-    format: {
-      type: "string",
-      description: "Output format: transcript | json | toon (long-form alias for --json / --toon)",
-    },
-    lang: {
-      type: "string",
-      description: "Expected language code, e.g. en or en-us (see docs/languages.md); warn if mismatch",
-    },
-    debug: {
-      type: "boolean",
-      description: "Trace engine subprocess calls on stderr (or KESHA_DEBUG=1)",
-      default: false,
-    },
-    vad: {
-      type: "boolean",
-      description: "Force Silero VAD preprocessing (kesha install --vad first). Without this, VAD auto-engages on audio ≥ 120s.",
-      default: false,
-    },
-    "no-vad": {
-      type: "boolean",
-      description: "Force full-file ASR for short/medium files; long audio fails early",
-      default: false,
-    },
-    // quiet and no-color are resolved before citty in dispatch.ts (so they
-    // apply to every command, not just transcribe); declared here only so they
-    // appear in `kesha --help`.
-    quiet: {
-      type: "boolean",
-      alias: "q",
-      description: "Suppress progress output; print only results and errors",
-      default: false,
-    },
-    "no-color": {
-      type: "boolean",
-      description: "Disable ANSI colors (also via NO_COLOR=1; auto-off when CI=true)",
-      default: false,
-    },
-  },
-  async run({ args, rawArgs }: { args: MainCommandArgs; rawArgs: string[] }) {
-    if (args.debug) log.debugEnabled = true;
-    // `log.quietEnabled` is set globally in dispatch.ts (where --quiet/-q is
-    // resolved and stripped before citty), so it already reflects --quiet here.
-    const files = args._;
-
-    const fmt = resolveOutputFormat({
-      json: args.json,
-      toon: args.toon,
-      format: args.format,
-    });
-    if (!fmt.ok) {
-      log.error(fmt.error);
-      process.exit(2);
-    }
-
-    const validated = validateTranscribeArgs(args, rawArgs, fmt);
-    if (!validated.ok) {
-      log.error(validated.error);
-      process.exit(2);
-    }
-    const { vadMode, outputFormat } = validated;
-
-    if (files.length === 0) {
-      log.info(
-        "Usage: kesha <audio_file> [audio_file ...]\n" +
-          "       kesha completions <bash|zsh|fish>\n" +
-          "       kesha doctor [--json] [--redact]\n" +
-          "       kesha install [--no-cache]\n" +
-          "       kesha logs [enable|disable|mode|status|path|reset]\n" +
-          "       kesha manpage\n" +
-          "       kesha record --out path.wav [--max-seconds 120]\n" +
-          "       kesha status\n" +
-          "       kesha say <text>\n" +
-          "       kesha stats [enable|disable|status|week|errors|export|reset|vacuum|retention]\n" +
-          "       kesha support-bundle [--output path.tar.gz]",
-      );
-      process.exit(1);
-    }
-
-    const wantsLangId = !!(args.lang || args.verbose || outputFormat !== "text");
-    const reportProgress = shouldReportTranscribeProgress({
-      stderrIsTty: process.stderr.isTTY === true,
-      stdoutIsTty: process.stdout.isTTY === true,
-      debugEnabled: log.isDebugEnabled(),
-      quiet: log.quietEnabled,
-    });
-
-    const { status } = await runCommandSession(
-      "transcribe",
-      {
-        itemCount: files.length,
-        outputFormat,
-        vadMode,
-        timestamps: args.timestamps,
-        speakers: args.speakers,
-        includeErrors: args["include-errors"],
-        hasExpectedLang: Boolean(args.lang),
+    args: {
+      json: {
+        type: "boolean",
+        description: "Output results as JSON",
+        default: false,
       },
-      async (session) => {
-        const results: TranscribeResult[] = [];
-        const errors: TranscribeErrorRecord[] = [];
-
-        for (const file of files) {
-          const outcome = await processFile(
-            file,
-            {
-              vadMode,
-              timestamps: args.timestamps,
-              speakers: args.speakers,
-              wantsLangId,
-              expectedLang: args.lang,
-              reportProgress,
-            },
-            session,
-          );
-          if (outcome.ok) {
-            results.push(outcome.result);
-          } else {
-            errors.push(outcome.error);
-          }
-        }
-
-        writeOutput(results, errors, outputFormat, {
-          includeErrors: args["include-errors"],
-          verbose: args.verbose,
-        });
-
-        return {
-          status: errors.length > 0 ? "failed" : "success",
-          itemCount: files.length,
-          finishFields: {
-            itemCount: files.length,
-            resultCount: results.length,
-            errorCount: errors.length,
-          },
-        };
+      toon: {
+        type: "boolean",
+        description: "Output results as TOON (compact, LLM-friendly encoding of the same data as --json)",
+        default: false,
       },
-    );
+      timestamps: {
+        type: "boolean",
+        description: "Include timestamped transcript segments in JSON/TOON output",
+        default: false,
+      },
+      speakers: {
+        type: "boolean",
+        description: "Include speaker labels in segments. Needs --json/--toon and darwin-arm64; run `kesha install --diarize` first. Implies --timestamps.",
+        default: false,
+      },
+      "include-errors": {
+        type: "boolean",
+        description: "With --json, output { results, errors } so scripts can read per-file failures without parsing stderr",
+        default: false,
+      },
+      verbose: {
+        type: "boolean",
+        description: "Show language detection details",
+        default: false,
+      },
+      format: {
+        type: "string",
+        description: "Output format: transcript | json | toon (long-form alias for --json / --toon)",
+      },
+      lang: {
+        type: "string",
+        description: "Expected language code, e.g. en or en-us (see docs/languages.md); warn if mismatch",
+      },
+      debug: {
+        type: "boolean",
+        description: "Trace engine subprocess calls on stderr (or KESHA_DEBUG=1)",
+        default: false,
+      },
+      vad: {
+        type: "boolean",
+        description: "Force Silero VAD preprocessing (kesha install --vad first). Without this, VAD auto-engages on audio ≥ 120s.",
+        default: false,
+      },
+      "no-vad": {
+        type: "boolean",
+        description: "Force full-file ASR for short/medium files; long audio fails early",
+        default: false,
+      },
+      // quiet and no-color are resolved before citty in dispatch.ts (so they
+      // apply to every command, not just transcribe); declared here only so they
+      // appear in `kesha --help`.
+      quiet: {
+        type: "boolean",
+        alias: "q",
+        description: "Suppress progress output; print only results and errors",
+        default: false,
+      },
+      "no-color": {
+        type: "boolean",
+        description: "Disable ANSI colors (also via NO_COLOR=1; auto-off when CI=true)",
+        default: false,
+      },
+    },
+    async run({ args, rawArgs }: { args: MainCommandArgs; rawArgs: string[] }) {
+      if (args.debug) log.debugEnabled = true;
+      const files = args._;
 
-    if (status === "failed") {
-      const signalExitCode = getPendingSignalExitCode();
-      if (signalExitCode !== null) {
-        await waitForPendingSignalCleanup();
-        process.exit(signalExitCode);
+      const fmt = resolveOutputFormat({
+        json: args.json,
+        toon: args.toon,
+        format: args.format,
+      });
+      if (!fmt.ok) {
+        log.error(fmt.error);
+        process.exit(2);
       }
-      process.exit(1);
-    }
-  },
-});
+
+      const validated = validateTranscribeArgs(args, rawArgs, fmt);
+      if (!validated.ok) {
+        log.error(validated.error);
+        process.exit(2);
+      }
+      const { vadMode, outputFormat } = validated;
+
+      if (files.length === 0) {
+        log.info(
+          "Usage: kesha <audio_file> [audio_file ...]\n" +
+            "       kesha completions <bash|zsh|fish>\n" +
+            "       kesha doctor [--json] [--redact]\n" +
+            "       kesha install [--no-cache]\n" +
+            "       kesha logs [enable|disable|mode|status|path|reset]\n" +
+            "       kesha manpage\n" +
+            "       kesha record --out path.wav [--max-seconds 120]\n" +
+            "       kesha status\n" +
+            "       kesha say <text>\n" +
+            "       kesha stats [enable|disable|status|week|errors|export|reset|vacuum|retention]\n" +
+            "       kesha support-bundle [--output path.tar.gz]",
+        );
+        process.exit(1);
+      }
+
+      const wantsLangId = !!(args.lang || args.verbose || outputFormat !== "text");
+      const reportProgress = shouldReportTranscribeProgress({
+        stderrIsTty: process.stderr.isTTY === true,
+        stdoutIsTty: process.stdout.isTTY === true,
+        debugEnabled: log.isDebugEnabled(),
+        quiet: context.quiet,
+      });
+
+      const { status } = await runCommandSession(
+        "transcribe",
+        {
+          itemCount: files.length,
+          outputFormat,
+          vadMode,
+          timestamps: args.timestamps,
+          speakers: args.speakers,
+          includeErrors: args["include-errors"],
+          hasExpectedLang: Boolean(args.lang),
+        },
+        async (session) => {
+          const results: TranscribeResult[] = [];
+          const errors: TranscribeErrorRecord[] = [];
+
+          for (const file of files) {
+            const outcome = await processFile(
+              file,
+              {
+                vadMode,
+                timestamps: args.timestamps,
+                speakers: args.speakers,
+                wantsLangId,
+                expectedLang: args.lang,
+                reportProgress,
+              },
+              session,
+            );
+            if (outcome.ok) {
+              results.push(outcome.result);
+            } else {
+              errors.push(outcome.error);
+            }
+          }
+
+          writeOutput(results, errors, outputFormat, {
+            includeErrors: args["include-errors"],
+            verbose: args.verbose,
+          });
+
+          return {
+            status: errors.length > 0 ? "failed" : "success",
+            itemCount: files.length,
+            finishFields: {
+              itemCount: files.length,
+              resultCount: results.length,
+              errorCount: errors.length,
+            },
+          };
+        },
+      );
+
+      if (status === "failed") {
+        const signalExitCode = getPendingSignalExitCode();
+        if (signalExitCode !== null) {
+          await waitForPendingSignalCleanup();
+          process.exit(signalExitCode);
+        }
+        process.exit(1);
+      }
+    },
+  });
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -575,3 +575,6 @@ export function createMainCommand(context: CliContext = { quiet: false, disableC
     },
   });
 }
+
+/** Package-root export kept for consumers importing `mainCommand`; the default-context binding. */
+export const mainCommand = createMainCommand();

--- a/src/shell-artifacts.ts
+++ b/src/shell-artifacts.ts
@@ -4,7 +4,7 @@ import { doctorCommand } from "./cli/doctor";
 import { initCommand } from "./cli/init";
 import { installCommand } from "./cli/install";
 import { logsCommand } from "./cli/logs";
-import { mainCommand } from "./cli/main";
+import { createMainCommand } from "./cli/main";
 import { manpageCommand } from "./cli/manpage";
 import { mcpCommand } from "./cli/mcp";
 import { recordCommand } from "./cli/record";
@@ -115,7 +115,7 @@ async function commandToArtifact(name: string, command: CommandDef<any>): Promis
 
 async function buildModel(): Promise<ArtifactModel> {
   return {
-    root: await commandToArtifact("kesha", mainCommand),
+    root: await commandToArtifact("kesha", createMainCommand()),
     commands: await Promise.all(CLI_COMMANDS.map((entry) => commandToArtifact(entry.name, entry.command))),
   };
 }

--- a/tests/unit/cli-context.test.ts
+++ b/tests/unit/cli-context.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  applyCliContext,
+  applyColorEnv,
+  resolveCliContext,
+  USER_FORCED_NO_COLOR,
+} from "../../src/cli/context";
+import { log, setColorEnabled } from "../../src/log";
+
+describe("resolveCliContext", () => {
+  test("resolves both global flags in one pass and strips both tokens", () => {
+    const ctx = resolveCliContext(["--quiet", "--no-color", "say", "hello"], {});
+    expect(ctx.quiet).toBe(true);
+    expect(ctx.disableColor).toBe(true);
+    expect(ctx.rawArgs).toEqual(["say", "hello"]);
+  });
+
+  test("defaults to neither flag when no tokens are present", () => {
+    const ctx = resolveCliContext(["a.ogg"], {});
+    expect(ctx).toEqual({ quiet: false, disableColor: false, rawArgs: ["a.ogg"] });
+  });
+
+  test("CI disables color without affecting quiet", () => {
+    const ctx = resolveCliContext(["a.ogg"], { CI: "true" });
+    expect(ctx.disableColor).toBe(true);
+    expect(ctx.quiet).toBe(false);
+  });
+
+  test("explicit opt-outs beat their default", () => {
+    const ctx = resolveCliContext(["--no-color=false", "--quiet=false"], { CI: "false" });
+    expect(ctx.disableColor).toBe(false);
+    expect(ctx.quiet).toBe(false);
+    expect(ctx.rawArgs).toEqual([]);
+  });
+
+  test("the tokens are stripped even ahead of a subcommand", () => {
+    expect(resolveCliContext(["-q", "stats", "status"], {}).rawArgs).toEqual(["stats", "status"]);
+  });
+
+  test("resolution does not mutate the caller's rawArgs", () => {
+    const rawArgs = ["--quiet", "a.ogg"];
+    resolveCliContext(rawArgs, {});
+    expect(rawArgs).toEqual(["--quiet", "a.ogg"]);
+  });
+});
+
+describe("applyCliContext", () => {
+  const savedNoColor = process.env.NO_COLOR;
+
+  afterEach(() => {
+    if (savedNoColor === undefined) delete process.env.NO_COLOR;
+    else process.env.NO_COLOR = savedNoColor;
+    log.quietEnabled = false;
+    setColorEnabled(true);
+  });
+
+  test("mirrors quiet onto the log sink", () => {
+    applyCliContext({ quiet: true, disableColor: false });
+    expect(log.quietEnabled).toBe(true);
+  });
+
+  test("re-applying a non-quiet context clears an earlier quiet run", () => {
+    applyCliContext({ quiet: true, disableColor: false });
+    applyCliContext({ quiet: false, disableColor: false });
+    expect(log.quietEnabled).toBe(false);
+  });
+
+  test("exports NO_COLOR so engine subprocesses inherit the decision", () => {
+    applyCliContext({ quiet: false, disableColor: true });
+    expect(process.env.NO_COLOR).toBe("1");
+  });
+
+  test("clears NO_COLOR when colors are back on, unless the user exported it", () => {
+    applyCliContext({ quiet: false, disableColor: true });
+    applyCliContext({ quiet: false, disableColor: false });
+    if (USER_FORCED_NO_COLOR) expect(process.env.NO_COLOR).toBe("1");
+    else expect(process.env.NO_COLOR).toBeUndefined();
+  });
+});
+
+describe("applyColorEnv", () => {
+  const savedNoColor = process.env.NO_COLOR;
+
+  afterEach(() => {
+    if (savedNoColor === undefined) delete process.env.NO_COLOR;
+    else process.env.NO_COLOR = savedNoColor;
+  });
+
+  test("disabling color exports NO_COLOR=1", () => {
+    delete process.env.NO_COLOR;
+    applyColorEnv(true);
+    expect(process.env.NO_COLOR as string | undefined).toBe("1");
+  });
+
+  test("disabling color overwrites an existing falsey NO_COLOR", () => {
+    process.env.NO_COLOR = "0";
+    applyColorEnv(true);
+    expect(process.env.NO_COLOR).toBe("1");
+  });
+
+  test("enabling color clears NO_COLOR only when the user did not export it", () => {
+    applyColorEnv(true);
+    applyColorEnv(false);
+    if (USER_FORCED_NO_COLOR) expect(process.env.NO_COLOR).toBe("1");
+    else expect(process.env.NO_COLOR).toBeUndefined();
+  });
+});

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from "bun:test";
 import { renderUsage } from "citty";
 import { decode as decodeToon } from "@toon-format/toon";
-import { mainCommand, completionsCommand, doctorCommand, initCommand, installCommand, logsCommand, manpageCommand, recordCommand, statusCommand, statsCommand, supportBundleCommand, sayCommand, formatTextOutput, formatJsonOutput, formatToonOutput, detectLanguage, checkLanguageMismatch, estimateTranscriptDurationSeconds, resolveOutputFormat, resolveRecordArgs, shouldReportTranscribeProgress, shouldRunAudioLanguageDetection, validateTranscribeArgs } from "../../src/cli";
+import { createMainCommand, completionsCommand, doctorCommand, initCommand, installCommand, logsCommand, manpageCommand, recordCommand, statusCommand, statsCommand, supportBundleCommand, sayCommand, formatTextOutput, formatJsonOutput, formatToonOutput, detectLanguage, checkLanguageMismatch, estimateTranscriptDurationSeconds, resolveOutputFormat, resolveRecordArgs, shouldReportTranscribeProgress, shouldRunAudioLanguageDetection, validateTranscribeArgs } from "../../src/cli";
 import type { ResolvedOutputFormat } from "../../src/cli";
 
 type MainRun = (input: { args: Record<string, unknown>; rawArgs: string[] }) => Promise<void>;
@@ -50,7 +50,7 @@ async function expectMainExit(
     process.exit = ((code?: string | number | null | undefined) => {
       throw new Error(`exit:${code ?? 0}`);
     }) as typeof process.exit;
-    await (mainCommand.run as MainRun)({ args, rawArgs });
+    await (createMainCommand().run as MainRun)({ args, rawArgs });
     throw new Error("main command did not exit");
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -65,13 +65,13 @@ async function expectMainExit(
 
 describe("CLI help", () => {
   test("main help contains usage and install info", async () => {
-    const usage = await renderUsage(mainCommand);
+    const usage = await renderUsage(createMainCommand());
     expect(usage).toContain("USAGE");
     expect(usage).toContain("install");
   });
 
   test("main help shows subcommand inventory (#324)", async () => {
-    const usage = await renderUsage(mainCommand);
+    const usage = await renderUsage(createMainCommand());
     expect(usage).toContain("Commands:");
     expect(usage).toContain("completions");
     expect(usage).toContain("doctor     Collect support diagnostics.");
@@ -138,38 +138,38 @@ describe("CLI help", () => {
   });
 
   test("main help contains --json flag", async () => {
-    const usage = await renderUsage(mainCommand);
+    const usage = await renderUsage(createMainCommand());
     expect(usage).toContain("--json");
   });
 
   test("main help contains --include-errors flag (#324 P1)", async () => {
-    const usage = await renderUsage(mainCommand);
+    const usage = await renderUsage(createMainCommand());
     expect(usage).toContain("--include-errors");
   });
 
   test("main help contains --toon flag (#138)", async () => {
-    const usage = await renderUsage(mainCommand);
+    const usage = await renderUsage(createMainCommand());
     expect(usage).toContain("--toon");
     expect(usage).toMatch(/TOON|LLM/i);
   });
 
   test("main help contains --timestamps flag", async () => {
-    const usage = await renderUsage(mainCommand);
+    const usage = await renderUsage(createMainCommand());
     expect(usage).toContain("--timestamps");
   });
 
   test("main help contains --lang flag", async () => {
-    const usage = await renderUsage(mainCommand);
+    const usage = await renderUsage(createMainCommand());
     expect(usage).toContain("--lang");
   });
 
   test("main help contains --verbose flag", async () => {
-    const usage = await renderUsage(mainCommand);
+    const usage = await renderUsage(createMainCommand());
     expect(usage).toContain("--verbose");
   });
 
   test("main help contains --debug flag (#148)", async () => {
-    const usage = await renderUsage(mainCommand);
+    const usage = await renderUsage(createMainCommand());
     expect(usage).toContain("--debug");
     expect(usage).toMatch(/KESHA_DEBUG|trace/i);
   });
@@ -318,7 +318,7 @@ describe("CLI help golden contracts (#324 P1)", () => {
   });
 
   test("main help matches the normalized golden output", async () => {
-    expect(normalizeUsage(await renderUsage(mainCommand))).toBe(`Kesha Voice Kit — open-source voice toolkit for Apple Silicon.
+    expect(normalizeUsage(await renderUsage(createMainCommand()))).toBe(`Kesha Voice Kit — open-source voice toolkit for Apple Silicon.
 
 Examples:
   kesha audio.ogg          Transcribe an audio file.
@@ -588,17 +588,17 @@ describe("language detection", () => {
 
 describe("CLI help with status", () => {
   test("main description mentions install command", async () => {
-    const usage = await renderUsage(mainCommand);
+    const usage = await renderUsage(createMainCommand());
     expect(usage).toContain("install");
   });
 
   test("main help includes status command", async () => {
-    const usage = await renderUsage(mainCommand);
+    const usage = await renderUsage(createMainCommand());
     expect(usage).toContain("status");
   });
 
   test("main description mentions stats command", async () => {
-    const usage = await renderUsage(mainCommand);
+    const usage = await renderUsage(createMainCommand());
     expect(usage).toContain("stats");
   });
 });

--- a/tests/unit/color-and-quiet.test.ts
+++ b/tests/unit/color-and-quiet.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { resolveColorMode, resolveQuietMode } from "../../src/cli/dispatch";
+import { resolveColorMode, resolveQuietMode } from "../../src/cli/context";
 import { log, setColorEnabled } from "../../src/log";
 import { shouldReportTranscribeProgress } from "../../src/cli";
 

--- a/tests/unit/dispatch.test.ts
+++ b/tests/unit/dispatch.test.ts
@@ -1,51 +1,5 @@
-import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { applyColorEnv, classifyFirstArg } from "../../src/cli/dispatch";
-
-// ---------------------------------------------------------------------------
-// applyColorEnv
-// ---------------------------------------------------------------------------
-
-describe("applyColorEnv", () => {
-  let savedNoColor: string | undefined;
-
-  beforeEach(() => {
-    savedNoColor = process.env.NO_COLOR;
-  });
-
-  afterEach(() => {
-    // Restore whatever the test runner had on entry.
-    if (savedNoColor === undefined) {
-      delete process.env.NO_COLOR;
-    } else {
-      process.env.NO_COLOR = savedNoColor;
-    }
-  });
-
-  test("disableColor=true sets NO_COLOR=1", () => {
-    delete process.env.NO_COLOR;
-    applyColorEnv(true);
-    expect(process.env.NO_COLOR as unknown as string).toBe("1");
-  });
-
-  test("disableColor=false clears NO_COLOR when not user-forced", () => {
-    // Temporarily ensure USER_FORCED_NO_COLOR is false by starting with no env var.
-    // applyColorEnv reads the module-level constant captured at import time, so we
-    // can only test the branch where the constant is false (the normal test-runner
-    // case where NO_COLOR wasn't set at module load).
-    delete process.env.NO_COLOR;
-    applyColorEnv(true);  // set it first
-    applyColorEnv(false); // should clear it (assuming USER_FORCED_NO_COLOR=false)
-    // If USER_FORCED_NO_COLOR is true in this runner, NO_COLOR stays — we just
-    // assert the function doesn't throw and the type is correct.
-    expect(typeof process.env.NO_COLOR === "undefined" || process.env.NO_COLOR === "1").toBe(true);
-  });
-
-  test("disableColor=true overwrites an existing NO_COLOR value", () => {
-    process.env.NO_COLOR = "0";
-    applyColorEnv(true);
-    expect(process.env.NO_COLOR as unknown as string).toBe("1");
-  });
-});
+import { describe, test, expect } from "bun:test";
+import { classifyFirstArg } from "../../src/cli/dispatch";
 
 // ---------------------------------------------------------------------------
 // classifyFirstArg


### PR DESCRIPTION
Closes out the last Tier 2 item, following #607 and #608. (Started stacked on #608; rebased onto `main` once that merged, so this is now a single commit against `main`.)

## The problem

`dispatch.ts` resolved `--quiet`/`-q` and `--no-color` before citty (so they apply to every command), then stored the result on the **log singleton**. `main.ts` read `log.quietEnabled` back out to compute `shouldReportTranscribeProgress`.

So a *logger sink setting* was doubling as a *data channel* between two modules that don't import each other. That's the coupling behind the finding that started this: the two files share 8 commits — 50% of their co-changes — with no static dependency for any tool or reviewer to follow.

## The change

- **`src/cli/context.ts`** owns every pre-citty global flag. `resolveCliContext` resolves both in one pure pass and returns `rawArgs` with the tokens stripped; `applyCliContext` is the single place that mutates process-wide sinks (picocolors, `NO_COLOR`, `log.quietEnabled`). The flag-parsing helpers move here from `dispatch.ts` unchanged.
- **`createMainCommand(context)`** replaces the `mainCommand` singleton, so the transcribe handler takes `context.quiet` as a parameter instead of reading it off the logger. `dispatch` passes the context it just resolved — the dependency is now a typed import.
- **`dispatch.ts` is routing only**: 160 → 76 lines.
- The `applyColorEnv` tests move to the module that now owns them, and the NO_COLOR-clearing case asserts real behaviour against the newly exported `USER_FORCED_NO_COLOR` instead of the tautology it had (`undefined || "1"`).

## What this deliberately does *not* do

It does not thread a logger instance through the ~20 modules that call `log.*`. `log.quietEnabled` stays as a sink setting read inside `log.ts`, and colors stay picocolors-global — a CLI process has one stdout, and that state is legitimately global. The fix is to stop *reading it back across a module boundary*, not to abolish it.

## Verification

- `bun test` — **494 pass, 6 skip**, 0 fail; `bunx tsc --noEmit` clean
- `src/cli/context.ts`: **100% line and function coverage**
- No module reads `log.quietEnabled` across a boundary any more (`grep` shows only `log.ts` itself and the single write in `context.ts`)
- Behaviour unchanged — the spawned-CLI contract tests for `--quiet`, `--no-color`, and `CI=true` pass untouched

Note on the coverage table: `dispatch.ts` shows a *lower* percentage than before (67% → 52%) purely because its well-covered pure functions moved out to `context.ts`; what remains is `runCli`, exercised by spawned-CLI integration tests that the in-process coverage run doesn't instrument. Overall TS line coverage is 84.17% → 84.27%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DRnTxyiiF3XHiyFqZJ3soz