### PR TITLE
test(raycast): prune duplicate and implementation-detail tests

### DIFF
--- a/raycast/tests/dictation-controller.test.ts
+++ b/raycast/tests/dictation-controller.test.ts
@@ -264,6 +264,40 @@ describe("dictation controller", () => {
     expect(deps.cleanupTempDir).toHaveBeenCalledWith("/tmp/session");
   });
 
+  it("clears the idle state through the session when speech resumes", async () => {
+    let clock = 0;
+    let emit!: (patch: RecordingPatch) => void;
+    const recorder = deferred<void>();
+    const deps = createDeps({
+      now: () => clock,
+      startRecorder: vi.fn(() => ({ done: recorder.promise, stop: vi.fn() })),
+      startRecordingMonitor: vi.fn((onPatch) => {
+        emit = onPatch;
+        return vi.fn();
+      }),
+    });
+
+    const session = startDictationSession({}, deps.setState, deps);
+    await vi.waitFor(() => expect(deps.startRecorder).toHaveBeenCalled());
+
+    emit({ signal: emptySignal("listening") });
+    clock = 30_000;
+    emit({ signal: emptySignal("listening") });
+    expect(deps.current()).toMatchObject({ idle: true });
+
+    clock = 31_000;
+    emit({ signal: signalTick() });
+    expect(deps.current()).toMatchObject({
+      status: "recording",
+      idle: false,
+      silentForMs: 0,
+    });
+
+    session.cancel();
+    recorder.resolve();
+    await session.done;
+  });
+
   it("auto-stops and transcribes after continuous silence", async () => {
     let clock = 0;
     let emit!: (patch: RecordingPatch) => void;

--- a/raycast/tests/dictation-controller.test.ts
+++ b/raycast/tests/dictation-controller.test.ts
@@ -83,10 +83,6 @@ describe("dictation controller", () => {
       status: "error",
       message: "mic denied",
     });
-    expect(deps.toasts).toContainEqual({
-      style: "failure",
-      title: "Dictation failed",
-    });
   });
 
   it("shows an actionable error when kesha cannot be resolved", async () => {
@@ -288,14 +284,14 @@ describe("dictation controller", () => {
     const session = startDictationSession({}, deps.setState, deps);
     await vi.waitFor(() => expect(deps.startRecorder).toHaveBeenCalled());
 
-    emit({ signal: listeningSignal() });
+    emit({ signal: emptySignal("listening") });
     clock = 30_000;
-    emit({ signal: listeningSignal() });
+    emit({ signal: emptySignal("listening") });
     expect(deps.current()).toMatchObject({ status: "recording", idle: true });
     expect(recorderStop).not.toHaveBeenCalled();
 
     clock = 45_000;
-    emit({ signal: listeningSignal() });
+    emit({ signal: emptySignal("listening") });
     expect(recorderStop).toHaveBeenCalledTimes(1);
 
     await session.done;
@@ -304,77 +300,6 @@ describe("dictation controller", () => {
       style: "animated",
       title: "Stopped after silence.",
     });
-  });
-
-  it("clears the idle warning when speech returns before the grace stop", async () => {
-    let clock = 0;
-    let emit!: (patch: RecordingPatch) => void;
-    const recorder = deferred<void>();
-    const recorderStop = vi.fn(() => recorder.resolve());
-    const deps = createDeps({
-      now: () => clock,
-      startRecorder: vi.fn(() => ({
-        done: recorder.promise,
-        stop: recorderStop,
-      })),
-      startRecordingMonitor: vi.fn((onPatch) => {
-        emit = onPatch;
-        return vi.fn();
-      }),
-    });
-
-    const session = startDictationSession({}, deps.setState, deps);
-    await vi.waitFor(() => expect(deps.startRecorder).toHaveBeenCalled());
-
-    emit({ signal: listeningSignal() });
-    clock = 30_000;
-    emit({ signal: listeningSignal() });
-    expect(deps.current()).toMatchObject({ idle: true });
-
-    clock = 44_000;
-    emit({ signal: signalTick() });
-    expect(deps.current()).toMatchObject({
-      status: "recording",
-      idle: false,
-      silentForMs: 0,
-    });
-
-    clock = 90_000;
-    emit({ signal: listeningSignal() });
-    expect(recorderStop).not.toHaveBeenCalled();
-
-    session.cancel();
-    await session.done;
-  });
-
-  it("does not accumulate silence while the meter is still starting", async () => {
-    let clock = 0;
-    let emit!: (patch: RecordingPatch) => void;
-    const recorder = deferred<void>();
-    const recorderStop = vi.fn(() => recorder.resolve());
-    const deps = createDeps({
-      now: () => clock,
-      startRecorder: vi.fn(() => ({
-        done: recorder.promise,
-        stop: recorderStop,
-      })),
-      startRecordingMonitor: vi.fn((onPatch) => {
-        emit = onPatch;
-        return vi.fn();
-      }),
-    });
-
-    const session = startDictationSession({}, deps.setState, deps);
-    await vi.waitFor(() => expect(deps.startRecorder).toHaveBeenCalled());
-
-    emit({ signal: emptySignal("starting") });
-    clock = 60_000;
-    emit({ signal: emptySignal("starting") });
-    expect(deps.current()).toMatchObject({ idle: false, silentForMs: 0 });
-    expect(recorderStop).not.toHaveBeenCalled();
-
-    session.cancel();
-    await session.done;
   });
 });
 
