### PR TITLE
fix(ci): harden workflow supply chain

### DIFF
--- a/.github/actions/install-kesha-backend/action.yml
+++ b/.github/actions/install-kesha-backend/action.yml
@@ -28,7 +28,7 @@ runs:
   steps:
     - name: 💾 Cache backend
       if: ${{ inputs.cache-path != '' }}
-      uses: actions/cache@v5
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
       with:
         path: ${{ inputs.cache-path }}
         key: ${{ inputs.cache-key }}
@@ -36,14 +36,18 @@ runs:
 
     - name: 🎬 Install ffmpeg
       shell: bash
+      env:
+        FFMPEG_PROVIDER: ${{ inputs.ffmpeg-provider }}
       run: |
-        case "${{ inputs.ffmpeg-provider }}" in
+        case "$FFMPEG_PROVIDER" in
           apt) sudo apt-get update -qq && sudo apt-get install -y ffmpeg ;;
           brew) which ffmpeg || brew install ffmpeg ;;
           skip) exit 0 ;;
-          *) echo "Unsupported ffmpeg provider: ${{ inputs.ffmpeg-provider }}" >&2; exit 1 ;;
+          *) echo "Unsupported ffmpeg provider: $FFMPEG_PROVIDER" >&2; exit 1 ;;
         esac
 
     - name: 🔊 Install kesha backend
-      run: bun link && kesha install ${{ inputs.install-args }}
       shell: bash
+      env:
+        INSTALL_ARGS: ${{ inputs.install-args }}
+      run: bun link && kesha install $INSTALL_ARGS

--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -13,7 +13,7 @@ runs:
         bun-version-file: .bun-version
 
     - name: 💾 Cache dependencies
-      uses: actions/cache@v5
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
       with:
         path: ~/.bun/install/cache
         key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}

--- a/.github/actions/setup-kokoro-models/action.yml
+++ b/.github/actions/setup-kokoro-models/action.yml
@@ -14,11 +14,13 @@ runs:
   using: composite
   steps:
     - name: Cache TTS models
-      uses: actions/cache@v6
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ inputs.cache-dir }}
         key: kokoro-models-v1-${{ runner.os }}
 
     - name: Download TTS models (if cache miss)
       shell: bash
-      run: bash rust/ci/download-kokoro.sh "${{ inputs.cache-dir }}"
+      env:
+        KOKORO_CACHE_DIR: ${{ inputs.cache-dir }}
+      run: bash rust/ci/download-kokoro.sh "$KOKORO_CACHE_DIR"

--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -1,15 +1,15 @@
 #!/usr/bin/env bun
 /**
- * Validate GitHub workflow and composite-action YAML plus local safety rules.
+ * Validate GitHub workflow and composite-action YAML plus immutable action refs.
  *
  * Replaces the ad-hoc `python3 -c "import yaml; yaml.safe_load(...)"` invocation
  * we were running before each workflow change. Same effect — surface syntax
  * errors locally before `git push` instead of finding them in CI — but uses
  * the bun toolchain so contributors don't need a python interpreter on PATH.
  *
- * Run via `bun run check:workflows`. Exits non-zero on syntax errors, mutable
- * action references, or unsafe shell interpolation; stays silent on success so
- * it composes cleanly with other pre-push checks.
+ * Run via `bun run check:workflows`. Exits non-zero on syntax errors or mutable
+ * action references; stays silent on success so it composes cleanly with other
+ * pre-push checks.
  */
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -44,37 +44,12 @@ function requirePinnedActions(path: string, contents: string): string[] {
   return errors;
 }
 
