### PR TITLE
fix(ci): make dispatched releases build, and keep their Markdown headings

### DIFF
--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -31,20 +31,13 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  # Create + push the annotated tag from a workflow_dispatch with `inputs.tag`
-  # set, then self-dispatch against it (the "two-run" pattern, fix #306) — that
-  # second run executes the build matrix + release job below. Lets sandboxed
-  # automation cut a release without holding tag-push permission on the local
-  # git remote (the case that motivated #306 after v1.16.0). The hop is an
-  # explicit dispatch, not `on.push.tags`, which cannot fire here (#651).
+  # Lets sandboxed automation cut a release without local tag-push rights (#306).
   tag:
     if: github.event_name == 'workflow_dispatch' && inputs.tag != ''
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      # Needed by the self-dispatch below; a GITHUB_TOKEN tag push cannot
-      # start the build on its own.
-      actions: write
+      actions: write # for the self-dispatch below (#651)
     steps:
       - uses: actions/checkout@v7
         with:
@@ -77,9 +70,7 @@ jobs:
       # mirrors `.github/workflows/npm-publish.yml::Resolve tag` (post-#291).
       # `git tag -F -` reads the message from stdin so newlines/shell metachars
       # in INPUT_NOTES survive untouched (argv via `-m` would be a re-exposure).
-      # `--cleanup=verbatim` keeps Markdown headings: the default `whitespace`
-      # cleanup strips `#`-prefixed lines as comments, and the release job
-      # rebuilds the release body from this annotation (#651).
+      # Default cleanup would strip the `#` heading lines the release body needs (#651).
       - name: Create and push annotated tag
         env:
           INPUT_TAG: ${{ inputs.tag }}
@@ -90,12 +81,7 @@ jobs:
           printf '%s' "$INPUT_NOTES" | git tag -a "$INPUT_TAG" --cleanup=verbatim -F -
           git push origin "refs/tags/$INPUT_TAG"
 
-      # GitHub suppresses workflow triggers for pushes made with GITHUB_TOKEN,
-      # so `on.push.tags` never fires here and build + release would silently
-      # skip (#651). `workflow_dispatch` via the API is an explicit exception
-      # to that rule, so re-enter this workflow against the new tag: `tag` then
-      # skips (empty inputs.tag), `build` runs, and `release` sees a refs/tags
-      # ref. Cannot be a `needs:`-style local hop — `release` keys off github.ref.
+      # A GITHUB_TOKEN push never fires `on.push.tags`; workflow_dispatch is the exception (#651).
       - name: Trigger build + release for the new tag
         env:
           INPUT_TAG: ${{ inputs.tag }}
@@ -105,13 +91,7 @@ jobs:
           echo "Dispatched build + release against $INPUT_TAG."
 
   build:
-    # Skip the matrix when the dispatch run is creating a tag (fix #306) — that
-    # run self-dispatches a second one against the new tag, which is where build
-    # + release actually happen. Building here too would waste ~12 min and leave
-    # no `release` job to consume the artifacts (release.if: startsWith(
-    # github.ref, 'refs/tags/v') is false on the tag-creating run).
-    # Checkout below is ref-less, so the matrix builds github.ref — the new tag
-    # on the self-dispatched run, or `inputs.ref` when dispatched build-only.
+    # The tag-creating run has no `release` job to consume a build (#306).
     if: github.event_name != 'workflow_dispatch' || inputs.tag == ''
     strategy:
       fail-fast: false

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -32,16 +32,19 @@ env:
 
 jobs:
   # Create + push the annotated tag from a workflow_dispatch with `inputs.tag`
-  # set. Pushing the tag fires this workflow again via `on.push.tags` (the
-  # "two-run" pattern, fix #306) — that second run executes the build matrix +
-  # release job below. Lets sandboxed automation cut a release without holding
-  # tag-push permission on the local git remote (the case that motivated #306
-  # after v1.16.0).
+  # set, then self-dispatch against it (the "two-run" pattern, fix #306) — that
+  # second run executes the build matrix + release job below. Lets sandboxed
+  # automation cut a release without holding tag-push permission on the local
+  # git remote (the case that motivated #306 after v1.16.0). The hop is an
+  # explicit dispatch, not `on.push.tags`, which cannot fire here (#651).
   tag:
     if: github.event_name == 'workflow_dispatch' && inputs.tag != ''
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # Needed by the self-dispatch below; a GITHUB_TOKEN tag push cannot
+      # start the build on its own.
+      actions: write
     steps:
       - uses: actions/checkout@v7
         with:
@@ -74,6 +77,9 @@ jobs:
       # mirrors `.github/workflows/npm-publish.yml::Resolve tag` (post-#291).
       # `git tag -F -` reads the message from stdin so newlines/shell metachars
       # in INPUT_NOTES survive untouched (argv via `-m` would be a re-exposure).
+      # `--cleanup=verbatim` keeps Markdown headings: the default `whitespace`
+      # cleanup strips `#`-prefixed lines as comments, and the release job
+      # rebuilds the release body from this annotation (#651).
       - name: Create and push annotated tag
         env:
           INPUT_TAG: ${{ inputs.tag }}
@@ -81,19 +87,31 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          printf '%s' "$INPUT_NOTES" | git tag -a "$INPUT_TAG" -F -
+          printf '%s' "$INPUT_NOTES" | git tag -a "$INPUT_TAG" --cleanup=verbatim -F -
           git push origin "refs/tags/$INPUT_TAG"
