### PR TITLE
refactor(tts): share token helpers across the three normalizers

### DIFF
--- a/rust/src/tts/en/acronym.rs
+++ b/rust/src/tts/en/acronym.rs
@@ -14,6 +14,7 @@
 
 use super::letter_table::expand_chars;
 use crate::tts::ssml::Segment;
+use crate::tts::token::{for_each_token, is_ascii_acronym, split_punct, TokenEvent};
 
 const STOP_LIST: &[&str] = &[
     // Emphatic length-2 caps
@@ -50,22 +51,6 @@ const IPA_LEXICON: &[(&str, &str)] = &[
     ("Granola", "ɡrəˈnoʊlə"),
 ];
 
-const TRAILING_PUNCT: &[char] = &[
-    '.', ',', ':', ';', '!', '?', '»', ')', '„', '"', '…', '—', '–', '-',
-];
-
-const LEADING_PUNCT: &[char] = &['«', '(', '"', '„'];
-
-/// Returns true if `core` is a candidate for letter-by-letter spelling.
-/// Pure structural check — does not consult the stop-list or lexicon.
-fn is_acronym_token(core: &str) -> bool {
-    let len = core.chars().count();
-    if !(2..=5).contains(&len) {
-        return false;
-    }
-    core.chars().all(|c| c.is_ascii_uppercase())
-}
-
 /// Tokenize `text` and emit a segment list:
 /// - Tokens hit by `IPA_LEXICON` (case-sensitive on the punct-stripped core)
 ///   become `Segment::Ipa(...)`; surrounding head/tail punct rejoin the
@@ -79,22 +64,11 @@ fn is_acronym_token(core: &str) -> bool {
 pub fn expand_to_segments(text: &str, auto_expand: bool) -> Vec<Segment> {
     let mut out: Vec<Segment> = Vec::new();
     let mut buf = String::new();
-    let mut tok = String::new();
 
-    for c in text.chars() {
-        if c.is_whitespace() {
-            if !tok.is_empty() {
-                process_token(&tok, auto_expand, &mut buf, &mut out);
-                tok.clear();
-            }
-            buf.push(c);
-        } else {
-            tok.push(c);
-        }
-    }
-    if !tok.is_empty() {
-        process_token(&tok, auto_expand, &mut buf, &mut out);
-    }
+    for_each_token(text, |ev| match ev {
+        TokenEvent::Token(tok) => process_token(tok, auto_expand, &mut buf, &mut out),
+        TokenEvent::Gap(c) => buf.push(c),
+    });
     flush_buf(&mut buf, &mut out);
     out
 }
@@ -116,7 +90,7 @@ fn process_token(token: &str, auto_expand: bool, buf: &mut String, out: &mut Vec
         return;
     }
 
-    if auto_expand && is_acronym_token(mid) && !STOP_LIST.contains(&mid) {
+    if auto_expand && is_ascii_acronym(mid) && !STOP_LIST.contains(&mid) {
         buf.push_str(head);
         buf.push_str(&expand_chars(mid));
         buf.push_str(tail);
@@ -124,27 +98,6 @@ fn process_token(token: &str, auto_expand: bool, buf: &mut String, out: &mut Vec
     }
 
     buf.push_str(token);
-}
-
-fn split_punct(token: &str) -> (&str, &str, &str) {
-    let start = token
-        .char_indices()
-        .find(|(_, c)| !LEADING_PUNCT.contains(c))
-        .map(|(i, _)| i)
-        .unwrap_or(token.len());
-    let rest = &token[start..];
-    let mut end = rest.len();
-    for (idx, c) in rest.char_indices().rev() {
-        if TRAILING_PUNCT.contains(&c) {
-            end = idx;
-        } else {
-            break;
-        }
-    }
-    let head = &token[..start];
-    let core = &rest[..end];
-    let tail = &rest[end..];
-    (head, core, tail)
 }
 
 #[cfg(test)]
@@ -202,7 +155,7 @@ mod tests {
     #[test]
     fn microsoft_mixed_case_lexicon_hit() {
         let segs = expand_to_segments("IBM and Microsoft are competitors", true);
-        // IBM letter-spells (no IPA, is_acronym_token=true, not stop-listed).
+        // IBM letter-spells (no IPA, is_ascii_acronym=true, not stop-listed).
         // Microsoft IPA hit — separates Text segments around it.
         assert_eq!(
             flatten(&segs),

--- a/rust/src/tts/mod.rs
+++ b/rust/src/tts/mod.rs
@@ -18,6 +18,7 @@ pub mod ru;
 pub mod say;
 pub mod sessions;
 pub mod ssml;
+mod token;
 pub mod tokenizer;
 pub mod voices;
 pub mod vosk;

--- a/rust/src/tts/normalize/acronyms.rs
+++ b/rust/src/tts/normalize/acronyms.rs
@@ -151,15 +151,6 @@ fn lookup_letter(ch: char, table: &[(&str, &str)]) -> String {
         .unwrap_or_else(|| ch.to_lowercase().to_string())
 }
 
-/// Mirrors `en/acronym.rs::is_acronym_token`: all-caps, length 2..=5.
-pub fn is_acronym_token(token: &str) -> bool {
-    let len = token.chars().count();
-    if !(2..=5).contains(&len) {
-        return false;
-    }
-    token.chars().all(|c| c.is_ascii_uppercase())
-}
-
 /// Spell `token` letter-by-letter. `token` must be the punct-stripped core (all ASCII
 /// uppercase, 2..=5 chars). Unknown languages fall back to lowercased chars joined with spaces.
 pub fn spell(token: &str, lang: &str) -> String {

--- a/rust/src/tts/normalize/mod.rs
+++ b/rust/src/tts/normalize/mod.rs
@@ -6,34 +6,9 @@
 pub(crate) mod acronyms;
 pub(crate) mod numbers;
 
-use acronyms::{is_acronym_token, spell};
+use crate::tts::token::{for_each_token, is_ascii_acronym, split_punct, TokenEvent};
+use acronyms::spell;
 use numbers::to_words;
-
-const TRAILING_PUNCT: &[char] = &[
-    '.', ',', ':', ';', '!', '?', '»', ')', '„', '"', '…', '—', '–', '-',
-];
-const LEADING_PUNCT: &[char] = &['«', '(', '"', '„'];
-
-fn split_punct(token: &str) -> (&str, &str, &str) {
-    let start = token
-        .char_indices()
-        .find(|(_, c)| !LEADING_PUNCT.contains(c))
-        .map(|(i, _)| i)
-        .unwrap_or(token.len());
-    let rest = &token[start..];
-    let mut end = rest.len();
-    for (idx, c) in rest.char_indices().rev() {
-        if TRAILING_PUNCT.contains(&c) {
-            end = idx;
-        } else {
-            break;
-        }
-    }
-    let head = &token[..start];
-    let core = &rest[..end];
-    let tail = &rest[end..];
-    (head, core, tail)
-}
 
 /// Normalize one whitespace-separated token for lang ∈ {es, fr, it, pt}.
 fn normalize_token(token: &str, lang: &str) -> String {
@@ -47,7 +22,7 @@ fn normalize_token(token: &str, lang: &str) -> String {
         return token.to_string();
     }
 
-    if is_acronym_token(core) {
+    if is_ascii_acronym(core) {
         return format!("{head}{}{tail}", spell(core, lang));
     }
 
@@ -67,23 +42,10 @@ pub fn normalize(text: &str, lang: &str) -> String {
     }
 
     let mut result = String::with_capacity(text.len() + 32);
-    let mut tok_buf = String::new();
-
-    for c in text.chars() {
-        if c.is_whitespace() {
-            if !tok_buf.is_empty() {
-                result.push_str(&normalize_token(&tok_buf, lang));
-                tok_buf.clear();
-            }
-            result.push(c);
-        } else {
-            tok_buf.push(c);
-        }
-    }
-    if !tok_buf.is_empty() {
-        result.push_str(&normalize_token(&tok_buf, lang));
-    }
-
+    for_each_token(text, |ev| match ev {
+        TokenEvent::Token(tok) => result.push_str(&normalize_token(tok, lang)),
+        TokenEvent::Gap(c) => result.push(c),
+    });
     result
 }
 

--- a/rust/src/tts/ru/acronym.rs
+++ b/rust/src/tts/ru/acronym.rs
@@ -14,6 +14,7 @@
 //!    NOT expanded. Closes #232.
 //! 6. Otherwise, replace the token with `head + expand_chars(core) + tail`.
 
+use crate::tts::token::{for_each_token, split_punct, TokenEvent};
 use std::borrow::Cow;
 
 use super::letter_table::expand_chars;
@@ -26,12 +27,6 @@ const STOP_LIST: &[&str] = &[
     "ВСЁ", "ВЫ", "ДА", "ДЛЯ", "ЕЁ", "ЕМУ", "ЕЩЁ", "ИЛИ", "ИМ", "ИХ", "КАК", "КТО", "МНЕ", "МЫ",
     "НЕ", "НЕТ", "НИ", "ОН", "ОНА", "ОНИ", "ОНО", "ТОТ", "ТЫ", "УЖ", "ЧТО",
 ];
-
-const TRAILING_PUNCT: &[char] = &[
-    '.', ',', ':', ';', '!', '?', '»', ')', '„', '"', '…', '—', '–', '-',
-];
-
-const LEADING_PUNCT: &[char] = &['«', '(', '"', '„'];
 
 const VOWELS: &[char] = &['А', 'Е', 'Ё', 'И', 'О', 'У', 'Ы', 'Э', 'Ю', 'Я'];
 
@@ -65,21 +60,10 @@ fn is_acronym_token(core: &str) -> bool {
 /// Auto-expand all-uppercase Cyrillic acronyms in `input`.
 pub(super) fn expand_acronyms(input: &str) -> String {
     let mut out = String::with_capacity(input.len());
-    let mut buf = String::new();
-    for c in input.chars() {
-        if c.is_whitespace() {
-            if !buf.is_empty() {
-                out.push_str(expand_token(&buf).as_ref());
-                buf.clear();
-            }
-            out.push(c);
-        } else {
-            buf.push(c);
-        }
-    }
-    if !buf.is_empty() {
-        out.push_str(expand_token(&buf).as_ref());
-    }
+    for_each_token(input, |ev| match ev {
+        TokenEvent::Token(tok) => out.push_str(expand_token(tok).as_ref()),
+        TokenEvent::Gap(c) => out.push(c),
+    });
     out
 }
 
@@ -95,31 +79,6 @@ fn expand_token(token: &str) -> Cow<'_, str> {
     s.push_str(&expand_chars(mid));
     s.push_str(tail);
     Cow::Owned(s)
-}
-
-/// Peels leading/trailing punctuation so `«ВОЗ»` and `ФСБ.` are correctly matched.
-fn split_punct(token: &str) -> (&str, &str, &str) {
-    let start = token
-        .char_indices()
-        .find(|(_, c)| !LEADING_PUNCT.contains(c))
-        .map(|(i, _)| i)
-        .unwrap_or(token.len());
-
-    let rest = &token[start..];
-
-    let mut end = rest.len();
-    for (idx, c) in rest.char_indices().rev() {
-        if TRAILING_PUNCT.contains(&c) {
-            end = idx;
-        } else {
-            break;
-        }
-    }
-
-    let head = &token[..start];
-    let core = &rest[..end];
-    let tail = &rest[end..];
-    (head, core, tail)
 }
 
 #[cfg(test)]

--- a/rust/src/tts/token.rs
+++ b/rust/src/tts/token.rs
@@ -1,0 +1,101 @@
+//! Token-level helpers shared by the per-language text normalizers
+//! (`en::acronym`, `ru::acronym`, `normalize`).
+
+pub(crate) const TRAILING_PUNCT: &[char] = &[
+    '.', ',', ':', ';', '!', '?', '»', ')', '„', '"', '…', '—', '–', '-',
+];
+
+pub(crate) const LEADING_PUNCT: &[char] = &['«', '(', '"', '„'];
+
+/// Peel leading/trailing punctuation so `«ВОЗ».` matches as `ВОЗ`:
+/// returns `(head, core, tail)` slices of the original token.
+pub(crate) fn split_punct(token: &str) -> (&str, &str, &str) {
+    let start = token
+        .char_indices()
+        .find(|(_, c)| !LEADING_PUNCT.contains(c))
+        .map(|(i, _)| i)
+        .unwrap_or(token.len());
+    let rest = &token[start..];
+    let mut end = rest.len();
+    for (idx, c) in rest.char_indices().rev() {
+        if TRAILING_PUNCT.contains(&c) {
+            end = idx;
+        } else {
+            break;
+        }
+    }
+    let head = &token[..start];
+    let core = &rest[..end];
+    let tail = &rest[end..];
+    (head, core, tail)
+}
+
+/// One event of a whitespace-separated walk: a token, or a single gap char
+/// (whitespace is forwarded verbatim so sentence shape survives rebuilding).
+pub(crate) enum TokenEvent<'a> {
+    Token(&'a str),
+    Gap(char),
+}
+
+/// Walk `text`, emitting every token and every whitespace char in order.
+pub(crate) fn for_each_token(text: &str, mut f: impl FnMut(TokenEvent<'_>)) {
+    let mut tok = String::new();
+    for c in text.chars() {
+        if c.is_whitespace() {
+            if !tok.is_empty() {
+                f(TokenEvent::Token(&tok));
+                tok.clear();
+            }
+            f(TokenEvent::Gap(c));
+        } else {
+            tok.push(c);
+        }
+    }
+    if !tok.is_empty() {
+        f(TokenEvent::Token(&tok));
+    }
+}
+
+/// All-caps ASCII, length 2..=5 — the Latin acronym-candidate check shared by
+/// the English segmenter and the Romance normalizer.
+pub(crate) fn is_ascii_acronym(core: &str) -> bool {
+    let len = core.chars().count();
+    if !(2..=5).contains(&len) {
+        return false;
+    }
+    core.chars().all(|c| c.is_ascii_uppercase())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_punct_peels_both_ends() {
+        assert_eq!(split_punct("«ВОЗ»."), ("«", "ВОЗ", "»."));
+        assert_eq!(split_punct("(IBM),"), ("(", "IBM", "),"));
+        assert_eq!(split_punct("word"), ("", "word", ""));
+        assert_eq!(split_punct("..."), ("", "", "..."));
+    }
+
+    #[test]
+    fn for_each_token_round_trips_text() {
+        let text = "one  two\tthree\n";
+        let mut rebuilt = String::new();
+        for_each_token(text, |ev| match ev {
+            TokenEvent::Token(t) => rebuilt.push_str(t),
+            TokenEvent::Gap(c) => rebuilt.push(c),
+        });
+        assert_eq!(rebuilt, text);
+    }
+
+    #[test]
+    fn is_ascii_acronym_bounds() {
+        assert!(is_ascii_acronym("AI"));
+        assert!(is_ascii_acronym("NASA"));
+        assert!(!is_ascii_acronym("A"));
+        assert!(!is_ascii_acronym("TOOLONG"));
+        assert!(!is_ascii_acronym("НАТО"));
+        assert!(!is_ascii_acronym("Ibm"));
+    }
+}


### PR DESCRIPTION
From the rust review backlog (simplification #3). `split_punct`, the `LEADING_PUNCT`/`TRAILING_PUNCT` sets, the whitespace tokenize-and-rebuild loop, and the Latin acronym-candidate check were byte-identical copies across `tts/en/acronym.rs`, `tts/ru/acronym.rs`, and `tts/normalize/` (~90 duplicated lines, with a doc comment in `normalize/acronyms.rs` openly admitting the mirror). Any punctuation-set fix was a three-file edit.

- **`tts/token.rs`** now owns `split_punct`, the punct sets, `for_each_token` (event-based walk emitting tokens and whitespace verbatim), and `is_ascii_acronym` — each with its own unit tests.
- The three normalizers keep only their per-language decisions (English IPA-lexicon/stop-list segmenting, Cyrillic acronym structure, Romance number/letter expansion). Their existing test suites pass unmodified, which is the behavior-preservation evidence: the shared helpers reproduce the exact tokenize/rebuild semantics.

Verified: `cargo nextest run --features tts` (full suite green), `cargo fmt`, `cargo clippy --all-targets -- -D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012g6EWAkjR68hGC4BeasQzg