### PR TITLE
refactor(raycast): dead code removal, narrower deps, phased run()

### DIFF
--- a/openspec/specs/raycast-extension/spec.md
+++ b/openspec/specs/raycast-extension/spec.md
@@ -366,11 +366,12 @@ user-visible location and SHALL never leave the machine.
 - THEN the temporary directory is still removed
 - AND no partial recording remains on disk
 
-> *Technical Note — creation and path: `createTempDir` /
-> `audioPathForTempDir` in `raycast/src/lib/dictation-controller.ts` lines
-> 196–198 (`mkdtemp` under the OS temp dir, prefix `raycast-kesha-dictate-`,
-> file `dictation.wav`). Removal in the session's `finally`: line 184, with
-> `rm(dir, { recursive: true, force: true })` at line 197.*
+> *Technical Note — creation and path: `createTempDir` in
+> `raycast/src/lib/dictation-controller.ts` (`createDefaultDictationDeps`:
+> `mkdtemp` under the OS temp dir, prefix `raycast-kesha-dictate-`); the WAV
+> path is `join(tempDir, "dictation.wav")` inside `run()`. Removal in the
+> session's `finally` via `cleanupTempDir`
+> (`rm(dir, { recursive: true, force: true })`).*
 
 ## Open Issues
 

--- a/raycast/CLAUDE.md
+++ b/raycast/CLAUDE.md
@@ -1,0 +1,8 @@
+# raycast/ — Raycast extension
+
+Raycast-ecosystem directory: the repo-wide bun rules do NOT apply here.
+
+- **npm, not bun**: `npm ci`, `npm test` (vitest), `npm run lint` (`ray lint`, includes `tsc --noEmit`). CI runs exactly these in the `raycast-lint` job on Node 26. User-facing text about installing the kesha CLI itself still says bun.
+- **Upstream mirror**: this extension is synced with `raycast/extensions` (merged as raycast/extensions#29681). Every diff here enlarges the next sync — keep changes focused, no drive-by refactors.
+- **Testability convention**: modules take an optional trailing `deps` object for side effects (`spawn`, `kill`, timers, fs); `DictationControllerDeps` carries side effects only — pure helpers are imported directly, never injected. `tests/helpers/fake-process.ts` fakes child processes.
+- **UI stays thin**: `dictate-to-clipboard.tsx` only renders `DictationState`; logic lives in `src/lib/` where vitest can reach it without `@raycast/api`.

--- a/raycast/src/dictate-to-clipboard.tsx
+++ b/raycast/src/dictate-to-clipboard.tsx
@@ -84,7 +84,7 @@ export default function Command() {
     return (
       <Detail
         isLoading
-        markdown={buildTranscribingMarkdown(state)}
+        markdown={buildTranscribingMarkdown()}
         metadata={<TranscribingMetadata state={state} />}
         actions={
           <ActionPanel>

--- a/raycast/src/lib/dictation-controller.ts
+++ b/raycast/src/lib/dictation-controller.ts
@@ -72,13 +72,13 @@ export function startDictationSession(
         setState({
           status: "error",
           message: "kesha CLI not found.",
-          hint: deps.notFoundMessage(),
+          hint: notFoundMessage(),
         });
         return;
       }
 
       tempDir = await deps.createTempDir();
-      const audioPath = deps.audioPathForTempDir(tempDir);
+      const audioPath = join(tempDir, "dictation.wav");
 
       setState({
         status: "recording",
@@ -140,7 +140,7 @@ export function startDictationSession(
       await deps.showToast({
         style: "animated",
         title: "Transcribing",
-        message: deps.audioBasename(audioPath),
+        message: basename(audioPath),
       });
 
       stopTranscribeTimer = startTranscribingTimer(setState);
@@ -192,11 +192,8 @@ export function createDefaultDictationDeps(
   return {
     ...adapter,
     resolveKesha: resolveKeshaBin,
-    notFoundMessage,
     createTempDir: () => mkdtemp(join(tmpdir(), "raycast-kesha-dictate-")),
     cleanupTempDir: (dir) => rm(dir, { recursive: true, force: true }),
-    audioPathForTempDir: (dir) => join(dir, "dictation.wav"),
-    audioBasename: basename,
     startRecordingMonitor,
     startRecorder: (kesha, audioPath, maxSeconds) =>
       startKeshaRecorder(kesha, audioPath, maxSeconds),

--- a/raycast/src/lib/dictation-controller.ts
+++ b/raycast/src/lib/dictation-controller.ts
@@ -87,7 +87,7 @@ export function startDictationSession(
         silentForMs: 0,
         idle: false,
         mic: { name: "Default input device" },
-        signal: emptySignal("Starting microphone meter...", "starting"),
+        signal: emptySignal("starting"),
       });
       const silenceTracker = createSilenceTracker({
         now: deps.now,

--- a/raycast/src/lib/dictation-controller.ts
+++ b/raycast/src/lib/dictation-controller.ts
@@ -8,6 +8,7 @@ import {
   TRANSCRIBE_TIMEOUT_SECONDS,
 } from "./dictation-config";
 import { notFoundMessage, resolveKeshaBin } from "./kesha-bin";
+import type { KeshaSpawn } from "./kesha-bin";
 import { startKeshaRecorder, startKeshaTranscriber } from "./process-tasks";
 import { startRecordingMonitor } from "./recording-monitor";
 import { emptySignal } from "./recording-view";
@@ -80,51 +81,7 @@ export function startDictationSession(
       tempDir = await deps.createTempDir();
       const audioPath = join(tempDir, "dictation.wav");
 
-      setState({
-        status: "recording",
-        maxSeconds,
-        elapsedSeconds: 0,
-        silentForMs: 0,
-        idle: false,
-        mic: { name: "Default input device" },
-        signal: emptySignal("starting"),
-      });
-      const silenceTracker = createSilenceTracker({
-        now: deps.now,
-        onIdleStop: () => {
-          void deps.showToast({
-            style: "animated",
-            title: "Stopped after silence.",
-          });
-          recorder?.stop();
-        },
-      });
-      stopMonitoring = deps.startRecordingMonitor((patch) =>
-        patchRecordingState(setState, silenceTracker.track(patch)),
-      );
-      await deps.showToast({
-        style: "animated",
-        title: "Recording",
-        message: "Stops automatically when you pause",
-      });
-      if (cancelled) return;
-      if (stopRequested) {
-        setState({
-          status: "error",
-          message: "Recording stopped before any audio was captured.",
-        });
-        return;
-      }
-
-      recorder = deps.startRecorder(kesha, audioPath, maxSeconds);
-      try {
-        await recorder.done;
-      } finally {
-        recorder = null;
-        stopMonitoring?.();
-        stopMonitoring = null;
-      }
-      if (cancelled) return;
+      if (!(await recordPhase(kesha, audioPath, maxSeconds))) return;
 
       if (await deps.isSilentAudio(audioPath)) {
         throw new Error(
@@ -132,41 +89,10 @@ export function startDictationSession(
         );
       }
 
-      setState({
-        status: "transcribing",
-        elapsedSeconds: 0,
-        timeoutSeconds: TRANSCRIBE_TIMEOUT_SECONDS,
-      });
-      await deps.showToast({
-        style: "animated",
-        title: "Transcribing",
-        message: basename(audioPath),
-      });
-
-      stopTranscribeTimer = startTranscribingTimer(setState);
-      transcriber = deps.startTranscriber(kesha, audioPath);
-      const result = normalizeTranscribeResult(
-        audioPath,
-        await transcriber.done,
-      );
-      stopTranscribeTimer?.();
-      stopTranscribeTimer = null;
-      transcriber = null;
+      const result = await transcribePhase(kesha, audioPath);
       if (cancelled) return;
 
-      const transcript = result.text.trim();
-      if (!transcript) {
-        throw new Error("No speech was detected in the recording.");
-      }
-      await deps.copyToClipboard(transcript);
-      await deps.showToast({
-        style: "success",
-        title: "Copied transcript",
-      });
-      setState({
-        status: "ok",
-        result: { ...result, text: transcript },
-      });
+      await deliverTranscript(result);
     } catch (err: unknown) {
       if (cancelled) return;
       await deps.showToast({ style: "failure", title: "Dictation failed" });
@@ -175,14 +101,110 @@ export function startDictationSession(
         message: err instanceof Error ? err.message : String(err),
       });
     } finally {
-      recorder = null;
-      transcriber = null;
-      stopMonitoring?.();
-      stopMonitoring = null;
-      stopTranscribeTimer?.();
-      stopTranscribeTimer = null;
+      releaseResources();
       if (tempDir) await deps.cleanupTempDir(tempDir);
     }
+  }
+
+  async function recordPhase(
+    kesha: KeshaSpawn,
+    audioPath: string,
+    maxSeconds: number,
+  ): Promise<boolean> {
+    setState({
+      status: "recording",
+      maxSeconds,
+      elapsedSeconds: 0,
+      silentForMs: 0,
+      idle: false,
+      mic: { name: "Default input device" },
+      signal: emptySignal("starting"),
+    });
+    const silenceTracker = createSilenceTracker({
+      now: deps.now,
+      onIdleStop: () => {
+        void deps.showToast({
+          style: "animated",
+          title: "Stopped after silence.",
+        });
+        recorder?.stop();
+      },
+    });
+    stopMonitoring = deps.startRecordingMonitor((patch) =>
+      patchRecordingState(setState, silenceTracker.track(patch)),
+    );
+    await deps.showToast({
+      style: "animated",
+      title: "Recording",
+      message: "Stops automatically when you pause",
+    });
+    if (cancelled) return false;
+    if (stopRequested) {
+      setState({
+        status: "error",
+        message: "Recording stopped before any audio was captured.",
+      });
+      return false;
+    }
+
+    recorder = deps.startRecorder(kesha, audioPath, maxSeconds);
+    try {
+      await recorder.done;
+    } finally {
+      recorder = null;
+      stopMonitoring?.();
+      stopMonitoring = null;
+    }
+    return !cancelled;
+  }
+
+  async function transcribePhase(
+    kesha: KeshaSpawn,
+    audioPath: string,
+  ): Promise<TranscribeResult> {
+    setState({
+      status: "transcribing",
+      elapsedSeconds: 0,
+      timeoutSeconds: TRANSCRIBE_TIMEOUT_SECONDS,
+    });
+    await deps.showToast({
+      style: "animated",
+      title: "Transcribing",
+      message: basename(audioPath),
+    });
+
+    stopTranscribeTimer = startTranscribingTimer(setState);
+    transcriber = deps.startTranscriber(kesha, audioPath);
+    const result = normalizeTranscribeResult(audioPath, await transcriber.done);
+    stopTranscribeTimer?.();
+    stopTranscribeTimer = null;
+    transcriber = null;
+    return result;
+  }
+
+  async function deliverTranscript(result: TranscribeResult) {
+    const transcript = result.text.trim();
+    if (!transcript) {
+      throw new Error("No speech was detected in the recording.");
+    }
+    await deps.copyToClipboard(transcript);
+    await deps.showToast({
+      style: "success",
+      title: "Copied transcript",
+    });
+    setState({
+      status: "ok",
+      result: { ...result, text: transcript },
+    });
+  }
+
+  function releaseResources() {
+    recorder = null;
+    transcriber = null;
+    stopMonitoring?.();
+    stopMonitoring = null;
+    stopTranscribeTimer?.();
+    stopTranscribeTimer = null;
   }
 }
 

--- a/raycast/src/lib/dictation-types.ts
+++ b/raycast/src/lib/dictation-types.ts
@@ -18,7 +18,6 @@ export interface SignalLevel {
   peak: number;
   percent: number;
   state: SignalState;
-  status: string;
 }
 
 export type DictationState =

--- a/raycast/src/lib/dictation-types.ts
+++ b/raycast/src/lib/dictation-types.ts
@@ -59,11 +59,8 @@ export interface DictationSession {
 
 export interface DictationControllerDeps {
   resolveKesha: (preference: string | undefined) => Promise<KeshaSpawn | null>;
-  notFoundMessage: () => string;
   createTempDir: () => Promise<string>;
   cleanupTempDir: (tempDir: string) => Promise<void>;
-  audioPathForTempDir: (tempDir: string) => string;
-  audioBasename: (audioPath: string) => string;
   startRecordingMonitor: (
     onPatch: (patch: RecordingPatch) => void,
   ) => () => void;

--- a/raycast/src/lib/kesha-bin.ts
+++ b/raycast/src/lib/kesha-bin.ts
@@ -1,10 +1,6 @@
 import { access, constants, open, realpath } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
-
-const execFileAsync = promisify(execFile);
 
 const FALLBACK_CANDIDATES: ReadonlyArray<string> = [
   join(homedir(), ".bun", "bin", "kesha"),
@@ -104,23 +100,6 @@ export async function resolveKeshaBin(
     }
   }
   return null;
-}
-
-export async function probeKeshaVersion(
-  spawn: KeshaSpawn,
-): Promise<string | null> {
-  try {
-    const { stdout } = await execFileAsync(
-      spawn.command,
-      [...spawn.prefixArgs, "--version"],
-      {
-        timeout: 5000,
-      },
-    );
-    return stdout.trim() || null;
-  } catch {
-    return null;
-  }
 }
 
 export function notFoundMessage(): string {

--- a/raycast/src/lib/recording-view.ts
+++ b/raycast/src/lib/recording-view.ts
@@ -21,10 +21,7 @@ export function buildResultMarkdown(text: string): string {
   return ["# Dictation", "", text].join("\n");
 }
 
-export function buildTranscribingMarkdown(
-  state: Extract<DictationState, { status: "transcribing" }>,
-): string {
-  void state;
+export function buildTranscribingMarkdown(): string {
   return ["# Transcribing", "Processing locally with Kesha Voice Kit."].join(
     "\n\n",
   );

--- a/raycast/src/lib/recording-view.ts
+++ b/raycast/src/lib/recording-view.ts
@@ -4,11 +4,8 @@ import type {
   SignalState,
 } from "./dictation-types";
 
-export function emptySignal(
-  status: string,
-  state: SignalLevel["state"],
-): SignalLevel {
-  return { rms: 0, peak: 0, percent: 0, status, state };
+export function emptySignal(state: SignalLevel["state"]): SignalLevel {
+  return { rms: 0, peak: 0, percent: 0, state };
 }
 
 export function buildRecordingMarkdown(

--- a/raycast/src/lib/signal-meter.ts
+++ b/raycast/src/lib/signal-meter.ts
@@ -67,17 +67,8 @@ export function parseMeterLine(line: string): SignalLevel | null {
     const rms = numberValue(parsed.rms) ?? 0;
     const peak = numberValue(parsed.peak) ?? 0;
     const percent = Math.max(0, Math.min(100, Math.round(parsed.percent ?? 0)));
-    return {
-      rms,
-      peak,
-      percent,
-      state:
-        peak > SILENCE_PEAK_THRESHOLD || percent > 0 ? "signal" : "listening",
-      status:
-        peak > SILENCE_PEAK_THRESHOLD || percent > 0
-          ? "Signal detected"
-          : "Listening...",
-    };
+    const active = peak > SILENCE_PEAK_THRESHOLD || percent > 0;
+    return { rms, peak, percent, state: active ? "signal" : "listening" };
   } catch {
     return null;
   }
@@ -123,11 +114,11 @@ export function startLiveMicMeter(
   });
 
   proc.once("error", () => {
-    if (!stopped) onSignal(emptySignal("Meter unavailable", "unavailable"));
+    if (!stopped) onSignal(emptySignal("unavailable"));
   });
   proc.once("exit", () => {
     if (!stopped && !sawSignal) {
-      onSignal(emptySignal("Meter unavailable", "unavailable"));
+      onSignal(emptySignal("unavailable"));
     }
   });
 

--- a/raycast/tests/dictation-controller.test.ts
+++ b/raycast/tests/dictation-controller.test.ts
@@ -182,7 +182,7 @@ describe("dictation controller", () => {
     const deps = createDeps({
       startRecorder: vi.fn(() => resolvedTask(recorder.promise)),
       startRecordingMonitor: vi.fn((onPatch) => {
-        onPatch({ signal: emptySignal("Meter unavailable", "unavailable") });
+        onPatch({ signal: emptySignal("unavailable") });
         return vi.fn();
       }),
     });
@@ -193,10 +193,7 @@ describe("dictation controller", () => {
 
     expect(current()).toMatchObject({
       status: "recording",
-      signal: {
-        state: "unavailable",
-        status: "Meter unavailable",
-      },
+      signal: { state: "unavailable" },
     });
 
     recorder.resolve();
@@ -334,9 +331,9 @@ describe("dictation controller", () => {
     const session = startDictationSession({}, deps.setState, deps);
     await vi.waitFor(() => expect(deps.startRecorder).toHaveBeenCalled());
 
-    emit({ signal: emptySignal("Starting microphone meter...", "starting") });
+    emit({ signal: emptySignal("starting") });
     clock = 60_000;
-    emit({ signal: emptySignal("Starting microphone meter...", "starting") });
+    emit({ signal: emptySignal("starting") });
     expect(deps.current()).toMatchObject({ idle: false, silentForMs: 0 });
     expect(recorderStop).not.toHaveBeenCalled();
 
@@ -514,21 +511,9 @@ async function flushPromises() {
 }
 
 function listeningSignal(): SignalLevel {
-  return {
-    rms: 0,
-    peak: 0,
-    percent: 0,
-    state: "listening",
-    status: "Listening...",
-  };
+  return { rms: 0, peak: 0, percent: 0, state: "listening" };
 }
 
 function signalTick(): SignalLevel {
-  return {
-    rms: 0.02,
-    peak: 0.05,
-    percent: 24,
-    state: "signal",
-    status: "Signal detected",
-  };
+  return { rms: 0.02, peak: 0.05, percent: 24, state: "signal" };
 }

--- a/raycast/tests/dictation-controller.test.ts
+++ b/raycast/tests/dictation-controller.test.ts
@@ -93,7 +93,7 @@ describe("dictation controller", () => {
     expect(states.at(-1)).toEqual({
       status: "error",
       message: "kesha CLI not found.",
-      hint: "install kesha",
+      hint: expect.stringContaining("bun add -g @drakulavich/kesha-voice-kit"),
     });
   });
 
@@ -462,11 +462,8 @@ function createDeps(
   const toasts: unknown[] = [];
   const deps: DictationControllerDeps = {
     resolveKesha: vi.fn(async () => ({ command: "kesha", prefixArgs: [] })),
-    notFoundMessage: () => "install kesha",
     createTempDir: vi.fn(async () => "/tmp/session"),
     cleanupTempDir: vi.fn(async () => undefined),
-    audioPathForTempDir: (dir) => `${dir}/dictation.wav`,
-    audioBasename: (path) => path.split("/").at(-1) ?? path,
     startRecordingMonitor: vi.fn(() => vi.fn()),
     startRecorder: vi.fn(() => resolvedTask(Promise.resolve())),
     startTranscriber: vi.fn(() =>

--- a/raycast/tests/signal-meter.test.ts
+++ b/raycast/tests/signal-meter.test.ts
@@ -121,7 +121,7 @@ describe("recording markdown", () => {
       timeoutSeconds: 60,
     };
 
-    expect(buildTranscribingMarkdown(state)).toBe(
+    expect(buildTranscribingMarkdown()).toBe(
       "# Transcribing\n\nProcessing locally with Kesha Voice Kit.",
     );
     expect(formatDuration(state.elapsedSeconds)).toBe("0:12");

--- a/raycast/tests/signal-meter.test.ts
+++ b/raycast/tests/signal-meter.test.ts
@@ -17,14 +17,12 @@ describe("signal parsing", () => {
   it("parses valid meter JSON into listening and signal states", () => {
     expect(parseMeterLine('{"rms":0,"peak":0,"percent":0}')).toMatchObject({
       state: "listening",
-      status: "Listening...",
       percent: 0,
     });
     expect(
       parseMeterLine('{"rms":0.01,"peak":0.04,"percent":20}'),
     ).toMatchObject({
       state: "signal",
-      status: "Signal detected",
       percent: 20,
     });
   });
@@ -66,13 +64,7 @@ describe("recording markdown", () => {
       silentForMs: 0,
       idle: false,
       mic: { name: "Studio Mic", sampleRate: 48000, channels: 1 },
-      signal: {
-        rms: 0.01,
-        peak: 0.05,
-        percent: 24,
-        state: "signal",
-        status: "Signal detected",
-      },
+      signal: { rms: 0.01, peak: 0.05, percent: 24, state: "signal" },
     };
 
     expect(buildRecordingMarkdown(state)).toBe(
@@ -102,13 +94,7 @@ describe("recording markdown", () => {
       silentForMs: 32_000,
       idle: true,
       mic: { name: "Studio Mic" },
-      signal: {
-        rms: 0,
-        peak: 0,
-        percent: 0,
-        state: "listening",
-        status: "Listening...",
-      },
+      signal: { rms: 0, peak: 0, percent: 0, state: "listening" },
     };
 
     expect(buildRecordingMarkdown(state)).toBe(


### PR DESCRIPTION
First of two PRs from a simplification/testability review of the Raycast extension (second will add tests for `kesha-bin.ts`, `recording-monitor.ts`, `recording-view.ts`).

Behavior-preserving simplifications, one per commit:

- **Drop dead code**: `SignalLevel.status` was set and tested but never rendered — the UI derives labels from `signal.state` via `signalStatusLabel`. `probeKeshaVersion` had no callers. `parseMeterLine` loses its duplicated `peak > THRESHOLD || percent > 0` condition as a side effect.
- **`DictationControllerDeps` keeps side effects only**: `audioPathForTempDir`, `audioBasename`, `notFoundMessage` are pure; injecting them bought no testability (the test helper re-implemented `join`/`basename`). Interface shrinks 13 → 10 members.
- **`run()` split into named phases** (`recordPhase` / `transcribePhase` / `deliverTranscript`) with resource release consolidated into a single `releaseResources()` in `finally` — previously nulling/stopping was duplicated between the body and `finally`. States, toasts, and cancellation semantics unchanged.
- **`buildTranscribingMarkdown`** drops its unused `state` param (was `void state;`).
- **`raycast/CLAUDE.md`**: directory-scoped agent rules — npm-not-bun here, upstream `raycast/extensions` sync constraint, deps-injection convention.

Verified per commit: `npx vitest run` (43 tests) + `tsc --noEmit`; `npm run lint` (ray lint) green on the final tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012g6EWAkjR68hGC4BeasQzg