### PR TITLE
fix(ci): run real engine checks for TS adapters

### DIFF
--- a/.github/scripts/check-coverage.ts
+++ b/.github/scripts/check-coverage.ts
@@ -24,17 +24,20 @@ type FileCoverage = {
   linePct: number;
 };
 
-// Coverage policy: a single total-lines gate per language, no per-file floors.
-// The per-file map was an auto-ratchet pinned just below each file's current
-// coverage (with brittle 98%/100% outliers) — high friction (every feature that
-// touched a high-floor file had to add coverage-padding tests), low signal
-// (concentrated regressions are caught by review + the total gate). Dropped in
-// favour of one honest total floor.
+// Coverage policy: a total-lines gate plus a few risk-based floors at the TS
+// boundaries that invoke, install, or route the native engine. These are not
+// per-file ratchets: the floors keep critical paths from silently regressing
+// while allowing ordinary modules to evolve without coverage-padding tests.
 const presets: Record<PresetName, CoveragePreset> = {
   ts: {
     title: "TypeScript Coverage",
     minTotalLines: 70,
-    minFileLines: {},
+    minFileLines: {
+      "src/cli/main.ts": 35,
+      "src/cli/say.ts": 50,
+      "src/engine-install.ts": 15,
+      "src/engine.ts": 80,
+    },
   },
   rust: {
     title: "Rust Coverage",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,7 @@ jobs:
               - 'tests/integration/mcp-e2e.test.ts'
               - 'src/engine-install.ts'
               - 'src/engine.ts'
+              - 'src/lib.ts'
               - 'src/paths.ts'
               - 'src/transcribe.ts'
               - 'src/cli/dispatch.ts'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,8 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
       integration: ${{ steps.filter.outputs.integration }}
-      heavy_e2e: ${{ steps.filter.outputs.heavy_e2e }}
+      real_engine_e2e: ${{ steps.filter.outputs.real_engine_e2e }}
+      tts_e2e: ${{ steps.filter.outputs.tts_e2e }}
       raycast: ${{ steps.filter.outputs.raycast }}
       openspec: ${{ steps.filter.outputs.openspec }}
       nix: ${{ steps.filter.outputs.nix }}
@@ -56,14 +57,12 @@ jobs:
           #   — the `needs: unit-tests` gate then evaluates predictably without
           #   the skip-propagation hazard that #274 + the pre-rewrite of #280
           #   silently fell into.
-          # - `heavy_e2e` gates the model-DOWNLOADING lanes (integration-tests-full,
-          #   published-engine-smoke, tts-e2e): engine/model paths only (rust/**,
-          #   model pins, the real-engine e2e test files) — deliberately NOT
-          #   `src/**`, so TS-only PRs skip the 2.4GB download (the fake/stub
-          #   suites cover the TS contract in the fast lane). It is NOT a subset
-          #   of `code` (it includes `rust/**`), so those lanes use an
-          #   `always() && unit-tests != failure` gate to survive a legitimately
-          #   skipped `unit-tests` on a rust-only PR (the #274 skip hazard).
+          # - `real_engine_e2e` and `tts_e2e` gate model-downloading lanes.
+          #   The filters include their narrow TS adapters as well as engine/model
+          #   paths: fake/stub tests cannot prove that a changed adapter still
+          #   works with a released binary. Both include `rust/**`, so they are
+          #   not subsets of `code`; their jobs use an `always()` gate to survive
+          #   a legitimately skipped `unit-tests` on rust-only PRs (#274).
           filters: |
             code:
               - 'src/**'
@@ -88,14 +87,35 @@ jobs:
               - 'bun.lock'
               - '.github/workflows/ci.yml'
               - '.github/actions/**'
-            heavy_e2e:
+            real_engine_e2e:
               - 'rust/**'
               - 'package.json'
               - 'bun.lock'
               - 'tests/fixtures/**'
               - 'tests/integration/e2e-engine.test.ts'
               - 'tests/integration/mcp-e2e.test.ts'
+              - 'src/engine-install.ts'
+              - 'src/engine.ts'
+              - 'src/paths.ts'
+              - 'src/transcribe.ts'
+              - 'src/cli/dispatch.ts'
+              - 'src/cli/main.ts'
+              - 'src/cli/mcp.ts'
+              - 'src/mcp/**'
               - 'tests/integration/say-e2e.test.ts'
+              - '.github/workflows/ci.yml'
+              - '.github/actions/**'
+            tts_e2e:
+              - 'rust/**'
+              - 'package.json'
+              - 'bun.lock'
+              - 'tests/fixtures/**'
+              - 'tests/integration/say-e2e.test.ts'
+              - 'src/engine.ts'
+              - 'src/synth.ts'
+              - 'src/voice-routing.ts'
+              - 'src/cli/main.ts'
+              - 'src/cli/say.ts'
               - '.github/workflows/ci.yml'
               - '.github/actions/**'
             raycast:
@@ -325,14 +345,14 @@ jobs:
   integration-tests-full:
     # Real-engine integration: installs the ~2.4GB model bundle and runs the
     # model-dependent e2e suites (which self-skip in the fast lane). Gated to
-    # engine/model changes, push-to-main of those paths, and the nightly cron —
-    # so doc/TS-only PRs never download models. Nightly run on main also seeds
-    # the default-branch-scoped model cache. Keep the release/* + chore(release)
+    # engine/model changes, narrow TS engine adapters, push-to-main of those
+    # paths, and the nightly cron. Nightly run on main also seeds the
+    # default-branch-scoped model cache. Keep the release/* + chore(release)
     # guards: this lane downloads the PUBLISHED engine, which doesn't exist yet
     # during the release version-bump window.
     needs: [changes, unit-tests]
     # `always()` so a SKIPPED `unit-tests` (rust-only PRs have `code == 'false'`)
-    # doesn't skip-propagate and drop the heavy lane — `heavy_e2e` includes
+    # doesn't skip-propagate and drop the heavy lane — `real_engine_e2e` includes
     # `rust/**` but `code` does not, so unit-tests is legitimately skipped on a
     # rust-only PR yet the real-engine e2e must still run (#274 regression class).
     # Still fail-fast if unit-tests actively FAILED/cancelled.
@@ -344,7 +364,7 @@ jobs:
       (
         github.event_name == 'schedule' ||
         (
-          needs.changes.outputs.heavy_e2e == 'true' &&
+          needs.changes.outputs.real_engine_e2e == 'true' &&
           !startsWith(github.head_ref, 'release/') &&
           !startsWith(github.event.head_commit.message, 'chore(release):')
         )
@@ -396,7 +416,7 @@ jobs:
     # Linux x64 lane covers the currently supported non-Darwin release asset.
     needs: [changes, unit-tests]
     # `always()` so a SKIPPED `unit-tests` (rust-only PRs have `code == 'false'`)
-    # doesn't skip-propagate and drop the heavy lane — `heavy_e2e` includes
+    # doesn't skip-propagate and drop the heavy lane — `real_engine_e2e` includes
     # `rust/**` but `code` does not, so unit-tests is legitimately skipped on a
     # rust-only PR yet the real-engine e2e must still run (#274 regression class).
     # Still fail-fast if unit-tests actively FAILED/cancelled.
@@ -408,7 +428,7 @@ jobs:
       (
         github.event_name == 'schedule' ||
         (
-          needs.changes.outputs.heavy_e2e == 'true' &&
+          needs.changes.outputs.real_engine_e2e == 'true' &&
           !startsWith(github.head_ref, 'release/') &&
           !startsWith(github.event.head_commit.message, 'chore(release):')
         )
@@ -539,7 +559,7 @@ jobs:
       (
         github.event_name == 'schedule' ||
         (
-          needs.changes.outputs.heavy_e2e == 'true' &&
+          needs.changes.outputs.tts_e2e == 'true' &&
           !startsWith(github.head_ref, 'release/') &&
           !startsWith(github.event.head_commit.message, 'chore(release):')
         )


### PR DESCRIPTION
## What changed

- Split the model-backed CI selector into `real_engine_e2e` and `tts_e2e`.
- Run published-engine smoke and model-backed integration for narrow TypeScript adapters that invoke installation, engine execution, transcription, and MCP.
- Run TTS e2e when the TypeScript TTS adapter changes.
- Added conservative coverage floors for the native-engine boundary modules.

## Why

The fast suites use fake engines. Before this change, a TypeScript-only adapter regression could merge without exercising a released binary until the nightly job.

## Validation

- `bun run check:workflows`
- `bun run coverage:ts`
- `bun run coverage:check:ts` — 75.06% total; all four risk floors pass
- `bun run check` (428 passing)
- `bunx tsc --noEmit`