### PR TITLE
test: prune low-ROI rust tests (duplicates, tautologies, false coverage)

### DIFF
--- a/rust/src/backend/onnx.rs
+++ b/rust/src/backend/onnx.rs
@@ -212,12 +212,7 @@ impl OnnxBackend {
     }
 
     fn detokenize(&self, token_ids: &[usize]) -> String {
-        let text: String = token_ids
-            .iter()
-            .filter_map(|&id| self.vocab.get(id))
-            .map(|t| t.replace('\u{2581}', " "))
-            .collect();
-        text.trim().to_string()
+        detokenize(&self.vocab, token_ids)
     }
 }
 
@@ -254,6 +249,15 @@ impl TranscribeBackend for OnnxBackend {
 // ---------------------------------------------------------------------------
 // Pure helpers (no Session access)
 // ---------------------------------------------------------------------------
+
+fn detokenize(vocab: &[String], token_ids: &[usize]) -> String {
+    let text: String = token_ids
+        .iter()
+        .filter_map(|&id| vocab.get(id))
+        .map(|t| t.replace('\u{2581}', " "))
+        .collect();
+    text.trim().to_string()
+}
 
 /// Extracts one encoder frame: encoder_data is row-major [1, D, T'], so
 /// element [0, d, t] = d * T' + t.
@@ -474,38 +478,31 @@ fn load_vocab<P: AsRef<Path>>(path: P) -> Result<Vec<String>> {
 mod tests {
     use super::*;
 
-    // detokenize is an &self method on OnnxBackend, but its logic is purely a
-    // function of vocab + token_ids. Exercise it via a minimal stub vocab.
-    fn detokenize_with_vocab(vocab: &[&str], token_ids: &[usize]) -> String {
-        let text: String = token_ids
-            .iter()
-            .filter_map(|&id| vocab.get(id))
-            .map(|t| t.replace('\u{2581}', " "))
-            .collect();
-        text.trim().to_string()
+    fn vocab_of(tokens: &[&str]) -> Vec<String> {
+        tokens.iter().map(|s| s.to_string()).collect()
     }
 
     #[test]
     fn detokenize_sentencepiece_underscore() {
         // U+2581 marks a leading space in SentencePiece tokens
-        let vocab = ["h", "e", "l", "l", "o", "\u{2581}w", "o", "r", "l", "d"];
+        let vocab = vocab_of(&["h", "e", "l", "l", "o", "\u{2581}w", "o", "r", "l", "d"]);
         assert_eq!(
-            detokenize_with_vocab(&vocab, &[0, 1, 2, 2, 4, 5, 6, 7, 2, 9]),
+            detokenize(&vocab, &[0, 1, 2, 2, 4, 5, 6, 7, 2, 9]),
             "hello world"
         );
     }
 
     #[test]
     fn detokenize_trims_leading_space() {
-        let vocab = ["\u{2581}hi"];
-        assert_eq!(detokenize_with_vocab(&vocab, &[0]), "hi");
+        let vocab = vocab_of(&["\u{2581}hi"]);
+        assert_eq!(detokenize(&vocab, &[0]), "hi");
     }
 
     #[test]
     fn detokenize_out_of_range_ids_skipped() {
-        let vocab = ["a", "b"];
+        let vocab = vocab_of(&["a", "b"]);
         // id 99 is out of range → filtered out
-        assert_eq!(detokenize_with_vocab(&vocab, &[0, 99, 1]), "ab");
+        assert_eq!(detokenize(&vocab, &[0, 99, 1]), "ab");
     }
 
     #[test]

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -1049,30 +1049,27 @@ mod mirror_tests {
     #[test]
     fn unset_env_falls_through_to_upstream() {
         let _lock = crate::util::test_env::lock();
-        let _g = EnvGuard::unset("KESHA_MODEL_MIRROR");
-        assert_eq!(model_mirror(), None);
-        assert_eq!(
-            apply_mirror("https://huggingface.co/foo/bar/resolve/main/file.onnx"),
-            "https://huggingface.co/foo/bar/resolve/main/file.onnx"
-        );
-    }
 
-    #[test]
-    fn empty_env_falls_through_to_upstream() {
-        let _lock = crate::util::test_env::lock();
-        let _g = EnvGuard::set("KESHA_MODEL_MIRROR", "");
-        assert_eq!(model_mirror(), None);
-        assert_eq!(
-            apply_mirror("https://huggingface.co/foo/bar/resolve/main/file.onnx"),
-            "https://huggingface.co/foo/bar/resolve/main/file.onnx"
-        );
-    }
-
-    #[test]
-    fn whitespace_env_falls_through_to_upstream() {
-        let _lock = crate::util::test_env::lock();
-        let _g = EnvGuard::set("KESHA_MODEL_MIRROR", "   ");
-        assert_eq!(model_mirror(), None);
+        {
+            let _g = EnvGuard::unset("KESHA_MODEL_MIRROR");
+            assert_eq!(model_mirror(), None);
+            assert_eq!(
+                apply_mirror("https://huggingface.co/foo/bar/resolve/main/file.onnx"),
+                "https://huggingface.co/foo/bar/resolve/main/file.onnx"
+            );
+        }
+        {
+            let _g = EnvGuard::set("KESHA_MODEL_MIRROR", "");
+            assert_eq!(model_mirror(), None);
+            assert_eq!(
+                apply_mirror("https://huggingface.co/foo/bar/resolve/main/file.onnx"),
+                "https://huggingface.co/foo/bar/resolve/main/file.onnx"
+            );
+        }
+        {
+            let _g = EnvGuard::set("KESHA_MODEL_MIRROR", "   ");
+            assert_eq!(model_mirror(), None);
+        }
     }
 
     #[test]
@@ -1660,19 +1657,6 @@ mod characterization_tests {
     }
 
     #[test]
-    fn model_dir_at_joins_subdir_to_root() {
-        let root = std::path::Path::new("/fake/cache");
-        assert_eq!(
-            model_dir_at(ModelKind::Asr, root),
-            std::path::PathBuf::from("/fake/cache/models/parakeet-tdt-v3")
-        );
-        assert_eq!(
-            model_dir_at(ModelKind::Vad, root),
-            std::path::PathBuf::from("/fake/cache/models/silero-vad")
-        );
-    }
-
-    #[test]
     fn is_cached_in_asr_true_when_all_files_present() {
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path().join("models/parakeet-tdt-v3");
@@ -1694,38 +1678,6 @@ mod characterization_tests {
             fs::write(dir.join(name), b"dummy").unwrap();
         }
         assert!(!is_cached_in(ModelKind::Asr, &dir));
-    }
-
-    #[test]
-    fn is_cached_in_lang_id_true_when_all_files_present() {
-        let tmp = tempfile::tempdir().unwrap();
-        let dir = tmp.path().join("models/lang-id-ecapa");
-        fs::create_dir_all(&dir).unwrap();
-        for f in LANG_ID_FILES {
-            let name = std::path::Path::new(f.rel_path).file_name().unwrap();
-            fs::write(dir.join(name), b"dummy").unwrap();
-        }
-        assert!(is_cached_in(ModelKind::LangId, &dir));
-    }
-
-    #[test]
-    fn is_cached_in_vad_true_when_file_present() {
-        let tmp = tempfile::tempdir().unwrap();
-        let dir = tmp.path().join("models/silero-vad");
-        fs::create_dir_all(&dir).unwrap();
-        for f in VAD_FILES {
-            let name = std::path::Path::new(f.rel_path).file_name().unwrap();
-            fs::write(dir.join(name), b"dummy").unwrap();
-        }
-        assert!(is_cached_in(ModelKind::Vad, &dir));
-    }
-
-    #[test]
-    fn is_cached_in_vad_false_when_empty_dir() {
-        let tmp = tempfile::tempdir().unwrap();
-        let dir = tmp.path().join("models/silero-vad");
-        fs::create_dir_all(&dir).unwrap();
-        assert!(!is_cached_in(ModelKind::Vad, &dir));
     }
 
     #[cfg(feature = "tts")]

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -1657,6 +1657,26 @@ mod characterization_tests {
     }
 
     #[test]
+    fn is_cached_in_lang_id_and_vad_arms_check_their_own_files() {
+        // The match arms wire each kind to its own file list independently of
+        // the Asr/Vosk arms — pin present→true / empty→false per arm.
+        for (kind, files) in [
+            (ModelKind::LangId, LANG_ID_FILES),
+            (ModelKind::Vad, VAD_FILES),
+        ] {
+            let tmp = tempfile::tempdir().unwrap();
+            let dir = tmp.path().join(kind.subdir());
+            fs::create_dir_all(&dir).unwrap();
+            assert!(!is_cached_in(kind, &dir), "{kind:?} empty dir");
+            for f in files {
+                let name = std::path::Path::new(f.rel_path).file_name().unwrap();
+                fs::write(dir.join(name), b"dummy").unwrap();
+            }
+            assert!(is_cached_in(kind, &dir), "{kind:?} all files present");
+        }
+    }
+
+    #[test]
     fn is_cached_in_asr_true_when_all_files_present() {
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path().join("models/parakeet-tdt-v3");

--- a/rust/src/transcribe/mod.rs
+++ b/rust/src/transcribe/mod.rs
@@ -814,7 +814,7 @@ mod tests {
     }
 
     #[test]
-    fn auto_mode_long_wav_routes_to_vad_when_installed() {
+    fn probe_duration_reports_seconds_for_long_wav() {
         let tmp = tempfile::Builder::new()
             .prefix("kesha-auto-vad-long-")
             .suffix(".wav")
@@ -824,16 +824,6 @@ mod tests {
         let duration = probe_duration_if_plausible(tmp.path().to_str().unwrap());
         let secs = duration.expect("long WAV should probe to Some duration");
         assert!((120.0..122.0).contains(&secs), "expected ~121s, got {secs}");
-        assert_eq!(
-            decide(VadMode::Auto, duration, true),
-            VadDecision::Vad,
-            "long audio + installed → Vad"
-        );
-        assert_eq!(
-            decide(VadMode::Auto, duration, false),
-            VadDecision::PlainWithHint,
-            "long audio + not installed → Plain + hint"
-        );
     }
 
     #[test]
@@ -1195,29 +1185,6 @@ mod tests {
     }
 
     #[test]
-    fn transcription_segment_speaker_field_serializes_when_some() {
-        let s = TranscriptionSegment {
-            start: 0.0,
-            end: 1.0,
-            text: "hi".into(),
-            speaker: Some(2),
-        };
-        let json = serde_json::to_string(&s).unwrap();
-        assert!(
-            json.contains("\"speaker\":2"),
-            "expected speaker:2 in {json}"
-        );
-    }
-
-    #[test]
-    fn vad_mode_default_is_auto() {
-        // `TranscribeOptions::default()` only matches the legacy text-only
-        // `transcribe(_, VadMode::Auto)` behavior if VadMode's own Default
-        // is Auto. Lock that in.
-        assert_eq!(VadMode::default(), VadMode::Auto);
-    }
-
-    #[test]
     fn transcribe_options_default_is_text_only_auto() {
         // Must match the legacy `transcribe(_, mode)` text-only path: Auto VAD, no segments, no speakers.
         let o = TranscribeOptions::default();
@@ -1383,17 +1350,6 @@ mod tests {
         )
         .expect_err("exact boundary must be rejected");
         assert!(err.to_string().contains("refusing --no-vad"), "{err}");
-    }
-
-    // ── decide at exactly AUTO_VAD_MIN_SECONDS without VAD ───────────────────
-
-    #[test]
-    fn decide_at_exactly_auto_vad_min_seconds_without_vad_gives_plain_with_hint() {
-        // At exactly AUTO_VAD_MIN_SECONDS with vad_installed=false → PlainWithHint.
-        assert_eq!(
-            decide(VadMode::Auto, Some(AUTO_VAD_MIN_SECONDS), false),
-            VadDecision::PlainWithHint
-        );
     }
 
     // ── TranscriptionOutput JSON round-trip ──────────────────────────────────

--- a/rust/src/transcribe/options.rs
+++ b/rust/src/transcribe/options.rs
@@ -133,4 +133,20 @@ mod tests {
         assert!(opts.with_segments);
         assert!(opts.with_speakers);
     }
+
+    #[test]
+    fn vad_after_with_segments_matches_vad_before() {
+        // Pins the WithSegments::vad type-state method — without this row it
+        // has no callers and order-dependence could creep in unnoticed.
+        let before = TranscribeOptionsBuilder::new()
+            .vad(VadMode::On)
+            .with_segments()
+            .build();
+        let after = TranscribeOptionsBuilder::new()
+            .with_segments()
+            .vad(VadMode::On)
+            .build();
+        assert_eq!(before.mode, after.mode);
+        assert_eq!(before.with_segments, after.with_segments);
+    }
 }

--- a/rust/src/transcribe/options.rs
+++ b/rust/src/transcribe/options.rs
@@ -106,15 +106,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn builder_new_matches_struct_default() {
-        let from_builder = TranscribeOptionsBuilder::new().build();
-        let from_default = TranscribeOptions::default();
-        assert_eq!(from_builder.mode, from_default.mode);
-        assert_eq!(from_builder.with_segments, from_default.with_segments);
-        assert_eq!(from_builder.with_speakers, from_default.with_speakers);
-    }
-
-    #[test]
     fn no_segments_path_produces_text_only_options() {
         let opts = TranscribeOptionsBuilder::new().vad(VadMode::Off).build();
         assert_eq!(opts.mode, VadMode::Off);
@@ -141,35 +132,5 @@ mod tests {
             .build();
         assert!(opts.with_segments);
         assert!(opts.with_speakers);
-    }
-
-    #[test]
-    fn default_impl_matches_new() {
-        let from_default: TranscribeOptionsBuilder = TranscribeOptionsBuilder::default();
-        let opts = from_default.build();
-        assert_eq!(opts.mode, VadMode::Auto);
-        assert!(!opts.with_segments);
-        assert!(!opts.with_speakers);
-    }
-
-    #[test]
-    fn vad_is_callable_in_both_states_with_identical_results() {
-        // `vad()` is available before AND after `with_segments()`. Greptile
-        // P2 on #318 flagged the original "only NoSegments has vad()"
-        // as a foot-gun; lock the order-independence in.
-        let pre = TranscribeOptionsBuilder::new()
-            .vad(VadMode::On)
-            .with_segments()
-            .with_speakers()
-            .build();
-        let post = TranscribeOptionsBuilder::new()
-            .with_segments()
-            .vad(VadMode::On)
-            .with_speakers()
-            .build();
-        assert_eq!(pre.mode, VadMode::On);
-        assert_eq!(post.mode, VadMode::On);
-        assert!(pre.with_segments && post.with_segments);
-        assert!(pre.with_speakers && post.with_speakers);
     }
 }

--- a/rust/src/tts/charsiu/tokenizer.rs
+++ b/rust/src/tts/charsiu/tokenizer.rs
@@ -44,11 +44,6 @@ mod tests {
     }
 
     #[test]
-    fn decodes_byte_ids_back_to_utf8() {
-        assert_eq!(decode(&[107, 108]), "hi");
-    }
-
-    #[test]
     fn decode_skips_special_ids() {
         assert_eq!(decode(&[EOS_ID, 107, 108]), "hi");
     }

--- a/rust/src/tts/en/letter_table.rs
+++ b/rust/src/tts/en/letter_table.rs
@@ -78,12 +78,6 @@ mod tests {
     }
 
     #[test]
-    fn http_uses_double_yoo_for_w_via_lowercase_mixin() {
-        // "double yoo" is one entry, not two tokens.
-        assert_eq!(expand_chars("HTTP"), "aitch tee tee pee");
-    }
-
-    #[test]
     fn w_renders_as_double_yoo() {
         assert_eq!(expand_chars("WWW"), "double yoo double yoo double yoo");
     }

--- a/rust/src/tts/en/mod.rs
+++ b/rust/src/tts/en/mod.rs
@@ -57,47 +57,6 @@ mod tests {
     }
 
     #[test]
-    fn text_letter_spells_when_auto_expand() {
-        // FBI letter-spells (no IPA_LEXICON entry, not on stop-list).
-        let out = normalize_segments(vec![Segment::Text("FBI investigation".to_string())], true);
-        assert_eq!(
-            out,
-            vec![Segment::Text("ef bee eye investigation".to_string())]
-        );
-    }
-
-    #[test]
-    fn text_passes_through_when_auto_expand_false_and_no_lexicon_hit() {
-        let out = normalize_segments(vec![Segment::Text("FBI investigation".to_string())], false);
-        assert_eq!(out, vec![Segment::Text("FBI investigation".to_string())]);
-    }
-
-    #[test]
-    fn ipa_lexicon_hit_emits_ipa_segment() {
-        let out = normalize_segments(vec![Segment::Text("EPAM partners".to_string())], true);
-        assert_eq!(
-            out,
-            vec![
-                Segment::Ipa("ˈiːpæm".to_string()),
-                Segment::Text(" partners".to_string()),
-            ]
-        );
-    }
-
-    #[test]
-    fn ipa_lexicon_fires_even_without_auto_expand() {
-        // Lexicon overrides are intent-explicit; not gated by auto_expand.
-        let out = normalize_segments(vec![Segment::Text("EPAM partners".to_string())], false);
-        assert_eq!(
-            out,
-            vec![
-                Segment::Ipa("ˈiːpæm".to_string()),
-                Segment::Text(" partners".to_string()),
-            ]
-        );
-    }
-
-    #[test]
     fn spell_wins_even_when_auto_expand_is_false() {
         let out = normalize_segments(vec![Segment::Spell("OK".to_string())], false);
         assert_eq!(out, vec![Segment::Text("oh kay".to_string())]);

--- a/rust/src/tts/encode.rs
+++ b/rust/src/tts/encode.rs
@@ -623,48 +623,6 @@ mod tests {
     }
 
     #[test]
-    fn encode_wav_round_trip_matches_legacy_path() {
-        // Backwards compat: `encode(.., Wav)` must produce the *same* bytes the
-        // old `wav::encode_wav` produced — that's how we keep existing tests
-        // and downstream `--out foo.wav` callers green.
-        let samples: Vec<f32> = (0..2_400).map(|i| (i as f32 * 0.05).sin()).collect();
-        let from_encode = encode(&samples, 24_000, OutputFormat::Wav).unwrap();
-        let from_wav = wav::encode_wav(&samples, 24_000).unwrap();
-        assert_eq!(from_encode, from_wav);
-    }
-
-    #[test]
-    fn ogg_opus_produces_valid_oggs_magic() {
-        // 1 second of a 440 Hz tone at 24 kHz mono.
-        let sr = 24_000u32;
-        let samples: Vec<f32> = (0..sr)
-            .map(|i| (i as f32 * 2.0 * std::f32::consts::PI * 440.0 / sr as f32).sin() * 0.3)
-            .collect();
-        let bytes = encode(&samples, sr, OutputFormat::ogg_opus_default()).unwrap();
-        // Every Ogg page starts with "OggS" — minimum check that we wrote
-        // *something* well-formed enough for clients to demux.
-        assert_eq!(&bytes[..4], b"OggS");
-        // OpusHead lives in the first page payload, after the page header. We
-        // don't reparse pages here (the dedicated tts_opus.rs test does), but
-        // the magic must appear somewhere in the buffer.
-        assert!(
-            bytes.windows(8).any(|w| w == b"OpusHead"),
-            "OpusHead packet not found in OggOpus output"
-        );
-        assert!(
-            bytes.windows(8).any(|w| w == b"OpusTags"),
-            "OpusTags packet not found in OggOpus output"
-        );
-        // 1 second @ 32 kbps ≈ 4 KB. Allow generous slack — we just want to
-        // know we didn't accidentally ship megabytes of WAV-shaped bytes.
-        assert!(
-            bytes.len() < 12_000,
-            "ogg-opus payload way bigger than expected: {} bytes",
-            bytes.len()
-        );
-    }
-
-    #[test]
     fn ogg_opus_rejects_invalid_sample_rate() {
         let samples = vec![0.0f32; 1024];
         let res = encode(
@@ -692,18 +650,6 @@ mod tests {
         );
         let err = res.unwrap_err().to_string();
         assert!(err.contains("--bitrate"), "unexpected error: {err}");
-    }
-
-    #[test]
-    fn ogg_opus_resamples_when_engine_sr_mismatches() {
-        // Vosk-RU runs at 22.05 kHz natively. We can't feed that to libopus
-        // directly, so the encoder must resample to a supported rate first.
-        let src_sr = 22_050u32;
-        let samples: Vec<f32> = (0..src_sr)
-            .map(|i| (i as f32 * 0.001).sin() * 0.2)
-            .collect();
-        let bytes = encode(&samples, src_sr, OutputFormat::ogg_opus_default()).unwrap();
-        assert_eq!(&bytes[..4], b"OggS", "resampled output is still valid Ogg");
     }
 
     #[test]

--- a/rust/src/tts/fluid_kokoro.rs
+++ b/rust/src/tts/fluid_kokoro.rs
@@ -348,15 +348,6 @@ mod tests {
     }
 
     #[test]
-    fn synthesize_fails_fast_before_model_init() {
-        // Native-script input must error out *before* touching FluidAudio, so this
-        // needs no model download. Proves the gate refuses rather than emitting noise.
-        let err = synthesize("नमस्ते मेरा नाम केशा है", "hm_omega", 1.0)
-            .expect_err("native-script synth must fail fast");
-        assert_eq!(crate::errors::code_of(&err), ErrorCode::ScriptUnsupported);
-    }
-
-    #[test]
     fn synthesize_pcm_skips_no_phoneme_text_before_model_init() {
         // Bare-punctuation / whitespace-only segments (e.g. the trailing "." in
         // `<speak>Loop <emphasis>ssml</emphasis>.</speak>`, #543) have nothing to

--- a/rust/src/tts/g2p.rs
+++ b/rust/src/tts/g2p.rs
@@ -117,12 +117,6 @@ mod tests {
     }
 
     #[test]
-    fn english_routes_to_misaki() {
-        let ipa = text_to_ipa("hello", "en-us").unwrap();
-        assert!(!ipa.is_empty(), "misaki returned empty IPA");
-    }
-
-    #[test]
     fn english_dispatches_for_all_en_aliases() {
         for code in ["en", "en-us", "en-gb", "en-uk"] {
             let ipa = text_to_ipa("hello", code).unwrap();

--- a/rust/src/tts/ru/acronym.rs
+++ b/rust/src/tts/ru/acronym.rs
@@ -142,24 +142,6 @@ mod tests {
     }
 
     #[test]
-    fn vowel_cluster_or_short_or_consonant_cluster_only() {
-        // 0 vowels (all consonants → always has a same-type adjacent pair) → spell.
-        assert_eq!(expand_acronyms("ФСБ"), "эф эс бэ");
-        assert_eq!(expand_acronyms("МВД"), "эм вэ дэ");
-        // Consecutive vowels → spell.
-        assert_eq!(expand_acronyms("ОАЭ"), "о а э");
-        // Consonant cluster adjacent + vowel → spell.
-        assert_eq!(expand_acronyms("США"), "сэ шэ а");
-        // Length 2 → spell (always; only stop-list overrides).
-        assert_eq!(expand_acronyms("ИП"), "и пэ");
-        assert_eq!(expand_acronyms("ЕС"), "е эс");
-        // Alternating CVC / CVCV → don't spell.
-        assert_eq!(expand_acronyms("ВОЗ"), "ВОЗ");
-        assert_eq!(expand_acronyms("НАТО"), "НАТО");
-        assert_eq!(expand_acronyms("ОПЕК"), "ОПЕК");
-    }
-
-    #[test]
     fn every_stop_list_entry_round_trips() {
         for w in STOP_LIST {
             assert_eq!(expand_acronyms(w), *w, "stop-list entry escaped: {w}");

--- a/rust/src/tts/ru/letter_table.rs
+++ b/rust/src/tts/ru/letter_table.rs
@@ -110,11 +110,6 @@ mod tests {
     }
 
     #[test]
-    fn cska_uses_vosk_validated_chunking() {
-        assert_eq!(expand_chars("ЦСКА"), "цэ эс ка");
-    }
-
-    #[test]
     fn empty_input_returns_empty() {
         assert_eq!(expand_chars(""), "");
     }

--- a/rust/src/tts/ru/mod.rs
+++ b/rust/src/tts/ru/mod.rs
@@ -135,30 +135,6 @@ mod tests {
     }
 
     #[test]
-    fn emphasis_with_multiple_plus_markers_pass_all_through() {
-        let out = normalize_segments(
-            vec![Segment::Emphasis {
-                content: "я зн+аю это".to_string(),
-                suppress: false,
-            }],
-            false,
-        );
-        assert_eq!(out, vec![Segment::Text("я зн+аю это".to_string())]);
-    }
-
-    #[test]
-    fn emphasis_suppress_strips_multiple_plus_markers() {
-        let out = normalize_segments(
-            vec![Segment::Emphasis {
-                content: "я зн+аю +это".to_string(),
-                suppress: true,
-            }],
-            false,
-        );
-        assert_eq!(out, vec![Segment::Text("я знаю это".to_string())]);
-    }
-
-    #[test]
     fn prosody_rate_recurses_spell_inside() {
         // Regression: <prosody rate="slow"><say-as characters>ФСБ</say-as></prosody>
         // must still letter-spell the inner content.

--- a/rust/src/tts/ssml/segment.rs
+++ b/rust/src/tts/ssml/segment.rs
@@ -28,32 +28,3 @@ pub enum Segment {
 /// Default `<break/>` duration when the `time` attribute is omitted.
 /// Matches SSML 1.1's "medium" strength interpretation in most engines.
 pub(super) const DEFAULT_BREAK: Duration = Duration::from_millis(250);
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn segment_has_spell_variant() {
-        let s = Segment::Spell("ВОЗ".to_string());
-        match s {
-            Segment::Spell(t) => assert_eq!(t, "ВОЗ"),
-            _ => panic!("expected Segment::Spell"),
-        }
-    }
-
-    #[test]
-    fn segment_has_emphasis_variant() {
-        let s = Segment::Emphasis {
-            content: "д+ома".to_string(),
-            suppress: false,
-        };
-        match s {
-            Segment::Emphasis { content, suppress } => {
-                assert_eq!(content, "д+ома");
-                assert!(!suppress);
-            }
-            _ => panic!("expected Segment::Emphasis"),
-        }
-    }
-}

--- a/rust/src/tts/voices.rs
+++ b/rust/src/tts/voices.rs
@@ -350,13 +350,6 @@ mod tests {
     }
 
     #[test]
-    fn select_style_handles_zero() {
-        let voice = vec![0.0; VOICE_ROWS * VOICE_COLS];
-        let s = select_style(&voice, 0);
-        assert_eq!(s.len(), VOICE_COLS);
-    }
-
-    #[test]
     fn select_style_picks_correct_row() {
         let mut voice = Vec::with_capacity(VOICE_ROWS * VOICE_COLS);
         for row in 0..VOICE_ROWS {
@@ -668,30 +661,6 @@ mod tests {
             );
             assert_eq!(espeak_lang, expected_lang, "{voice_id}: wrong espeak_lang");
         }
-    }
-
-    #[cfg(not(all(
-        feature = "system_kokoro",
-        target_os = "macos",
-        target_arch = "aarch64"
-    )))]
-    #[test]
-    fn multilang_default_voices_resolve_correctly() {
-        let tmp = tempfile::tempdir().unwrap();
-        populate_multilang_cache(tmp.path());
-
-        let r = resolve_voice(tmp.path(), "es-em_alex").unwrap();
-        let (_, _, espeak_lang) = unwrap_kokoro(r);
-        assert_eq!(espeak_lang, "es");
-        let r = resolve_voice(tmp.path(), "fr-ff_siwis").unwrap();
-        let (_, _, espeak_lang) = unwrap_kokoro(r);
-        assert_eq!(espeak_lang, "fr");
-        let r = resolve_voice(tmp.path(), "it-im_nicola").unwrap();
-        let (_, _, espeak_lang) = unwrap_kokoro(r);
-        assert_eq!(espeak_lang, "it");
-        let r = resolve_voice(tmp.path(), "pt-pm_alex").unwrap();
-        let (_, _, espeak_lang) = unwrap_kokoro(r);
-        assert_eq!(espeak_lang, "pt");
     }
 
     #[cfg(not(all(

--- a/rust/src/tts/wav.rs
+++ b/rust/src/tts/wav.rs
@@ -76,14 +76,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn encodes_riff_header() {
-        let samples = vec![0.0f32; 24_000];
-        let wav = encode_wav(&samples, 24_000).unwrap();
-        assert_eq!(&wav[..4], b"RIFF", "not a RIFF: {:?}", &wav[..4]);
-        assert_eq!(&wav[8..12], b"WAVE");
-    }
-
-    #[test]
     fn round_trips_through_hound() {
         let samples: Vec<f32> = (0..2400).map(|i| (i as f32 * 0.1).sin()).collect();
         let wav = encode_wav(&samples, 24_000).unwrap();

--- a/rust/tests/ssml_integration.rs
+++ b/rust/tests/ssml_integration.rs
@@ -105,13 +105,6 @@ fn empty_input_errors() {
 }
 
 #[test]
-fn doctype_is_rejected() {
-    let input = r#"<!DOCTYPE speak SYSTEM "foo"><speak>Hi</speak>"#;
-    // DOCTYPE before <speak> → fails the <speak> root check first (still rejected)
-    assert!(parse(input).is_err());
-}
-
-#[test]
 fn doctype_inside_speak_is_rejected() {
     let input = "<speak><!DOCTYPE foo>Hi</speak>";
     let err = parse(input).unwrap_err();
@@ -296,18 +289,6 @@ fn emphasis_level_none_sets_suppress_true() {
 #[test]
 fn emphasis_level_strong_keeps_suppress_false() {
     let segs = parse(r#"<speak><emphasis level="strong">д+ома</emphasis></speak>"#).unwrap();
-    assert!(matches!(
-        segs.first(),
-        Some(Segment::Emphasis {
-            suppress: false,
-            ..
-        })
-    ));
-}
-
-#[test]
-fn emphasis_level_reduced_keeps_suppress_false() {
-    let segs = parse(r#"<speak><emphasis level="reduced">тест</emphasis></speak>"#).unwrap();
     assert!(matches!(
         segs.first(),
         Some(Segment::Emphasis {

--- a/rust/tests/tts_smoke.rs
+++ b/rust/tests/tts_smoke.rs
@@ -115,27 +115,6 @@ fn say_reads_stdin_when_no_positional() {
     assert_eq!(&out.stdout[..4], b"RIFF");
 }
 
-#[test]
-fn empty_text_exits_2() {
-    let out = Command::new(common::engine_bin())
-        .args([
-            "say",
-            "",
-            "--model",
-            "/nonexistent",
-            "--voice-file",
-            "/nonexistent",
-        ])
-        .output()
-        .expect("run");
-    assert_eq!(
-        out.status.code(),
-        Some(2),
-        "expected exit 2 for empty text\nstderr: {}",
-        String::from_utf8_lossy(&out.stderr)
-    );
-}
-
 // ONNX-path behavior: on darwin-arm64 `system_kokoro` the default en voice
 // resolves through FluidAudio (separate model cache) and synthesizes, so a
 // fresh KESHA_CACHE_DIR neither exits 1 nor prints an install hint.
@@ -237,28 +216,6 @@ fn list_voices_shows_installed() {
     assert!(
         stdout.contains("en-af_heart"),
         "expected en-af_heart, got: {stdout}"
-    );
-}
-
-#[test]
-fn text_too_long_exits_5() {
-    let huge = "a".repeat(10_000);
-    let out = Command::new(common::engine_bin())
-        .args([
-            "say",
-            &huge,
-            "--model",
-            "/nonexistent",
-            "--voice-file",
-            "/nonexistent",
-        ])
-        .output()
-        .expect("run");
-    assert_eq!(
-        out.status.code(),
-        Some(5),
-        "expected exit 5 for too-long text\nstderr: {}",
-        String::from_utf8_lossy(&out.stderr)
     );
 }
 

--- a/rust/tests/tts_stdin_loop.rs
+++ b/rust/tests/tts_stdin_loop.rs
@@ -141,16 +141,6 @@ fn empty_text_returns_err_frame_with_request_id() {
 }
 
 #[test]
-fn unknown_voice_returns_err_frame_with_request_id() {
-    let mut c = LoopChild::spawn();
-    c.send(r#"{"id": 9, "text": "hi", "voice": "zz-not-a-voice"}"#);
-    let f = c.recv();
-    assert_eq!(f.status, STATUS_ERR);
-    assert_eq!(f.id, 9);
-    c.close();
-}
-
-#[test]
 fn loop_synthesises_kokoro_and_caches_session() {
     // The loop-mode JSON request takes voice-by-name only — no `--model`
     // override path. So the test must materialise the runtime cache layout


### PR DESCRIPTION
Second PR from the test-ROI audit. Rust lane: −37 tests (430 → 393), −481 lines, zero unique failure modes lost — every deletion is a strict-subset duplicate, a tautology, or a near-identical table row inside one code branch.

Highlights beyond dead weight:
- **False coverage converted to real coverage**: the three `detokenize` tests exercised a test-local *copy* of the production body — deleting `OnnxBackend::detokenize` entirely left them green. The body is now an extracted free fn (pure-helpers section), the method delegates, and the same three tests pin the real code.
- Deleted the DOCTYPE SSML test whose own comment admitted it structurally cannot reach the DOCTYPE path (bare `is_err` duplicate of the root-check test; the message-asserting DOCTYPE tests remain).
- Unit↔integration dedup: OggS-magic/resample asserts strictly weaker than `tts_opus.rs`'s page-header parses; exit-code smokes triple-pinned via `cli/say.rs` + `tts_e2e.rs`; stdin-loop frame subset.
- Table-row collapses (ru/en acronym tables, env fall-through cases, decide() boundaries) where N rows drove one branch.

Kept-list calibration in the audit: UTF-8 boundary tests, granule duration property, fd-ordering pin, diarize speaker-collision, the ru matrix() table — untouched.

Verified: `cargo nextest run --features tts` 393/393, `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo check --features tts,system_kokoro`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012g6EWAkjR68hGC4BeasQzg