### PR TITLE
chore(deps): bump @toon-format/toon to 4.1.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@clack/prompts": "^1.5.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@toon-format/toon": "^2.1.0",
+        "@toon-format/toon": "^4.1.0",
         "citty": "^0.2.2",
         "fastest-levenshtein": "^1.0.16",
         "picocolors": "^1.1.1",
@@ -37,7 +37,7 @@
 
     "@nodable/entities": ["@nodable/entities@2.1.0", "", {}, "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA=="],
 
-    "@toon-format/toon": ["@toon-format/toon@2.1.0", "", {}, "sha512-JwWptdF5eOA0HaQxbKAzkpQtR4wSWTEfDlEy/y3/4okmOAX1qwnpLZMmtEWr+ncAhTTY1raCKH0kteHhSXnQqg=="],
+    "@toon-format/toon": ["@toon-format/toon@4.1.0", "", {}, "sha512-dBB3pkEx9QYvHnHR6rtkaBAh+7x4W/oA5ONur4G0fh7Ow69PbPuM7OFxzNRABqyxC0t6SZ3RixiGbCuaFjPDAQ=="],
 
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
   "dependencies": {
     "@clack/prompts": "^1.5.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@toon-format/toon": "^2.1.0",
+    "@toon-format/toon": "^4.1.0",
     "citty": "^0.2.2",
     "fastest-levenshtein": "^1.0.16",
     "picocolors": "^1.1.1",


### PR DESCRIPTION
## Summary

- upgrades the production TOON encoder dependency from 2.1.0 to 4.1.0
- regenerates `bun.lock` so frozen installs succeed

## Why

Supersedes Dependabot PR #653, whose dependency manifest update omitted the required Bun lockfile change and therefore failed `bun install --frozen-lockfile`.

## Validation

- `bun test tests/unit/cli.test.ts` — passed (including TOON encode/decode round-trip)
- `bunx tsc --noEmit` — passed
- `bun test` — unrelated baseline failure: nine Raycast dictation-controller tests call `vi.waitFor`, which is unavailable under Bun's test runner; reproduced unchanged on `main`.