@@ -386,16 +311,16 @@ describe("createSilenceTracker", () => {
       onIdleStop: vi.fn(),
     });
 
-    expect(tracker.track({ signal: listeningSignal() })).toMatchObject({
+    expect(tracker.track({ signal: emptySignal("listening") })).toMatchObject({
       silentForMs: 0,
       idle: false,
     });
     clock = 29_999;
-    expect(tracker.track({ signal: listeningSignal() })).toMatchObject({
+    expect(tracker.track({ signal: emptySignal("listening") })).toMatchObject({
       idle: false,
     });
     clock = 30_000;
-    expect(tracker.track({ signal: listeningSignal() })).toMatchObject({
+    expect(tracker.track({ signal: emptySignal("listening") })).toMatchObject({
       silentForMs: 30_000,
       idle: true,
     });
@@ -406,11 +331,11 @@ describe("createSilenceTracker", () => {
     const onIdleStop = vi.fn();
     const tracker = createSilenceTracker({ now: () => clock, onIdleStop });
 
-    tracker.track({ signal: listeningSignal() });
+    tracker.track({ signal: emptySignal("listening") });
     clock = 45_000;
-    tracker.track({ signal: listeningSignal() });
+    tracker.track({ signal: emptySignal("listening") });
     clock = 60_000;
-    tracker.track({ signal: listeningSignal() });
+    tracker.track({ signal: emptySignal("listening") });
 
     expect(onIdleStop).toHaveBeenCalledTimes(1);
   });
@@ -420,14 +345,14 @@ describe("createSilenceTracker", () => {
     const onIdleStop = vi.fn();
     const tracker = createSilenceTracker({ now: () => clock, onIdleStop });
 
-    tracker.track({ signal: listeningSignal() });
+    tracker.track({ signal: emptySignal("listening") });
     clock = 44_000;
     expect(tracker.track({ signal: signalTick() })).toMatchObject({
       silentForMs: 0,
       idle: false,
     });
     clock = 80_000;
-    expect(tracker.track({ signal: listeningSignal() })).toMatchObject({
+    expect(tracker.track({ signal: emptySignal("listening") })).toMatchObject({
       silentForMs: 0,
       idle: false,
     });
@@ -437,6 +362,14 @@ describe("createSilenceTracker", () => {
   it("leaves non-signal patches untouched", () => {
     const tracker = createSilenceTracker({ onIdleStop: vi.fn() });
     expect(tracker.track({ elapsedSeconds: 5 })).toEqual({ elapsedSeconds: 5 });
+  });
+
+  it("does not accumulate silence while the meter is still starting", () => {
+    const tracker = createSilenceTracker({ onIdleStop: vi.fn() });
+    expect(tracker.track({ signal: emptySignal("starting") })).toMatchObject({
+      silentForMs: 0,
+      idle: false,
+    });
   });
 });
 
@@ -473,12 +406,17 @@ describe("startTranscribingTimer", () => {
 
     now = 3_400;
     vi.advanceTimersByTime(500);
-    stop();
-
     expect(states.at(-1)).toMatchObject({
       status: "transcribing",
       elapsedSeconds: 2,
     });
+
+    state = { status: "starting" };
+    now = 8_000;
+    vi.advanceTimersByTime(500);
+    expect(states.at(-1)).toEqual({ status: "starting" });
+
+    stop();
     vi.useRealTimers();
   });
 });
@@ -526,10 +464,6 @@ function createDeps(
 
 function resolvedTask<T>(done: Promise<T>): RunningTask<T> {
   return { done, stop: vi.fn() };
-}
-
-function listeningSignal(): SignalLevel {
-  return { rms: 0, peak: 0, percent: 0, state: "listening" };
 }
 
 function signalTick(): SignalLevel {

--- a/raycast/tests/kesha-bin.test.ts
+++ b/raycast/tests/kesha-bin.test.ts
@@ -60,6 +60,11 @@ describe("resolveKeshaBin", () => {
     expect(await resolveKeshaBin("/missing/kesha", deps)).toBeNull();
   });
 
+  it("returns null when every fallback candidate is non-executable", async () => {
+    const deps = fakeDeps({}, { candidates: ["/a/kesha", "/b/kesha"] });
+    expect(await resolveKeshaBin(undefined, deps)).toBeNull();
+  });
+
   it("picks the first executable fallback candidate", async () => {
     const deps = fakeDeps(
       { "/second/kesha": {}, "/third/kesha": {} },

--- a/raycast/tests/kesha-bin.test.ts
+++ b/raycast/tests/kesha-bin.test.ts
@@ -8,13 +8,7 @@ describe("parseShebang", () => {
       "/usr/bin/env bun",
     );
     expect(parseShebang(Buffer.from("#!/bin/sh -e\n"))).toBe("/bin/sh -e");
-  });
-
-  it("handles a header without a newline in the first bytes", () => {
     expect(parseShebang(Buffer.from("#!/bin/sh"))).toBe("/bin/sh");
-  });
-
-  it("trims whitespace including CRLF line endings", () => {
     expect(parseShebang(Buffer.from("#!/usr/bin/env bun\r\nrest"))).toBe(
       "/usr/bin/env bun",
     );
@@ -75,11 +69,6 @@ describe("resolveKeshaBin", () => {
       command: "/second/kesha",
       prefixArgs: [],
     });
-  });
-
-  it("returns null when nothing is executable", async () => {
-    const deps = fakeDeps({}, { candidates: ["/a/kesha", "/b/kesha"] });
-    expect(await resolveKeshaBin("", deps)).toBeNull();
   });
 
   it("runs an env-shebang script through a matching interpreter", async () => {

--- a/raycast/tests/process-tasks.test.ts
+++ b/raycast/tests/process-tasks.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  capTail,
   startKeshaRecorder,
   startKeshaTranscriber,
   stopProcessWithWatchdog,
@@ -10,6 +11,12 @@ import { FakeProcess, createSpawnRecorder } from "./helpers/fake-process";
 const kesha = { command: "kesha", prefixArgs: ["--prefix"] };
 
 describe("process task helpers", () => {
+  it("capTail keeps the tail once the cap is exceeded", () => {
+    expect(capTail("abcdef", 3)).toBe("def");
+    expect(capTail("ab", 3)).toBe("ab");
+  });
+
+
   it("starts recorder with plain record args and surfaces stderr on failure", async () => {
     const { spawn, calls, processes } = createSpawnRecorder();
     const task = startKeshaRecorder(kesha, "/tmp/audio.wav", 12, { spawn });

--- a/raycast/tests/process-tasks.test.ts
+++ b/raycast/tests/process-tasks.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
 import {
-  capTail,
   startKeshaRecorder,
   startKeshaTranscriber,
   stopProcessWithWatchdog,
@@ -11,11 +10,6 @@ import { FakeProcess, createSpawnRecorder } from "./helpers/fake-process";
 const kesha = { command: "kesha", prefixArgs: ["--prefix"] };
 
 describe("process task helpers", () => {
-  it("caps captured output to the tail", () => {
-    expect(capTail("abcdef", 3)).toBe("def");
-    expect(capTail("ab", 3)).toBe("ab");
-  });
-
   it("starts recorder with plain record args and surfaces stderr on failure", async () => {
     const { spawn, calls, processes } = createSpawnRecorder();
     const task = startKeshaRecorder(kesha, "/tmp/audio.wav", 12, { spawn });

--- a/raycast/tests/recording-monitor.test.ts
+++ b/raycast/tests/recording-monitor.test.ts
@@ -6,7 +6,6 @@ import type {
 } from "../src/lib/recording-monitor";
 import type { RecordingPatch, SignalLevel } from "../src/lib/dictation-types";
 import { emptySignal } from "../src/lib/recording-view";
-import { METER_INTERVAL_MS } from "../src/lib/dictation-config";
 import { deferred, flushPromises } from "./helpers/async";
 
 function createHarness() {
@@ -53,17 +52,9 @@ function createHarness() {
 }
 
 describe("startRecordingMonitor", () => {
-  it("emits an immediate elapsed tick and schedules the meter interval", () => {
-    const harness = createHarness();
-    expect(harness.patches).toContainEqual({ elapsedSeconds: 0 });
-    expect(harness.schedule).toHaveBeenCalledWith(
-      expect.any(Function),
-      METER_INTERVAL_MS,
-    );
-  });
-
   it("reports elapsed whole seconds from its start time", () => {
     const harness = createHarness();
+    expect(harness.patches).toContainEqual({ elapsedSeconds: 0 });
     harness.setClock(2_400);
     harness.fireTick();
     expect(harness.patches.at(-1)).toEqual({ elapsedSeconds: 2 });

--- a/raycast/tests/signal-meter.test.ts
+++ b/raycast/tests/signal-meter.test.ts
@@ -72,10 +72,7 @@ describe("recording markdown", () => {
       "# Recording\n\nSpeak now. Kesha records locally from your default microphone.",
     );
     expect(formatInputFormat(state.mic)).toBe("48000 Hz, 1 channel");
-    expect(formatDuration(state.elapsedSeconds)).toBe("0:07");
     expect(signalProgress(state.signal)).toBe(0.24);
-    expect(signalStatusLabel(state.signal.state)).toBe("Signal");
-    expect(signalStatusTone(state.signal.state)).toBe("green");
     expect(recordingStatusLabel(state)).toBe("Signal");
     expect(recordingStatusTone(state)).toBe("green");
   });
@@ -83,6 +80,9 @@ describe("recording markdown", () => {
   it("renders the transcript under a Dictation heading", () => {
     expect(buildResultMarkdown("hello world")).toBe(
       "# Dictation\n\nhello world",
+    );
+    expect(buildTranscribingMarkdown()).toBe(
+      "# Transcribing\n\nProcessing locally with Kesha Voice Kit.",
     );
   });
 
@@ -119,18 +119,7 @@ describe("recording markdown", () => {
     expect(signalStatusTone("starting")).toBe("blue");
     expect(signalStatusLabel("listening")).toBe("Listening");
     expect(signalStatusTone("listening")).toBe("secondary");
-  });
-
-  it("keeps transcribing markdown minimal and exposes elapsed via helpers", () => {
-    const state: Extract<DictationState, { status: "transcribing" }> = {
-      status: "transcribing",
-      elapsedSeconds: 12,
-      timeoutSeconds: 60,
-    };
-
-    expect(buildTranscribingMarkdown()).toBe(
-      "# Transcribing\n\nProcessing locally with Kesha Voice Kit.",
-    );
-    expect(formatDuration(state.elapsedSeconds)).toBe("0:12");
+    expect(signalStatusLabel("signal")).toBe("Signal");
+    expect(signalStatusTone("signal")).toBe("green");
   });
 });

--- a/raycast/tests/wav.test.ts
+++ b/raycast/tests/wav.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isSilentWav, wavPayloadFormat, findWavChunk } from "../src/lib/wav";
+import { isSilentWav, findWavChunk } from "../src/lib/wav";
 
 describe("isSilentWav", () => {
   it("detects silent and non-silent Float32 WAV files", () => {
@@ -27,9 +27,6 @@ describe("isSilentWav", () => {
       bits: 32,
       samples: [0, 0.02],
     });
-    const fmt = findWavChunk(wav, "fmt ");
-    expect(fmt).not.toBeNull();
-    expect(wavPayloadFormat(wav, fmt!, 0xfffe)).toBe(3);
     expect(isSilentWav(wav)).toBe(false);
   });
 


### PR DESCRIPTION
First of three PRs from the test-ROI audit (rust / TS / raycast suites, three parallel review agents + adversarial verification). Raycast lane: 61 → 54 tests, −106 net lines, zero unique failure modes lost.

- Deleted session-harness duplicates of pure `createSilenceTracker` scenarios (same clock values, same branch) and moved the meter-warm-up story into a one-row tracker case.
- Collapsed `parseShebang` triplet into one table; dropped the degenerate nothing-executable case (same falsy branch as the covered ones).
- Removed implementation-detail pins: `findWavChunk`/`wavPayloadFormat` internals (kept the behavioral `isSilentWav` assert), the tautological `setInterval(METER_INTERVAL_MS)` constant pin, `capTail` restatement, duplicated failure-toast copy asserts.
- Replaced the drift-prone `listeningSignal()` fixture with the existing `emptySignal("listening")` at 11 call sites.
- Made `updates elapsed seconds only while transcribing` honest: the non-transcribing guard is now actually exercised.

Every deletion is a strict-subset duplicate or a pin on symbols exported solely for tests; the keep-list (cancel race, silence auto-stop, kesha-bin resolution chain, watchdogs) is untouched. `npm test` 54/54 + `ray lint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012g6EWAkjR68hGC4BeasQzg