### PR TITLE
refactor(tts): inject sessions into say arms, collapse say_loop handlers

### DIFF
--- a/rust/src/say_loop.rs
+++ b/rust/src/say_loop.rs
@@ -99,16 +99,9 @@ fn default_expand_abbrev() -> bool {
 }
 
 struct LoopState {
-    /// `Option` to defer load until the first Kokoro request; `ensure_model` handles swaps.
-    kokoro: Option<tts::sessions::KokoroSession>,
-    /// Vosk cache by model directory. The Russian path uses one model dir
-    /// today, but keep it map-shaped so adding more languages is a no-op.
-    vosk: tts::sessions::VoskCache,
-    /// Cached CharsiuG2P session (three ONNX sessions, ~100 MB). Loaded once
-    /// on the first Romance-language (es/fr/it/pt) request and reused for all
-    /// subsequent ones. Fixes Greptile P1 (#509): previously `text_to_ipa`
-    /// reloaded the three sessions from disk on every request.
-    charsiu: tts::sessions::CharsiuCache,
+    /// Kokoro loads on the first request; CharsiuG2P (three ONNX sessions,
+    /// ~100 MB) is cached per #509; Vosk stays map-shaped per model dir.
+    sessions: tts::sessions::TtsSessions,
 }
 
 /// Drive the loop. Returns 0 on clean stdin EOF, 4 on read error.
@@ -118,9 +111,7 @@ pub fn run() -> i32 {
     let stdout = std::io::stdout();
     let mut stdout = stdout.lock();
     let mut state = LoopState {
-        kokoro: None,
-        vosk: tts::sessions::VoskCache::new(),
-        charsiu: tts::sessions::CharsiuCache::new(),
+        sessions: tts::sessions::TtsSessions::default(),
     };
 
     let mut buf: Vec<u8> = Vec::with_capacity(4096);
@@ -253,16 +244,8 @@ fn handle(req: &LoopRequest, state: &mut LoopState) -> Result<Vec<u8>, String> {
     }
 }
 
