### PR TITLE
test(raycast): cover kesha-bin resolution, recording monitor, error-path toasts

### DIFF
--- a/raycast/src/lib/kesha-bin.ts
+++ b/raycast/src/lib/kesha-bin.ts
@@ -24,7 +24,15 @@ export interface KeshaSpawn {
   prefixArgs: string[];
 }
 
-async function isExecutable(path: string): Promise<boolean> {
+export interface KeshaBinDeps {
+  candidates?: ReadonlyArray<string>;
+  interpreterCandidates?: ReadonlyArray<string>;
+  isExecutable?: (path: string) => Promise<boolean>;
+  readShebang?: (path: string) => Promise<string | null>;
+  realpath?: (path: string) => Promise<string>;
+}
+
+async function defaultIsExecutable(path: string): Promise<boolean> {
   try {
     await access(path, constants.X_OK);
     return true;
@@ -33,18 +41,22 @@ async function isExecutable(path: string): Promise<boolean> {
   }
 }
 
-async function readShebang(path: string): Promise<string | null> {
+export function parseShebang(head: Buffer): string | null {
+  if (head.length < 2 || head[0] !== 0x23 || head[1] !== 0x21) {
+    return null;
+  }
+  const eol = head.indexOf(0x0a);
+  const end = eol > 0 ? eol : head.length;
+  return head.subarray(2, end).toString("utf8").trim();
+}
+
+async function defaultReadShebang(path: string): Promise<string | null> {
   try {
     const fd = await open(path, "r");
     try {
       const buf = Buffer.alloc(128);
       const { bytesRead } = await fd.read(buf, 0, 128, 0);
-      if (bytesRead < 2 || buf[0] !== 0x23 || buf[1] !== 0x21) {
-        return null;
-      }
-      const eol = buf.indexOf(0x0a, 0);
-      const end = eol > 0 ? eol : bytesRead;
-      return buf.slice(2, end).toString("utf8").trim();
+      return parseShebang(buf.subarray(0, bytesRead));
     } finally {
       await fd.close();
     }
@@ -53,8 +65,12 @@ async function readShebang(path: string): Promise<string | null> {
   }
 }
 
-async function findInterpreter(name: string): Promise<string | null> {
-  for (const path of INTERPRETER_CANDIDATES) {
+async function findInterpreter(
+  name: string,
+  deps: KeshaBinDeps,
+): Promise<string | null> {
+  const isExecutable = deps.isExecutable ?? defaultIsExecutable;
+  for (const path of deps.interpreterCandidates ?? INTERPRETER_CANDIDATES) {
     if (path.endsWith(`/${name}`) && (await isExecutable(path))) {
       return path;
     }
@@ -62,13 +78,19 @@ async function findInterpreter(name: string): Promise<string | null> {
   return null;
 }
 
-async function buildSpawn(path: string): Promise<KeshaSpawn | null> {
+async function buildSpawn(
+  path: string,
+  deps: KeshaBinDeps,
+): Promise<KeshaSpawn | null> {
+  const isExecutable = deps.isExecutable ?? defaultIsExecutable;
+  const readShebang = deps.readShebang ?? defaultReadShebang;
+  const resolvePath = deps.realpath ?? realpath;
   if (!(await isExecutable(path))) {
     return null;
   }
   let resolved = path;
   try {
-    resolved = await realpath(path);
+    resolved = await resolvePath(path);
   } catch {
     // Keep original path if the symlink target cannot be resolved.
   }
@@ -78,7 +100,7 @@ async function buildSpawn(path: string): Promise<KeshaSpawn | null> {
   }
   const envMatch = shebang.match(/^\/usr\/bin\/env\s+([\w.-]+)/);
   if (envMatch) {
-    const interp = await findInterpreter(envMatch[1]);
+    const interp = await findInterpreter(envMatch[1], deps);
     if (interp) {
       return { command: interp, prefixArgs: [resolved] };
     }
@@ -88,13 +110,14 @@ async function buildSpawn(path: string): Promise<KeshaSpawn | null> {
 
 export async function resolveKeshaBin(
   preference: string | undefined,
+  deps: KeshaBinDeps = {},
 ): Promise<KeshaSpawn | null> {
   const trimmed = preference?.trim();
   if (trimmed) {
-    return buildSpawn(trimmed);
+    return buildSpawn(trimmed, deps);
   }
-  for (const candidate of FALLBACK_CANDIDATES) {
-    const spawn = await buildSpawn(candidate);
+  for (const candidate of deps.candidates ?? FALLBACK_CANDIDATES) {
+    const spawn = await buildSpawn(candidate, deps);
     if (spawn) {
       return spawn;
     }

--- a/raycast/src/lib/kesha-bin.ts
+++ b/raycast/src/lib/kesha-bin.ts
@@ -65,13 +65,23 @@ async function defaultReadShebang(path: string): Promise<string | null> {
   }
 }
 
+function withDefaults(deps: KeshaBinDeps): Required<KeshaBinDeps> {
+  return {
+    candidates: FALLBACK_CANDIDATES,
+    interpreterCandidates: INTERPRETER_CANDIDATES,
+    isExecutable: defaultIsExecutable,
+    readShebang: defaultReadShebang,
+    realpath,
+    ...deps,
+  };
+}
+
 async function findInterpreter(
   name: string,
-  deps: KeshaBinDeps,
+  deps: Required<KeshaBinDeps>,
 ): Promise<string | null> {
-  const isExecutable = deps.isExecutable ?? defaultIsExecutable;
-  for (const path of deps.interpreterCandidates ?? INTERPRETER_CANDIDATES) {
-    if (path.endsWith(`/${name}`) && (await isExecutable(path))) {
+  for (const path of deps.interpreterCandidates) {
+    if (path.endsWith(`/${name}`) && (await deps.isExecutable(path))) {
       return path;
     }
   }
@@ -80,21 +90,18 @@ async function findInterpreter(
 
 async function buildSpawn(
   path: string,
-  deps: KeshaBinDeps,
+  deps: Required<KeshaBinDeps>,
 ): Promise<KeshaSpawn | null> {
-  const isExecutable = deps.isExecutable ?? defaultIsExecutable;
-  const readShebang = deps.readShebang ?? defaultReadShebang;
-  const resolvePath = deps.realpath ?? realpath;
-  if (!(await isExecutable(path))) {
+  if (!(await deps.isExecutable(path))) {
     return null;
   }
   let resolved = path;
   try {
-    resolved = await resolvePath(path);
+    resolved = await deps.realpath(path);
   } catch {
     // Keep original path if the symlink target cannot be resolved.
   }
-  const shebang = await readShebang(resolved);
+  const shebang = await deps.readShebang(resolved);
   if (!shebang) {
     return { command: path, prefixArgs: [] };
   }
@@ -112,12 +119,13 @@ export async function resolveKeshaBin(
   preference: string | undefined,
   deps: KeshaBinDeps = {},
 ): Promise<KeshaSpawn | null> {
+  const resolved = withDefaults(deps);
   const trimmed = preference?.trim();
   if (trimmed) {
-    return buildSpawn(trimmed, deps);
+    return buildSpawn(trimmed, resolved);
   }
-  for (const candidate of deps.candidates ?? FALLBACK_CANDIDATES) {
-    const spawn = await buildSpawn(candidate, deps);
+  for (const candidate of resolved.candidates) {
+    const spawn = await buildSpawn(candidate, resolved);
     if (spawn) {
       return spawn;
     }

--- a/raycast/src/lib/recording-monitor.ts
+++ b/raycast/src/lib/recording-monitor.ts
@@ -7,10 +7,12 @@ import { startLiveMicMeter } from "./signal-meter";
 
 const execFileAsync = promisify(execFile);
 
+export type MonitorTimer = ReturnType<typeof setInterval>;
+
 export interface RecordingMonitorDeps {
   now?: () => number;
-  setInterval?: typeof setInterval;
-  clearInterval?: typeof clearInterval;
+  setInterval?: (fn: () => void, ms: number) => MonitorTimer;
+  clearInterval?: (timer: MonitorTimer) => void;
   resolveDefaultMicInfo?: () => Promise<RecordingPatch["mic"]>;
   startLiveMicMeter?: (onSignal: (signal: SignalLevel) => void) => () => void;
 }

--- a/raycast/tests/dictation-controller.test.ts
+++ b/raycast/tests/dictation-controller.test.ts
@@ -13,6 +13,7 @@ import type {
   SignalLevel,
 } from "../src/lib/dictation-types";
 import { emptySignal } from "../src/lib/recording-view";
+import { deferred, flushPromises } from "./helpers/async";
 
 describe("dictation controller", () => {
   it("runs the happy path and copies the trimmed transcript", async () => {
@@ -498,21 +499,6 @@ function createDeps(
 
 function resolvedTask<T>(done: Promise<T>): RunningTask<T> {
   return { done, stop: vi.fn() };
-}
-
-function deferred<T>() {
-  let resolve!: (value: T | PromiseLike<T>) => void;
-  let reject!: (reason?: unknown) => void;
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-  return { promise, resolve, reject };
-}
-
-async function flushPromises() {
-  await Promise.resolve();
-  await Promise.resolve();
 }
 
 function listeningSignal(): SignalLevel {

--- a/raycast/tests/dictation-controller.test.ts
+++ b/raycast/tests/dictation-controller.test.ts
@@ -59,6 +59,10 @@ describe("dictation controller", () => {
       message:
         "Recorded audio is silent. Check macOS Microphone permission for Raycast and the selected input device.",
     });
+    expect(deps.toasts).toContainEqual({
+      style: "failure",
+      title: "Dictation failed",
+    });
     expect(deps.cleanupTempDir).toHaveBeenCalledWith("/tmp/session");
   });
 
@@ -77,6 +81,10 @@ describe("dictation controller", () => {
     expect(states.at(-1)).toMatchObject({
       status: "error",
       message: "mic denied",
+    });
+    expect(deps.toasts).toContainEqual({
+      style: "failure",
+      title: "Dictation failed",
     });
   });
 

--- a/raycast/tests/helpers/async.ts
+++ b/raycast/tests/helpers/async.ts
@@ -1,0 +1,14 @@
+export function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+export async function flushPromises() {
+  await Promise.resolve();
+  await Promise.resolve();
+}

--- a/raycast/tests/kesha-bin.test.ts
+++ b/raycast/tests/kesha-bin.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { parseShebang, resolveKeshaBin } from "../src/lib/kesha-bin";
 import type { KeshaBinDeps } from "../src/lib/kesha-bin";
 
@@ -29,24 +29,19 @@ describe("parseShebang", () => {
 });
 
 interface FakeFile {
-  shebang?: string | null;
+  shebang?: string;
   realpath?: string;
 }
 
 function fakeDeps(
   files: Record<string, FakeFile>,
-  overrides: Partial<KeshaBinDeps> = {},
+  overrides: KeshaBinDeps = {},
 ): KeshaBinDeps {
   return {
-    candidates: [],
     interpreterCandidates: [],
     isExecutable: async (path) => path in files,
     readShebang: async (path) => files[path]?.shebang ?? null,
-    realpath: async (path) => {
-      const target = files[path]?.realpath;
-      if (!target) throw new Error(`ENOENT: ${path}`);
-      return target;
-    },
+    realpath: async (path) => files[path]?.realpath ?? path,
     ...overrides,
   };
 }
@@ -109,9 +104,7 @@ describe("resolveKeshaBin", () => {
   it("falls back to direct execution when no interpreter matches", async () => {
     const deps = fakeDeps(
       {
-        "/global/kesha": {
-          realpath: "/pkg/cli.ts",
-        },
+        "/global/kesha": { realpath: "/pkg/cli.ts" },
         "/pkg/cli.ts": { shebang: "/usr/bin/env bun" },
         "/opt/bin/node": {},
       },
@@ -126,17 +119,24 @@ describe("resolveKeshaBin", () => {
     });
   });
 
-  it("keeps the original path when realpath fails", async () => {
-    const readShebang = vi.fn(async () => null);
+  it("reads the shebang from the original path when realpath fails", async () => {
     const deps = fakeDeps(
-      { "/global/kesha": {} },
-      { candidates: ["/global/kesha"], readShebang },
+      {
+        "/global/kesha": { shebang: "/usr/bin/env bun" },
+        "/opt/bin/bun": {},
+      },
+      {
+        candidates: ["/global/kesha"],
+        interpreterCandidates: ["/opt/bin/bun"],
+        realpath: async (path) => {
+          throw new Error(`ENOENT: ${path}`);
+        },
+      },
     );
     expect(await resolveKeshaBin(undefined, deps)).toEqual({
-      command: "/global/kesha",
-      prefixArgs: [],
+      command: "/opt/bin/bun",
+      prefixArgs: ["/global/kesha"],
     });
-    expect(readShebang).toHaveBeenCalledWith("/global/kesha");
   });
 
   it("executes non-env shebangs directly", async () => {

--- a/raycast/tests/kesha-bin.test.ts
+++ b/raycast/tests/kesha-bin.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it, vi } from "vitest";
+import { parseShebang, resolveKeshaBin } from "../src/lib/kesha-bin";
+import type { KeshaBinDeps } from "../src/lib/kesha-bin";
+
+describe("parseShebang", () => {
+  it("extracts the interpreter line from a shebang header", () => {
+    expect(parseShebang(Buffer.from("#!/usr/bin/env bun\nconsole.log()"))).toBe(
+      "/usr/bin/env bun",
+    );
+    expect(parseShebang(Buffer.from("#!/bin/sh -e\n"))).toBe("/bin/sh -e");
+  });
+
+  it("handles a header without a newline in the first bytes", () => {
+    expect(parseShebang(Buffer.from("#!/bin/sh"))).toBe("/bin/sh");
+  });
+
+  it("trims whitespace including CRLF line endings", () => {
+    expect(parseShebang(Buffer.from("#!/usr/bin/env bun\r\nrest"))).toBe(
+      "/usr/bin/env bun",
+    );
+    expect(parseShebang(Buffer.from("#! /bin/sh \n"))).toBe("/bin/sh");
+  });
+
+  it("returns null for binaries and empty files", () => {
+    expect(parseShebang(Buffer.from([0x7f, 0x45, 0x4c, 0x46]))).toBeNull();
+    expect(parseShebang(Buffer.alloc(0))).toBeNull();
+    expect(parseShebang(Buffer.from("#"))).toBeNull();
+  });
+});
+
+interface FakeFile {
+  shebang?: string | null;
+  realpath?: string;
+}
+
+function fakeDeps(
+  files: Record<string, FakeFile>,
+  overrides: Partial<KeshaBinDeps> = {},
+): KeshaBinDeps {
+  return {
+    candidates: [],
+    interpreterCandidates: [],
+    isExecutable: async (path) => path in files,
+    readShebang: async (path) => files[path]?.shebang ?? null,
+    realpath: async (path) => {
+      const target = files[path]?.realpath;
+      if (!target) throw new Error(`ENOENT: ${path}`);
+      return target;
+    },
+    ...overrides,
+  };
+}
+
+describe("resolveKeshaBin", () => {
+  it("prefers the explicit preference and trims it", async () => {
+    const deps = fakeDeps(
+      { "/custom/kesha": {} },
+      { candidates: ["/fallback/kesha"] },
+    );
+    expect(await resolveKeshaBin(" /custom/kesha ", deps)).toEqual({
+      command: "/custom/kesha",
+      prefixArgs: [],
+    });
+  });
+
+  it("does not fall back to candidates when the preference is unusable", async () => {
+    const deps = fakeDeps(
+      { "/fallback/kesha": {} },
+      { candidates: ["/fallback/kesha"] },
+    );
+    expect(await resolveKeshaBin("/missing/kesha", deps)).toBeNull();
+  });
+
+  it("picks the first executable fallback candidate", async () => {
+    const deps = fakeDeps(
+      { "/second/kesha": {}, "/third/kesha": {} },
+      { candidates: ["/first/kesha", "/second/kesha", "/third/kesha"] },
+    );
+    expect(await resolveKeshaBin(undefined, deps)).toEqual({
+      command: "/second/kesha",
+      prefixArgs: [],
+    });
+  });
+
+  it("returns null when nothing is executable", async () => {
+    const deps = fakeDeps({}, { candidates: ["/a/kesha", "/b/kesha"] });
+    expect(await resolveKeshaBin("", deps)).toBeNull();
+  });
+
+  it("runs an env-shebang script through a matching interpreter", async () => {
+    const deps = fakeDeps(
+      {
+        "/global/kesha": { realpath: "/pkg/cli.ts" },
+        "/pkg/cli.ts": { shebang: "/usr/bin/env bun" },
+        "/opt/bin/node": {},
+        "/opt/bin/bun": {},
+      },
+      {
+        candidates: ["/global/kesha"],
+        interpreterCandidates: ["/opt/bin/node", "/opt/bin/bun"],
+      },
+    );
+    expect(await resolveKeshaBin(undefined, deps)).toEqual({
+      command: "/opt/bin/bun",
+      prefixArgs: ["/pkg/cli.ts"],
+    });
+  });
+
+  it("falls back to direct execution when no interpreter matches", async () => {
+    const deps = fakeDeps(
+      {
+        "/global/kesha": {
+          realpath: "/pkg/cli.ts",
+        },
+        "/pkg/cli.ts": { shebang: "/usr/bin/env bun" },
+        "/opt/bin/node": {},
+      },
+      {
+        candidates: ["/global/kesha"],
+        interpreterCandidates: ["/opt/bin/node"],
+      },
+    );
+    expect(await resolveKeshaBin(undefined, deps)).toEqual({
+      command: "/global/kesha",
+      prefixArgs: [],
+    });
+  });
+
+  it("keeps the original path when realpath fails", async () => {
+    const readShebang = vi.fn(async () => null);
+    const deps = fakeDeps(
+      { "/global/kesha": {} },
+      { candidates: ["/global/kesha"], readShebang },
+    );
+    expect(await resolveKeshaBin(undefined, deps)).toEqual({
+      command: "/global/kesha",
+      prefixArgs: [],
+    });
+    expect(readShebang).toHaveBeenCalledWith("/global/kesha");
+  });
+
+  it("executes non-env shebangs directly", async () => {
+    const deps = fakeDeps(
+      {
+        "/global/kesha": { realpath: "/pkg/kesha.sh" },
+        "/pkg/kesha.sh": { shebang: "/bin/sh" },
+      },
+      { candidates: ["/global/kesha"] },
+    );
+    expect(await resolveKeshaBin(undefined, deps)).toEqual({
+      command: "/global/kesha",
+      prefixArgs: [],
+    });
+  });
+});

--- a/raycast/tests/recording-monitor.test.ts
+++ b/raycast/tests/recording-monitor.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from "vitest";
+import { startRecordingMonitor } from "../src/lib/recording-monitor";
+import type { RecordingMonitorDeps } from "../src/lib/recording-monitor";
+import type { RecordingPatch, SignalLevel } from "../src/lib/dictation-types";
+import { emptySignal } from "../src/lib/recording-view";
+import { METER_INTERVAL_MS } from "../src/lib/dictation-config";
+
+function createHarness(overrides: Partial<RecordingMonitorDeps> = {}) {
+  let clock = 0;
+  let tick: (() => void) | null = null;
+  let onSignal: ((signal: SignalLevel) => void) | null = null;
+  const patches: RecordingPatch[] = [];
+  const timerToken = {} as ReturnType<typeof setInterval>;
+  const clearIntervalSpy = vi.fn();
+  const stopMeter = vi.fn();
+  const micInfo = deferred<RecordingPatch["mic"]>();
+
+  const schedule = vi.fn((fn: () => void) => {
+    tick = fn;
+    return timerToken;
+  }) as unknown as typeof setInterval;
+
+  const deps: RecordingMonitorDeps = {
+    now: () => clock,
+    setInterval: schedule,
+    clearInterval: clearIntervalSpy as unknown as typeof clearInterval,
+    resolveDefaultMicInfo: () => micInfo.promise,
+    startLiveMicMeter: (cb) => {
+      onSignal = cb;
+      return stopMeter;
+    },
+    ...overrides,
+  };
+
+  const stop = startRecordingMonitor((patch) => patches.push(patch), deps);
+  return {
+    patches,
+    stop,
+    stopMeter,
+    clearIntervalSpy,
+    timerToken,
+    micInfo,
+    schedule,
+    setClock: (value: number) => {
+      clock = value;
+    },
+    fireTick: () => tick?.(),
+    emitSignal: (signal: SignalLevel) => onSignal?.(signal),
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+describe("startRecordingMonitor", () => {
+  it("emits an immediate elapsed tick and schedules the meter interval", () => {
+    const harness = createHarness();
+    expect(harness.patches).toEqual([{ elapsedSeconds: 0 }]);
+    expect(harness.schedule).toHaveBeenCalledWith(
+      expect.any(Function),
+      METER_INTERVAL_MS,
+    );
+  });
+
+  it("reports elapsed whole seconds from its start time", () => {
+    const harness = createHarness();
+    harness.setClock(2_400);
+    harness.fireTick();
+    expect(harness.patches.at(-1)).toEqual({ elapsedSeconds: 2 });
+  });
+
+  it("forwards mic info and meter signals as patches", async () => {
+    const harness = createHarness();
+    harness.emitSignal(emptySignal("unavailable"));
+    harness.micInfo.resolve({ name: "Studio Mic", sampleRate: 48000 });
+    await Promise.resolve();
+
+    expect(harness.patches).toContainEqual({
+      signal: emptySignal("unavailable"),
+    });
+    expect(harness.patches).toContainEqual({
+      mic: { name: "Studio Mic", sampleRate: 48000 },
+    });
+  });
+
+  it("stops the timer and meter, then drops late updates", async () => {
+    const harness = createHarness();
+    harness.stop();
+
+    expect(harness.clearIntervalSpy).toHaveBeenCalledWith(harness.timerToken);
+    expect(harness.stopMeter).toHaveBeenCalledTimes(1);
+
+    const seen = harness.patches.length;
+    harness.fireTick();
+    harness.emitSignal(emptySignal("unavailable"));
+    harness.micInfo.resolve({ name: "Late Mic" });
+    await Promise.resolve();
+    expect(harness.patches).toHaveLength(seen);
+  });
+});

--- a/raycast/tests/recording-monitor.test.ts
+++ b/raycast/tests/recording-monitor.test.ts
@@ -1,35 +1,38 @@
 import { describe, expect, it, vi } from "vitest";
 import { startRecordingMonitor } from "../src/lib/recording-monitor";
-import type { RecordingMonitorDeps } from "../src/lib/recording-monitor";
+import type {
+  MonitorTimer,
+  RecordingMonitorDeps,
+} from "../src/lib/recording-monitor";
 import type { RecordingPatch, SignalLevel } from "../src/lib/dictation-types";
 import { emptySignal } from "../src/lib/recording-view";
 import { METER_INTERVAL_MS } from "../src/lib/dictation-config";
+import { deferred, flushPromises } from "./helpers/async";
 
-function createHarness(overrides: Partial<RecordingMonitorDeps> = {}) {
+function createHarness() {
   let clock = 0;
   let tick: (() => void) | null = null;
   let onSignal: ((signal: SignalLevel) => void) | null = null;
   const patches: RecordingPatch[] = [];
-  const timerToken = {} as ReturnType<typeof setInterval>;
+  const timerToken = {} as MonitorTimer;
   const clearIntervalSpy = vi.fn();
   const stopMeter = vi.fn();
   const micInfo = deferred<RecordingPatch["mic"]>();
 
-  const schedule = vi.fn((fn: () => void) => {
+  const schedule = vi.fn((fn: () => void, _ms: number) => {
     tick = fn;
     return timerToken;
-  }) as unknown as typeof setInterval;
+  });
 
   const deps: RecordingMonitorDeps = {
     now: () => clock,
     setInterval: schedule,
-    clearInterval: clearIntervalSpy as unknown as typeof clearInterval,
+    clearInterval: clearIntervalSpy,
     resolveDefaultMicInfo: () => micInfo.promise,
     startLiveMicMeter: (cb) => {
       onSignal = cb;
       return stopMeter;
     },
-    ...overrides,
   };
 
   const stop = startRecordingMonitor((patch) => patches.push(patch), deps);
@@ -49,18 +52,10 @@ function createHarness(overrides: Partial<RecordingMonitorDeps> = {}) {
   };
 }
 
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((res) => {
-    resolve = res;
-  });
-  return { promise, resolve };
-}
-
 describe("startRecordingMonitor", () => {
   it("emits an immediate elapsed tick and schedules the meter interval", () => {
     const harness = createHarness();
-    expect(harness.patches).toEqual([{ elapsedSeconds: 0 }]);
+    expect(harness.patches).toContainEqual({ elapsedSeconds: 0 });
     expect(harness.schedule).toHaveBeenCalledWith(
       expect.any(Function),
       METER_INTERVAL_MS,
@@ -78,7 +73,7 @@ describe("startRecordingMonitor", () => {
     const harness = createHarness();
     harness.emitSignal(emptySignal("unavailable"));
     harness.micInfo.resolve({ name: "Studio Mic", sampleRate: 48000 });
-    await Promise.resolve();
+    await flushPromises();
 
     expect(harness.patches).toContainEqual({
       signal: emptySignal("unavailable"),
@@ -99,7 +94,7 @@ describe("startRecordingMonitor", () => {
     harness.fireTick();
     harness.emitSignal(emptySignal("unavailable"));
     harness.micInfo.resolve({ name: "Late Mic" });
-    await Promise.resolve();
+    await flushPromises();
     expect(harness.patches).toHaveLength(seen);
   });
 });

--- a/raycast/tests/signal-meter.test.ts
+++ b/raycast/tests/signal-meter.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildRecordingMarkdown,
+  buildResultMarkdown,
   buildTranscribingMarkdown,
   formatDuration,
   formatInputFormat,
@@ -77,6 +78,12 @@ describe("recording markdown", () => {
     expect(signalStatusTone(state.signal.state)).toBe("green");
     expect(recordingStatusLabel(state)).toBe("Signal");
     expect(recordingStatusTone(state)).toBe("green");
+  });
+
+  it("renders the transcript under a Dictation heading", () => {
+    expect(buildResultMarkdown("hello world")).toBe(
+      "# Dictation\n\nhello world",
+    );
   });
 
   it("renders elapsed durations as m:ss and never advertises a max", () => {


### PR DESCRIPTION
Second PR from the raycast simplification/testability review (follow-up to #613). Closes the coverage gaps found there plus a nit from an external adversarial review.

- **`kesha-bin.ts`** — the trickiest platform-specific logic (symlink → shebang → `/usr/bin/env` → interpreter search) had zero tests and was untestable: candidates and fs calls were hardwired at module level. `parseShebang` is now a pure function and `resolveKeshaBin` takes the same optional trailing `deps` object the other modules use (candidates + fs injectors); defaults unchanged. 12 tests pin the resolution chain, including preference-does-not-fall-back, interpreter-name matching, realpath failure, and non-env shebangs.
- **`recording-monitor.ts`** — DI was already in place, tests weren't: immediate elapsed tick, interval scheduling, mic-info/signal patches, and the stopped-guard dropping late updates after teardown.
- **Error-path toasts** — silent-audio and recorder-failure tests now assert the `Dictation failed` failure toast (pre-existing gap flagged by an external grok review of #613).
- **`buildResultMarkdown`** — was the one view helper without coverage.

`npx vitest run` 60/60 (was 43), `tsc --noEmit`, `npm run lint` (ray lint) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012g6EWAkjR68hGC4BeasQzg