-          echo "Pushed $INPUT_TAG. on.push.tags will now fire a second workflow run for build + release."
+
+      # GitHub suppresses workflow triggers for pushes made with GITHUB_TOKEN,
+      # so `on.push.tags` never fires here and build + release would silently
+      # skip (#651). `workflow_dispatch` via the API is an explicit exception
+      # to that rule, so re-enter this workflow against the new tag: `tag` then
+      # skips (empty inputs.tag), `build` runs, and `release` sees a refs/tags
+      # ref. Cannot be a `needs:`-style local hop — `release` keys off github.ref.
+      - name: Trigger build + release for the new tag
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run build-engine.yml --ref "$INPUT_TAG"
+          echo "Dispatched build + release against $INPUT_TAG."
 
   build:
-    # Skip the matrix when the dispatch run is creating a tag (fix #306) —
-    # the push of that tag fires a second workflow run via `on.push.tags`
-    # which runs build + release with `github.ref` set to the new tag.
-    # Running the matrix twice wastes ~12 min and the dispatch-run build
-    # would have no `release` job to consume its artifacts anyway
-    # (release.if: startsWith(github.ref, 'refs/tags/v') would be false).
-    # When `inputs.tag` is empty, the dispatch is in build-only mode (today's
-    # behavior) — matrix runs from `inputs.ref`.
+    # Skip the matrix when the dispatch run is creating a tag (fix #306) — that
+    # run self-dispatches a second one against the new tag, which is where build
+    # + release actually happen. Building here too would waste ~12 min and leave
+    # no `release` job to consume the artifacts (release.if: startsWith(
+    # github.ref, 'refs/tags/v') is false on the tag-creating run).
+    # Checkout below is ref-less, so the matrix builds github.ref — the new tag
+    # on the self-dispatched run, or `inputs.ref` when dispatched build-only.
     if: github.event_name != 'workflow_dispatch' || inputs.tag == ''
     strategy:
       fail-fast: false

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "scripts": {
     "test": "bun test --timeout 30000",
     "test:watch": "bun test --timeout 30000 --watch",
-    "test:unit": "bun test tests/unit/",
+    "test:unit": "bun test --timeout 30000 tests/unit/",
     "test:cli-fast": "bun test --timeout 30000 tests/unit/ tests/integration/cli-contracts.test.ts tests/integration/e2e-cli.test.ts tests/integration/say.test.ts",
     "test:integration": "bun test --timeout 30000 tests/integration/",
     "coverage:ts": "bun run test:cli-fast --coverage --coverage-reporter=text --coverage-reporter=lcov --coverage-dir=coverage/ts",


### PR DESCRIPTION
Fixes the two `build-engine.yml` bugs hit while cutting v1.24.7, plus the `test:unit` gap left by #649.

Refs #651

## 1. Dispatched releases created a tag and built nothing

`gh workflow run build-engine.yml -f tag=vX.Y.Z` ran `tag`, pushed the tag, and logged *"on.push.tags will now fire a second workflow run"*. It never does — GitHub suppresses workflow triggers for pushes made with the default `GITHUB_TOKEN`. Meanwhile `build` had already skipped itself expecting that run.

Result: **a permanent tag, no binaries, no release.** Evidence on v1.24.7 — run `30264002192`: `tag` success, `build` skipped, `release` skipped.

Every prior release (v1.24.4/5/6) arrived as a `push` event, i.e. a manual `git push origin <tag>`, so this path had likely never been exercised.

**Fix:** `workflow_dispatch` via the API is an explicit exception to that trigger suppression, so the `tag` job now self-dispatches against the new tag (requires `actions: write`). On that second run `tag` skips (empty `inputs.tag`), `build` runs, and `release` sees a `refs/tags/*` ref — which it needs, since it keys off `github.ref`, not a job output. That is exactly the shape of the manual recovery used to rescue v1.24.7.

## 2. Markdown headings stripped from release bodies

`git tag -a "$INPUT_TAG" -F -` used git's default `whitespace` cleanup, which treats `#`-prefixed lines as comments and deletes them. The `release` job rebuilds the release body from `git tag -l --format='%(contents)'`, so every `##` heading in the dispatched notes vanished.

v1.24.7's draft shipped with **0** heading lines and had to be repaired with `gh release edit --notes-file`. **Fix:** `--cleanup=verbatim`.

## 3. `test:unit` timeout (gap from #649)

#649 raised the harness and bun timeouts for the integration scripts, but `tests/unit/engine.test.ts::fakeEngine` writes and chmods a fresh executable per call — the same cold-binary pattern that triggers macOS first-exec scanning. `test:unit` was left on bun's 5 s default and timed out under CPU load. Now `--timeout 30000`, matching the other scripts.

Stale comments describing the old (impossible) mechanism are updated in the same pass.

## Verification

- `bun run check:workflows` — pass (the `workflow-lint` gate)
- `bun run check:release-manifest` — pass
- `make check` — pass: 402 unit, 47 integration, 0 fail
- YAML parses; `tag` job permissions resolve to `{contents: write, actions: write}`
- No `rust/**` changes, so no Rust gate

**Not verifiable pre-merge:** the self-dispatch cannot be exercised without cutting a release. The second half — a tag-ref dispatch producing a correct build + draft release — was proven manually on v1.24.7; the untested part is the `gh workflow run` call issued from inside the job. Worth watching on the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012g6EWAkjR68hGC4BeasQzg