### PR TITLE
fix(raycast): stop transcription cancel racing the transcribing toast

### DIFF
--- a/raycast/src/lib/dictation-controller.ts
+++ b/raycast/src/lib/dictation-controller.ts
@@ -90,7 +90,7 @@ export function startDictationSession(
       }
 
       const result = await transcribePhase(kesha, audioPath);
-      if (cancelled) return;
+      if (!result || cancelled) return;
 
       await deliverTranscript(result);
     } catch (err: unknown) {
@@ -161,7 +161,7 @@ export function startDictationSession(
   async function transcribePhase(
     kesha: KeshaSpawn,
     audioPath: string,
-  ): Promise<TranscribeResult> {
+  ): Promise<TranscribeResult | null> {
     setState({
       status: "transcribing",
       elapsedSeconds: 0,
@@ -172,6 +172,7 @@ export function startDictationSession(
       title: "Transcribing",
       message: basename(audioPath),
     });
+    if (cancelled) return null;
 
     stopTranscribeTimer = startTranscribingTimer(setState);
     transcriber = deps.startTranscriber(kesha, audioPath);

--- a/raycast/tests/dictation-controller.test.ts
+++ b/raycast/tests/dictation-controller.test.ts
@@ -241,6 +241,33 @@ describe("dictation controller", () => {
     await session.done;
   });
 
+  it("does not start the transcriber when cancelled during the transcribing toast", async () => {
+    const transcribingToast = deferred<void>();
+    const deps = createDeps({
+      showToast: vi.fn(async (toast) => {
+        deps.toasts.push(toast);
+        if (toast.title === "Transcribing") {
+          await transcribingToast.promise;
+        }
+      }),
+    });
+    const { states } = deps;
+
+    const session = startDictationSession({}, deps.setState, deps);
+    await vi.waitFor(() => expect(states.at(-1)?.status).toBe("transcribing"));
+
+    session.cancelTranscription();
+    transcribingToast.resolve();
+    await session.done;
+
+    expect(deps.startTranscriber).not.toHaveBeenCalled();
+    expect(states.at(-1)).toEqual({
+      status: "error",
+      message: "Transcription cancelled.",
+    });
+    expect(deps.cleanupTempDir).toHaveBeenCalledWith("/tmp/session");
+  });
+
   it("auto-stops and transcribes after continuous silence", async () => {
     let clock = 0;
     let emit!: (patch: RecordingPatch) => void;


### PR DESCRIPTION
Fixes the last open finding from the adversarial (grok) review of #613: `cancelTranscription()` landing while the `Transcribing` toast was awaited set the `cancelled` flag, but `startTranscriber` spawned right after anyway — the engine ran a full transcription (up to the 60 s timeout) whose result was then discarded by the `if (cancelled) return` guard.

`transcribePhase` now re-checks `cancelled` after the toast and returns `null` without spawning, mirroring the identical guard `recordPhase` already has after the `Recording` toast. New test pins it: cancel during the toast → transcriber never started, `Transcription cancelled.` state, temp dir cleaned.

61/61 tests, `tsc --noEmit`, `ray lint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012g6EWAkjR68hGC4BeasQzg