### PR TITLE
test: widen CLI scenario timeouts past the macOS first-exec scan

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,11 +41,11 @@
     "version": "1.24.6"
   },
   "scripts": {
-    "test": "bun test",
-    "test:watch": "bun test --watch",
+    "test": "bun test --timeout 30000",
+    "test:watch": "bun test --timeout 30000 --watch",
     "test:unit": "bun test tests/unit/",
-    "test:cli-fast": "bun test tests/unit/ tests/integration/cli-contracts.test.ts tests/integration/e2e-cli.test.ts tests/integration/say.test.ts",
-    "test:integration": "bun test tests/integration/",
+    "test:cli-fast": "bun test --timeout 30000 tests/unit/ tests/integration/cli-contracts.test.ts tests/integration/e2e-cli.test.ts tests/integration/say.test.ts",
+    "test:integration": "bun test --timeout 30000 tests/integration/",
     "coverage:ts": "bun run test:cli-fast --coverage --coverage-reporter=text --coverage-reporter=lcov --coverage-dir=coverage/ts",
     "coverage:check:ts": "bun .github/scripts/check-coverage.ts --preset=ts --lcov=coverage/ts/lcov.info --summary=coverage/ts/summary.md",
     "coverage:rust": "mkdir -p coverage/rust && cd rust && cargo llvm-cov nextest --features tts --lcov --output-path ../coverage/rust/lcov.info",

--- a/tests/integration/cli-contracts.test.ts
+++ b/tests/integration/cli-contracts.test.ts
@@ -776,7 +776,7 @@ describe("CLI contracts", () => {
       KESHA_ENGINE_BIN: enginePath,
     };
 
-    const run = await runCli(["--json", mediaPath], { env, timeoutMs: 4_000 });
+    const run = await runCli(["--json", mediaPath], { env });
 
     expectContract(run, {
       exitCode: 1,

--- a/tests/integration/cli-scenario.ts
+++ b/tests/integration/cli-scenario.ts
@@ -2,7 +2,9 @@ import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "fs
 import { delimiter, dirname, join } from "path";
 
 const DEFAULT_CWD = import.meta.dir + "/../..";
-const DEFAULT_TIMEOUT_MS = 4_000;
+// macOS scans every freshly-written executable on first exec, and these scenarios
+// mint a new fake engine per test: 2-9 s observed locally, ~0.4 s once warm.
+const DEFAULT_TIMEOUT_MS = 15_000;
 const FORCE_KILL_GRACE_MS = 1_000;
 
 export interface CliScenarioArtifactRequest {


### PR DESCRIPTION
## Problem

`tests/integration/cli-contracts.test.ts` → *"diagnostic logs record successful install events without content"* fails on macOS against the harness's 4 s budget:

```
(fail) ... [5005.64ms]  ^ this test timed out after 5000ms.
CliScenarioTimeoutError: CLI timed out after 4000ms: kesha install --vad
elapsedMs=5017  exitCode=137
stdout=Engine binary already installed (v1.24.6).
Installing models...
Backend installed successfully.
```

## It is not a hang

The CLI completes — stdout reaches `Backend installed successfully.`, and exit 137 is the harness SIGKILL, not the CLI.

`createFakeEngine` + `markFakeEngineInstalled` write a brand-new executable into a fresh temp dir on every test (plus empty `say-avspeech` / `kesha-textlang` executables on darwin-arm64). macOS scans each newly-written binary on first exec. Measured through the real `runCliScenario`:

| Condition | Elapsed |
|---|---|
| Cold binary (fresh temp dir each run) | 2285 / 2684 / 6574 / 6979 / 8793 ms |
| Same binary, warm | ~400 ms |
| Bare CLI startup (`--version`) | ~70 ms |

Linux CI never pays this cost, which is why `main` stayed green while the local gate was red.

## Fix

Two timeouts had to move together — raising only the harness budget would leave bun's own 5 s per-test default to kill the test first:

- `cli-scenario.ts`: `DEFAULT_TIMEOUT_MS` 4 s → 15 s
- `package.json`: `--timeout 30000` on the bun test scripts (covers Makefile and CI, which both go through `test:unit` / `test:integration`)
- Dropped an explicit `timeoutMs: 4_000` that merely restated the old default on a test which also mints a cold engine

No test asserts that a timeout fires, so widening the budget loses no signal — it stays a hang safety net.

## Verification

- `bun run test:integration` green on **3/3** consecutive runs — 47 pass, 0 fail (was 46 pass + 1 fail)
- `make test` green
- `bunx tsc --noEmit` clean

Pre-existing and unrelated: bare `bun test` from the repo root sweeps in `raycast/tests/*`, which use the vitest `vi` API and fail (9) identically on unmodified `main`. Untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012g6EWAkjR68hGC4BeasQzg