### PR TITLE
refactor: share install plan model metadata

### DIFF
--- a/model-plan.json
+++ b/model-plan.json
@@ -1,0 +1,43 @@
+{
+  "asr": [
+    { "relPath": "models/parakeet-tdt-v3/encoder-model.onnx", "sizeBytes": 41770866 },
+    { "relPath": "models/parakeet-tdt-v3/encoder-model.onnx.data", "sizeBytes": 2435420160 },
+    { "relPath": "models/parakeet-tdt-v3/decoder_joint-model.onnx", "sizeBytes": 72520893 },
+    { "relPath": "models/parakeet-tdt-v3/nemo128.onnx", "sizeBytes": 139764 },
+    { "relPath": "models/parakeet-tdt-v3/vocab.txt", "sizeBytes": 93939 }
+  ],
+  "langId": [
+    { "relPath": "models/lang-id-ecapa/lang-id-ecapa.onnx", "sizeBytes": 759814 },
+    { "relPath": "models/lang-id-ecapa/lang-id-ecapa.onnx.data", "sizeBytes": 85327872 },
+    { "relPath": "models/lang-id-ecapa/labels.json", "sizeBytes": 646 }
+  ],
+  "vad": [
+    { "relPath": "models/silero-vad/silero_vad.onnx", "sizeBytes": 2327524 }
+  ],
+  "g2pCharsiu": [
+    { "relPath": "models/g2p/byt5-tiny/encoder_model.onnx", "sizeBytes": 12478704 },
+    { "relPath": "models/g2p/byt5-tiny/decoder_model.onnx", "sizeBytes": 11983268 },
+    { "relPath": "models/g2p/byt5-tiny/decoder_with_past_model.onnx", "sizeBytes": 5427260 }
+  ],
+  "kokoroGraph": { "relPath": "models/kokoro-82m/model.onnx", "sizeBytes": 325532387 },
+  "kokoroVoices": {
+    "en": { "relPath": "models/kokoro-82m/voices/am_michael.bin", "sizeBytes": 522240 },
+    "es": { "relPath": "models/kokoro-82m/voices/em_alex.bin", "sizeBytes": 522240 },
+    "fr": { "relPath": "models/kokoro-82m/voices/ff_siwis.bin", "sizeBytes": 522240 },
+    "it": { "relPath": "models/kokoro-82m/voices/im_nicola.bin", "sizeBytes": 522240 },
+    "pt": { "relPath": "models/kokoro-82m/voices/pm_alex.bin", "sizeBytes": 522240 }
+  },
+  "voskRu": [
+    { "relPath": "models/vosk-ru/model.onnx", "sizeBytes": 179314533 },
+    { "relPath": "models/vosk-ru/dictionary", "sizeBytes": 101431118 },
+    { "relPath": "models/vosk-ru/config.json", "sizeBytes": 1518 },
+    { "relPath": "models/vosk-ru/bert/model.onnx", "sizeBytes": 654361598 },
+    { "relPath": "models/vosk-ru/bert/vocab.txt", "sizeBytes": 1780720 }
+  ],
+  "diarize": [
+    { "relPath": "models/diarize/SortformerNvidiaLow_v2.mlpackage/Manifest.json", "sizeBytes": 617 },
+    { "relPath": "models/diarize/SortformerNvidiaLow_v2.mlpackage/Data/com.apple.CoreML/model.mlmodel", "sizeBytes": 7080357 },
+    { "relPath": "models/diarize/SortformerNvidiaLow_v2.mlpackage/Data/com.apple.CoreML/weights/0-weight.bin", "sizeBytes": 5930400 },
+    { "relPath": "models/diarize/SortformerNvidiaLow_v2.mlpackage/Data/com.apple.CoreML/weights/1-weight.bin", "sizeBytes": 232161600 }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "completions/",
     "man/",
     "src/",
+    "model-plan.json",
     "package.json",
     "tsconfig.json",
     "openclaw.plugin.json",

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -824,6 +824,79 @@ fn parallel_download(cache: &Path, manifest: &[&ModelFile], no_cache: bool) -> R
 mod manifest_tests {
     use super::*;
 
+    fn assert_plan_paths(plan: &serde_json::Value, key: &str, files: &[ModelFile]) {
+        let plan_paths = plan[key]
+            .as_array()
+            .unwrap_or_else(|| panic!("install plan {key} must be an array"))
+            .iter()
+            .map(|file| {
+                file["relPath"]
+                    .as_str()
+                    .unwrap_or_else(|| panic!("install plan {key} entry needs relPath"))
+            })
+            .collect::<Vec<_>>();
+        let runtime_paths = files.iter().map(|file| file.rel_path).collect::<Vec<_>>();
+        assert_eq!(
+            plan_paths, runtime_paths,
+            "install plan {key} drifted from runtime manifest"
+        );
+    }
+
+    #[cfg(all(
+        feature = "tts",
+        not(all(
+            feature = "system_kokoro",
+            target_os = "macos",
+            target_arch = "aarch64"
+        ))
+    ))]
+    fn assert_plan_path(plan: &serde_json::Value, key: &str, file: &ModelFile) {
+        let plan_path = plan[key]["relPath"]
+            .as_str()
+            .unwrap_or_else(|| panic!("install plan {key} needs relPath"));
+        assert_eq!(
+            plan_path, file.rel_path,
+            "install plan {key} drifted from runtime manifest"
+        );
+    }
+
+    #[test]
+    fn install_plan_model_paths_match_runtime_manifests() {
+        let plan: serde_json::Value = serde_json::from_str(include_str!("../../model-plan.json"))
+            .expect("model plan JSON must parse");
+
+        assert_plan_paths(&plan, "asr", ASR_FILES);
+        assert_plan_paths(&plan, "langId", LANG_ID_FILES);
+        assert_plan_paths(&plan, "vad", VAD_FILES);
+
+        #[cfg(feature = "system_diarize")]
+        assert_plan_paths(&plan, "diarize", DIARIZE_FILES);
+
+        #[cfg(feature = "tts")]
+        assert_plan_paths(&plan, "voskRu", VOSK_RU_FILES);
+
+        #[cfg(all(
+            feature = "tts",
+            not(all(
+                feature = "system_kokoro",
+                target_os = "macos",
+                target_arch = "aarch64"
+            ))
+        ))]
+        {
+            assert_plan_paths(&plan, "g2pCharsiu", G2P_CHARSIU_FILES);
+            assert_plan_path(&plan, "kokoroGraph", &KOKORO_GRAPH);
+            assert_plan_path(&plan["kokoroVoices"], "en", &KOKORO_EN_VOICE);
+            for lang in ["es", "fr", "it", "pt"] {
+                assert_plan_path(
+                    &plan["kokoroVoices"],
+                    lang,
+                    &multilang_voice(lang).expect("known Kokoro language"),
+                );
+            }
+        }
+    }
+
     #[test]
     fn asr_manifest_has_expected_files_and_hashes() {
         assert_eq!(ASR_FILES.len(), 5);

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -76,7 +76,7 @@ const VAD_FILES: &[ModelFile] = &[ModelFile {
 /// (Manifest.json + model.mlmodel + 2 weight blobs) rather than the
 /// alternative pre-compiled `.mlmodelc` form, since the upstream HF tree
 /// ships both and the .mlpackage is roughly half the bytes.
-#[cfg(feature = "system_diarize")]
+#[cfg(any(feature = "system_diarize", test))]
 const DIARIZE_FILES: &[ModelFile] = &[
     ModelFile {
         rel_path: "models/diarize/SortformerNvidiaLow_v2.mlpackage/Manifest.json",
@@ -869,7 +869,6 @@ mod manifest_tests {
         assert_plan_paths(&plan, "langId", LANG_ID_FILES);
         assert_plan_paths(&plan, "vad", VAD_FILES);
 
-        #[cfg(feature = "system_diarize")]
         assert_plan_paths(&plan, "diarize", DIARIZE_FILES);
 
         #[cfg(feature = "tts")]

--- a/src/install-plan.ts
+++ b/src/install-plan.ts
@@ -11,6 +11,7 @@ import {
   fluidKokoroCachePath,
   isDarwinArm64,
 } from "./fluid-kokoro-cache";
+import modelPlan from "../model-plan.json" with { type: "json" };
 
 export interface InstallPlanOptions {
   noCache?: boolean;
@@ -24,6 +25,17 @@ export interface InstallPlanOptions {
 interface PlanFile {
   relPath: string;
   sizeBytes: number;
+}
+
+interface ModelPlan {
+  asr: PlanFile[];
+  langId: PlanFile[];
+  vad: PlanFile[];
+  g2pCharsiu: PlanFile[];
+  kokoroGraph: PlanFile;
+  kokoroVoices: Record<string, PlanFile>;
+  voskRu: PlanFile[];
+  diarize: PlanFile[];
 }
 
 interface PlanComponent {
@@ -45,46 +57,19 @@ interface ReleaseAssetSpec {
   sizeBytes: number;
 }
 
-// Mirrors the pinned runtime manifests so `kesha install --plan` works before
-// the engine exists. Keep in sync with rust/src/models.rs and release assets.
-const ASR_FILES: PlanFile[] = [
-  { relPath: "models/parakeet-tdt-v3/encoder-model.onnx", sizeBytes: 41_770_866 },
-  { relPath: "models/parakeet-tdt-v3/encoder-model.onnx.data", sizeBytes: 2_435_420_160 },
-  { relPath: "models/parakeet-tdt-v3/decoder_joint-model.onnx", sizeBytes: 72_520_893 },
-  { relPath: "models/parakeet-tdt-v3/nemo128.onnx", sizeBytes: 139_764 },
-  { relPath: "models/parakeet-tdt-v3/vocab.txt", sizeBytes: 93_939 },
-];
-
-const LANG_ID_FILES: PlanFile[] = [
-  { relPath: "models/lang-id-ecapa/lang-id-ecapa.onnx", sizeBytes: 759_814 },
-  { relPath: "models/lang-id-ecapa/lang-id-ecapa.onnx.data", sizeBytes: 85_327_872 },
-  { relPath: "models/lang-id-ecapa/labels.json", sizeBytes: 646 },
-];
-
-const VAD_FILES: PlanFile[] = [
-  { relPath: "models/silero-vad/silero_vad.onnx", sizeBytes: 2_327_524 },
-];
-
-// klebster CharsiuG2P byt5-tiny ONNX export (CC-BY 4.0 — see NOTICES.md). Multilingual G2P for es/fr/it/pt (#212).
-const G2P_CHARSIU_FILES: PlanFile[] = [
-  { relPath: "models/g2p/byt5-tiny/encoder_model.onnx", sizeBytes: 12_478_704 },
-  { relPath: "models/g2p/byt5-tiny/decoder_model.onnx", sizeBytes: 11_983_268 },
-  { relPath: "models/g2p/byt5-tiny/decoder_with_past_model.onnx", sizeBytes: 5_427_260 },
-];
-
-// Kokoro ONNX graph (shared by all Kokoro languages on non-darwin builds).
-const KOKORO_GRAPH_FILE: PlanFile = { relPath: "models/kokoro-82m/model.onnx", sizeBytes: 325_532_387 };
-
-// Multilingual voice packs for es/fr/it/pt (#212).
-// em_alex (es, male), ff_siwis (fr, female — only French voice in Kokoro v1.0),
-// im_nicola (it, male), pm_alex (pt, male).
-const KOKORO_VOICE_FILES: Record<string, PlanFile> = {
-  en: { relPath: "models/kokoro-82m/voices/am_michael.bin", sizeBytes: 522_240 },
-  es: { relPath: "models/kokoro-82m/voices/em_alex.bin", sizeBytes: 522_240 },
-  fr: { relPath: "models/kokoro-82m/voices/ff_siwis.bin", sizeBytes: 522_240 },
-  it: { relPath: "models/kokoro-82m/voices/im_nicola.bin", sizeBytes: 522_240 },
-  pt: { relPath: "models/kokoro-82m/voices/pm_alex.bin", sizeBytes: 522_240 },
-};
+// Shared plan metadata keeps `kesha install --plan` usable before the engine
+// exists. Rust tests guard these cache paths against its pinned manifests.
+const plan: ModelPlan = modelPlan;
+const {
+  asr: ASR_FILES,
+  langId: LANG_ID_FILES,
+  vad: VAD_FILES,
+  g2pCharsiu: G2P_CHARSIU_FILES,
+  kokoroGraph: KOKORO_GRAPH_FILE,
+  kokoroVoices: KOKORO_VOICE_FILES,
+  voskRu: VOSK_RU_FILES,
+  diarize: DIARIZE_FILES,
+} = plan;
 
 function kokoroPlanFiles(langs: string[]): PlanFile[] {
   const files: PlanFile[] = [KOKORO_GRAPH_FILE];
@@ -94,30 +79,6 @@ function kokoroPlanFiles(langs: string[]): PlanFile[] {
   }
   return files;
 }
-
-const VOSK_RU_FILES: PlanFile[] = [
-  { relPath: "models/vosk-ru/model.onnx", sizeBytes: 179_314_533 },
-  { relPath: "models/vosk-ru/dictionary", sizeBytes: 101_431_118 },
-  { relPath: "models/vosk-ru/config.json", sizeBytes: 1_518 },
-  { relPath: "models/vosk-ru/bert/model.onnx", sizeBytes: 654_361_598 },
-  { relPath: "models/vosk-ru/bert/vocab.txt", sizeBytes: 1_780_720 },
-];
-
-const DIARIZE_FILES: PlanFile[] = [
-  { relPath: "models/diarize/SortformerNvidiaLow_v2.mlpackage/Manifest.json", sizeBytes: 617 },
-  {
-    relPath: "models/diarize/SortformerNvidiaLow_v2.mlpackage/Data/com.apple.CoreML/model.mlmodel",
-    sizeBytes: 7_080_357,
-  },
-  {
-    relPath: "models/diarize/SortformerNvidiaLow_v2.mlpackage/Data/com.apple.CoreML/weights/0-weight.bin",
-    sizeBytes: 5_930_400,
-  },
-  {
-    relPath: "models/diarize/SortformerNvidiaLow_v2.mlpackage/Data/com.apple.CoreML/weights/1-weight.bin",
-    sizeBytes: 232_161_600,
-  },
-];
 
 // The sidecar list (and the asset-name → installed-filename mapping) lives in
 // SIDECARS in engine-install.ts; only the release-asset sizes are pinned here,

--- a/tests/unit/package-metadata.test.ts
+++ b/tests/unit/package-metadata.test.ts
@@ -8,6 +8,13 @@ interface PackageJson {
 }
 
 describe("package metadata", () => {
+  test("publishes install-plan model metadata", () => {
+    const pkgPath = fileURLToPath(new URL("../../package.json", import.meta.url));
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as PackageJson;
+
+    expect(pkg.files).toContain("model-plan.json");
+  });
+
   test("does not publish lifecycle scripts", () => {
     const pkgPath = fileURLToPath(new URL("../../package.json", import.meta.url));
     const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as PackageJson;


### PR DESCRIPTION
## What changed

Moved `kesha install --plan` model paths and byte sizes into `model-plan.json`, consumed directly by the TypeScript CLI.

Added a Rust regression test that compares every applicable shared cache path with the engine pinned runtime manifest.

## Why

The CLI plan must work before `kesha-engine` is installed, but its manually duplicated file lists could silently drift from the engine downloaded-model manifests.

## Validation

- `bun test tests/unit/install-plan.test.ts`
- `bunx tsc --noEmit`
- `cargo test --lib models::manifest_tests`
- `cargo fmt`
- `cargo clippy --all-targets -- -D warnings`
- `make rust-test` (396 passed)

`bun test` still has the known nine Raycast `vi.waitFor` failures on `main`; they are fixed independently in #658 and intentionally not duplicated here.