### PR TITLE
docs: move TTS and release reference into on-demand skills

### DIFF
--- a/.claude/skills/release-mechanics/SKILL.md
+++ b/.claude/skills/release-mechanics/SKILL.md
@@ -1,8 +1,9 @@
-# Release Runbook
+---
+name: release-mechanics
+description: Use when touching anything release-shaped — version bumps, tags, draft releases, npm publish and provenance, the build-engine feature matrix, release/* PRs, bun link, or CI jobs that download a published engine. Explains why CLI and engine version independently, why tag names are one-use, why draft assets 404 for anonymous clients, and how Greptile re-review and auto-merge behave. To actually cut a release use the release-engine skill instead; this one is the reference behind it.
+---
 
-> Extracted from CLAUDE.md (chore/slim-claudemd, 2026-05-31) to keep the always-loaded
-> instructions under Claude Code's 40k-char performance threshold. Read this when cutting
-> or publishing a release.
+# Release mechanics
 
 ## RELEASE PROCESS — CLI AND ENGINE ARE VERSIONED INDEPENDENTLY
 

--- a/.claude/skills/tts-internals/SKILL.md
+++ b/.claude/skills/tts-internals/SKILL.md
@@ -1,8 +1,9 @@
-# TTS Internals Runbook
+---
+name: tts-internals
+description: Use when working on kesha TTS internals — voice routing and which engine serves which voice-id prefix, Kokoro/Vosk ONNX I/O shapes, the CharsiuG2P vs FluidAudio G2P split, SSML handling, multilingual behaviour (es/fr/it/pt on ONNX, hi/ja/zh on darwin-arm64), or the KESHA_* TTS environment variables. Explains why darwin-arm64 routes differently from every other build.
+---
 
-> Extracted from CLAUDE.md (chore/slim-claudemd, 2026-05-31) to keep the always-loaded
-> instructions under Claude Code's 40k-char performance threshold. Read this when changing
-> TTS synthesis, voices, G2P, or SSML.
+# TTS internals
 
 ## Engines
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ Rust toolchain quirks (CI rustc drift, rustfmt, `protoc`) and language gotchas: 
 
 ### GREPTILE PR REVIEW IS A GATE
 
-Greptile reviews on open and on every new commit. **P1/P2 findings are merge blockers.** Do not stop at the PR URL: wait for CI and Greptile to cover the latest head SHA, then report whether it is green. Clear false positives may be dismissed with a PR comment explaining why — rare in practice. Re-review and auto-merge mechanics: `docs/runbooks/release.md`.
+Greptile reviews on open and on every new commit. **P1/P2 findings are merge blockers.** Do not stop at the PR URL: wait for CI and Greptile to cover the latest head SHA, then report whether it is green. Clear false positives may be dismissed with a PR comment explaining why — rare in practice. Re-review and auto-merge mechanics: the `release-mechanics` skill.
 
 ### ERROR HANDLING
 
@@ -136,7 +136,7 @@ Three invariants worth knowing before you touch a release:
 - **Un-drafting fires npm publish and is effectively permanent.** Validate the draft binary first with authenticated `gh release download` (draft asset URLs 404 for anonymous clients, so `curl` / `make smoke-test` can false-green through an old global shim) and exercise it end-to-end.
 - **`integration-tests-full` skips on `release/*`** via `!startsWith(github.head_ref, 'release/')` — that is the job which downloads the *published* engine, whose tag doesn't exist yet on a release PR. The lighter `integration-tests` job carries no such guard and is safe there. Don't remove the filter; reuse it for new engine-downloading jobs.
 
-Full procedure, `bun link` gotchas, and re-review mechanics: **`docs/runbooks/release.md`**.
+Full procedure, `bun link` gotchas, and re-review mechanics: the **`release-mechanics`** skill (loads on demand). To cut a release, invoke **`release-engine`**.
 
 ## Build Commands
 
@@ -172,7 +172,7 @@ Engine is picked by voice-id prefix: `en-*` → Kokoro-82M (24 kHz), `ru-*` → 
 
 `kesha install --tts [<langs>…]` installs explicitly and additively (bare `--tts` = English only). `kesha say` writes audio to stdout unless `--out` is given, so **stderr carries all progress and errors**; auto-routing for an omitted `--voice` lives in `src/voice-routing.ts::pickVoiceForLang`.
 
-Engine internals, ONNX I/O shapes, G2P split, SSML, `KESHA_*` env vars: **`docs/runbooks/tts-internals.md`**.
+Engine internals, ONNX I/O shapes, G2P split, SSML, `KESHA_*` env vars: the **`tts-internals`** skill (loads on demand).
 
 ## Code Style
 
@@ -182,8 +182,10 @@ Engine internals, ONNX I/O shapes, G2P split, SSML, `KESHA_*` env vars: **`docs/
 - **No inline CI scripts over 3 lines** — extract to `.github/scripts/`.
 - **Comments: default to NONE.** Delete any comment that only restates the code. Never narrate mechanics, restate a name, or add section banners. A comment is allowed only when it carries what the code cannot: non-obvious *why*, a gotcha, an issue reference, a spec citation, `// SAFETY:`, a public-API doc contract (state the contract, not the implementation), or a `TODO` with context. One line, except SAFETY blocks and doc contracts. Bias below the surrounding density — and hold agent-generated code to the same bar in review.
 
-## Runbooks
+## Deeper references
 
-`docs/runbooks/` — [release](docs/runbooks/release.md) · [rust-gotchas](docs/runbooks/rust-gotchas.md) · [tts-internals](docs/runbooks/tts-internals.md) · [openclaw-plugin](docs/runbooks/openclaw-plugin.md)
+Topic knowledge lives in on-demand **skills** under `.claude/skills/` rather than here, so it costs nothing until it's relevant: `tts-internals`, `release-mechanics`, `release-engine` (cuts a release, explicit invoke only), `verify-pin-bump` (model SHA-256 mismatches).
+
+Still plain runbooks: [rust-gotchas](docs/runbooks/rust-gotchas.md) · [openclaw-plugin](docs/runbooks/openclaw-plugin.md).
 
 The OpenClaw plugin (`openclaw.plugin.json` + `openclaw-plugin.cjs`) routes audio through the `type: "cli"` path in `tools.media.audio.models`, and its `dangerous-exec` scanner is a naive regex that also reads comments — never name a forbidden module substring anywhere in that file.


### PR DESCRIPTION
**Stacked on #610** — the diff shown is against `docs/claude-md-pareto`; base retargets to `main` once that merges. Follow-up I flagged there.

[Anthropic's guidance](https://code.claude.com/docs/en/best-practices): *"For domain knowledge or workflows that are only relevant sometimes, use skills instead. Claude loads them on demand without bloating every conversation."*

A runbook linked from CLAUDE.md is only read if the agent decides to follow the pointer. A skill surfaces itself from its `description`. Same content, better delivery.

| Was | Now |
|---|---|
| `docs/runbooks/tts-internals.md` | `.claude/skills/tts-internals/` |
| `docs/runbooks/release.md` | `.claude/skills/release-mechanics/` |

Content moves verbatim; only the H1 and the "extracted from CLAUDE.md" note are replaced by trigger-shaped frontmatter.

## The release one closes a real gap

`release-engine` already existed — but it carries `disable-model-invocation: true`, so the model never auto-loads it. Release *knowledge* was therefore unreachable unless you explicitly ran the release flow: an agent editing `npm-publish.yml`, adding a CI job that downloads a published engine, or touching the `release/*` filter got none of the traps.

The two are disambiguated in their descriptions — `release-mechanics` is the reference, `release-engine` cuts the release and says so.

## Not changed

`rust-gotchas` and `openclaw-plugin` stay plain runbooks. They are the same case and can follow if this shape works — I'd rather prove the pattern on two than convert four blind.

`.agents/skills/` is gitignored, so there is nothing to mirror.

## Verification

- All 9 skills' frontmatter parses; every `name:` matches its directory.
- No reference anywhere still points at the two deleted runbook paths (the historical `docs/superpowers/plans/` record is deliberately left alone).
- `bun test` and `bunx tsc --noEmit` green.
- CLAUDE.md's "Runbooks" index becomes "Deeper references", naming the four skills and the two remaining runbooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DRnTxyiiF3XHiyFqZJ3soz