### PR TITLE
test: one EnvGuard and one env lock for the whole crate

### DIFF
--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -1035,53 +1035,12 @@ mod diarize_sidecar_tests {
 #[cfg(test)]
 mod mirror_tests {
     use super::*;
-    use std::sync::Mutex;
-
-    // env-var tests race if parallelized — serialize them here.
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
-
-    struct MirrorEnv {
-        _guard: std::sync::MutexGuard<'static, ()>,
-        original: Option<String>,
-    }
-
-    impl MirrorEnv {
-        fn set(val: &str) -> Self {
-            let guard = ENV_LOCK.lock().unwrap();
-            let original = std::env::var("KESHA_MODEL_MIRROR").ok();
-            unsafe {
-                std::env::set_var("KESHA_MODEL_MIRROR", val);
-            }
-            Self {
-                _guard: guard,
-                original,
-            }
-        }
-        fn unset() -> Self {
-            let guard = ENV_LOCK.lock().unwrap();
-            let original = std::env::var("KESHA_MODEL_MIRROR").ok();
-            unsafe {
-                std::env::remove_var("KESHA_MODEL_MIRROR");
-            }
-            Self {
-                _guard: guard,
-                original,
-            }
-        }
-    }
-
-    impl Drop for MirrorEnv {
-        fn drop(&mut self) {
-            match &self.original {
-                Some(v) => unsafe { std::env::set_var("KESHA_MODEL_MIRROR", v) },
-                None => unsafe { std::env::remove_var("KESHA_MODEL_MIRROR") },
-            }
-        }
-    }
+    use crate::util::test_env::EnvGuard;
 
     #[test]
     fn unset_env_falls_through_to_upstream() {
-        let _g = MirrorEnv::unset();
+        let _lock = crate::util::test_env::lock();
+        let _g = EnvGuard::unset("KESHA_MODEL_MIRROR");
         assert_eq!(model_mirror(), None);
         assert_eq!(
             apply_mirror("https://huggingface.co/foo/bar/resolve/main/file.onnx"),
@@ -1091,7 +1050,8 @@ mod mirror_tests {
 
     #[test]
     fn empty_env_falls_through_to_upstream() {
-        let _g = MirrorEnv::set("");
+        let _lock = crate::util::test_env::lock();
+        let _g = EnvGuard::set("KESHA_MODEL_MIRROR", "");
         assert_eq!(model_mirror(), None);
         assert_eq!(
             apply_mirror("https://huggingface.co/foo/bar/resolve/main/file.onnx"),
@@ -1101,13 +1061,15 @@ mod mirror_tests {
 
     #[test]
     fn whitespace_env_falls_through_to_upstream() {
-        let _g = MirrorEnv::set("   ");
+        let _lock = crate::util::test_env::lock();
+        let _g = EnvGuard::set("KESHA_MODEL_MIRROR", "   ");
         assert_eq!(model_mirror(), None);
     }
 
     #[test]
     fn rewrites_hf_url_onto_mirror_base_preserving_path() {
-        let _g = MirrorEnv::set("https://mirror.example.com/kesha");
+        let _lock = crate::util::test_env::lock();
+        let _g = EnvGuard::set("KESHA_MODEL_MIRROR", "https://mirror.example.com/kesha");
         assert_eq!(
             apply_mirror("https://huggingface.co/foo/bar/resolve/main/file.onnx"),
             "https://mirror.example.com/kesha/foo/bar/resolve/main/file.onnx"
@@ -1116,7 +1078,8 @@ mod mirror_tests {
 
     #[test]
     fn strips_trailing_slash_from_mirror_base() {
-        let _g = MirrorEnv::set("https://mirror.example.com/kesha/");
+        let _lock = crate::util::test_env::lock();
+        let _g = EnvGuard::set("KESHA_MODEL_MIRROR", "https://mirror.example.com/kesha/");
         assert_eq!(
             apply_mirror("https://huggingface.co/x/y/resolve/main/z.bin"),
             "https://mirror.example.com/kesha/x/y/resolve/main/z.bin"
@@ -1127,7 +1090,8 @@ mod mirror_tests {
     fn non_hf_urls_pass_through_unchanged() {
         // github.com release assets (engine binary + avspeech sidecar) must
         // NOT be redirected — KESHA_MODEL_MIRROR only covers model files.
-        let _g = MirrorEnv::set("https://mirror.example.com");
+        let _lock = crate::util::test_env::lock();
+        let _g = EnvGuard::set("KESHA_MODEL_MIRROR", "https://mirror.example.com");
         let url = "https://github.com/drakulavich/kesha-voice-kit/releases/download/v1.3.0/kesha-engine-darwin-arm64";
         assert_eq!(apply_mirror(url), url);
     }
@@ -1218,39 +1182,13 @@ mod tts_tests {
 
     #[test]
     fn cache_dir_honors_env_var() {
+        let _lock = crate::util::test_env::lock();
         let guard = EnvGuard::set("KESHA_CACHE_DIR", "/tmp/kesha-test-xyz");
         assert_eq!(cache_dir(), PathBuf::from("/tmp/kesha-test-xyz"));
         drop(guard);
     }
 
-    /// Restores the env var to its original value on drop.
-    struct EnvGuard {
-        key: &'static str,
-        original: Option<String>,
-    }
-
-    impl EnvGuard {
-        fn set(key: &'static str, val: &str) -> Self {
-            let original = std::env::var(key).ok();
-            unsafe {
-                std::env::set_var(key, val);
-            }
-            Self { key, original }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            match &self.original {
-                Some(v) => unsafe {
-                    std::env::set_var(self.key, v);
-                },
-                None => unsafe {
-                    std::env::remove_var(self.key);
-                },
-            }
-        }
-    }
+    use crate::util::test_env::EnvGuard;
 
     #[test]
     fn tts_languages_includes_en_and_ru_everywhere() {

--- a/rust/src/transcribe/diarize.rs
+++ b/rust/src/transcribe/diarize.rs
@@ -435,7 +435,7 @@ mod tests {
 
     #[test]
     fn adaptive_timeout_floor_covers_cold_e5rt_compile() {
-        let _guard = EnvLockGuard::new();
+        let _guard = crate::util::test_env::lock();
         let segs = vec![seg(0.0, 1.0, "a")];
 
         unsafe {
@@ -463,7 +463,7 @@ mod tests {
 
     #[test]
     fn adaptive_timeout_scales_for_long_audio() {
-        let _guard = EnvLockGuard::new();
+        let _guard = crate::util::test_env::lock();
         let segs: Vec<_> = (0..6_000)
             .map(|i| {
                 let start = i as f32;
@@ -483,7 +483,7 @@ mod tests {
 
     #[test]
     fn adaptive_timeout_is_capped() {
-        let _guard = EnvLockGuard::new();
+        let _guard = crate::util::test_env::lock();
         let segs: Vec<_> = (0..100_000)
             .map(|i| {
                 let start = i as f32;
@@ -503,57 +503,13 @@ mod tests {
 
     #[test]
     fn adaptive_timeout_env_override_wins() {
-        let _guard = EnvLockGuard::new();
+        let _guard = crate::util::test_env::lock();
         let segs = vec![seg(0.0, 1.0, "a")];
-        let _env = EnvGuard::set("KESHA_DIARIZE_TIMEOUT_SECS", "3600");
+        let _env = crate::util::test_env::EnvGuard::set("KESHA_DIARIZE_TIMEOUT_SECS", "3600");
 
         assert_eq!(
             diarize_timeout(&segs, Some(1.0)),
             Duration::from_secs(3_600)
         );
-    }
-
-    struct EnvLockGuard {
-        _guard: std::sync::MutexGuard<'static, ()>,
-    }
-
-    impl EnvLockGuard {
-        fn new() -> Self {
-            static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
-            Self {
-                _guard: LOCK
-                    .get_or_init(|| std::sync::Mutex::new(()))
-                    .lock()
-                    .unwrap_or_else(|e| e.into_inner()),
-            }
-        }
-    }
-
-    struct EnvGuard {
-        key: &'static str,
-        original: Option<String>,
-    }
-
-    impl EnvGuard {
-        fn set(key: &'static str, val: &str) -> Self {
-            let original = std::env::var(key).ok();
-            unsafe {
-                std::env::set_var(key, val);
-            }
-            Self { key, original }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            match &self.original {
-                Some(v) => unsafe {
-                    std::env::set_var(self.key, v);
-                },
-                None => unsafe {
-                    std::env::remove_var(self.key);
-                },
-            }
-        }
     }
 }

--- a/rust/src/transcribe/mod.rs
+++ b/rust/src/transcribe/mod.rs
@@ -1249,11 +1249,12 @@ mod tests {
     #[cfg(all(feature = "system_diarize", target_os = "macos"))]
     #[test]
     fn transcribe_with_speakers_checks_diarize_model_before_asr_install() {
-        let _env_lock = env_lock().lock().unwrap();
+        let _env_lock = crate::util::test_env::lock();
         let cache = tempfile::tempdir().unwrap();
         let missing_diarize_model = cache.path().join("missing-diarize.mlpackage");
-        let _cache_guard = EnvGuard::set("KESHA_CACHE_DIR", cache.path().to_str().unwrap());
-        let _diarize_guard = EnvGuard::set(
+        let _cache_guard =
+            crate::util::test_env::EnvGuard::set("KESHA_CACHE_DIR", cache.path().to_str().unwrap());
+        let _diarize_guard = crate::util::test_env::EnvGuard::set(
             "KESHA_DIARIZE_MODEL_PATH",
             missing_diarize_model.to_str().unwrap(),
         );
@@ -1281,44 +1282,7 @@ mod tests {
     }
 
     #[cfg(all(feature = "system_diarize", target_os = "macos"))]
-    fn env_lock() -> &'static std::sync::Mutex<()> {
-        static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
-        LOCK.get_or_init(|| std::sync::Mutex::new(()))
-    }
-
-    #[cfg(all(feature = "system_diarize", target_os = "macos"))]
-    struct EnvGuard {
-        key: &'static str,
-        original: Option<String>,
-    }
-
-    #[cfg(all(feature = "system_diarize", target_os = "macos"))]
-    impl EnvGuard {
-        fn set(key: &'static str, val: &str) -> Self {
-            let original = std::env::var(key).ok();
-            unsafe {
-                std::env::set_var(key, val);
-            }
-            Self { key, original }
-        }
-    }
-
-    #[cfg(all(feature = "system_diarize", target_os = "macos"))]
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            match &self.original {
-                Some(v) => unsafe {
-                    std::env::set_var(self.key, v);
-                },
-                None => unsafe {
-                    std::env::remove_var(self.key);
-                },
-            }
-        }
-    }
-
     // ── trim_repeated_prefix characterization tests ─────────────────────────
-
     #[test]
     fn trim_repeated_prefix_empty_prev_returns_current_unchanged() {
         assert_eq!(trim_repeated_prefix("", "hello world"), "hello world");

--- a/rust/src/transcribe/mod.rs
+++ b/rust/src/transcribe/mod.rs
@@ -1281,7 +1281,6 @@ mod tests {
         );
     }
 
-    #[cfg(all(feature = "system_diarize", target_os = "macos"))]
     // ── trim_repeated_prefix characterization tests ─────────────────────────
     #[test]
     fn trim_repeated_prefix_empty_prev_returns_current_unchanged() {

--- a/rust/src/util.rs
+++ b/rust/src/util.rs
@@ -20,3 +20,51 @@ pub fn argmax(xs: &[f32]) -> usize {
     }
     best
 }
+
+/// Test-only env mutation helpers. Env-mutating tests across the crate must
+/// serialize on [`test_env::lock`] — previously three modules kept private
+/// mutexes, so their tests could still race each other in one process.
+#[cfg(test)]
+pub mod test_env {
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    /// Crate-wide lock for every env-mutating test. Poisoning is ignored:
+    /// a panicked env test must not cascade into unrelated ones.
+    pub fn lock() -> MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// Restores the env var to its original value on drop. Hold the guard
+    /// from [`lock`] for the whole test — `EnvGuard` deliberately does not
+    /// take it itself so a test can set several vars.
+    pub struct EnvGuard {
+        key: &'static str,
+        original: Option<String>,
+    }
+
+    impl EnvGuard {
+        pub fn set(key: &'static str, val: &str) -> Self {
+            let original = std::env::var(key).ok();
+            unsafe { std::env::set_var(key, val) };
+            Self { key, original }
+        }
+
+        pub fn unset(key: &'static str) -> Self {
+            let original = std::env::var(key).ok();
+            unsafe { std::env::remove_var(key) };
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.original {
+                Some(v) => unsafe { std::env::set_var(self.key, v) },
+                None => unsafe { std::env::remove_var(self.key) },
+            }
+        }
+    }
+}


### PR DESCRIPTION
From the rust review backlog (simplification #9). `EnvGuard` existed as three identical copies (`models.rs`, `transcribe/mod.rs`, `transcribe/diarize.rs`) plus a fourth `KESHA_MODEL_MIRROR`-specialized bundle, and the serializing mutexes were per-module (`env_lock()`, `EnvLockGuard`, `ENV_LOCK`) — so env-mutating tests in *different* modules could still race each other in a single `cargo test --lib` process, and the models tts/cache tests took no lock at all.

`util::test_env` (cfg(test)) now owns the single `EnvGuard { set, unset }` and a crate-wide `lock()` over one `OnceLock<Mutex<()>>` (poisoning ignored so a panicked env test can't cascade). All call sites rewired; the previously lock-free `models` env tests now serialize too. ~120 lines of test-only copy-paste removed.

Verified: `cargo nextest run --features tts` 403/403, `cargo fmt`, `cargo clippy --all-targets -- -D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012g6EWAkjR68hGC4BeasQzg