### PR TITLE
fix(transcribe): clamp chunk-overlap tail to a char boundary

### DIFF
--- a/rust/src/transcribe/mod.rs
+++ b/rust/src/transcribe/mod.rs
@@ -551,8 +551,11 @@ where
                 // is both wasteful and increases false-positive risk from
                 // repeated phrases appearing elsewhere in the recording.
                 let overlap_chars = (FIXED_CHUNK_OVERLAP_SECONDS * 20.0).ceil() as usize;
-                let acc_tail =
-                    &accumulated_text[accumulated_text.len().saturating_sub(overlap_chars * 4)..];
+                let mut tail_start = accumulated_text.len().saturating_sub(overlap_chars * 4);
+                while !accumulated_text.is_char_boundary(tail_start) {
+                    tail_start -= 1;
+                }
+                let acc_tail = &accumulated_text[tail_start..];
                 let trimmed = trim_repeated_prefix(acc_tail, text.trim());
                 if trimmed.is_empty() {
                     continue;
@@ -1029,6 +1032,27 @@ mod tests {
         .unwrap();
         assert_eq!(segs.len(), 1);
         assert_eq!(segs[0].text, "spoken tail");
+    }
+
+    #[test]
+    fn chunked_segments_clamp_overlap_tail_to_char_boundary() {
+        let samples = vec![0.0_f32; 30];
+        let long_ru = "я".repeat(300);
+        let mut call = 0usize;
+        let segs = build_chunked_output_segments(&samples, 10.0, 1.0, 0.2, |_slice| {
+            call += 1;
+            Ok(match call {
+                1 => long_ru.clone(),
+                2 => "привет".to_string(),
+                3 => "мир".to_string(),
+                _ => "конец".to_string(),
+            })
+        })
+        .expect("cyrillic transcripts must not panic while trimming overlap");
+
+        assert_eq!(segs.len(), 4);
+        assert_eq!(segs[0].text, long_ru);
+        assert_eq!(segs[3].text, "конец");
     }
 
     #[test]


### PR DESCRIPTION
First PR from the rust/ simplification & testability review. `build_chunked_output_segments` sliced the accumulated transcript at a raw byte offset (`len - overlap_chars * 4`) to bound the overlap-trimming window. On any transcript where that offset lands inside a multi-byte codepoint — a Cyrillic recording longer than ~400 bytes of text with mixed ASCII spacing, i.e. the primary kesha use case — the engine panicked:

```
byte index 213 is not a char boundary; it is inside 'я' (bytes 212..214)
```

TDD: the new `chunked_segments_clamp_overlap_tail_to_char_boundary` test reproduced the panic verbatim against the old code, then the fix (clamp `tail_start` down to `is_char_boundary`) turns it green. Verified: `cargo nextest run --features tts` 387/387, `cargo fmt`, `cargo clippy --all-targets -- -D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012g6EWAkjR68hGC4BeasQzg