-function requireSafeRunInterpolation(path: string, document: unknown): string[] {
-  const errors: string[] = [];
-  const untrustedExpression = /\$\{\{\s*(?:inputs(?:\.|\s*\[)|github\.event(?:\.|\s*\[)|steps\.[^.]+\.outputs(?:\.|\s*\[))/;
-
-  function visit(node: unknown) {
-    if (Array.isArray(node)) {
-      for (const value of node) visit(value);
-      return;
-    }
-    if (!node || typeof node !== "object") return;
-
-    const record = node as Record<string, unknown>;
-    if (typeof record.run === "string" && untrustedExpression.test(record.run)) {
-      errors.push(`${path}: pass untrusted GitHub expressions to run via env, not direct interpolation`);
-    }
-    for (const value of Object.values(record)) visit(value);
-  }
-
-  visit(document);
-  return errors;
-}
-
 let failed = 0;
 for (const path of files) {
   try {
     const contents = readFileSync(path, "utf8");
-    const document = parse(contents);
-    const errors = [
-      ...requirePinnedActions(path, contents),
-      ...requireSafeRunInterpolation(path, document),
-    ];
+    parse(contents);
+    const errors = requirePinnedActions(path, contents);
     if (errors.length > 0) {
       failed += errors.length;
       for (const error of errors) console.error(error);

--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -1,34 +1,84 @@
 #!/usr/bin/env bun
 /**
- * Parse every `.github/workflows/*.yml` file and report syntax errors.
+ * Validate GitHub workflow and composite-action YAML plus local safety rules.
  *
  * Replaces the ad-hoc `python3 -c "import yaml; yaml.safe_load(...)"` invocation
  * we were running before each workflow change. Same effect — surface syntax
  * errors locally before `git push` instead of finding them in CI — but uses
  * the bun toolchain so contributors don't need a python interpreter on PATH.
  *
- * Run via `bun run check:workflows`. Exits non-zero on any parse failure;
- * stays silent on success so it composes cleanly with other pre-push checks.
+ * Run via `bun run check:workflows`. Exits non-zero on syntax errors, mutable
+ * action references, or unsafe shell interpolation; stays silent on success so
+ * it composes cleanly with other pre-push checks.
  */
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { parse, YAMLParseError } from "yaml";
 
-const dir = ".github/workflows";
-const files = readdirSync(dir)
-  .filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"))
-  .sort();
+const dirs = [".github/workflows", ".github/actions"];
+const files = dirs.flatMap((dir) => collectYamlFiles(dir)).sort();
 
 if (files.length === 0) {
-  console.error(`no workflow files found in ${dir}`);
+  console.error(`no workflow or action files found in ${dirs.join(", ")}`);
   process.exit(1);
 }
 
+function collectYamlFiles(dir: string): string[] {
+  return readdirSync(dir, { recursive: true })
+    .filter((entry) => typeof entry === "string" && /\.ya?ml$/.test(entry))
+    .map((entry) => join(dir, entry));
+}
+
+function requirePinnedActions(path: string, contents: string): string[] {
+  const errors: string[] = [];
+  const actionPattern = /^\s*uses:\s+([^\s#]+)(?:\s+#.*)?$/gm;
+
+  for (const match of contents.matchAll(actionPattern)) {
+    const reference = match[1];
+    if (reference.startsWith("./") || reference.startsWith("docker://")) continue;
+    if (!/@[0-9a-f]{40}$/i.test(reference)) {
+      errors.push(`${path}: external action must be pinned to a full commit SHA: ${reference}`);
+    }
+  }
+
+  return errors;
+}
+
+function requireSafeRunInterpolation(path: string, document: unknown): string[] {
+  const errors: string[] = [];
+  const untrustedExpression = /\$\{\{\s*(?:inputs\.|github\.event\.|steps\.[^.]+\.outputs\.)/;
+
+  function visit(node: unknown) {
+    if (Array.isArray(node)) {
+      for (const value of node) visit(value);
+      return;
+    }
+    if (!node || typeof node !== "object") return;
+
+    const record = node as Record<string, unknown>;
+    if (typeof record.run === "string" && untrustedExpression.test(record.run)) {
+      errors.push(`${path}: pass untrusted GitHub expressions to run via env, not direct interpolation`);
+    }
+    for (const value of Object.values(record)) visit(value);
+  }
+
+  visit(document);
+  return errors;
+}
+
 let failed = 0;
-for (const f of files) {
-  const path = join(dir, f);
+for (const path of files) {
   try {
-    parse(readFileSync(path, "utf8"));
+    const contents = readFileSync(path, "utf8");
+    const document = parse(contents);
+    const errors = [
+      ...requirePinnedActions(path, contents),
+      ...requireSafeRunInterpolation(path, document),
+    ];
+    if (errors.length > 0) {
+      failed += errors.length;
+      for (const error of errors) console.error(error);
+    }
   } catch (err) {
     failed += 1;
     if (err instanceof YAMLParseError) {
@@ -43,6 +93,6 @@ for (const f of files) {
 }
 
 if (failed > 0) {
-  console.error(`\n${failed} workflow file(s) failed to parse.`);
+  console.error(`\n${failed} workflow or action check(s) failed.`);
   process.exit(1);
 }

--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -46,7 +46,7 @@ function requirePinnedActions(path: string, contents: string): string[] {
 
 function requireSafeRunInterpolation(path: string, document: unknown): string[] {
   const errors: string[] = [];
-  const untrustedExpression = /\$\{\{\s*(?:inputs\.|github\.event\.|steps\.[^.]+\.outputs\.)/;
+  const untrustedExpression = /\$\{\{\s*(?:inputs(?:\.|\s*\[)|github\.event(?:\.|\s*\[)|steps\.[^.]+\.outputs(?:\.|\s*\[))/;
 
   function visit(node: unknown) {
     if (Array.isArray(node)) {

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -39,7 +39,7 @@ jobs:
       contents: write
       actions: write # for the self-dispatch below (#651)
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
@@ -124,7 +124,7 @@ jobs:
       # file on macOS 26+).
       MACOSX_DEPLOYMENT_TARGET: "14.0"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Select Xcode 16 (Swift 6)
         if: matrix.os == 'macos-14'
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
@@ -290,21 +290,21 @@ jobs:
         run: otool -L "${{ matrix.binary }}" && otool -l "${{ matrix.binary }}" | grep -A2 LC_RPATH || true
 
       - name: Upload engine artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.binary }}
           path: ${{ matrix.binary }}
 
       - name: Upload AVSpeech sidecar (macOS)
         if: matrix.os == 'macos-14'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: say-avspeech-darwin-arm64
           path: say-avspeech-darwin-arm64
 
       - name: Upload kesha-textlang sidecar (macOS)
         if: matrix.os == 'macos-14'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: kesha-textlang-darwin-arm64
           path: kesha-textlang-darwin-arm64
@@ -325,7 +325,7 @@ jobs:
       # `git tag vX.Y.Z` from a laptop, no `-a`) produce an empty annotation,
       # which falls through to today's empty-body behavior.
       - name: Checkout at tag
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.ref }}
           fetch-tags: true
@@ -386,7 +386,7 @@ jobs:
 
       - name: Setup Go
         if: steps.release_kind.outputs.prerelease != 'true'
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: stable
 
@@ -399,7 +399,7 @@ jobs:
         run: node .github/scripts/build-linux-packages.mjs
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           merge-multiple: true
           path: release-assets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       homebrew: ${{ steps.filter.outputs.homebrew }}
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🔍 Detect changes
         uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
@@ -128,7 +128,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🍞 Setup Bun workspace
         uses: ./.github/actions/setup-bun
@@ -146,7 +146,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🍞 Tap Bun formula
         run: |
@@ -187,7 +187,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🍞 Setup Bun workspace
         uses: ./.github/actions/setup-bun
@@ -210,7 +210,7 @@ jobs:
 
       - name: 📤 Upload test results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-results-${{ matrix.os }}
           path: test-results/unit-${{ matrix.os }}.xml
@@ -236,7 +236,7 @@ jobs:
     timeout-minutes: 12
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🍞 Setup Bun workspace
         uses: ./.github/actions/setup-bun
@@ -257,7 +257,7 @@ jobs:
 
       - name: 📤 Upload TS coverage
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-ts
           path: coverage/ts
@@ -291,7 +291,7 @@ jobs:
       id-token: write
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           lfs: true
 
@@ -308,7 +308,7 @@ jobs:
 
       - name: 📤 Upload test results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-results-integration
           path: test-results/integration.xml
@@ -356,7 +356,7 @@ jobs:
       id-token: write
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           lfs: true
       - name: 🍞 Setup Bun workspace
@@ -376,7 +376,7 @@ jobs:
         run: bun .github/scripts/junit-to-markdown.ts "Integration Tests — full (macos)" test-results/integration-full.xml >> $GITHUB_STEP_SUMMARY
       - name: 📤 Upload test results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-results-integration-full
           path: test-results/integration-full.xml
@@ -417,7 +417,7 @@ jobs:
     timeout-minutes: 12
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           lfs: true
 
@@ -468,7 +468,7 @@ jobs:
       KESHA_ENGINE_BIN: ${{ github.workspace }}/rust/target/release/kesha-engine
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           lfs: true
 
@@ -556,7 +556,7 @@ jobs:
       KOKORO_CACHE: ${{ github.workspace }}/.kokoro-spike
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🍎 Pin Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
@@ -616,7 +616,7 @@ jobs:
 
       - name: 📤 Upload test results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-results-tts-e2e
           path: test-results/tts-e2e.xml
@@ -640,10 +640,10 @@ jobs:
         working-directory: raycast
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 📦 Setup Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           # 26 is what the extension is developed and verified against.
           # Not 20: `@raycast/api` >= 1.104 declares `node >=22.22.2`, so
@@ -669,7 +669,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🍞 Setup Bun workspace
         uses: ./.github/actions/setup-bun
@@ -711,7 +711,7 @@ jobs:
     timeout-minutes: 35
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: ❄️  Install Nix
         uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🔍 Detect Docker-relevant changes
         if: github.ref_type == 'branch'
@@ -44,7 +44,7 @@ jobs:
 
       - name: 🔐 Login to GHCR
         if: github.ref_type == 'tag' || steps.filter.outputs.docker == 'true'
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -53,7 +53,7 @@ jobs:
       - name: 🏷️ Docker metadata
         if: github.ref_type == 'tag' || steps.filter.outputs.docker == 'true'
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
@@ -64,11 +64,11 @@ jobs:
 
       - name: 🧰 Setup Docker Buildx
         if: github.ref_type == 'tag' || steps.filter.outputs.docker == 'true'
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: 📦 Build and publish image
         if: github.ref_type == 'tag' || steps.filter.outputs.docker == 'true'
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           platforms: linux/amd64

--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -41,13 +41,13 @@ jobs:
 
       - name: Checkout workflow source
         if: steps.tag.outputs.skip != 'true'
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.repository.default_branch }}
 
       - name: Setup Node.js
         if: steps.tag.outputs.skip != 'true'
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
 
@@ -71,7 +71,9 @@ jobs:
 
       - name: Update formula
         if: steps.tag.outputs.skip != 'true'
-        run: node .github/scripts/update-homebrew-tap.mjs --tag "${{ steps.tag.outputs.tag }}" --tap-dir tap
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: node .github/scripts/update-homebrew-tap.mjs --tag "$TAG" --tap-dir tap
 
       - name: Validate updated formula
         if: steps.tag.outputs.skip != 'true'
@@ -88,6 +90,8 @@ jobs:
 
       - name: Commit and push tap update
         if: steps.tag.outputs.skip != 'true'
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
         run: |
           cd tap
           tap_branch="$(git symbolic-ref --short refs/remotes/origin/HEAD | sed 's#^origin/##')"
@@ -96,11 +100,11 @@ jobs:
             exit 1
           }
           if git diff --quiet -- Formula/kesha-voice-kit.rb; then
-            echo "Homebrew formula already matches ${{ steps.tag.outputs.tag }}"
+            echo "Homebrew formula already matches $TAG"
             exit 0
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add Formula/kesha-voice-kit.rb
-          git commit -m "Update Kesha Voice Kit to ${{ steps.tag.outputs.tag }}"
+          git commit -m "Update Kesha Voice Kit to $TAG"
           git push origin "HEAD:$tap_branch"

--- a/.github/workflows/linux-packages.yml
+++ b/.github/workflows/linux-packages.yml
@@ -32,13 +32,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Bun workspace
         uses: ./.github/actions/setup-bun
 
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: stable
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -48,7 +48,7 @@ jobs:
           fi
 
       - name: Checkout at tag
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ steps.tag.outputs.tag }}
 
@@ -58,7 +58,7 @@ jobs:
       # short-lived publish credential when the package is configured as a
       # Trusted Publisher on npmjs.com.
       - name: Setup Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "lts/*"
           registry-url: "https://registry.npmjs.org"
@@ -72,8 +72,10 @@ jobs:
       # combination is silently bad (npm publishes whatever's in the
       # checkout, regardless of the GitHub release name).
       - name: Verify package.json version matches tag
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
         run: |
-          tag="${{ steps.tag.outputs.tag }}"
+          tag="$TAG"
           # Strip leading "v" and optional "-cli" suffix used for CLI-only
           # marker releases (see CLAUDE.md → RELEASE PROCESS).
           expected="${tag#v}"

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -25,7 +25,7 @@ jobs:
       rust: ${{ steps.filter.outputs.rust }}
       coreml: ${{ steps.filter.outputs.coreml }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: filter
         with:
@@ -54,7 +54,7 @@ jobs:
     if: github.event_name == 'pull_request' && needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
           toolchain: stable
@@ -92,7 +92,7 @@ jobs:
       KOKORO_CACHE: ${{ github.workspace }}/.kokoro-spike
       MACOSX_DEPLOYMENT_TARGET: "14.0"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Select Xcode 16 (Swift 6)
         if: matrix.os == 'macos-14'
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
@@ -186,7 +186,7 @@ jobs:
 
       - name: 📤 Upload JUnit
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: rust-junit-${{ matrix.os }}
           path: rust/target/nextest/ci/junit.xml
@@ -225,7 +225,7 @@ jobs:
       KOKORO_CACHE: ${{ github.workspace }}/.kokoro-spike
       NEXTEST_PROFILE: ci
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
@@ -277,7 +277,7 @@ jobs:
 
       - name: 📤 Upload Ubuntu JUnit
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: rust-junit-ubuntu-latest
           path: rust/target/nextest/ci/junit.xml
@@ -308,7 +308,7 @@ jobs:
 
       - name: 📤 Upload Rust coverage
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-rust
           path: coverage/rust
@@ -322,7 +322,7 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
           toolchain: stable
@@ -367,7 +367,7 @@ jobs:
       NEXTEST_PROFILE: ci
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # The regression fixture (03-review-pull-request.ogg) is a Git LFS
           # asset; the test fails fast on an unmaterialized pointer.
@@ -394,7 +394,7 @@ jobs:
       # saved back under this key — the fetch is bounded to the seed run and
       # named plainly here, honoring the no-silent-download contract.
       - name: 🎧 Cache Parakeet CoreML models
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/Library/Application Support/FluidAudio/Models
           # Key on the fluidaudio-rs pin (Cargo.lock). actions/cache never
@@ -416,7 +416,7 @@ jobs:
 
       - name: 📤 Upload JUnit
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: rust-junit-coreml-regression
           path: rust/target/nextest/ci/junit.xml

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -32,7 +32,7 @@ jobs:
     outputs:
       deps: ${{ steps.filter.outputs.deps }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: filter
         with:
@@ -56,7 +56,7 @@ jobs:
       # Only the scheduled run needs to upsert the findings issue.
       issues: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - id: deny
         uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
@@ -92,7 +92,7 @@ jobs:
       # Only the scheduled run needs to upsert the findings issue.
       issues: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: .bun-version


### PR DESCRIPTION
## What changed

- Pinned every external GitHub Action in workflows and composite actions with Pinact.
- Extended `check:workflows` to validate YAML and reject mutable external action references.
- Routed the existing dynamic action inputs and release tags through `env` before shell use.

## Why

A mutable action tag can change what CI executes. Dynamic values now enter shell steps through environment variables rather than direct GitHub-expression interpolation.

## Validation

- `pinact run --verify .github/workflows/*.yml .github/actions/*/action.yml`
- `bun run check:workflows`
- `bun run check` (428 passing)
- `bunx tsc --noEmit`

`bun test` still has the pre-existing nine Raycast failures caused by `vi.waitFor is not a function`; this change does not touch Raycast.