### PR TITLE
docs(raycast): lead the README with brew, matching the in-app setup hint

### DIFF
--- a/raycast/README.md
+++ b/raycast/README.md
@@ -18,14 +18,17 @@ Transcription runs locally (NVIDIA Parakeet TDT, multilingual) and the transcrip
 
 ## Prerequisites
 
-Install a Kesha Voice Kit release whose engine supports `kesha record`, then fetch the local engine + ASR models:
+Install the Kesha Voice Kit CLI, then fetch the local engine + ASR models:
 
 ```bash
-bun add -g @drakulavich/kesha-voice-kit@latest
+brew install drakulavich/tap/kesha-voice-kit
 kesha install
 ```
 
-Verify the installed engine before using the extension:
+Prefer bun? `bun add -g @drakulavich/kesha-voice-kit@latest` installs the same CLI.
+
+`kesha install` downloads ~2.5 GB of engine and speech-to-text models on first
+run, so give it a few minutes. Verify the result before using the extension:
 
 ```bash
 kesha record --help


### PR DESCRIPTION
Metadata audit of the Raycast extension against the [Store preparation docs](https://developers.raycast.com/basics/prepare-an-extension-for-store) found one genuine inconsistency, fixed here.

`notFoundMessage()` has led with `brew install drakulavich/tap/kesha-voice-kit` since #641, but the README — which the Store renders as "About This Extension" — still led with `bun add -g`. A new user therefore got two different first steps depending on where they read. The README now mirrors the in-app hint (brew first, bun as the alternative) and states the ~2.5 GB `kesha install` cost, matching the main README's Quick Start.

Everything else in the audit is already compliant: icon 512×512 PNG, screenshot 2000×1250 PNG in `metadata/`, categories in Title Case, manifest carrying every Store-relevant field, command naming per the Apple Style Guide convention, and no README media inside `metadata/`.

One recommendation is **not** addressed here because it needs the Raycast app: the docs suggest at least three screenshots (max six) and the extension ships one. Capturing them requires Window Capture with "Save to Metadata" in development mode, so it's a manual step — the new finish-setup and no-signal states from #641 would be the natural subjects.

`npm run lint` and the vitest suite (75 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012g6EWAkjR68hGC4BeasQzg