-/// Empty-segment check centralised here so every engine arm gets the same error.
-fn parse_ssml_or_err(text: &str) -> Result<Vec<tts::ssml::Segment>, String> {
-    let segments = tts::ssml::parse(text).map_err(|e| format!("ssml: {e}"))?;
-    if segments.is_empty() {
-        return Err("SSML had no speakable content".into());
-    }
-    Ok(segments)
-}
-
-/// Kokoro arm of [`handle`]: session reuse across ssml / English-segment / G2P-IPA paths.
+/// Kokoro arm of [`handle`]: shared dispatch in `tts::say::say_kokoro`, with
+/// this process's cached sessions injected.
 fn handle_kokoro(
     req: &LoopRequest,
     state: &mut LoopState,
@@ -271,70 +254,21 @@ fn handle_kokoro(
     espeak_lang: &str,
     format: tts::encode::OutputFormat,
 ) -> Result<Vec<u8>, String> {
-    let sess = match state.kokoro.as_mut() {
-        Some(s) => {
-            s.ensure_model(model_path)
-                .map_err(|e| format!("kokoro reload: {e}"))?;
-            s
-        }
-        None => state.kokoro.insert(
-            tts::sessions::KokoroSession::load(model_path)
-                .map_err(|e| format!("kokoro load: {e}"))?,
-        ),
-    };
-
-    if req.ssml {
-        let segments = parse_ssml_or_err(&req.text)?;
-        // Apply English acronym normalization (Spell→letter names,
-        // Text→expand when expand_abbrev) for en-* voices. Mirrors
-        // the one-shot path in tts::synth_segments_kokoro (#244).
-        let segments = if tts::en::is_en(espeak_lang) {
-            tts::en::normalize_segments(segments, req.expand_abbrev)
-        } else {
-            segments
-        };
-        tts::synth_segments_kokoro_with(sess, &segments, espeak_lang, voice_path, req.rate, format)
-            .map_err(|e| e.to_string())
-    } else if tts::en::is_en(espeak_lang) {
-        // Route through segment pipeline so IPA_LEXICON overrides bypass G2P (#244).
-        let segments = tts::en::normalize_segments(
-            vec![tts::ssml::Segment::Text(req.text.clone())],
-            req.expand_abbrev,
-        );
-        tts::synth_segments_kokoro_with(sess, &segments, espeak_lang, voice_path, req.rate, format)
-            .map_err(|e| e.to_string())
-    } else {
-        // es/fr/it/pt use the cached CharsiuG2P session to avoid reloading ~100 MB per request.
-        let ipa = if matches!(
-            crate::tts::charsiu::base_lang(espeak_lang),
-            "es" | "fr" | "it" | "pt"
-        ) {
-            state
-                .charsiu
-                .to_ipa(
-                    &models::cache_dir().join("models/g2p/byt5-tiny"),
-                    &req.text,
-                    espeak_lang,
-                )
-                .map_err(|e| format!("g2p: {e}"))?
-        } else {
-            tts::g2p::text_to_ipa(&req.text, espeak_lang).map_err(|e| format!("g2p: {e}"))?
-        };
-        if ipa.trim().is_empty() {
-            return Err("no phonemes produced for input (empty after G2P)".into());
-        }
-        let audio = sess
-            .infer_ipa(&ipa, voice_path, req.rate)
-            .map_err(|e| format!("infer: {e}"))?;
-        if audio.is_empty() {
-            return Err("no recognizable phonemes in input".into());
-        }
-        tts::encode::encode(&audio, tts::kokoro::SAMPLE_RATE, format)
-            .map_err(|e| format!("encode: {e}"))
-    }
+    tts::say::say_kokoro(
+        &mut state.sessions,
+        &req.text,
+        espeak_lang,
+        model_path,
+        voice_path,
+        req.rate,
+        format,
+        req.ssml,
+        req.expand_abbrev,
+    )
+    .map_err(loop_error_text)
 }
 
-/// Vosk arm of [`handle`]: cached-session synth.
+/// Vosk arm of [`handle`]: cached-session synth via the shared dispatch.
 fn handle_vosk(
     req: &LoopRequest,
     state: &mut LoopState,
@@ -342,29 +276,27 @@ fn handle_vosk(
     speaker_id: u32,
     format: tts::encode::OutputFormat,
 ) -> Result<Vec<u8>, String> {
-    if req.ssml {
-        let segments = parse_ssml_or_err(&req.text)?;
-        let segments = tts::ru::normalize_segments(segments, req.expand_abbrev);
-        tts::synth_segments_vosk_with(
-            &mut state.vosk,
-            &segments,
-            model_dir,
-            speaker_id,
-            req.rate,
-            format,
-        )
-        .map_err(|e| e.to_string())
-    } else {
-        let text: std::borrow::Cow<'_, str> = if req.expand_abbrev {
-            std::borrow::Cow::Owned(tts::ru::expand_text(&req.text))
-        } else {
-            std::borrow::Cow::Borrowed(&req.text)
-        };
-        let (audio, sample_rate) = state
-            .vosk
-            .infer(model_dir, &text, speaker_id, req.rate)
-            .map_err(|e| format!("vosk: {e}"))?;
-        tts::encode::encode(&audio, sample_rate, format).map_err(|e| format!("encode: {e}"))
+    tts::say::say_vosk(
+        &mut state.sessions.vosk,
+        &req.text,
+        model_dir,
+        speaker_id,
+        req.rate,
+        format,
+        req.ssml,
+        req.expand_abbrev,
+    )
+    .map_err(loop_error_text)
+}
+
+/// ERR frames carry a bare message; unwrap the `TtsError` display prefixes so
+/// loop clients keep seeing the same strings as before the shared dispatch
+/// ("g2p: ...", "vosk: ...", not "synthesis failed: g2p: ...").
+fn loop_error_text(e: tts::TtsError) -> String {
+    match e {
+        tts::TtsError::SynthesisFailed(message) => message,
+        tts::TtsError::Coded { message, .. } => message,
+        other => other.to_string(),
     }
 }
 
@@ -623,9 +555,7 @@ mod tests {
             expand_abbrev: true,
         };
         let mut state = LoopState {
-            kokoro: None,
-            vosk: tts::sessions::VoskCache::new(),
-            charsiu: tts::sessions::CharsiuCache::new(),
+            sessions: tts::sessions::TtsSessions::default(),
         };
 
         let err = handle(&req, &mut state).unwrap_err();

--- a/rust/src/tts/g2p.rs
+++ b/rust/src/tts/g2p.rs
@@ -13,6 +13,17 @@ use anyhow::Result;
 /// - `es`/`fr`/`it`/`pt` → normalize → CharsiuG2P (byt5-tiny ONNX)
 /// - `ru` and others → error with a pointer to the engine-specific G2P
 pub fn text_to_ipa(text: &str, lang: &str) -> Result<String> {
+    text_to_ipa_cached(&mut crate::tts::sessions::CharsiuCache::new(), text, lang)
+}
+
+/// Same routing as [`text_to_ipa`], but Romance languages go through the
+/// caller's [`CharsiuCache`] so long-lived callers (`--stdin-loop`) don't
+/// reload the ~100 MB ByT5 sessions per request (#509).
+pub fn text_to_ipa_cached(
+    charsiu: &mut crate::tts::sessions::CharsiuCache,
+    text: &str,
+    lang: &str,
+) -> Result<String> {
     let text_chars = text.chars().count();
     if text.trim().is_empty() {
         crate::dtrace!("g2p::route lang={lang} backend=empty text_chars={text_chars}");
@@ -25,8 +36,7 @@ pub fn text_to_ipa(text: &str, lang: &str) -> Result<String> {
         crate::dtrace!("g2p::route lang={lang} backend=charsiu text_chars={text_chars}");
         let dir = crate::models::cache_dir().join("models/g2p/byt5-tiny");
         check_charsiu_files(&dir)?;
-        let mut g = crate::tts::charsiu::Charsiu::load(&dir)?;
-        let ipa = charsiu_ipa(&mut g, text, &lower)?;
+        let ipa = charsiu.to_ipa(&dir, text, &lower)?;
         crate::dtrace!("g2p::result ipa_chars={}", ipa.chars().count());
         return Ok(ipa);
     }

--- a/rust/src/tts/mod.rs
+++ b/rust/src/tts/mod.rs
@@ -25,7 +25,7 @@ pub mod warn;
 pub mod wav;
 
 pub use encode::OutputFormat;
-pub use say::{say, synth_segments_kokoro_with, synth_segments_vosk_with};
+pub use say::say;
 
 #[cfg(all(feature = "system_tts", target_os = "macos"))]
 pub mod avspeech;

--- a/rust/src/tts/say.rs
+++ b/rust/src/tts/say.rs
@@ -2,11 +2,10 @@
 //! pipeline (Kokoro / Vosk / AVSpeech), thread SSML segmentation through it,
 //! and encode the result into the caller's chosen wire format.
 //!
-//! Public entry points re-exported from `tts/mod.rs`:
-//! - [`say`] — one-shot synth-and-encode
-//! - [`synth_segments_kokoro_with`] / [`synth_segments_vosk_with`] —
-//!   drive an existing engine handle from a segment list (used by the
-//!   `--stdin-loop` long-lived path, #213)
+//! Public entry points:
+//! - [`say`] — one-shot synth-and-encode (re-exported from `tts/mod.rs`)
+//! - [`say_kokoro`] / [`say_vosk`] — the same per-engine dispatch with the
+//!   caller's cached sessions injected (the `--stdin-loop` path, #213)
 
 use std::borrow::Cow;
 use std::path::Path;
@@ -108,6 +107,7 @@ pub fn say(opts: SayOptions) -> Result<Vec<u8>, TtsError> {
             speaker_id,
             speed,
         } => say_vosk(
+            &mut sessions::VoskCache::new(),
             opts.text,
             model_dir,
             speaker_id,
@@ -121,6 +121,7 @@ pub fn say(opts: SayOptions) -> Result<Vec<u8>, TtsError> {
             voice_path,
             speed,
         } => say_kokoro(
+            &mut sessions::TtsSessions::default(),
             opts.text,
             opts.lang,
             model_path,
@@ -195,7 +196,9 @@ fn say_avspeech(
 }
 
 /// Vosk arm: owns its own G2P + text normalisation; bypasses our espeak/misaki path.
-fn say_vosk(
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn say_vosk(
+    vosk: &mut sessions::VoskCache,
     text: &str,
     model_dir: &Path,
     speaker_id: u32,
@@ -205,14 +208,33 @@ fn say_vosk(
     expand_abbrev: bool,
 ) -> Result<Vec<u8>, TtsError> {
     if ssml {
-        return synth_segments_vosk(text, model_dir, speaker_id, speed, format, expand_abbrev);
+        return synth_segments_vosk(
+            vosk,
+            text,
+            model_dir,
+            speaker_id,
+            speed,
+            format,
+            expand_abbrev,
+        );
     }
-    say_with_vosk(text, model_dir, speaker_id, speed, format, expand_abbrev)
+    say_with_vosk(
+        vosk,
+        text,
+        model_dir,
+        speaker_id,
+        speed,
+        format,
+        expand_abbrev,
+    )
 }
 
 /// Kokoro arm: SSML, English segment pipeline, and non-English G2P paths.
+/// Sessions are injected so `--stdin-loop` reuses them across requests while
+/// the one-shot path passes a fresh [`sessions::TtsSessions`].
 #[allow(clippy::too_many_arguments)]
-fn say_kokoro(
+pub(crate) fn say_kokoro(
+    tts_sessions: &mut sessions::TtsSessions,
     text: &str,
     lang: &str,
     model_path: &Path,
@@ -222,7 +244,7 @@ fn say_kokoro(
     ssml: bool,
     expand_abbrev: bool,
 ) -> Result<Vec<u8>, TtsError> {
-    if ssml {
+    let segments = if ssml {
         let segments = ssml::parse(text).map_err(|e| TtsError::Coded {
             code: crate::errors::code_of(&e),
             message: format!("ssml: {e:#}"),
@@ -232,48 +254,22 @@ fn say_kokoro(
                 "SSML had no speakable content".into(),
             ));
         }
-        return synth_segments_kokoro(
-            segments,
-            lang,
-            model_path,
-            voice_path,
-            speed,
-            format,
-            expand_abbrev,
-        );
-    }
-    // English: segment pipeline so IPA_LEXICON overrides bypass G2P;
-    // letter-spell + STOP_LIST run inside en::normalize_segments (#244).
-    if en::is_en(lang) {
-        return synth_segments_kokoro(
-            vec![ssml::Segment::Text(text.to_string())],
-            lang,
-            model_path,
-            voice_path,
-            speed,
-            format,
-            expand_abbrev,
-        );
-    }
-    let ipa =
-        g2p::text_to_ipa(text, lang).map_err(|e| TtsError::SynthesisFailed(format!("g2p: {e}")))?;
-    if ipa.trim().is_empty() {
-        return Err(TtsError::SynthesisFailed(
-            "no phonemes produced for input (empty after G2P)".into(),
-        ));
-    }
-    say_with_kokoro(&ipa, model_path, voice_path, speed, format)
-}
-
-fn synth_segments_kokoro(
-    segments: Vec<ssml::Segment>,
-    lang: &str,
-    model_path: &Path,
-    voice_path: &Path,
-    speed: f32,
-    format: OutputFormat,
-    expand_abbrev: bool,
-) -> Result<Vec<u8>, TtsError> {
+        segments
+    } else if en::is_en(lang) {
+        // English: segment pipeline so IPA_LEXICON overrides bypass G2P;
+        // letter-spell + STOP_LIST run inside en::normalize_segments (#244).
+        vec![ssml::Segment::Text(text.to_string())]
+    } else {
+        let ipa = g2p::text_to_ipa_cached(&mut tts_sessions.charsiu, text, lang)
+            .map_err(|e| TtsError::SynthesisFailed(format!("g2p: {e}")))?;
+        if ipa.trim().is_empty() {
+            return Err(TtsError::SynthesisFailed(
+                "no phonemes produced for input (empty after G2P)".into(),
+            ));
+        }
+        let sess = kokoro_session(&mut tts_sessions.kokoro, model_path)?;
+        return say_with_kokoro(sess, &ipa, voice_path, speed, format);
+    };
     // en::normalize_segments maps Spell→Text, expands acronyms, strips Emphasis.
     // Mirror of synth_segments_vosk's ru::normalize_segments call (#244).
     let segments = if en::is_en(lang) {
@@ -281,9 +277,16 @@ fn synth_segments_kokoro(
     } else {
         segments
     };
-    let mut sess = sessions::KokoroSession::load(model_path)
-        .map_err(|e| TtsError::SynthesisFailed(e.to_string()))?;
-    synth_segments_kokoro_with(&mut sess, &segments, lang, voice_path, speed, format)
+    let sess = kokoro_session(&mut tts_sessions.kokoro, model_path)?;
+    synth_segments_kokoro_with(sess, &segments, lang, voice_path, speed, format)
+}
+
+fn kokoro_session<'s>(
+    slot: &'s mut sessions::KokoroSlot,
+    model_path: &Path,
+) -> Result<&'s mut sessions::KokoroSession, TtsError> {
+    slot.get(model_path)
+        .map_err(|e| TtsError::SynthesisFailed(format!("{e:#}")))
 }
 
 /// Synthesize a single SSML segment through Kokoro; `ProsodyRate` recurses with
@@ -337,7 +340,7 @@ fn synth_one_kokoro(
 
 /// Drive an SSML segment list against an already-constructed Kokoro session.
 /// Used by both the one-shot SSML path and the long-lived `--stdin-loop` (#213).
-pub fn synth_segments_kokoro_with(
+pub(crate) fn synth_segments_kokoro_with(
     sess: &mut sessions::KokoroSession,
     segments: &[ssml::Segment],
     lang: &str,
@@ -477,14 +480,12 @@ fn synth_one_fluid_kokoro(
 }
 
 fn say_with_kokoro(
+    sess: &mut sessions::KokoroSession,
     ipa: &str,
-    model_path: &Path,
     voice_path: &Path,
     speed: f32,
     format: OutputFormat,
 ) -> Result<Vec<u8>, TtsError> {
-    let mut sess = sessions::KokoroSession::load(model_path)
-        .map_err(|e| TtsError::SynthesisFailed(e.to_string()))?;
     // #275 D1: boundary trace so a "no recognizable phonemes in input"
     // bail carries inputs (IPA length + voice file) and outputs (sample
     // count + wall time) instead of pointing at nothing.
@@ -515,6 +516,7 @@ fn say_with_kokoro(
 }
 
 fn say_with_vosk(
+    vosk: &mut sessions::VoskCache,
     text: &str,
     model_dir: &Path,
     speaker_id: u32,
@@ -527,14 +529,15 @@ fn say_with_vosk(
     } else {
         Cow::Borrowed(text)
     };
-    let mut cache = sessions::VoskCache::new();
-    let (audio, sample_rate) = cache
+    let (audio, sample_rate) = vosk
         .infer(model_dir, normalized.as_ref(), speaker_id, speed)
         .map_err(|e| TtsError::SynthesisFailed(format!("vosk: {e}")))?;
     encode_or_fail(&audio, sample_rate, format)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn synth_segments_vosk(
+    vosk: &mut sessions::VoskCache,
     text: &str,
     model_dir: &Path,
     speaker_id: u32,
@@ -552,8 +555,7 @@ fn synth_segments_vosk(
         ));
     }
     let segments = ru::normalize_segments(segments, expand_abbrev);
-    let mut cache = sessions::VoskCache::new();
-    synth_segments_vosk_with(&mut cache, &segments, model_dir, speaker_id, speed, format)
+    synth_segments_vosk_with(vosk, &segments, model_dir, speaker_id, speed, format)
 }
 
 /// Synthesize a single SSML segment through Vosk; `ProsodyRate` recurses with
@@ -613,7 +615,7 @@ fn synth_one_vosk(
 
 /// Drive an SSML segment list against a Vosk cache. Mirrors
 /// [`synth_segments_kokoro_with`].
-pub fn synth_segments_vosk_with(
+pub(crate) fn synth_segments_vosk_with(
     cache: &mut sessions::VoskCache,
     segments: &[ssml::Segment],
     model_dir: &Path,

--- a/rust/src/tts/sessions.rs
+++ b/rust/src/tts/sessions.rs
@@ -93,10 +93,6 @@ impl KokoroSession {
     }
 }
 
-/// Map of `Vosk` instances keyed by model directory. Eviction on infer error.
-///
-/// Vosk holds mutable BERT prosody / dictionary state; a synth error may leave
-/// it inconsistent, so we evict rather than risk poisoning the next call.
 /// Lazily-loaded [`KokoroSession`] that survives model swaps. `get` loads on
 /// first use and delegates to `ensure_model` afterwards, so callers share one
 /// code path whether they are one-shot (fresh slot per call) or long-lived
@@ -130,6 +126,10 @@ pub struct TtsSessions {
     pub charsiu: CharsiuCache,
 }
 
+/// Map of `Vosk` instances keyed by model directory. Eviction on infer error.
+///
+/// Vosk holds mutable BERT prosody / dictionary state; a synth error may leave
+/// it inconsistent, so we evict rather than risk poisoning the next call.
 /// Kokoro's `Session::run` is stateless per call, so no eviction needed there.
 #[derive(Default)]
 pub struct VoskCache {

--- a/rust/src/tts/sessions.rs
+++ b/rust/src/tts/sessions.rs
@@ -97,6 +97,39 @@ impl KokoroSession {
 ///
 /// Vosk holds mutable BERT prosody / dictionary state; a synth error may leave
 /// it inconsistent, so we evict rather than risk poisoning the next call.
+/// Lazily-loaded [`KokoroSession`] that survives model swaps. `get` loads on
+/// first use and delegates to `ensure_model` afterwards, so callers share one
+/// code path whether they are one-shot (fresh slot per call) or long-lived
+/// (`--stdin-loop` holds the slot across requests).
+#[derive(Default)]
+pub struct KokoroSlot {
+    inner: Option<KokoroSession>,
+}
+
+impl KokoroSlot {
+    pub fn get(&mut self, model_path: &Path) -> anyhow::Result<&mut KokoroSession> {
+        use anyhow::Context;
+        match self.inner.as_mut() {
+            Some(sess) => sess.ensure_model(model_path).context("kokoro reload")?,
+            None => {
+                self.inner = Some(KokoroSession::load(model_path).context("kokoro load")?);
+            }
+        }
+        Ok(self.inner.as_mut().expect("kokoro session just ensured"))
+    }
+}
+
+/// The full set of cacheable TTS sessions. The one-shot `tts::say()` path
+/// constructs this fresh per call; `--stdin-loop` holds one across requests
+/// so Kokoro (~1 s), Vosk RU (~21 s cold), and CharsiuG2P (~100 MB, #509)
+/// load at most once per process.
+#[derive(Default)]
+pub struct TtsSessions {
+    pub kokoro: KokoroSlot,
+    pub vosk: VoskCache,
+    pub charsiu: CharsiuCache,
+}
+
 /// Kokoro's `Session::run` is stateless per call, so no eviction needed there.
 #[derive(Default)]
 pub struct VoskCache {


### PR DESCRIPTION
Fifth PR from the rust/ review. `say_loop.rs::handle_kokoro`/`handle_vosk` re-implemented the `tts::say` per-engine dispatch (~100 lines) solely to reuse cached sessions, and the copies had drifted: the loop cached CharsiuG2P (#509) while the one-shot path reloaded the ~100 MB ByT5 sessions on every call; the en-normalization gating and empty-G2P error strings existed in three places each.

- **`sessions::KokoroSlot`** — lazily-loaded session that survives model swaps (`load` on first use, `ensure_model` after); **`sessions::TtsSessions`** bundles it with the Vosk and Charsiu caches. `--stdin-loop` holds one across requests; the one-shot path constructs it fresh per call, preserving current behavior.
- **`g2p::text_to_ipa_cached`** — same routing as `text_to_ipa` but Romance languages go through the caller's cache; `text_to_ipa` is now a thin wrapper. One-shot es/fr/it/pt calls stop double-loading Charsiu; the loop path gains the `check_charsiu_files` actionable-error preflight and G2P dtrace lines it was missing.
- **`say_kokoro`/`say_vosk`** take the injected sessions and became the single dispatch; the loop handlers collapse to one call each. All 14 stdin-loop tests pass unmodified.
- `synth_segments_kokoro_with`/`synth_segments_vosk_with` drop out of the public `tts::` surface (loop no longer needs them).

**Disclosed behavior deltas on the stdin-loop ERR surface** (the module doc marks this protocol as not-public and changeable between minor releases; details verified by an external adversarial review):

1. **ERR message prefixes are now uniform.** Segment paths (SSML, English plain-text, Vosk SSML) previously surfaced `synthesis failed: g2p: …` via `TtsError` Display while the loop's manual paths emitted bare `g2p: …` / `vosk: …`. `loop_error_text` standardizes every path on the bare form. Plain G2P / plain Vosk / load-reload strings are byte-identical to before.
2. **Failure ordering.** The shared dispatch parses SSML / normalizes / runs G2P before loading the Kokoro session on the loop path (matching the one-shot order). When both would fail — e.g. missing model *and* invalid SSML — the ERR now reports the parse/G2P failure where it previously reported `kokoro load: …`.
3. One-shot Kokoro load errors gain the `kokoro load:` / `kokoro reload:` context prefix.

Verified: `cargo nextest run --features tts` 400/400, `cargo fmt`, `cargo clippy --all-targets -- -D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012g6EWAkjR68hGC4BeasQzg