### PR TITLE
refactor: declare the module tree once, in lib.rs

### DIFF
--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,33 +1,7 @@
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 
-mod audio;
-mod backend;
-mod capabilities;
-mod cli;
-mod debug;
-mod errors;
-#[cfg(all(
-    target_os = "macos",
-    any(
-        feature = "coreml",
-        feature = "system_diarize",
-        feature = "system_kokoro"
-    )
-))]
-mod fluid_stdout;
-mod lang_id;
-mod models;
-mod process_tree;
-mod record;
-#[cfg(feature = "tts")]
-mod say_loop;
-mod text_lang;
-mod transcribe;
-#[cfg(feature = "tts")]
-mod tts;
-mod util;
-mod vad;
+use kesha_engine::{capabilities, cli, debug, errors};
 
 #[derive(Parser)]
 #[command(name = "kesha-engine", version)]


### PR DESCRIPTION
From the rust review backlog (simplification #1). `main.rs` re-declared the entire module tree — 16 `mod` lines plus a hand-mirrored copy of the three-way `fluid_stdout` cfg block — so the whole crate compiled twice per build (once for the lib, once inside the bin) and adding a module meant editing two files with matching cfgs.

The bin now does `use kesha_engine::{capabilities, cli, debug, errors};` and links the library like any other consumer. Everything it touches was already `pub` in `lib.rs`; `fluid_stdout`/`process_tree` stay lib-internal. No behavior change — same CLI surface, same features.

Verified: `cargo nextest run --features tts` 404/404, `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo check --features coreml --no-default-features`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012g6EWAkjR68hGC4BeasQzg