### PR TITLE
docs(raycast): point README at the Raycast Store, describe the live view

### DIFF
--- a/raycast/README.md
+++ b/raycast/README.md
@@ -2,11 +2,19 @@
 
 Offline microphone dictation for Raycast, powered by the [Kesha Voice Kit](https://github.com/drakulavich/kesha-voice-kit) CLI. Recording and transcription stay local; no API keys, no cloud roundtrips.
 
+[![Install from the Raycast Store](https://www.raycast.com/drakulavich/kesha-voice-kit/install_button@2x.png)](https://www.raycast.com/drakulavich/kesha-voice-kit)
+
 ## Commands
 
 ### Dictate to Clipboard
 
-Starts recording from the default microphone, stops when you press **Stop and Transcribe** or when the configured time limit is reached, then transcribes locally and copies the transcript to the clipboard.
+Starts recording from the default microphone and shows a live view while you speak:
+
+- **Signal meter** — input level plus the microphone's name and format, so you can tell at a glance whether the right device is live.
+- **Auto-stop on silence** — after ~30 s without speech the status flips to Idle, and ~15 s later recording stops on its own; speaking again resets the timer.
+- **Stop and Transcribe** — or let the configured time limit end the session.
+
+Transcription runs locally (NVIDIA Parakeet TDT, multilingual) and the transcript is copied to the clipboard automatically. A running transcription can be cancelled from the action panel.
 
 ## Prerequisites
 


### PR DESCRIPTION
The extension is now live on the Raycast Store (https://www.raycast.com/drakulavich/kesha-voice-kit) — the README predates publication and undersold the current UX.

- Adds the official Store install badge under the intro.
- Documents what the live recording view actually shows since the recent iterations: signal meter with mic name/format, idle detection with silence auto-stop (~30 s warn + ~15 s grace), and transcription cancel from the action panel.
- Notes the ASR engine (NVIDIA Parakeet TDT, multilingual) on the transcription line.

Prerequisites, preferences, and contribution pointers unchanged. `ray lint` + vitest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012g6EWAkjR68hGC4BeasQzg