### PR TITLE
chore(release): bump to 1.24.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.24.6",
+  "version": "1.24.7",
   "description": "Give your tools a voice — speech to text and back, 25 languages, up to ~19× faster than Whisper. On your machine.",
   "type": "module",
   "bin": {
@@ -38,7 +38,7 @@
     }
   },
   "keshaEngine": {
-    "version": "1.24.6"
+    "version": "1.24.7"
   },
   "scripts": {
     "test": "bun test --timeout 30000",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "kesha-engine"
-version = "1.24.6"
+version = "1.24.7"
 dependencies = [
  "anyhow",
  "audioadapter-buffers",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesha-engine"
-version = "1.24.6"
+version = "1.24.7"
 edition = "2021"
 description = "Inference engine for Kesha Voice Kit: ASR + language detection"
 # Not for crates.io. The library target (`src/lib.rs`) exists only for the


### PR DESCRIPTION
Version bump only — no behaviour change. Prepares the v1.24.7 release.

## Changes

| Source | From | To |
|---|---|---|
| `package.json#version` | 1.24.6 | 1.24.7 |
| `package.json#keshaEngine.version` | 1.24.6 | 1.24.7 |
| `rust/Cargo.toml#version` | 1.24.6 | 1.24.7 |

`rust/Cargo.lock` refreshed to match. No other `1.24.6` references remain in the tree.

## Why the engine version moves too

This is not a CLI-only republish: `rust/` changed across 36 files since `v1.24.6`, including user-visible fixes — #619 (atomic `download_verified` via a `.part` sibling), #616 (chunk-overlap tail clamped to a char boundary), #632 (orphaned download-staging sweep). New engine binaries need to be built, so `keshaEngine.version` and the crate version move with the CLI.

Patch bump: 47 commits since `v1.24.6`, all `fix:` / `refactor:` / `test:` / `docs:` — no `feat:`.

## Verification

- `bun run check:versions` — pass (the three-source drift gate)
- `make check` — pass (lint + versions + unit 402 + integration 47/0 fail)
- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo nextest run --features tts` — 395/395
- `cargo check --features coreml --no-default-features` — exit 0 (required: `backend/onnx.rs` changed since v1.24.6)
- Build-engine feature matrix audited: `tts` present in all three rows, `onnx` correctly absent from the CoreML row

`make smoke-test` was deliberately **not** run: it would resolve `keshaEngine.version` 1.24.7 and try to download an engine whose tag does not exist yet. Same reason `integration-tests-full` is filtered off `release/*` — hence the branch name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012g6EWAkjR68hGC4BeasQzg