### PR TITLE
debug(ci): surface FluidAudio stdout in coreml-regression [TEMPORARY]

### DIFF
--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -409,16 +409,28 @@ jobs:
       # TEMPORARY DEBUG — revert with this whole branch.
       # KESHA_DEBUG_FLUID_STDOUT disables the fd-1 silencer in fluid_stdout.rs so
       # FluidAudio's own diagnostic reaches nextest's capture instead of /dev/null.
+      # TEMPORARY DEBUG — the failure is intermittent (3 pass / 1 fail observed over
+      # 2026-08-04), so one attempt per job is a coin flip. Repeat until it trips and
+      # stop there, leaving the failing attempt's stdout as the last thing in the log.
       - name: 🧪 CoreML decoder-state regression (ANE)
         env:
           KESHA_DEBUG_FLUID_STDOUT: "1"
           RUST_BACKTRACE: "1"
         run: |
           cd rust
-          cargo nextest run \
-            --no-default-features --features coreml \
-            --run-ignored all \
-            -E 'test(transcribe_samples_is_stateless_across_calls)'
+          for attempt in 1 2 3 4 5 6; do
+            echo "::group::attempt $attempt"
+            cargo nextest run \
+              --no-default-features --features coreml \
+              --run-ignored all \
+              -E 'test(transcribe_samples_is_stateless_across_calls)' || {
+                echo "::endgroup::"
+                echo "::error::failed on attempt $attempt of 6"
+                exit 1
+              }
+            echo "::endgroup::"
+          done
+          echo "6 consecutive passes — did not reproduce in this job"
 
       # TEMPORARY DEBUG — revert with this whole branch.
       # The test passes locally against a long-lived model dir but fails in CI,

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -406,13 +406,39 @@ jobs:
           restore-keys: |
             parakeet-coreml-models-v1-${{ runner.os }}-
 
+      # TEMPORARY DEBUG — revert with this whole branch.
+      # KESHA_DEBUG_FLUID_STDOUT disables the fd-1 silencer in fluid_stdout.rs so
+      # FluidAudio's own diagnostic reaches nextest's capture instead of /dev/null.
       - name: 🧪 CoreML decoder-state regression (ANE)
+        env:
+          KESHA_DEBUG_FLUID_STDOUT: "1"
+          RUST_BACKTRACE: "1"
         run: |
           cd rust
           cargo nextest run \
             --no-default-features --features coreml \
             --run-ignored all \
             -E 'test(transcribe_samples_is_stateless_across_calls)'
+
+      # TEMPORARY DEBUG — revert with this whole branch.
+      # The test passes locally against a long-lived model dir but fails in CI,
+      # where the cache is always cold and init_asr() re-downloads. Inventory the
+      # bundle so a truncated/partial fetch is visible instead of inferred.
+      - name: 🔎 Inventory downloaded CoreML models
+        if: always()
+        run: |
+          DIR="$HOME/Library/Application Support/FluidAudio/Models"
+          echo "::group::model inventory"
+          if [ -d "$DIR" ]; then
+            # stat -f keeps size and path in one field pair, so the spaces in
+            # "Application Support" don't shred the columns the way awk would.
+            du -sh "$DIR"
+            find "$DIR" -type f | wc -l | xargs echo "files:"
+            find "$DIR" -type f -exec stat -f '%z %N' {} + | sort -k2
+          else
+            echo "MISSING: $DIR"
+          fi
+          echo "::endgroup::"
 
       - name: 📤 Upload JUnit
         if: always()

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -418,6 +418,15 @@ jobs:
           RUST_BACKTRACE: "1"
         run: |
           cd rust
+          # EXPERIMENT: every observed failure landed on the first invocation — the one
+          # that compiles the ANE program. Pay that cost in a throwaway run whose result
+          # is ignored; if the theory holds, the six graded attempts below never fail.
+          echo "::group::warm-up (result ignored)"
+          cargo nextest run \
+            --no-default-features --features coreml \
+            --run-ignored all \
+            -E 'test(transcribe_samples_is_stateless_across_calls)' || echo "warm-up failed (expected on a cold e5rt cache)"
+          echo "::endgroup::"
           for attempt in 1 2 3 4 5 6; do
             echo "::group::attempt $attempt"
             cargo nextest run \

--- a/rust/src/fluid_stdout.rs
+++ b/rust/src/fluid_stdout.rs
@@ -25,6 +25,15 @@ use std::os::fd::OwnedFd;
 pub(crate) fn with_silenced_stdout<R>(devnull: Option<&OwnedFd>, f: impl FnOnce() -> R) -> R {
     use std::os::fd::{AsRawFd, FromRawFd};
 
+    // TEMPORARY DEBUG — revert with this whole branch.
+    // `coreml-regression` fails inside `transcribe_samples` with an opaque
+    // "Swift bridge error: Transcription failed"; FluidAudio's real diagnostic
+    // goes to stdout and this silencer discards it. Setting this in the CI step
+    // leaves fd 1 alone so nextest captures the message on failure.
+    if std::env::var_os("KESHA_DEBUG_FLUID_STDOUT").is_some() {
+        return f();
+    }
+
     struct StdoutGuard {
         saved: Option<OwnedFd>,
     }


### PR DESCRIPTION
**Do not merge — throwaway diagnostic branch, delete once the CoreML failure is understood.**

## Why

`coreml-regression` is red on #656 and fails inside `transcribe_samples` with an opaque error:

```
first transcribe_samples: FluidAudio sample transcription failed
Caused by: Swift bridge error: Transcription failed
```

`FluidAudioBackend::new()` (which runs `init_asr()` — download + ANE compile) succeeds, so the failure is the transcription call itself. FluidAudio prints its real diagnostic to **stdout**, and `with_silenced_stdout` points fd 1 at `/dev/null` for exactly that call (#259) — so the cause never reaches CI.

The test **passes locally** on Apple Silicon in 44.6s against a long-lived model dir (57 files / 935M). CI differs in one way that matters: the model cache is never warm, so `init_asr()` re-downloads the bundle every run.

## What this branch does

- `KESHA_DEBUG_FLUID_STDOUT` makes `with_silenced_stdout` a no-op, so nextest captures FluidAudio's message and prints it on failure. Production behaviour is unchanged when the variable is unset.
- Adds `RUST_BACKTRACE=1` to the test step.
- Inventories `~/Library/Application Support/FluidAudio/Models` after the run, so a truncated or partial download shows up as evidence instead of inference. Local baseline to compare against: **57 files, 935M**.

## Also worth noting

The model cache never survives: the repo sits at **11.84 GB against GitHub's 10 GB limit**, so LRU eviction drops the multi-GB Parakeet bundle within a day. Every `coreml-regression` run therefore re-downloads it. That is a separate defect from whatever this branch turns up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ADEmaZeJvxQNQQixswCd3U