### PR TITLE
docs(mcp): prerequisites and PATH caveat; absolute-path contract in transcribe_audio

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -7,6 +7,7 @@ any MCP client. Models are never auto-downloaded — tools fail with a
 
 ## Prerequisites
 
+- Install [Bun](https://bun.sh) if you don't have it (the CLI's runtime)
 - Install the CLI: `bun add -g @drakulavich/kesha-voice-kit`
 - `kesha install` — downloads the ASR engine + models
 - `kesha install --tts` — downloads TTS models, needed for `synthesize_speech`
@@ -80,7 +81,7 @@ Add to `.cursor/mcp.json`:
 
 GUI-launched clients (Claude Desktop, Cursor) don't inherit your shell's `PATH`,
 so `"command": "kesha"` can fail to start the server. If it does, replace it
-with the absolute path from `which kesha`:
+with the absolute path from `which kesha` (PowerShell: `Get-Command kesha`):
 
 ```json
 { "mcpServers": { "kesha": { "command": "/Users/you/.bun/bin/kesha", "args": ["mcp"] } } }

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -5,6 +5,13 @@
 any MCP client. Models are never auto-downloaded — tools fail with a
 `kesha install` / `kesha install --tts` hint when missing.
 
+## Prerequisites
+
+- Install the CLI: `bun add -g @drakulavich/kesha-voice-kit`
+- `kesha install` — downloads the ASR engine + models
+- `kesha install --tts` — downloads TTS models, needed for `synthesize_speech`
+- `kesha status` — verify what's installed before wiring up a client
+
 Add to your client config:
 
 ```json
@@ -70,6 +77,14 @@ Add to `.cursor/mcp.json`:
 ```
 
 </details>
+
+GUI-launched clients (Claude Desktop, Cursor) don't inherit your shell's `PATH`,
+so `"command": "kesha"` can fail to start the server. If it does, replace it
+with the absolute path from `which kesha`:
+
+```json
+{ "mcpServers": { "kesha": { "command": "/Users/you/.bun/bin/kesha", "args": ["mcp"] } } }
+```
 
 If a tool returns "models not installed", run `kesha install` (ASR) or
 `kesha install --tts` (TTS) once, then retry.

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -2,7 +2,7 @@ import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mc
 import { errorMessage } from "../error-utils";
 import { z } from "zod";
 import { chmodSync, existsSync, readFileSync, statSync } from "fs";
-import { basename, join } from "path";
+import { basename, isAbsolute, join } from "path";
 import { transcribe, transcribeWithTimestamps } from "../lib";
 import { listVoices, aggregateLanguages } from "./voices";
 import { say, type SayFormat } from "../synth";
@@ -90,7 +90,11 @@ export function registerTools(server: McpServer): void {
       title: "Transcribe audio",
       description: "Transcribe a local audio file to text. Set timestamps for segment timings.",
       inputSchema: {
-        path: z.string().describe("Absolute or relative path to a local audio file"),
+        path: z
+          .string()
+          .describe(
+            "Absolute path to a local audio file. Relative paths resolve against the MCP server's own working directory, not the client's — pass an absolute path.",
+          ),
         timestamps: z.boolean().optional().describe("Return per-segment start/end times"),
       },
       outputSchema: {
@@ -111,7 +115,10 @@ export function registerTools(server: McpServer): void {
         return { isError: true, content: [{ type: "text" as const, text: "request cancelled" }] };
       }
       if (!existsSync(path)) {
-        return { isError: true, content: [{ type: "text" as const, text: `File not found: ${path}` }] };
+        const hint = isAbsolute(path)
+          ? ""
+          : ` (relative paths resolve against the MCP server's working directory, ${process.cwd()} — pass an absolute path instead)`;
+        return { isError: true, content: [{ type: "text" as const, text: `File not found: ${path}${hint}` }] };
       }
       try {
         if (timestamps) {

--- a/tests/unit/mcp-transcribe-errors.test.ts
+++ b/tests/unit/mcp-transcribe-errors.test.ts
@@ -18,4 +18,14 @@ describe("transcribe_audio errors", () => {
     expect(res.isError).toBe(true);
     expect((res.content as Array<{ text: string }>)[0].text).toContain("File not found");
   });
+
+  test("missing relative path explains cwd resolution and recommends absolute path", async () => {
+    const res = await call("transcribe_audio", { path: "./no-such-file.wav" });
+    expect(res.isError).toBe(true);
+    const text = (res.content as Array<{ text: string }>)[0].text;
+    expect(text).toContain("File not found");
+    expect(text).toContain("relative paths resolve against the MCP server's working directory");
+    expect(text).toContain(process.cwd());
+    expect(text).toContain("absolute path");
+  });
 });


### PR DESCRIPTION
Lane 4 of the first-touch UX audit (OpenSpec change `first-touch-ux-fixes`; the change artifacts land with the docs-lane PR).

- **docs/mcp.md** gains a `## Prerequisites` section above the first config snippet (install CLI, `kesha install`, `--tts` for synthesis, `kesha status` to verify) — previously the doc jumped straight to JSON config and mentioned models only as failure-mode trivia.
- **GUI-client PATH caveat** under the snippets: Claude Desktop/Cursor launch with a minimal PATH that excludes `~/.bun/bin`, so the bare `"command": "kesha"` silently fails to start — the doc now shows the `which kesha` absolute-path alternative. (The repo already solved this exact problem for Raycast in `kesha-bin.ts`; MCP users just weren't told.)
- **`transcribe_audio` path contract**: the arg description now requires an absolute path, and a not-found error for a relative input explains that relative paths resolve against the MCP server's working directory (naming the actual cwd). New unit test via the existing InMemoryTransport harness.

Satisfies the `mcp-server` delta spec scenarios (path contract half; the `list_voices` guard ships in the CLI-guards lane). `bun test` (pre-existing failures byte-identical via stash-diff) + `bunx tsc --noEmit` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012g6EWAkjR68hGC4BeasQzg