### PR TITLE
feat(status): machine-readable `kesha status --json`

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ kesha --json --timestamps audio.ogg        # JSON with timestamped segments
 kesha --toon audio.ogg                     # compact LLM-friendly TOON
 kesha status                               # show installed backend info
 kesha status --disk                        # + recursive cache disk usage
+kesha status --json                        # machine-readable, for scripts
 ```
 
 Multiple files get `head`-style headers; stdout is the transcript, stderr is errors — pipe-friendly:

--- a/completions/kesha.bash
+++ b/completions/kesha.bash
@@ -28,7 +28,7 @@ _kesha_completion() {
     record) opts="--help -h --out --max-seconds --debug" ;;
     say) opts="--help -h --voice --lang --out --rate --list-voices --ssml --format --bitrate --sample-rate --no-expand-abbrev --verbose --debug" ;;
     stats) opts="--help -h --format" ;;
-    status) opts="--help -h --disk" ;;
+    status) opts="--help -h --disk --json" ;;
     support-bundle) opts="--help -h --output --include-logs" ;;
     *) opts="--help -h --version -v --json --toon --timestamps --speakers --include-errors --verbose --format --lang --debug --vad --no-vad --quiet --no-color" ;;
   esac

--- a/completions/kesha.fish
+++ b/completions/kesha.fish
@@ -86,6 +86,7 @@ complete -c kesha -n '__fish_seen_subcommand_from stats' -l format -r -d 'Export
 complete -c kesha -n '__fish_seen_subcommand_from status' -l help -d 'Show help'
 complete -c kesha -n '__fish_seen_subcommand_from status' -s h -d 'Show help'
 complete -c kesha -n '__fish_seen_subcommand_from status' -l disk -d 'Include recursive cache disk usage'
+complete -c kesha -n '__fish_seen_subcommand_from status' -l json -d 'Output status as JSON'
 complete -c kesha -n '__fish_seen_subcommand_from support-bundle' -l help -d 'Show help'
 complete -c kesha -n '__fish_seen_subcommand_from support-bundle' -s h -d 'Show help'
 complete -c kesha -n '__fish_seen_subcommand_from support-bundle' -l output -r -d 'Write archive to this .tar.gz path'

--- a/completions/kesha.zsh
+++ b/completions/kesha.zsh
@@ -121,7 +121,8 @@ _kesha() {
     status)
       _arguments '--help[Show help]' \
         '-h[Show help]' \
-        '--disk[Include recursive cache disk usage]'
+        '--disk[Include recursive cache disk usage]' \
+        '--json[Output status as JSON]'
       ;;
     support-bundle)
       _arguments '--help[Show help]' \

--- a/docs/runbooks/mirror-sync-647.md
+++ b/docs/runbooks/mirror-sync-647.md
@@ -1,0 +1,40 @@
+# Mirror sync for #647 — deferred until the CLI ships `status --json`
+
+Prepared while #647 was in flight. **Do not open the upstream PR yet.**
+
+## Why it waits
+
+The extension's new probe calls `kesha status --json`. That flag does not exist
+in any published CLI — 1.24.7 is current on npm, and the flag lands in #664. On
+a published CLI the probe therefore falls through to the prose fallback: safe,
+but the change does nothing for anyone until a CLI release carries the flag.
+
+Order: merge #664 → release the CLI → sync the mirror.
+
+Syncing earlier means shipping an inert feature to the Store and syncing twice.
+
+## Preconditions
+
+- [ ] #664 merged into `main`
+- [ ] A CLI release published to npm whose `status` accepts `--json`
+      (verify: `bunx @drakulavich/kesha-voice-kit@latest status --json | jq .engine.installed`)
+
+## What moves
+
+`raycast/` → `extensions/kesha-voice-kit/` in the fork
+`drakulavich/raycast-extensions` (already exists; prior syncs were
+raycast/extensions#29681 and #29758).
+
+Files changed by #664:
+
+- `src/lib/kesha-bin.ts` — structured probe, contract/repair hints, prose fallback anchored to the Binary line
+- `src/lib/dictation-controller.ts` — `preflightMessage` maps the reason to copy
+- `tests/kesha-bin.test.ts`, `tests/kesha-bin-status-json.test.ts`, `tests/dictation-controller.test.ts`
+- `CHANGELOG.md` — the `{PR_MERGE_DATE}` entry is already written; Raycast substitutes the date on merge
+
+## Before opening
+
+- `cd extensions/kesha-voice-kit && npm ci && npm test && npm run lint`
+- Confirm the CHANGELOG entry is user-facing wording, not implementation notes —
+  Raycast reviewers care about this.
+- Keep the diff to the files above. Every extra file enlarges the next sync.

--- a/man/kesha.1
+++ b/man/kesha.1
@@ -200,6 +200,9 @@ Export format: json | csv
 .TP
 .B \-\-disk
 Include recursive cache disk usage
+.TP
+.B \-\-json
+Output status as JSON
 .SS support-bundle
 .TP
 .B \-\-output

--- a/openspec/changes/status-json-output/.openspec.yaml
+++ b/openspec/changes/status-json-output/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-01

--- a/openspec/changes/status-json-output/design.md
+++ b/openspec/changes/status-json-output/design.md
@@ -51,19 +51,89 @@ the human path formats it; `--json` serializes it. `--disk` sets a flag on the
 collector so the disk breakdown is computed only when asked (it walks the cache
 recursively and is not free).
 
-**Probe strategy: try structured, fall back to prose.** `probeEngineAvailability`
-runs `kesha status --json`, attempts `JSON.parse` on stdout, and:
+**Probe strategy: try structured, fall back to prose — but only for non-JSON
+stdout.** The naive rule "parse fails *or* the field is absent → prose fallback"
+is unsafe. Consider stdout that is valid JSON yet lacks the contract field:
 
-- parses and the payload has the engine-presence boolean → use it;
-- parse throws, or the boolean is absent → fall back to the existing
-  `stdout.includes("not installed")` match;
-- spawn fails outright → fail open, unchanged from today.
+```json
+{"ok":true,"engine":{"path":"/x"},"hint":"Run `kesha install` …"}
+```
 
-The parse failure *is* the version detection. Alternatives considered: probing
+`JSON.parse` succeeds, the boolean is absent, the fallback runs, the string does
+not contain `"not installed"` — and the probe reports the engine as available
+when it is missing. Field-name drift between extension and CLI produces exactly
+this shape. So the acceptance rule is by *stdout kind*, not by parse outcome:
+
+| stdout | probe result |
+|---|---|
+| JSON object, `installed` is a boolean | use it (plus capabilities, below) |
+| JSON object, `installed` not a boolean | contract error → **unavailable**, never prose |
+| not JSON at all | prose fallback (`includes("not installed")`) |
+| empty / garbage | fail open, as today |
+| spawn throws | fail open, as today |
+
+Only genuinely non-JSON output means "old CLI". A malformed object means the
+contract broke, and reporting a broken contract as available is the one outcome
+worth failing closed on — an unavailable verdict costs Maks a setup view he can
+dismiss, while a false available costs him a recording.
+
+The parse outcome *is* the version detection. Alternatives considered: probing
 `kesha --version` and comparing semver (an extra spawn before every session, plus
 a version table to maintain), or a `--capabilities`-style CLI self-description
 (more surface than this problem justifies). Both lose to letting the old CLI's own
 output be the signal.
+
+**Prose fallback pins to the Binary line, not the whole stdout.** `"not
+installed"` is `formatStatusLine`'s default `missingLabel` (`src/status.ts:27`),
+so any future line rendered as missing would emit it too. Today only the Binary
+line can (`src/status.ts:64`) — the Capabilities line passes `"probe failed"`
+explicitly — but a global substring match would silently start reading unrelated
+lines. The fallback matches the marker on the Binary line.
+
+**Normative payload.** The spec states outcomes; this is the wire shape those
+outcomes assume, so implementers do not each invent one. Names mirror
+`DoctorReport` (`src/doctor.ts`) — `installed`, nested `capabilities` — so the
+codebase keeps one vocabulary even though the types stay separate. Pretty-printed
+with `JSON.stringify(payload, null, 2)`, matching `doctor` and `logs`.
+
+Healthy engine:
+
+```json
+{
+  "cliVersion": "1.24.7",
+  "engine": {
+    "installed": true,
+    "binPath": "/Users/maks/.cache/kesha/engine/bin/kesha-engine",
+    "capabilities": { "backend": "coreml", "protocolVersion": 3, "features": ["tts"] }
+  },
+  "voices": ["en-am_michael", "ru-vosk-m02"],
+  "runtime": { "bun": "1.3.13", "platform": "darwin", "arch": "arm64" },
+  "modelMirror": null,
+  "hint": null
+}
+```
+
+Engine missing — `binPath` still reports where it would live, `voices` is `[]`
+(not omitted; the human path hides the empty section, the payload does not):
+
+```json
+{
+  "cliVersion": "1.24.7",
+  "engine": { "installed": false, "binPath": "/Users/maks/.cache/…/kesha-engine", "capabilities": null },
+  "voices": [],
+  "runtime": { "bun": "1.3.13", "platform": "darwin", "arch": "arm64" },
+  "modelMirror": null,
+  "hint": "Run `kesha install` to download the engine and models."
+}
+```
+
+Present but unusable: `installed: true` with `capabilities: null`. One nested
+null, not three sibling nulls — so the consumer rule is a single check rather
+than an argument about which of three fields must be non-null.
+
+Every key is always present; absent values are `null` (or `[]` for `voices`).
+Nothing is omitted, so a consumer never has to distinguish "missing key" from
+"null value". `--disk` adds a `disk` key; without it the key is `null`.
 
 **Hint moves into the payload; stderr stays quiet under `--json`.** The human path
 writes the setup hint via `log.warn` to stderr, and the probe currently harvests

--- a/openspec/changes/status-json-output/design.md
+++ b/openspec/changes/status-json-output/design.md
@@ -154,8 +154,13 @@ match reads — so the guarantee holds on the structured path only. That is toda
 behaviour too, so it is a gap being narrowed rather than a regression.
 
 **Capabilities failure reports nulls, not omissions.** `getEngineCapabilities()`
-(`src/engine.ts:348`) already collapses "binary missing", "non-zero exit", and
-"unparseable JSON" into a single `null`. The payload mirrors that: engine present
+(`src/engine.ts:348`) collapses "binary missing", "non-zero exit", and
+"unparseable JSON" into a single `null` — but it used to cast the parsed value
+without checking its shape, so syntactically valid nonsense (`{}`, `[]`, an
+older engine's schema) survived as a truthy object. Callers reach straight for
+`.features.join()`, so that null was not the guarantee this design assumed. It
+now validates the three fields callers actually consume, and returns `null`
+otherwise; a newer engine adding fields still validates. The payload mirrors that: engine present
 `true`, backend/protocol/features `null`. A consumer distinguishing "no engine"
 from "broken engine" reads the boolean and the nulls separately. Adding a
 `capabilitiesProbeFailed` boolean was rejected as redundant with the nulls.

--- a/openspec/changes/status-json-output/design.md
+++ b/openspec/changes/status-json-output/design.md
@@ -1,0 +1,122 @@
+## Context
+
+`showStatus` (`src/status.ts:59`) both gathers state and renders it, interleaving
+`log.info` calls with the lookups that feed them. There is no value to serialize —
+the data only ever exists as formatted lines. Adding `--json` therefore means
+splitting collection from rendering, not bolting a second printer onto the first.
+
+The consumer that motivates this, `probeEngineAvailability`
+(`raycast/src/lib/kesha-bin.ts:166`), spawns whatever `kesha` it resolves on the
+user's machine. The extension ships through the Raycast Store on its own cadence,
+so extension version and CLI version are independent: a new extension will meet
+old CLIs, and the probe must keep working on both.
+
+Verified while writing this design (worktree, engine absent):
+
+```
+$ bun bin/kesha.js status --json ; echo $?
+0
+# stdout: human-readable status; stderr: "Run `kesha install` to download …"
+```
+
+citty ignores an unknown flag — no error, exit 0, unchanged output. That is the
+property the compatibility story rests on, and it is now a measured fact rather
+than an assumption.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One collector feeding both renderings, so human and JSON output cannot drift.
+- A payload a consumer can branch on with a boolean, never a substring.
+- A probe that works against both new and old CLIs without version sniffing.
+- Stdout under `--json` parses as exactly one JSON object.
+
+**Non-Goals:**
+
+- Unifying with `doctor --json`'s report type. They overlap, but `doctor` is a
+  redaction-aware diagnostic dump and `status` is a fast install check; merging
+  them would drag redaction semantics into a hot path the extension calls before
+  every Dictation session.
+- A schema version field in the payload (see Decisions).
+- Changing the engine. Everything here composes data the CLI already has.
+
+## Decisions
+
+**Split `showStatus` into `collectStatus()` + `renderStatus()`.** The alternative —
+a parallel `showStatusJson()` — was rejected because it duplicates the Kokoro/Vosk
+enumeration and mirror-resolution logic, which is exactly the kind of duplication
+that lets the two modes disagree silently. `collectStatus()` returns the payload;
+the human path formats it; `--json` serializes it. `--disk` sets a flag on the
+collector so the disk breakdown is computed only when asked (it walks the cache
+recursively and is not free).
+
+**Probe strategy: try structured, fall back to prose.** `probeEngineAvailability`
+runs `kesha status --json`, attempts `JSON.parse` on stdout, and:
+
+- parses and the payload has the engine-presence boolean → use it;
+- parse throws, or the boolean is absent → fall back to the existing
+  `stdout.includes("not installed")` match;
+- spawn fails outright → fail open, unchanged from today.
+
+The parse failure *is* the version detection. Alternatives considered: probing
+`kesha --version` and comparing semver (an extra spawn before every session, plus
+a version table to maintain), or a `--capabilities`-style CLI self-description
+(more surface than this problem justifies). Both lose to letting the old CLI's own
+output be the signal.
+
+**Hint moves into the payload; stderr stays quiet under `--json`.** The human path
+writes the setup hint via `log.warn` to stderr, and the probe currently harvests
+stderr for it. Under `--json` the hint is a payload field and is not duplicated on
+stderr, so stdout+payload is self-contained. The prose fallback path still reads
+stderr, because that is what an old CLI produces.
+
+**Capabilities failure reports nulls, not omissions.** `getEngineCapabilities()`
+(`src/engine.ts:348`) already collapses "binary missing", "non-zero exit", and
+"unparseable JSON" into a single `null`. The payload mirrors that: engine present
+`true`, backend/protocol/features `null`. A consumer distinguishing "no engine"
+from "broken engine" reads the boolean and the nulls separately. Adding a
+`capabilitiesProbeFailed` boolean was rejected as redundant with the nulls.
+
+**No schema version field.** The CLI is versioned and consumers already know which
+CLI they spawned; a second version number would need its own bump discipline to
+stay honest, and nothing enforces that. Growth is additive-only by convention, and
+the risk this leaves is recorded in the spec's Open Issues rather than papered
+over.
+
+## Risks / Trade-offs
+
+- **The prose marker stays load-bearing indefinitely** → the fallback keeps
+  `"not installed"` meaningful for as long as old CLIs exist, which is the exact
+  coupling this change set out to remove — just narrowed to a fallback path.
+  Mitigation: a CLI-side test asserts the marker's presence in human output with a
+  comment naming the extension as its consumer, so a reword fails locally instead
+  of in the Store. Full removal needs a deprecation call nobody can make yet.
+- **Two renderings of one payload can still drift in *content*** (a field added to
+  the payload but never shown to Maks) → mitigation: the human renderer takes the
+  payload as its only input, so a new field is visibly unused rather than
+  invisibly missing.
+- **`--json --disk` invites a slow path into a script** → the disk walk is
+  recursive over the model cache. It stays opt-in behind `--disk`, exactly as
+  today; plain `--json` does not touch it.
+- **The mirrored `raycast/extensions` copy drifts** → this lands as its own PR
+  here and a follow-up upstream sync, per the existing mirror discipline. Until
+  the sync lands, Store users are on the fallback path — which is why the fallback
+  is not optional.
+
+## Migration Plan
+
+Additive; no migration. The flag is new, the default output is byte-identical, and
+the extension change is backward compatible in both directions (new extension +
+old CLI works via fallback; old extension + new CLI works because human output is
+unchanged). Rollback is reverting the PR — no persisted state, no format anyone
+has stored.
+
+## Open Questions
+
+- Should `kesha stats status --json` follow in the same PR? The `diagnostics` spec
+  lists it as a sibling gap. Kept out of scope here to keep the change reviewable,
+  but if the collector split lands cleanly the same shape applies.
+- Is there a second consumer for this payload (MCP server, OpenClaw plugin) that
+  would change what belongs in it? Neither reads `status` today, so the payload is
+  designed for the extension's needs plus obvious diagnostics.

--- a/openspec/changes/status-json-output/design.md
+++ b/openspec/changes/status-json-output/design.md
@@ -71,6 +71,18 @@ stderr for it. Under `--json` the hint is a payload field and is not duplicated 
 stderr, so stdout+payload is self-contained. The prose fallback path still reads
 stderr, because that is what an old CLI produces.
 
+**Presence and usability are two different questions.** The boolean answers "is
+there a binary", not "can it run" — an Engine that exists but cannot report its
+capabilities is present and unusable at the same time. The probe therefore
+requires presence AND non-null capabilities before starting a Dictation session,
+rather than branching on the boolean alone. Collapsing both into a single
+`usable` boolean was rejected: the extension needs the two apart to word the
+finish-setup view correctly, since repairing a broken install is a different
+instruction from performing a first one. Note the prose fallback cannot make this
+distinction at all — an older CLI's "probe failed" line is not what the marker
+match reads — so the guarantee holds on the structured path only. That is today's
+behaviour too, so it is a gap being narrowed rather than a regression.
+
 **Capabilities failure reports nulls, not omissions.** `getEngineCapabilities()`
 (`src/engine.ts:348`) already collapses "binary missing", "non-zero exit", and
 "unparseable JSON" into a single `null`. The payload mirrors that: engine present

--- a/openspec/changes/status-json-output/design.md
+++ b/openspec/changes/status-json-output/design.md
@@ -92,8 +92,8 @@ lines. The fallback matches the marker on the Binary line.
 
 **Normative payload.** The spec states outcomes; this is the wire shape those
 outcomes assume, so implementers do not each invent one. Names mirror
-`DoctorReport` (`src/doctor.ts`) — `installed`, nested `capabilities` — so the
-codebase keeps one vocabulary even though the types stay separate. Pretty-printed
+`DoctorReport` (`src/doctor.ts`) — `path`, `installed`, nested `capabilities` — so
+the codebase keeps one vocabulary even though the types stay separate. Pretty-printed
 with `JSON.stringify(payload, null, 2)`, matching `doctor` and `logs`.
 
 Healthy engine:
@@ -103,7 +103,7 @@ Healthy engine:
   "cliVersion": "1.24.7",
   "engine": {
     "installed": true,
-    "binPath": "/Users/maks/.cache/kesha/engine/bin/kesha-engine",
+    "path": "/Users/maks/.cache/kesha/engine/bin/kesha-engine",
     "capabilities": { "backend": "coreml", "protocolVersion": 3, "features": ["tts"] }
   },
   "voices": ["en-am_michael", "ru-vosk-m02"],
@@ -113,13 +113,13 @@ Healthy engine:
 }
 ```
 
-Engine missing — `binPath` still reports where it would live, `voices` is `[]`
+Engine missing — `path` still reports where it would live, `voices` is `[]`
 (not omitted; the human path hides the empty section, the payload does not):
 
 ```json
 {
   "cliVersion": "1.24.7",
-  "engine": { "installed": false, "binPath": "/Users/maks/.cache/…/kesha-engine", "capabilities": null },
+  "engine": { "installed": false, "path": "/Users/maks/.cache/…/kesha-engine", "capabilities": null },
   "voices": [],
   "runtime": { "bun": "1.3.13", "platform": "darwin", "arch": "arm64" },
   "modelMirror": null,

--- a/openspec/changes/status-json-output/proposal.md
+++ b/openspec/changes/status-json-output/proposal.md
@@ -1,0 +1,71 @@
+## Why
+
+The Raycast extension decides whether the Engine is installed by string-matching
+`"not installed"` in `kesha status` stdout (`raycast/src/lib/kesha-bin.ts:172`).
+That couples a consumer to human-readable prose nobody would think twice about
+rewording — and `raycast/` is mirrored into `raycast/extensions`, so a break
+ships to Store users before we notice. The CLI already exposes machine-readable
+output everywhere else this matters (`kesha doctor --json`, `kesha logs status
+--json`, `kesha stats export --format json`); `status` is the gap.
+
+## What Changes
+
+- `kesha status` gains a `--json` flag that prints one JSON object to stdout and
+  nothing else, replacing the human-readable rendering (same precedent as
+  `kesha doctor --json`).
+- The payload carries what a consumer needs to branch on: engine presence as a
+  boolean, binary path, backend, protocol version, features, installed TTS voice
+  ids, Bun runtime, platform, active model mirror, and the setup hint the human
+  path prints to stderr.
+- `--json --disk` includes the per-component disk-usage breakdown; plain `--json`
+  omits it, mirroring the human flag's scope.
+- The Raycast extension's `probeEngineAvailability` reads the boolean instead of
+  matching prose, and keeps the current string match as a fallback so an older
+  CLI on a user's machine still probes correctly.
+- The `diagnostics` spec's "Open Issues" note about missing machine-readable
+  status output is resolved for `status` (the `stats status` gap stays).
+
+No breaking changes: the default human-readable output is untouched, and the new
+flag is additive.
+
+## Capabilities
+
+### New Capabilities
+
+None. This extends an existing command and an existing consumer.
+
+### Modified Capabilities
+
+- `diagnostics`: the `kesha status` requirement gains a machine-readable output
+  mode — payload contract, stdout purity, and `--disk` interaction.
+- `raycast-extension`: the pre-recording setup probe requirement changes from
+  "match a stdout marker" to "read the structured engine-presence field, with a
+  prose fallback for older CLIs".
+
+## Impact
+
+- `src/cli/status.ts` — new `json` arg, wired like `doctor`'s.
+- `src/status.ts` — `showStatus` splits into a data collector (returns the
+  payload) and the existing renderer, so both modes read one source of truth.
+- `raycast/src/lib/kesha-bin.ts` — `probeEngineAvailability` switches to
+  `status --json`, retaining the marker match as fallback.
+- `raycast/` is mirrored into `raycast/extensions`: this needs its own PR here
+  plus a follow-up upstream sync, and the payload becomes a compatibility
+  surface the extension depends on across CLI versions.
+- Tests: `test/` unit coverage for the payload shape and the `--disk`
+  interaction; `raycast/src/lib/__tests__` coverage for both probe paths
+  (structured hit, prose fallback).
+- Docs: `README` status section and `openspec/specs/diagnostics/spec.md`.
+
+## Non-goals
+
+- No `--json` for `kesha stats status` — a separate gap, tracked in the
+  `diagnostics` spec's Open Issues.
+- No `--toon` variant. That flag exists for multi-file transcription payloads
+  piped into an LLM; a single status object gains nothing from it.
+- No change to the human-readable output — wording, colors, and ordering stay
+  exactly as they are.
+- No new engine-side surface. The payload composes what the CLI already knows
+  plus the existing `--capabilities-json` probe; `kesha-engine` is not touched.
+- No stability guarantee beyond additive evolution — the payload is versioned by
+  the CLI's own version, not by a separate schema version field.

--- a/openspec/changes/status-json-output/proposal.md
+++ b/openspec/changes/status-json-output/proposal.md
@@ -53,8 +53,8 @@ None. This extends an existing command and an existing consumer.
   plus a follow-up upstream sync, and the payload becomes a compatibility
   surface the extension depends on across CLI versions.
 - Tests: `test/` unit coverage for the payload shape and the `--disk`
-  interaction; `raycast/src/lib/__tests__` coverage for both probe paths
-  (structured hit, prose fallback).
+  interaction; `raycast/tests/kesha-bin.test.ts` and
+  `raycast/tests/dictation-controller.test.ts` for the probe matrix.
 - Docs: `README` status section and `openspec/specs/diagnostics/spec.md`.
 
 ## Non-goals
@@ -67,5 +67,8 @@ None. This extends an existing command and an existing consumer.
   exactly as they are.
 - No new engine-side surface. The payload composes what the CLI already knows
   plus the existing `--capabilities-json` probe; `kesha-engine` is not touched.
-- No stability guarantee beyond additive evolution — the payload is versioned by
-  the CLI's own version, not by a separate schema version field.
+- No stability guarantee beyond additive evolution — the payload carries the CLI
+  version rather than a separate schema version field.
+- No validation of the engine's own Capabilities JSON shape. "Readable
+  capabilities" means the probe returned an object, not that dictation will
+  succeed; tightening that is a separate concern.

--- a/openspec/changes/status-json-output/specs/diagnostics/spec.md
+++ b/openspec/changes/status-json-output/specs/diagnostics/spec.md
@@ -24,11 +24,12 @@ platform and architecture, the active Model mirror, and — when the Engine is
 absent — the same setup hint the human path writes to stderr.
 
 The presence boolean SHALL report only that the Engine binary exists, not that it
-is usable. A binary that exists but whose Capabilities JSON cannot be read is
-reported as present with Backend, protocol version, and features null; consumers
-deciding whether the Engine can actually run SHALL require presence AND non-null
-capabilities. Consumers SHALL be able to reach both conclusions from these fields
-without matching any human-readable prose.
+is usable. Backend, protocol version, and features SHALL be grouped under a single
+nested capabilities value so that a binary which cannot report them yields one
+null rather than three, making "can the Engine run" a single check; consumers
+deciding that SHALL require presence AND non-null capabilities. Consumers SHALL be
+able to reach both conclusions from these fields without matching any
+human-readable prose.
 
 Every documented key SHALL be present in every payload: absent values are null
 (or the empty list for Voice ids), never omitted, so a consumer never has to tell
@@ -98,8 +99,8 @@ Engine is installed, matching the human path.
 - GIVEN the Engine binary exists but `--capabilities-json` cannot be read
   (corrupt or incompatible binary)
 - WHEN Ira runs `kesha status --json`
-- THEN Engine presence is reported as `true` while Backend, protocol version, and
-  features are reported as null rather than omitted or guessed
+- THEN Engine presence is reported as `true` while the capabilities value is null
+  rather than omitted or guessed
 - AND a consumer reading presence together with the null capabilities can tell
   this apart from both a healthy Engine and a missing one
 - AND the process exits 0, matching the human path's "probe failed" line

--- a/openspec/changes/status-json-output/specs/diagnostics/spec.md
+++ b/openspec/changes/status-json-output/specs/diagnostics/spec.md
@@ -21,9 +21,14 @@ stdout and SHALL print nothing else to stdout. The object SHALL report, at minim
 Engine presence as a boolean, the resolved Engine binary path, Backend, protocol
 version, and features, the installed TTS Voice ids, the Bun runtime version, the
 platform and architecture, the active Model mirror, and — when the Engine is
-absent — the same setup hint the human path writes to stderr. Consumers SHALL be
-able to decide whether the Engine is usable from the boolean alone, without
-matching any human-readable prose.
+absent — the same setup hint the human path writes to stderr.
+
+The presence boolean SHALL report only that the Engine binary exists, not that it
+is usable. A binary that exists but whose Capabilities JSON cannot be read is
+reported as present with Backend, protocol version, and features null; consumers
+deciding whether the Engine can actually run SHALL require presence AND non-null
+capabilities. Consumers SHALL be able to reach both conclusions from these fields
+without matching any human-readable prose.
 
 Under `--json` the setup hint SHALL NOT also be written to stderr, because it is
 carried in the payload; `--json --disk` SHALL include the per-component disk
@@ -80,6 +85,8 @@ Engine is installed, matching the human path.
 - WHEN Ira runs `kesha status --json`
 - THEN Engine presence is reported as `true` while Backend, protocol version, and
   features are reported as null rather than omitted or guessed
+- AND a consumer reading presence together with the null capabilities can tell
+  this apart from both a healthy Engine and a missing one
 - AND the process exits 0, matching the human path's "probe failed" line
 
 > *Technical Note — sources: `src/status.ts::showStatus`, `src/status.ts::showDiskUsage`,

--- a/openspec/changes/status-json-output/specs/diagnostics/spec.md
+++ b/openspec/changes/status-json-output/specs/diagnostics/spec.md
@@ -30,10 +30,18 @@ deciding whether the Engine can actually run SHALL require presence AND non-null
 capabilities. Consumers SHALL be able to reach both conclusions from these fields
 without matching any human-readable prose.
 
+Every documented key SHALL be present in every payload: absent values are null
+(or the empty list for Voice ids), never omitted, so a consumer never has to tell
+a missing key apart from a null value. The payload SHALL also carry the CLI
+version, so a consumer that needs to distinguish payload shapes has the version
+to key off without a second invocation.
+
 Under `--json` the setup hint SHALL NOT also be written to stderr, because it is
 carried in the payload; `--json --disk` SHALL include the per-component disk
 breakdown as structured data, and plain `--json` SHALL omit it, mirroring the
-human flag's scope. Both modes SHALL derive their content from one collector, so
+human flag's scope. When the Engine is absent, `--json --disk` SHALL report the
+disk breakdown as null rather than walking the Model cache, matching the human
+path, which computes disk usage only when the Engine is installed. Both modes SHALL derive their content from one collector, so
 the two renderings can never disagree. `--json` SHALL exit 0 whether or not the
 Engine is installed, matching the human path.
 
@@ -58,6 +66,13 @@ Engine is installed, matching the human path.
 - THEN the output shows a red cross for the Engine binary
 - AND an actionable setup hint is printed — `kesha init` on an interactive TTY,
   `kesha install` when stderr is piped (`installHint()`, `src/status.ts:88`)
+- AND the process exits 0
+
+#### Scenario: Ira asks for disk usage with no Engine installed
+
+- GIVEN no Engine is installed
+- WHEN Ira runs `kesha status --json --disk`
+- THEN the disk breakdown is reported as null and the Model cache is not walked
 - AND the process exits 0
 
 #### Scenario: Ira branches on install state without parsing prose
@@ -109,10 +124,10 @@ Engine is installed, matching the human path.
   the only way to include log contents is via `kesha support-bundle --include-logs`.
 - `kesha stats` has no `--json` flag on `status`; machine-readable stats output
   requires `export --format json`.
-- The `status --json` payload has no explicit schema version field: consumers are
-  expected to tolerate additive growth and to key off the CLI version when they
-  need to distinguish shapes. Whether that holds once a second consumer beyond the
-  Raycast extension exists is unresolved.
+- The payload carries the CLI version but no separate schema version: consumers
+  are expected to tolerate additive growth and to key off the CLI version when
+  they need to distinguish shapes. Whether that holds once a second consumer
+  beyond the Raycast extension exists is unresolved.
 - `kesha doctor --json` and `kesha status --json` overlap in what they report but
   do not share a payload type; keeping them consistent is currently a convention,
   not something a test enforces.

--- a/openspec/changes/status-json-output/specs/diagnostics/spec.md
+++ b/openspec/changes/status-json-output/specs/diagnostics/spec.md
@@ -1,0 +1,111 @@
+## MODIFIED Requirements
+
+### Requirement: `kesha status` shows engine and voice install state
+
+`kesha status` SHALL print a concise install summary: Engine binary path and install
+status; Backend, protocol version, and features (from Capabilities JSON); Bun runtime
+version and platform; active Model mirror (when `KESHA_MODEL_MIRROR` is set); and the
+list of installed TTS Voice ids.
+
+`--disk` SHALL additionally print a per-component disk-usage table (Engine, ASR,
+Language ID, VAD, TTS Kokoro, TTS Vosk) and the grand total. The FluidAudio Kokoro
+external cache is reported separately when it exists, because it lives outside
+Kesha's Model cache.
+
+When the Engine is not installed, `kesha status` prints an actionable setup hint
+(`kesha init` on an interactive TTY, `kesha install` when stderr is piped) and
+exits 0.
+
+`--json` SHALL replace the human-readable rendering with a single JSON object on
+stdout and SHALL print nothing else to stdout. The object SHALL report, at minimum:
+Engine presence as a boolean, the resolved Engine binary path, Backend, protocol
+version, and features, the installed TTS Voice ids, the Bun runtime version, the
+platform and architecture, the active Model mirror, and — when the Engine is
+absent — the same setup hint the human path writes to stderr. Consumers SHALL be
+able to decide whether the Engine is usable from the boolean alone, without
+matching any human-readable prose.
+
+Under `--json` the setup hint SHALL NOT also be written to stderr, because it is
+carried in the payload; `--json --disk` SHALL include the per-component disk
+breakdown as structured data, and plain `--json` SHALL omit it, mirroring the
+human flag's scope. Both modes SHALL derive their content from one collector, so
+the two renderings can never disagree. `--json` SHALL exit 0 whether or not the
+Engine is installed, matching the human path.
+
+#### Scenario: Ira checks install state in a script
+
+- GIVEN the Engine and ASR models are installed with TTS English
+- WHEN Ira runs `kesha status`
+- THEN the output shows a green check for the Engine binary and its backend
+- AND lists `en-am_michael` (and other installed Kokoro voices) under TTS voices
+- AND the process exits 0
+
+#### Scenario: Maks sees disk usage
+
+- WHEN Maks runs `kesha status --disk`
+- THEN a disk-usage table appears with per-component sizes and a bold Total
+- AND if FluidAudio Kokoro cache exists it is listed under "External caches"
+
+#### Scenario: Engine missing
+
+- GIVEN no Engine is installed
+- WHEN Ira runs `kesha status`
+- THEN the output shows a red cross for the Engine binary
+- AND an actionable setup hint is printed — `kesha init` on an interactive TTY,
+  `kesha install` when stderr is piped (`installHint()`, `src/status.ts:88`)
+- AND the process exits 0
+
+#### Scenario: Ira branches on install state without parsing prose
+
+- GIVEN the Engine is installed
+- WHEN Ira runs `kesha status --json`
+- THEN stdout parses as a single JSON object and contains nothing else
+- AND the object reports Engine presence as `true`, the binary path, the Backend,
+  the protocol version, the features, and the installed TTS Voice ids
+- AND the process exits 0
+
+#### Scenario: Engine missing under `--json`
+
+- GIVEN no Engine is installed
+- WHEN Ira runs `kesha status --json`
+- THEN the object reports Engine presence as `false` and carries the same
+  actionable setup hint the human path writes to stderr
+- AND stderr does not repeat that hint
+- AND the process exits 0
+
+#### Scenario: Capabilities probe fails under `--json`
+
+- GIVEN the Engine binary exists but `--capabilities-json` cannot be read
+  (corrupt or incompatible binary)
+- WHEN Ira runs `kesha status --json`
+- THEN Engine presence is reported as `true` while Backend, protocol version, and
+  features are reported as null rather than omitted or guessed
+- AND the process exits 0, matching the human path's "probe failed" line
+
+> *Technical Note — sources: `src/status.ts::showStatus`, `src/status.ts::showDiskUsage`,
+> `src/cli/status.ts::statusCommand`. TTS voice enumeration reads `kokoro-82m/voices/*.bin`
+> (prefixed `en-`) and checks `vosk-ru/model.onnx` + `vosk-ru/bert/model.onnx` presence
+> (voices `ru-vosk-f01`, `ru-vosk-f02`, `ru-vosk-f03`, `ru-vosk-m01`, `ru-vosk-m02`).
+> `activeModelMirror()` trims and strips trailing slashes from `KESHA_MODEL_MIRROR`;
+> returns null when unset or empty. Capabilities come from
+> `src/engine.ts::getEngineCapabilities` (`src/engine.ts:348`), which returns null on a
+> failed or unparseable probe — that null is what the payload reports. The `--json`
+> flag follows the `doctor` precedent at `src/cli/doctor.ts:16-32`.*
+
+## Open Issues
+
+- `kesha doctor` does not surface the FluidAudio Kokoro external cache size in the
+  plain-text format (it is included in the JSON and in the cache components list, but
+  the human-readable section omits it); the `--disk` flag on `kesha status` does show
+  it correctly.
+- `kesha logs` has no `tail` or `cat` action for reading log contents from the CLI;
+  the only way to include log contents is via `kesha support-bundle --include-logs`.
+- `kesha stats` has no `--json` flag on `status`; machine-readable stats output
+  requires `export --format json`.
+- The `status --json` payload has no explicit schema version field: consumers are
+  expected to tolerate additive growth and to key off the CLI version when they
+  need to distinguish shapes. Whether that holds once a second consumer beyond the
+  Raycast extension exists is unresolved.
+- `kesha doctor --json` and `kesha status --json` overlap in what they report but
+  do not share a payload type; keeping them consistent is currently a convention,
+  not something a test enforces.

--- a/openspec/changes/status-json-output/specs/raycast-extension/spec.md
+++ b/openspec/changes/status-json-output/specs/raycast-extension/spec.md
@@ -6,7 +6,16 @@ Before entering the recording state, the extension SHALL probe the resolved CLI 
 
 The probe SHALL decide Engine availability from the CLI's machine-readable status
 output rather than by matching human-readable prose, so that rewording the CLI's
-status text cannot break a published extension. When the resolved CLI is older
+status text cannot break a published extension.
+
+Engine availability SHALL mean present AND reporting readable capabilities. An
+Engine binary that exists but cannot report its capabilities is unusable, and the
+probe SHALL treat it as unavailable rather than starting a Dictation session that
+will fail during Transcription. The finish-setup view SHALL distinguish this case
+from a never-installed Engine, because the remedy differs — repairing a broken
+install is not the same instruction as performing a first one.
+
+When the resolved CLI is older
 than the machine-readable output and therefore does not produce it, the probe
 SHALL fall back to the previous prose marker rather than reporting a broken
 install — the extension is distributed through the Raycast Store and cannot
@@ -26,6 +35,14 @@ guards report the real problem with a better message than the probe could.
 - **WHEN** Maks starts a Dictation session
 - **THEN** the probe reports the Engine as available without inspecting any human-readable text
 - **AND** recording starts without a finish-setup view
+
+#### Scenario: Engine present but unusable
+
+- **GIVEN** the Engine binary exists but cannot report its capabilities (corrupt or incompatible)
+- **WHEN** Maks starts a Dictation session
+- **THEN** the probe reports the Engine as unavailable despite it being present
+- **AND** the finish-setup view names repairing the install, distinct from the never-installed wording
+- **AND** no recording starts
 
 #### Scenario: Older CLI without machine-readable status
 
@@ -53,3 +70,12 @@ guards report the real problem with a better message than the probe could.
   stays a load-bearing string for as long as older CLIs are in the wild. There is
   no agreed point at which the fallback can be dropped, and nothing fails loudly
   if the marker is reworded while the fallback is still relied upon.
+- The prose fallback cannot detect a present-but-unusable Engine: an older CLI's
+  human output says "probe failed" on a line the marker match does not read, so on
+  those CLIs a corrupt Engine still reaches recording and fails during
+  Transcription. This matches today's behaviour and is not a regression, but it
+  means the broken-Engine guarantee holds only on the structured path.
+- The exact remedy for a corrupt Engine is unverified: `kesha install` has no
+  documented force/repair flag, so what the finish-setup view should tell Maks to
+  run — and whether a plain re-run of `kesha install` overwrites an existing
+  binary — needs to be established during implementation.

--- a/openspec/changes/status-json-output/specs/raycast-extension/spec.md
+++ b/openspec/changes/status-json-output/specs/raycast-extension/spec.md
@@ -26,11 +26,16 @@ rather than reporting a broken install — the extension is distributed through 
 assume the CLI on a given machine matches it.
 
 The prose fallback SHALL be taken only when the output is not machine-readable at
-all. Output that is machine-readable but does not satisfy the contract SHALL be
-treated as unavailable, never passed to the prose fallback: a structured response
-missing the presence field would otherwise also fail the prose match and be
-reported as a healthy Engine. Failing closed here costs Maks a dismissible setup
-view; failing open costs him a Dictation session. The prose match SHALL be
+all, and only when that output is recognisably a status report; unrecognisable
+output SHALL fail open rather than be searched for loose text. Output that is
+machine-readable but does not satisfy the contract SHALL be treated as
+unavailable, never passed to the prose fallback: a structured response missing
+the presence field would otherwise also fail the prose match and be reported as a
+healthy Engine. Failing closed here costs Maks a dismissible setup view; failing
+open costs him a Dictation session. A contract failure SHALL be reported as a
+version mismatch between CLI and extension rather than as a broken Engine, since
+re-downloading the Engine would not resolve it. Readable capabilities SHALL mean
+a non-empty structured value, not merely a non-null one. The prose match SHALL be
 anchored to the Engine binary line rather than to the whole output, so an
 unrelated line rendered with the same missing-marker cannot be misread as the
 Engine being absent.
@@ -70,6 +75,7 @@ guards report the real problem with a better message than the probe could.
 - **GIVEN** the resolved CLI emits machine-readable output without the presence field
 - **WHEN** Maks starts a Dictation session
 - **THEN** the probe reports the Engine as unavailable rather than falling back to the prose match
+- **AND** the setup view names a CLI/extension version mismatch, not a broken Engine
 - **AND** no recording starts
 
 #### Scenario: Probe cannot run

--- a/openspec/changes/status-json-output/specs/raycast-extension/spec.md
+++ b/openspec/changes/status-json-output/specs/raycast-extension/spec.md
@@ -12,13 +12,14 @@ Engine availability SHALL mean present AND reporting readable capabilities. An
 Engine binary that exists but cannot report its capabilities is unusable, and the
 probe SHALL treat it as unavailable rather than starting a Dictation session that
 will fail during Transcription. The finish-setup view SHALL distinguish this case
-from a never-installed Engine, because the remedy differs — repairing a broken
-install is not the same instruction as performing a first one.
+from a never-installed Engine in both its message and its hint, because the
+remedy differs: a plain `kesha install` takes the cached-engine path and only
+re-trusts an existing binary, so repairing one requires `kesha install
+--no-cache`.
 
-When the resolved CLI is older
-than the machine-readable output and therefore does not produce it, the probe
-SHALL fall back to the previous prose marker rather than reporting a broken
-install — the extension is distributed through the Raycast Store and cannot
+When the resolved CLI is older than the machine-readable output and therefore
+does not produce it, the probe SHALL fall back to the previous prose marker
+rather than reporting a broken install — the extension is distributed through the Raycast Store and cannot
 assume the CLI on a given machine matches it.
 
 The prose fallback SHALL be taken only when the output is not machine-readable at
@@ -74,12 +75,15 @@ guards report the real problem with a better message than the probe could.
 - **THEN** the probe fails open and the Dictation session proceeds
 - **AND** any real problem is reported by the CLI's own error path
 
-> *Technical Note — sources: `raycast/src/lib/kesha-bin.ts::probeEngineAvailability`
-> (`raycast/src/lib/kesha-bin.ts:166-181`), which today spawns `kesha status` and tests
-> `stdout.includes("not installed")` (`:172`), returning the trimmed stderr as the hint.
-> The structured path reads the Engine-presence boolean and hint from `kesha status
-> --json` (see the `diagnostics` capability). `raycast/` is mirrored into
-> `raycast/extensions`, so a change here needs a follow-up upstream sync.*
+> *Technical Note — sources: `raycast/src/lib/kesha-bin.ts::probeEngineAvailability`,
+> which spawns `kesha status --json` and branches on stdout kind:
+> `parseStatusObject` accepts only a JSON object, `readStructuredStatus` requires
+> `engine.installed` to be a boolean and treats a null `engine.capabilities` as
+> unusable, and `proseSaysEngineMissing` matches the legacy marker on the Binary
+> line. The verdict reaches the setup view through `EnginePreflightResult.reason`
+> (`"missing"` / `"unusable"`), which `dictation-controller.ts` maps to distinct
+> messages. `raycast/` is mirrored into `raycast/extensions`, so a change here
+> needs a follow-up upstream sync.*
 
 ## Open Issues
 
@@ -92,13 +96,6 @@ guards report the real problem with a better message than the probe could.
   those CLIs a corrupt Engine still reaches recording and fails during
   Transcription. This matches today's behaviour and is not a regression, but it
   means the broken-Engine guarantee holds only on the structured path.
-- The exact remedy for a corrupt Engine is unverified: `kesha install` has no
-  documented force/repair flag, so what the finish-setup view should tell Maks to
-  run — and whether a plain re-run of `kesha install` overwrites an existing
-  binary — needs to be established during implementation.
-- Distinguishing the broken-install view from the never-installed one needs a
-  change beyond the probe: `dictation-controller.ts:90` hardcodes a single
-  message (`"Kesha setup isn't finished yet."`) and varies only the hint.
 - "Readable capabilities" is a weaker guarantee than "Dictation will succeed": it
   says the Engine can describe itself, not that ASR models are present.
   `getEngineCapabilities` (`src/engine.ts:367`) casts parsed JSON without

--- a/openspec/changes/status-json-output/specs/raycast-extension/spec.md
+++ b/openspec/changes/status-json-output/specs/raycast-extension/spec.md
@@ -106,7 +106,7 @@ guards report the real problem with a better message than the probe could.
   Transcription. This matches today's behaviour and is not a regression, but it
   means the broken-Engine guarantee holds only on the structured path.
 - "Readable capabilities" is a weaker guarantee than "Dictation will succeed": it
-  says the Engine can describe itself, not that ASR models are present.
-  `getEngineCapabilities` (`src/engine.ts:367`) casts parsed JSON without
-  validating its shape, so a well-formed-but-wrong object counts as readable and
-  can still fail later. Closing that gap is a separate concern from this change.
+  says the Engine can describe itself, not that ASR models are present. The CLI
+  now validates the capabilities shape before reporting it, but the extension
+  keeps its own check because it meets whatever CLI version is on the machine,
+  including ones that predate that validation.

--- a/openspec/changes/status-json-output/specs/raycast-extension/spec.md
+++ b/openspec/changes/status-json-output/specs/raycast-extension/spec.md
@@ -1,0 +1,55 @@
+## MODIFIED Requirements
+
+### Requirement: Setup problems surface before recording
+
+Before entering the recording state, the extension SHALL probe the resolved CLI (version/engine availability) and, on failure, render a dedicated finish-setup view naming the exact remaining command instead of starting a recording that cannot succeed.
+
+The probe SHALL decide Engine availability from the CLI's machine-readable status
+output rather than by matching human-readable prose, so that rewording the CLI's
+status text cannot break a published extension. When the resolved CLI is older
+than the machine-readable output and therefore does not produce it, the probe
+SHALL fall back to the previous prose marker rather than reporting a broken
+install — the extension is distributed through the Raycast Store and cannot
+assume the CLI on a given machine matches it.
+
+A probe that cannot run at all SHALL continue to fail open, letting the CLI's own
+guards report the real problem with a better message than the probe could.
+
+#### Scenario: CLI present but engine not installed
+
+- **WHEN** Maks starts dictation with the CLI installed but `kesha install` never run
+- **THEN** a finish-setup view names `kesha install` before any recording toast appears
+
+#### Scenario: Engine present, structured probe succeeds
+
+- **GIVEN** the resolved CLI produces machine-readable status output and the Engine is installed
+- **WHEN** Maks starts a Dictation session
+- **THEN** the probe reports the Engine as available without inspecting any human-readable text
+- **AND** recording starts without a finish-setup view
+
+#### Scenario: Older CLI without machine-readable status
+
+- **GIVEN** the resolved CLI predates the machine-readable status output
+- **WHEN** Maks starts a Dictation session with no Engine installed
+- **THEN** the probe falls back to the prose marker and still renders the finish-setup view
+- **AND** an installed Engine on that same older CLI still starts recording normally
+
+#### Scenario: Probe cannot run
+
+- **WHEN** the resolved CLI cannot be spawned or exits unexpectedly during the probe
+- **THEN** the probe fails open and the Dictation session proceeds
+- **AND** any real problem is reported by the CLI's own error path
+
+> *Technical Note — sources: `raycast/src/lib/kesha-bin.ts::probeEngineAvailability`
+> (`raycast/src/lib/kesha-bin.ts:166-181`), which today spawns `kesha status` and tests
+> `stdout.includes("not installed")` (`:172`), returning the trimmed stderr as the hint.
+> The structured path reads the Engine-presence boolean and hint from `kesha status
+> --json` (see the `diagnostics` capability). `raycast/` is mirrored into
+> `raycast/extensions`, so a change here needs a follow-up upstream sync.*
+
+## Open Issues
+
+- The fallback path means the prose marker `"not installed"` in `kesha status`
+  stays a load-bearing string for as long as older CLIs are in the wild. There is
+  no agreed point at which the fallback can be dropped, and nothing fails loudly
+  if the marker is reworded while the fallback is still relied upon.

--- a/openspec/changes/status-json-output/specs/raycast-extension/spec.md
+++ b/openspec/changes/status-json-output/specs/raycast-extension/spec.md
@@ -15,7 +15,10 @@ will fail during Transcription. The finish-setup view SHALL distinguish this cas
 from a never-installed Engine in both its message and its hint, because the
 remedy differs: a plain `kesha install` takes the cached-engine path and only
 re-trusts an existing binary, so repairing one requires `kesha install
---no-cache`.
+--no-cache`. On a read-only engine directory (a Nix-store install) that flag is
+deliberately a no-op, and the probe cannot tell the two topologies apart, so the
+hint SHALL name both routes rather than promising a repair that would silently
+skip.
 
 When the resolved CLI is older than the machine-readable output and therefore
 does not produce it, the probe SHALL fall back to the previous prose marker

--- a/openspec/changes/status-json-output/specs/raycast-extension/spec.md
+++ b/openspec/changes/status-json-output/specs/raycast-extension/spec.md
@@ -21,6 +21,16 @@ SHALL fall back to the previous prose marker rather than reporting a broken
 install — the extension is distributed through the Raycast Store and cannot
 assume the CLI on a given machine matches it.
 
+The prose fallback SHALL be taken only when the output is not machine-readable at
+all. Output that is machine-readable but does not satisfy the contract SHALL be
+treated as unavailable, never passed to the prose fallback: a structured response
+missing the presence field would otherwise also fail the prose match and be
+reported as a healthy Engine. Failing closed here costs Maks a dismissible setup
+view; failing open costs him a Dictation session. The prose match SHALL be
+anchored to the Engine binary line rather than to the whole output, so an
+unrelated line rendered with the same missing-marker cannot be misread as the
+Engine being absent.
+
 A probe that cannot run at all SHALL continue to fail open, letting the CLI's own
 guards report the real problem with a better message than the probe could.
 
@@ -51,6 +61,13 @@ guards report the real problem with a better message than the probe could.
 - **THEN** the probe falls back to the prose marker and still renders the finish-setup view
 - **AND** an installed Engine on that same older CLI still starts recording normally
 
+#### Scenario: Structured output that breaks the contract
+
+- **GIVEN** the resolved CLI emits machine-readable output without the presence field
+- **WHEN** Maks starts a Dictation session
+- **THEN** the probe reports the Engine as unavailable rather than falling back to the prose match
+- **AND** no recording starts
+
 #### Scenario: Probe cannot run
 
 - **WHEN** the resolved CLI cannot be spawned or exits unexpectedly during the probe
@@ -79,3 +96,11 @@ guards report the real problem with a better message than the probe could.
   documented force/repair flag, so what the finish-setup view should tell Maks to
   run — and whether a plain re-run of `kesha install` overwrites an existing
   binary — needs to be established during implementation.
+- Distinguishing the broken-install view from the never-installed one needs a
+  change beyond the probe: `dictation-controller.ts:90` hardcodes a single
+  message (`"Kesha setup isn't finished yet."`) and varies only the hint.
+- "Readable capabilities" is a weaker guarantee than "Dictation will succeed": it
+  says the Engine can describe itself, not that ASR models are present.
+  `getEngineCapabilities` (`src/engine.ts:367`) casts parsed JSON without
+  validating its shape, so a well-formed-but-wrong object counts as readable and
+  can still fail later. Closing that gap is a separate concern from this change.

--- a/openspec/changes/status-json-output/tasks.md
+++ b/openspec/changes/status-json-output/tasks.md
@@ -46,10 +46,16 @@
 - [ ] 4.2 Keep the `stdout.includes("not installed")` match as the fallback taken
       when the parse throws or the boolean is absent
 - [ ] 4.3 Preserve the existing fail-open behavior when the spawn itself fails
-- [ ] 4.4 Test: structured path (engine present, engine absent)
-- [ ] 4.5 Test: fallback path with human-readable stdout from an older CLI —
+- [ ] 4.4 Treat present-with-null-capabilities as unavailable, with finish-setup
+      wording distinct from the never-installed case; establish what the repair
+      command actually is first (see the spec's Open Issue — `install` has no
+      documented force flag)
+- [ ] 4.5 Test: structured path (engine present, engine absent)
+- [ ] 4.6 Test: engine present but capabilities null → unavailable, repair wording,
+      no recording started
+- [ ] 4.7 Test: fallback path with human-readable stdout from an older CLI —
       both installed and not-installed cases
-- [ ] 4.6 Test: unparseable/empty stdout still fails open
+- [ ] 4.8 Test: unparseable/empty stdout still fails open
 
 ## 5. Docs and specs
 

--- a/openspec/changes/status-json-output/tasks.md
+++ b/openspec/changes/status-json-output/tasks.md
@@ -1,0 +1,71 @@
+## 1. Split collection from rendering
+
+- [ ] 1.1 Define the status payload type in `src/status.ts` — engine presence
+      boolean, binary path, backend / protocol version / features (nullable),
+      voices, Bun runtime, platform + arch, model mirror, hint, optional disk
+      breakdown
+- [ ] 1.2 Extract `collectStatus({ disk })` from `showStatus`, returning that
+      payload; move the Kokoro/Vosk enumeration, mirror resolution, and
+      capabilities probe into it unchanged
+- [ ] 1.3 Rewrite `showStatus` to take the payload as its only input and emit
+      today's exact lines — same wording, colors, ordering, and stderr hint
+- [ ] 1.4 Restructure `showDiskUsage` so the sizes are collected as data and the
+      table is formatted from it; keep the recursive walk behind the `disk` flag
+- [ ] 1.5 Verify byte-identical human output before/after by diffing captured
+      `kesha status` and `kesha status --disk` runs
+
+## 2. Wire the CLI flag
+
+- [ ] 2.1 Add the `json` boolean arg to `src/cli/status.ts`, mirroring
+      `src/cli/doctor.ts:16-32`
+- [ ] 2.2 Serialize the payload to stdout with `console.log(JSON.stringify(...))`
+      and return before any `log.*` call, so stdout carries only the object
+- [ ] 2.3 Suppress the stderr setup hint under `--json` (it ships in the payload)
+- [ ] 2.4 Confirm `--json --disk` includes the disk breakdown and plain `--json`
+      omits it
+
+## 3. CLI tests
+
+- [ ] 3.1 Test: engine installed → payload reports presence `true`, path,
+      backend, protocol version, features, and voice ids
+- [ ] 3.2 Test: engine absent → presence `false`, hint present in the payload,
+      hint absent from stderr, exit 0
+- [ ] 3.3 Test: capabilities probe fails while the binary exists → presence
+      `true` with backend / protocol / features null, exit 0
+- [ ] 3.4 Test: stdout under `--json` parses as exactly one object and contains
+      nothing else
+- [ ] 3.5 Test: `--disk` presence/absence toggles the disk section
+- [ ] 3.6 Test: human output still contains the `"not installed"` marker, with a
+      comment naming the Raycast probe fallback as its consumer (design's
+      mitigation for the load-bearing string)
+
+## 4. Raycast probe
+
+- [ ] 4.1 Rewrite `probeEngineAvailability` to spawn `kesha status --json`, parse
+      stdout, and read the engine-presence boolean and hint
+- [ ] 4.2 Keep the `stdout.includes("not installed")` match as the fallback taken
+      when the parse throws or the boolean is absent
+- [ ] 4.3 Preserve the existing fail-open behavior when the spawn itself fails
+- [ ] 4.4 Test: structured path (engine present, engine absent)
+- [ ] 4.5 Test: fallback path with human-readable stdout from an older CLI —
+      both installed and not-installed cases
+- [ ] 4.6 Test: unparseable/empty stdout still fails open
+
+## 5. Docs and specs
+
+- [ ] 5.1 Document `--json` in the README status section
+- [ ] 5.2 Run `/opsx:sync` to fold both delta specs into
+      `openspec/specs/diagnostics/spec.md` and
+      `openspec/specs/raycast-extension/spec.md`
+- [ ] 5.3 Carry the new Open Issues (no schema version field; prose marker still
+      load-bearing; `doctor`/`status` payload overlap unenforced) into the synced
+      specs
+
+## 6. Verification
+
+- [ ] 6.1 `bun test && bunx tsc --noEmit`
+- [ ] 6.2 Run the Raycast extension's own test suite under `raycast/`
+- [ ] 6.3 Manual check against a real install: `kesha status --json | jq .` with
+      the engine present, and with `KESHA_ENGINE_BIN` pointed at a missing path
+- [ ] 6.4 Open the PR with `Closes #647` in the body; note in the description
+      that the `raycast/extensions` mirror sync is a required follow-up

--- a/openspec/changes/status-json-output/tasks.md
+++ b/openspec/changes/status-json-output/tasks.md
@@ -1,9 +1,9 @@
 ## 1. Split collection from rendering
 
-- [ ] 1.1 Define the status payload type in `src/status.ts` — engine presence
-      boolean, binary path, backend / protocol version / features (nullable),
-      voices, Bun runtime, platform + arch, model mirror, hint, optional disk
-      breakdown
+- [ ] 1.1 Define the status payload type in `src/status.ts` to match the
+      normative example in design.md exactly — nested `engine.capabilities`
+      (one null, not three), every key always present, `voices: []` when empty,
+      `cliVersion`, `disk: null` without `--disk`
 - [ ] 1.2 Extract `collectStatus({ disk })` from `showStatus`, returning that
       payload; move the Kokoro/Vosk enumeration, mirror resolution, and
       capabilities probe into it unchanged
@@ -11,15 +11,17 @@
       today's exact lines — same wording, colors, ordering, and stderr hint
 - [ ] 1.4 Restructure `showDiskUsage` so the sizes are collected as data and the
       table is formatted from it; keep the recursive walk behind the `disk` flag
-- [ ] 1.5 Verify byte-identical human output before/after by diffing captured
-      `kesha status` and `kesha status --disk` runs
+- [ ] 1.5 Verify the human output still carries the same information before/after;
+      assert the `"not installed"` marker on the Binary line rather than diffing
+      bytes, which colors and TTY detection make brittle
 
 ## 2. Wire the CLI flag
 
 - [ ] 2.1 Add the `json` boolean arg to `src/cli/status.ts`, mirroring
       `src/cli/doctor.ts:16-32`
-- [ ] 2.2 Serialize the payload to stdout with `console.log(JSON.stringify(...))`
-      and return before any `log.*` call, so stdout carries only the object
+- [ ] 2.2 Serialize with `JSON.stringify(payload, null, 2)` (matching `doctor`
+      and `logs`) and return before any `log.*` call — `log.info` writes to
+      stdout (`src/log.ts:46`), so a stray call corrupts the payload
 - [ ] 2.3 Suppress the stderr setup hint under `--json` (it ships in the payload)
 - [ ] 2.4 Confirm `--json --disk` includes the disk breakdown and plain `--json`
       omits it
@@ -33,9 +35,11 @@
 - [ ] 3.3 Test: capabilities probe fails while the binary exists → presence
       `true` with backend / protocol / features null, exit 0
 - [ ] 3.4 Test: stdout under `--json` parses as exactly one object and contains
-      nothing else
-- [ ] 3.5 Test: `--disk` presence/absence toggles the disk section
-- [ ] 3.6 Test: human output still contains the `"not installed"` marker, with a
+      no other bytes
+- [ ] 3.5 Test: `--json --disk` with no engine reports the disk breakdown as null
+      without walking the cache
+- [ ] 3.6 Test: `--disk` presence/absence toggles the disk section
+- [ ] 3.7 Test: human output still contains the `"not installed"` marker, with a
       comment naming the Raycast probe fallback as its consumer (design's
       mitigation for the load-bearing string)
 
@@ -43,19 +47,26 @@
 
 - [ ] 4.1 Rewrite `probeEngineAvailability` to spawn `kesha status --json`, parse
       stdout, and read the engine-presence boolean and hint
-- [ ] 4.2 Keep the `stdout.includes("not installed")` match as the fallback taken
-      when the parse throws or the boolean is absent
+- [ ] 4.2 Keep the `stdout.includes("not installed")` match as the fallback, taken
+      when stdout is not JSON at all — not when it parses but breaks the contract
+      (see 4.5)
 - [ ] 4.3 Preserve the existing fail-open behavior when the spawn itself fails
 - [ ] 4.4 Treat present-with-null-capabilities as unavailable, with finish-setup
       wording distinct from the never-installed case; establish what the repair
       command actually is first (see the spec's Open Issue — `install` has no
       documented force flag)
-- [ ] 4.5 Test: structured path (engine present, engine absent)
-- [ ] 4.6 Test: engine present but capabilities null → unavailable, repair wording,
-      no recording started
-- [ ] 4.7 Test: fallback path with human-readable stdout from an older CLI —
-      both installed and not-installed cases
-- [ ] 4.8 Test: unparseable/empty stdout still fails open
+- [ ] 4.5 Take the prose fallback only for non-JSON stdout; JSON whose `installed`
+      is not a boolean is a contract error → unavailable, never prose
+- [ ] 4.6 Anchor the prose match to the Binary line instead of whole-stdout
+- [ ] 4.7 Vary the finish-setup message, not just the hint, in
+      `raycast/src/lib/dictation-controller.ts:90` — it currently hardcodes one
+      message for every preflight failure
+- [ ] 4.8 Cover the full probe matrix with tests, one case per row of the table in
+      design.md: contract JSON installed / not installed / caps-null; non-JSON
+      with and without the marker; JSON with a wrong shape; empty and garbage
+      stdout; spawn throw with and without an install hint on stderr
+- [ ] 4.9 Tests live in `raycast/tests/kesha-bin.test.ts` and
+      `raycast/tests/dictation-controller.test.ts`
 
 ## 5. Docs and specs
 
@@ -63,9 +74,10 @@
 - [ ] 5.2 Run `/opsx:sync` to fold both delta specs into
       `openspec/specs/diagnostics/spec.md` and
       `openspec/specs/raycast-extension/spec.md`
-- [ ] 5.3 Carry the new Open Issues (no schema version field; prose marker still
-      load-bearing; `doctor`/`status` payload overlap unenforced) into the synced
-      specs
+- [ ] 5.3 Carry the new Open Issues into the synced specs: prose marker still
+      load-bearing; `doctor`/`status` payload overlap unenforced; repair command
+      unverified; controller message hardcoded; capabilities readable ≠ dictation
+      will succeed
 
 ## 6. Verification
 

--- a/openspec/changes/status-json-output/tasks.md
+++ b/openspec/changes/status-json-output/tasks.md
@@ -1,89 +1,92 @@
 ## 1. Split collection from rendering
 
-- [ ] 1.1 Define the status payload type in `src/status.ts` to match the
+- [x] 1.1 Define the status payload type in `src/status.ts` to match the
       normative example in design.md exactly — nested `engine.capabilities`
       (one null, not three), every key always present, `voices: []` when empty,
       `cliVersion`, `disk: null` without `--disk`
-- [ ] 1.2 Extract `collectStatus({ disk })` from `showStatus`, returning that
+- [x] 1.2 Extract `collectStatus({ disk })` from `showStatus`, returning that
       payload; move the Kokoro/Vosk enumeration, mirror resolution, and
       capabilities probe into it unchanged
-- [ ] 1.3 Rewrite `showStatus` to take the payload as its only input and emit
+- [x] 1.3 Rewrite `showStatus` to take the payload as its only input and emit
       today's exact lines — same wording, colors, ordering, and stderr hint
-- [ ] 1.4 Restructure `showDiskUsage` so the sizes are collected as data and the
+- [x] 1.4 Restructure `showDiskUsage` so the sizes are collected as data and the
       table is formatted from it; keep the recursive walk behind the `disk` flag
-- [ ] 1.5 Verify the human output still carries the same information before/after;
+- [x] 1.5 Verify the human output still carries the same information before/after;
       assert the `"not installed"` marker on the Binary line rather than diffing
       bytes, which colors and TTY detection make brittle
 
 ## 2. Wire the CLI flag
 
-- [ ] 2.1 Add the `json` boolean arg to `src/cli/status.ts`, mirroring
+- [x] 2.1 Add the `json` boolean arg to `src/cli/status.ts`, mirroring
       `src/cli/doctor.ts:16-32`
-- [ ] 2.2 Serialize with `JSON.stringify(payload, null, 2)` (matching `doctor`
+- [x] 2.2 Serialize with `JSON.stringify(payload, null, 2)` (matching `doctor`
       and `logs`) and return before any `log.*` call — `log.info` writes to
       stdout (`src/log.ts:46`), so a stray call corrupts the payload
-- [ ] 2.3 Suppress the stderr setup hint under `--json` (it ships in the payload)
-- [ ] 2.4 Confirm `--json --disk` includes the disk breakdown and plain `--json`
+- [x] 2.3 Suppress the stderr setup hint under `--json` (it ships in the payload)
+- [x] 2.4 Confirm `--json --disk` includes the disk breakdown and plain `--json`
       omits it
 
 ## 3. CLI tests
 
-- [ ] 3.1 Test: engine installed → payload reports presence `true`, path,
+- [x] 3.1 Test: engine installed → payload reports presence `true`, path,
       backend, protocol version, features, and voice ids
-- [ ] 3.2 Test: engine absent → presence `false`, hint present in the payload,
+- [x] 3.2 Test: engine absent → presence `false`, hint present in the payload,
       hint absent from stderr, exit 0
-- [ ] 3.3 Test: capabilities probe fails while the binary exists → presence
+- [x] 3.3 Test: capabilities probe fails while the binary exists → presence
       `true` with backend / protocol / features null, exit 0
-- [ ] 3.4 Test: stdout under `--json` parses as exactly one object and contains
+- [x] 3.4 Test: stdout under `--json` parses as exactly one object and contains
       no other bytes
-- [ ] 3.5 Test: `--json --disk` with no engine reports the disk breakdown as null
+- [x] 3.5 Test: `--json --disk` with no engine reports the disk breakdown as null
       without walking the cache
-- [ ] 3.6 Test: `--disk` presence/absence toggles the disk section
-- [ ] 3.7 Test: human output still contains the `"not installed"` marker, with a
+- [x] 3.6 Test: `--disk` presence/absence toggles the disk section
+- [x] 3.7 Test: human output still contains the `"not installed"` marker, with a
       comment naming the Raycast probe fallback as its consumer (design's
       mitigation for the load-bearing string)
 
 ## 4. Raycast probe
 
-- [ ] 4.1 Rewrite `probeEngineAvailability` to spawn `kesha status --json`, parse
+- [x] 4.1 Rewrite `probeEngineAvailability` to spawn `kesha status --json`, parse
       stdout, and read the engine-presence boolean and hint
-- [ ] 4.2 Keep the `stdout.includes("not installed")` match as the fallback, taken
+- [x] 4.2 Keep the `stdout.includes("not installed")` match as the fallback, taken
       when stdout is not JSON at all — not when it parses but breaks the contract
       (see 4.5)
-- [ ] 4.3 Preserve the existing fail-open behavior when the spawn itself fails
-- [ ] 4.4 Treat present-with-null-capabilities as unavailable, with finish-setup
+- [x] 4.3 Preserve the existing fail-open behavior when the spawn itself fails
+- [x] 4.4 Treat present-with-null-capabilities as unavailable, with finish-setup
       wording distinct from the never-installed case; establish what the repair
       command actually is first (see the spec's Open Issue — `install` has no
       documented force flag)
-- [ ] 4.5 Take the prose fallback only for non-JSON stdout; JSON whose `installed`
+- [x] 4.5 Take the prose fallback only for non-JSON stdout; JSON whose `installed`
       is not a boolean is a contract error → unavailable, never prose
-- [ ] 4.6 Anchor the prose match to the Binary line instead of whole-stdout
-- [ ] 4.7 Vary the finish-setup message, not just the hint, in
+- [x] 4.6 Anchor the prose match to the Binary line instead of whole-stdout
+- [x] 4.7 Vary the finish-setup message, not just the hint, in
       `raycast/src/lib/dictation-controller.ts:90` — it currently hardcodes one
       message for every preflight failure
-- [ ] 4.8 Cover the full probe matrix with tests, one case per row of the table in
+- [x] 4.8 Cover the full probe matrix with tests, one case per row of the table in
       design.md: contract JSON installed / not installed / caps-null; non-JSON
       with and without the marker; JSON with a wrong shape; empty and garbage
       stdout; spawn throw with and without an install hint on stderr
-- [ ] 4.9 Tests live in `raycast/tests/kesha-bin.test.ts` and
+- [x] 4.9 Tests live in `raycast/tests/kesha-bin.test.ts` and
       `raycast/tests/dictation-controller.test.ts`
 
 ## 5. Docs and specs
 
-- [ ] 5.1 Document `--json` in the README status section
-- [ ] 5.2 Run `/opsx:sync` to fold both delta specs into
+- [x] 5.1 Document `--json` in the README status section
+- [x] 5.2 Run `/opsx:sync` to fold both delta specs into
       `openspec/specs/diagnostics/spec.md` and
       `openspec/specs/raycast-extension/spec.md`
-- [ ] 5.3 Carry the new Open Issues into the synced specs: prose marker still
+- [x] 5.3 Carry the new Open Issues into the synced specs: prose marker still
       load-bearing; `doctor`/`status` payload overlap unenforced; repair command
       unverified; controller message hardcoded; capabilities readable ≠ dictation
       will succeed
 
 ## 6. Verification
 
-- [ ] 6.1 `bun test && bunx tsc --noEmit`
-- [ ] 6.2 Run the Raycast extension's own test suite under `raycast/`
-- [ ] 6.3 Manual check against a real install: `kesha status --json | jq .` with
-      the engine present, and with `KESHA_ENGINE_BIN` pointed at a missing path
-- [ ] 6.4 Open the PR with `Closes #647` in the body; note in the description
+- [x] 6.1 `bun test && bunx tsc --noEmit`
+- [x] 6.2 Run the Raycast extension's own test suite under `raycast/`
+- [~] 6.3 Manual check: the missing-engine path was exercised end-to-end
+      (`--json`, `--json --disk`, exit 0, empty stderr). The engine-present path
+      was NOT run against a real install — no engine on this machine — and is
+      covered only by unit tests driving a fake `--capabilities-json` binary.
+      Worth one real run before the mirror sync.
+- [x] 6.4 Open the PR with `Closes #647` in the body; note in the description
       that the `raycast/extensions` mirror sync is a required follow-up

--- a/openspec/specs/diagnostics/spec.md
+++ b/openspec/specs/diagnostics/spec.md
@@ -93,6 +93,36 @@ When the Engine is not installed, `kesha status` prints an actionable setup hint
 (`kesha init` on an interactive TTY, `kesha install` when stderr is piped) and
 exits 0.
 
+`--json` SHALL replace the human-readable rendering with a single JSON object on
+stdout and SHALL print nothing else to stdout. The object SHALL report, at minimum:
+Engine presence as a boolean, the resolved Engine binary path, Backend, protocol
+version, and features, the installed TTS Voice ids, the Bun runtime version, the
+platform and architecture, the active Model mirror, and — when the Engine is
+absent — the same setup hint the human path writes to stderr.
+
+The presence boolean SHALL report only that the Engine binary exists, not that it
+is usable. Backend, protocol version, and features SHALL be grouped under a single
+nested capabilities value so that a binary which cannot report them yields one
+null rather than three, making "can the Engine run" a single check; consumers
+deciding that SHALL require presence AND non-null capabilities. Consumers SHALL be
+able to reach both conclusions from these fields without matching any
+human-readable prose.
+
+Every documented key SHALL be present in every payload: absent values are null
+(or the empty list for Voice ids), never omitted, so a consumer never has to tell
+a missing key apart from a null value. The payload SHALL also carry the CLI
+version, so a consumer that needs to distinguish payload shapes has the version
+to key off without a second invocation.
+
+Under `--json` the setup hint SHALL NOT also be written to stderr, because it is
+carried in the payload; `--json --disk` SHALL include the per-component disk
+breakdown as structured data, and plain `--json` SHALL omit it, mirroring the
+human flag's scope. When the Engine is absent, `--json --disk` SHALL report the
+disk breakdown as null rather than walking the Model cache, matching the human
+path, which computes disk usage only when the Engine is installed. Both modes SHALL derive their content from one collector, so
+the two renderings can never disagree. `--json` SHALL exit 0 whether or not the
+Engine is installed, matching the human path.
+
 #### Scenario: Ira checks install state in a script
 
 - GIVEN the Engine and ASR models are installed with TTS English
@@ -113,15 +143,54 @@ exits 0.
 - WHEN Ira runs `kesha status`
 - THEN the output shows a red cross for the Engine binary
 - AND an actionable setup hint is printed — `kesha init` on an interactive TTY,
-  `kesha install` when stderr is piped (`installHint()`, `src/status.ts:86`)
+  `kesha install` when stderr is piped (`installHint()`, `src/status.ts:88`)
 - AND the process exits 0
+
+#### Scenario: Ira asks for disk usage with no Engine installed
+
+- GIVEN no Engine is installed
+- WHEN Ira runs `kesha status --json --disk`
+- THEN the disk breakdown is reported as null and the Model cache is not walked
+- AND the process exits 0
+
+#### Scenario: Ira branches on install state without parsing prose
+
+- GIVEN the Engine is installed
+- WHEN Ira runs `kesha status --json`
+- THEN stdout parses as a single JSON object and contains nothing else
+- AND the object reports Engine presence as `true`, the binary path, the Backend,
+  the protocol version, the features, and the installed TTS Voice ids
+- AND the process exits 0
+
+#### Scenario: Engine missing under `--json`
+
+- GIVEN no Engine is installed
+- WHEN Ira runs `kesha status --json`
+- THEN the object reports Engine presence as `false` and carries the same
+  actionable setup hint the human path writes to stderr
+- AND stderr does not repeat that hint
+- AND the process exits 0
+
+#### Scenario: Capabilities probe fails under `--json`
+
+- GIVEN the Engine binary exists but `--capabilities-json` cannot be read
+  (corrupt or incompatible binary)
+- WHEN Ira runs `kesha status --json`
+- THEN Engine presence is reported as `true` while the capabilities value is null
+  rather than omitted or guessed
+- AND a consumer reading presence together with the null capabilities can tell
+  this apart from both a healthy Engine and a missing one
+- AND the process exits 0, matching the human path's "probe failed" line
 
 > *Technical Note — sources: `src/status.ts::showStatus`, `src/status.ts::showDiskUsage`,
 > `src/cli/status.ts::statusCommand`. TTS voice enumeration reads `kokoro-82m/voices/*.bin`
 > (prefixed `en-`) and checks `vosk-ru/model.onnx` + `vosk-ru/bert/model.onnx` presence
 > (voices `ru-vosk-f01`, `ru-vosk-f02`, `ru-vosk-f03`, `ru-vosk-m01`, `ru-vosk-m02`).
 > `activeModelMirror()` trims and strips trailing slashes from `KESHA_MODEL_MIRROR`;
-> returns null when unset or empty.*
+> returns null when unset or empty. Capabilities come from
+> `src/engine.ts::getEngineCapabilities` (`src/engine.ts:348`), which returns null on a
+> failed or unparseable probe — that null is what the payload reports. The `--json`
+> flag follows the `doctor` precedent at `src/cli/doctor.ts:16-32`.*
 
 ### Requirement: `kesha logs` manages privacy-safe NDJSON Diagnostic logs
 
@@ -359,3 +428,10 @@ as invariants, not options:
   the only way to include log contents is via `kesha support-bundle --include-logs`.
 - `kesha stats` has no `--json` flag on `status`; machine-readable stats output
   requires `export --format json`.
+- The payload carries the CLI version but no separate schema version: consumers
+  are expected to tolerate additive growth and to key off the CLI version when
+  they need to distinguish shapes. Whether that holds once a second consumer
+  beyond the Raycast extension exists is unresolved.
+- `kesha doctor --json` and `kesha status --json` overlap in what they report but
+  do not share a payload type; keeping them consistent is currently a convention,
+  not something a test enforces.

--- a/openspec/specs/raycast-extension/spec.md
+++ b/openspec/specs/raycast-extension/spec.md
@@ -400,7 +400,10 @@ will fail during Transcription. The finish-setup view SHALL distinguish this cas
 from a never-installed Engine in both its message and its hint, because the
 remedy differs: a plain `kesha install` takes the cached-engine path and only
 re-trusts an existing binary, so repairing one requires `kesha install
---no-cache`.
+--no-cache`. On a read-only engine directory (a Nix-store install) that flag is
+deliberately a no-op, and the probe cannot tell the two topologies apart, so the
+hint SHALL name both routes rather than promising a repair that would silently
+skip.
 
 When the resolved CLI is older than the machine-readable output and therefore
 does not produce it, the probe SHALL fall back to the previous prose marker

--- a/openspec/specs/raycast-extension/spec.md
+++ b/openspec/specs/raycast-extension/spec.md
@@ -411,11 +411,16 @@ rather than reporting a broken install — the extension is distributed through 
 assume the CLI on a given machine matches it.
 
 The prose fallback SHALL be taken only when the output is not machine-readable at
-all. Output that is machine-readable but does not satisfy the contract SHALL be
-treated as unavailable, never passed to the prose fallback: a structured response
-missing the presence field would otherwise also fail the prose match and be
-reported as a healthy Engine. Failing closed here costs Maks a dismissible setup
-view; failing open costs him a Dictation session. The prose match SHALL be
+all, and only when that output is recognisably a status report; unrecognisable
+output SHALL fail open rather than be searched for loose text. Output that is
+machine-readable but does not satisfy the contract SHALL be treated as
+unavailable, never passed to the prose fallback: a structured response missing
+the presence field would otherwise also fail the prose match and be reported as a
+healthy Engine. Failing closed here costs Maks a dismissible setup view; failing
+open costs him a Dictation session. A contract failure SHALL be reported as a
+version mismatch between CLI and extension rather than as a broken Engine, since
+re-downloading the Engine would not resolve it. Readable capabilities SHALL mean
+a non-empty structured value, not merely a non-null one. The prose match SHALL be
 anchored to the Engine binary line rather than to the whole output, so an
 unrelated line rendered with the same missing-marker cannot be misread as the
 Engine being absent.
@@ -455,6 +460,7 @@ guards report the real problem with a better message than the probe could.
 - **GIVEN** the resolved CLI emits machine-readable output without the presence field
 - **WHEN** Maks starts a Dictation session
 - **THEN** the probe reports the Engine as unavailable rather than falling back to the prose match
+- **AND** the setup view names a CLI/extension version mismatch, not a broken Engine
 - **AND** no recording starts
 
 #### Scenario: Probe cannot run

--- a/openspec/specs/raycast-extension/spec.md
+++ b/openspec/specs/raycast-extension/spec.md
@@ -386,11 +386,89 @@ Every error state SHALL render an ActionPanel with at least: copy the error text
 - **THEN** the user can copy the error, open preferences, or open the setup guide without leaving Raycast
 
 ### Requirement: Setup problems surface before recording
+
 Before entering the recording state, the extension SHALL probe the resolved CLI (version/engine availability) and, on failure, render a dedicated finish-setup view naming the exact remaining command instead of starting a recording that cannot succeed.
 
+The probe SHALL decide Engine availability from the CLI's machine-readable status
+output rather than by matching human-readable prose, so that rewording the CLI's
+status text cannot break a published extension.
+
+Engine availability SHALL mean present AND reporting readable capabilities. An
+Engine binary that exists but cannot report its capabilities is unusable, and the
+probe SHALL treat it as unavailable rather than starting a Dictation session that
+will fail during Transcription. The finish-setup view SHALL distinguish this case
+from a never-installed Engine in both its message and its hint, because the
+remedy differs: a plain `kesha install` takes the cached-engine path and only
+re-trusts an existing binary, so repairing one requires `kesha install
+--no-cache`.
+
+When the resolved CLI is older than the machine-readable output and therefore
+does not produce it, the probe SHALL fall back to the previous prose marker
+rather than reporting a broken install — the extension is distributed through the Raycast Store and cannot
+assume the CLI on a given machine matches it.
+
+The prose fallback SHALL be taken only when the output is not machine-readable at
+all. Output that is machine-readable but does not satisfy the contract SHALL be
+treated as unavailable, never passed to the prose fallback: a structured response
+missing the presence field would otherwise also fail the prose match and be
+reported as a healthy Engine. Failing closed here costs Maks a dismissible setup
+view; failing open costs him a Dictation session. The prose match SHALL be
+anchored to the Engine binary line rather than to the whole output, so an
+unrelated line rendered with the same missing-marker cannot be misread as the
+Engine being absent.
+
+A probe that cannot run at all SHALL continue to fail open, letting the CLI's own
+guards report the real problem with a better message than the probe could.
+
 #### Scenario: CLI present but engine not installed
-- **WHEN** the user starts dictation with the CLI installed but `kesha install` never run
+
+- **WHEN** Maks starts dictation with the CLI installed but `kesha install` never run
 - **THEN** a finish-setup view names `kesha install` before any recording toast appears
+
+#### Scenario: Engine present, structured probe succeeds
+
+- **GIVEN** the resolved CLI produces machine-readable status output and the Engine is installed
+- **WHEN** Maks starts a Dictation session
+- **THEN** the probe reports the Engine as available without inspecting any human-readable text
+- **AND** recording starts without a finish-setup view
+
+#### Scenario: Engine present but unusable
+
+- **GIVEN** the Engine binary exists but cannot report its capabilities (corrupt or incompatible)
+- **WHEN** Maks starts a Dictation session
+- **THEN** the probe reports the Engine as unavailable despite it being present
+- **AND** the finish-setup view names repairing the install, distinct from the never-installed wording
+- **AND** no recording starts
+
+#### Scenario: Older CLI without machine-readable status
+
+- **GIVEN** the resolved CLI predates the machine-readable status output
+- **WHEN** Maks starts a Dictation session with no Engine installed
+- **THEN** the probe falls back to the prose marker and still renders the finish-setup view
+- **AND** an installed Engine on that same older CLI still starts recording normally
+
+#### Scenario: Structured output that breaks the contract
+
+- **GIVEN** the resolved CLI emits machine-readable output without the presence field
+- **WHEN** Maks starts a Dictation session
+- **THEN** the probe reports the Engine as unavailable rather than falling back to the prose match
+- **AND** no recording starts
+
+#### Scenario: Probe cannot run
+
+- **WHEN** the resolved CLI cannot be spawned or exits unexpectedly during the probe
+- **THEN** the probe fails open and the Dictation session proceeds
+- **AND** any real problem is reported by the CLI's own error path
+
+> *Technical Note — sources: `raycast/src/lib/kesha-bin.ts::probeEngineAvailability`,
+> which spawns `kesha status --json` and branches on stdout kind:
+> `parseStatusObject` accepts only a JSON object, `readStructuredStatus` requires
+> `engine.installed` to be a boolean and treats a null `engine.capabilities` as
+> unusable, and `proseSaysEngineMissing` matches the legacy marker on the Binary
+> line. The verdict reaches the setup view through `EnginePreflightResult.reason`
+> (`"missing"` / `"unusable"`), which `dictation-controller.ts` maps to distinct
+> messages. `raycast/` is mirrored into `raycast/extensions`, so a change here
+> needs a follow-up upstream sync.*
 
 ### Requirement: Missing microphone input is reported early
 When the signal meter delivers no sample within a short window (~8 s) of recording start, the extension SHALL surface microphone-permission guidance as a non-blocking warning while recording continues — a meter failure alone MUST NOT abort a session that may still be capturing audio. An unavailable meter MUST NOT disarm the silence auto-stop, so a session without input ends at the idle stop instead of the maximum duration.
@@ -434,3 +512,17 @@ When the signal meter delivers no sample within a short window (~8 s) of recordi
   `raycast/extensions`; the divergence that produced PR
   raycast/extensions#29681 (review fixes landing upstream only) has no automated
   guard.
+- The fallback path means the prose marker `"not installed"` in `kesha status`
+  stays a load-bearing string for as long as older CLIs are in the wild. There is
+  no agreed point at which the fallback can be dropped, and nothing fails loudly
+  if the marker is reworded while the fallback is still relied upon.
+- The prose fallback cannot detect a present-but-unusable Engine: an older CLI's
+  human output says "probe failed" on a line the marker match does not read, so on
+  those CLIs a corrupt Engine still reaches recording and fails during
+  Transcription. This matches today's behaviour and is not a regression, but it
+  means the broken-Engine guarantee holds only on the structured path.
+- "Readable capabilities" is a weaker guarantee than "Dictation will succeed": it
+  says the Engine can describe itself, not that ASR models are present.
+  `getEngineCapabilities` (`src/engine.ts:367`) casts parsed JSON without
+  validating its shape, so a well-formed-but-wrong object counts as readable and
+  can still fail later. Closing that gap is a separate concern from this change.

--- a/openspec/specs/raycast-extension/spec.md
+++ b/openspec/specs/raycast-extension/spec.md
@@ -531,7 +531,7 @@ When the signal meter delivers no sample within a short window (~8 s) of recordi
   Transcription. This matches today's behaviour and is not a regression, but it
   means the broken-Engine guarantee holds only on the structured path.
 - "Readable capabilities" is a weaker guarantee than "Dictation will succeed": it
-  says the Engine can describe itself, not that ASR models are present.
-  `getEngineCapabilities` (`src/engine.ts:367`) casts parsed JSON without
-  validating its shape, so a well-formed-but-wrong object counts as readable and
-  can still fail later. Closing that gap is a separate concern from this change.
+  says the Engine can describe itself, not that ASR models are present. The CLI
+  now validates the capabilities shape before reporting it, but the extension
+  keeps its own check because it meets whatever CLI version is on the machine,
+  including ones that predate that validation.

--- a/raycast/CHANGELOG.md
+++ b/raycast/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Kesha Voice Kit Changelog
 
+## [Sturdier setup detection] - {PR_MERGE_DATE}
+
+- Detect whether the engine is installed from the CLI's machine-readable status output instead of matching its wording, so a reworded CLI message can no longer be mistaken for a broken install. Older CLIs keep working through the previous check.
+- Refuse to start a session when the engine is installed but cannot run, instead of recording audio that could never be transcribed, and say how to repair it.
+- Tell a CLI/extension version mismatch apart from a broken engine, so the suggested fix matches the actual problem.
+
 ## [Setup guidance and faster failure feedback] - 2026-07-27
 
 - Rewrite the "kesha CLI not found" message as numbered setup steps, leading with Homebrew so the guidance works without knowing about bun, and include the required `kesha install` step.

--- a/raycast/src/lib/dictation-controller.ts
+++ b/raycast/src/lib/dictation-controller.ts
@@ -87,12 +87,7 @@ export function startDictationSession(
       if (!preflight.ok) {
         setState({
           status: "error",
-          // Repairing a broken install is a different instruction from doing a
-          // first one, so the message tracks the reason, not just the hint (#647).
-          message:
-            preflight.reason === "unusable"
-              ? "Kesha's engine is installed but not working."
-              : "Kesha setup isn't finished yet.",
+          message: preflightMessage(preflight.reason),
           hint: preflight.hint ?? notFoundMessage(),
         });
         return;
@@ -250,6 +245,20 @@ export function startDictationSession(
     stopMonitoring = null;
     stopTranscribeTimer?.();
     stopTranscribeTimer = null;
+  }
+}
+
+// Each reason has its own remedy, so the headline tracks it: re-downloading a
+// broken engine, finishing a first install, and upgrading a version-skewed CLI
+// are three different instructions (#647).
+function preflightMessage(reason: EnginePreflightResult["reason"]): string {
+  switch (reason) {
+    case "unusable":
+      return "Kesha's engine is installed but not working.";
+    case "contract":
+      return "Kesha CLI and this extension are out of sync.";
+    default:
+      return "Kesha setup isn't finished yet.";
   }
 }
 

--- a/raycast/src/lib/dictation-controller.ts
+++ b/raycast/src/lib/dictation-controller.ts
@@ -87,7 +87,12 @@ export function startDictationSession(
       if (!preflight.ok) {
         setState({
           status: "error",
-          message: "Kesha setup isn't finished yet.",
+          // Repairing a broken install is a different instruction from doing a
+          // first one, so the message tracks the reason, not just the hint (#647).
+          message:
+            preflight.reason === "unusable"
+              ? "Kesha's engine is installed but not working."
+              : "Kesha setup isn't finished yet.",
           hint: preflight.hint ?? notFoundMessage(),
         });
         return;

--- a/raycast/src/lib/kesha-bin.ts
+++ b/raycast/src/lib/kesha-bin.ts
@@ -149,34 +149,109 @@ export interface ProbeDeps {
 export interface EnginePreflightResult {
   ok: boolean;
   hint?: string;
+  /** Why the engine is unusable — lets the setup view name the right remedy (#647). */
+  reason?: "missing" | "unusable";
 }
 
-function runKesha(spawn: KeshaSpawn, verb: string, deps: ProbeDeps) {
+const MISSING_ENGINE_MARKER = "not installed";
+// A corrupt binary is not repaired by a plain `kesha install`: that hits the
+// cached-engine path and only re-trusts it. `--no-cache` forces the re-download
+// (`cacheValid = versionMatches && (!noCache || !canWriteEngineDir)`).
+const REPAIR_HINT = "Run `kesha install --no-cache` to re-download the engine.";
+
+function runKesha(spawn: KeshaSpawn, args: string[], deps: ProbeDeps) {
   const run = deps.execFile ?? execFileAsync;
-  return run(spawn.command, [...spawn.prefixArgs, verb], {
+  return run(spawn.command, [...spawn.prefixArgs, ...args], {
     timeout: PROBE_TIMEOUT_MS,
   });
 }
 
-// `kesha status` marks a missing engine as "not installed" on stdout and warns
-// on stderr with the exact remaining setup command (`installHint()`). Keying
-// off the stdout marker keeps unrelated stderr (KESHA_DEBUG traces, warnings)
-// from failing a healthy install; a probe that cannot run at all fails open —
-// the CLI's own guards report the real problem with a better message.
+function parseStatusObject(stdout: string): Record<string, unknown> | null {
+  const trimmed = stdout.trim();
+  if (!trimmed.startsWith("{")) return null;
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+// Anchored to the Binary line rather than the whole output: "not installed" is
+// `formatStatusLine`'s default missing label, so a future missing line would
+// otherwise read as the engine being absent.
+function proseSaysEngineMissing(stdout: string): boolean {
+  const binaryLine = stdout
+    .split("\n")
+    .find((line) => line.includes("Binary:"));
+  if (binaryLine) return binaryLine.includes(MISSING_ENGINE_MARKER);
+  return stdout.includes(MISSING_ENGINE_MARKER);
+}
+
+function readStructuredStatus(
+  payload: Record<string, unknown>,
+): EnginePreflightResult | null {
+  const engine = payload.engine;
+  if (!engine || typeof engine !== "object") return null;
+  const { installed, capabilities } = engine as Record<string, unknown>;
+  if (typeof installed !== "boolean") return null;
+
+  if (!installed) {
+    const hint = typeof payload.hint === "string" ? payload.hint.trim() : "";
+    return { ok: false, reason: "missing", hint: hint || undefined };
+  }
+  // Present is not usable: a binary that cannot report its capabilities would
+  // fail during transcription, after the recording is already gone (#647).
+  if (capabilities === null || capabilities === undefined) {
+    return { ok: false, reason: "unusable", hint: REPAIR_HINT };
+  }
+  return { ok: true };
+}
+
+/**
+ * Decides whether the engine can run before a session starts.
+ *
+ * Reads `kesha status --json` when the resolved CLI emits it. A CLI too old for
+ * that flag prints human text instead (citty ignores unknown flags), which is
+ * the signal to fall back to the prose marker — so the fallback is chosen by
+ * stdout *kind*, never by parse outcome. Output that is a JSON object but
+ * breaks the contract fails closed: it would also miss the prose marker and be
+ * reported as healthy. A probe that cannot run at all still fails open, letting
+ * the CLI's own guards report the real problem with a better message.
+ */
 export async function probeEngineAvailability(
   spawn: KeshaSpawn,
   deps: ProbeDeps = {},
 ): Promise<EnginePreflightResult> {
   try {
-    const { stdout, stderr } = await runKesha(spawn, "status", deps);
-    if (!stdout.includes("not installed")) return { ok: true };
-    return { ok: false, hint: stderr.trim() || undefined };
+    const { stdout, stderr } = await runKesha(
+      spawn,
+      ["status", "--json"],
+      deps,
+    );
+    const payload = parseStatusObject(stdout);
+    if (payload) {
+      return (
+        readStructuredStatus(payload) ?? {
+          ok: false,
+          reason: "unusable",
+          hint: REPAIR_HINT,
+        }
+      );
+    }
+    if (proseSaysEngineMissing(stdout)) {
+      return { ok: false, reason: "missing", hint: stderr.trim() || undefined };
+    }
+    return { ok: true };
   } catch (err) {
     const stderr =
       err && typeof err === "object" && "stderr" in err
         ? String((err as { stderr?: unknown }).stderr ?? "").trim()
         : "";
-    if (stderr.includes("kesha install")) return { ok: false, hint: stderr };
+    if (stderr.includes("kesha install"))
+      return { ok: false, reason: "missing", hint: stderr };
     return { ok: true };
   }
 }

--- a/raycast/src/lib/kesha-bin.ts
+++ b/raycast/src/lib/kesha-bin.ts
@@ -149,8 +149,12 @@ export interface ProbeDeps {
 export interface EnginePreflightResult {
   ok: boolean;
   hint?: string;
-  /** Why the engine is unusable — lets the setup view name the right remedy (#647). */
-  reason?: "missing" | "unusable";
+  /**
+   * Why the engine is unavailable — lets the setup view name the right remedy.
+   * `contract` is a CLI/extension version skew, not a broken engine: sending
+   * those users to re-download would fix nothing (#647).
+   */
+  reason?: "missing" | "unusable" | "contract";
 }
 
 const MISSING_ENGINE_MARKER = "not installed";
@@ -162,6 +166,8 @@ const MISSING_ENGINE_MARKER = "not installed";
 // promising a fix that would silently skip.
 const REPAIR_HINT =
   "Run `kesha install --no-cache` to re-download the engine. On a read-only (Nix) install, repair it through your package manager instead.";
+const CONTRACT_HINT =
+  "Update the kesha CLI and this extension to matching versions — `bun add -g @drakulavich/kesha-voice-kit@latest`.";
 
 function runKesha(spawn: KeshaSpawn, args: string[], deps: ProbeDeps) {
   const run = deps.execFile ?? execFileAsync;
@@ -185,13 +191,25 @@ function parseStatusObject(stdout: string): Record<string, unknown> | null {
 
 // Anchored to the Binary line rather than the whole output: "not installed" is
 // `formatStatusLine`'s default missing label, so a future missing line would
-// otherwise read as the engine being absent.
+// otherwise read as the engine being absent. No Binary line means this is not
+// status output at all — garbage fails open rather than matching loose text.
 function proseSaysEngineMissing(stdout: string): boolean {
   const binaryLine = stdout
     .split("\n")
     .find((line) => line.includes("Binary:"));
-  if (binaryLine) return binaryLine.includes(MISSING_ENGINE_MARKER);
-  return stdout.includes(MISSING_ENGINE_MARKER);
+  return binaryLine !== undefined && binaryLine.includes(MISSING_ENGINE_MARKER);
+}
+
+// Non-null is too weak a bar for "the engine can describe itself": the CLI
+// forwards whatever the engine's capabilities JSON parsed to, without shape
+// validation, so `false`, `[]` and `{}` would otherwise pass as healthy.
+function capabilitiesAreReadable(capabilities: unknown): boolean {
+  return (
+    typeof capabilities === "object" &&
+    capabilities !== null &&
+    !Array.isArray(capabilities) &&
+    Object.keys(capabilities).length > 0
+  );
 }
 
 function readStructuredStatus(
@@ -208,7 +226,7 @@ function readStructuredStatus(
   }
   // Present is not usable: a binary that cannot report its capabilities would
   // fail during transcription, after the recording is already gone (#647).
-  if (capabilities === null || capabilities === undefined) {
+  if (!capabilitiesAreReadable(capabilities)) {
     return { ok: false, reason: "unusable", hint: REPAIR_HINT };
   }
   return { ok: true };
@@ -240,8 +258,8 @@ export async function probeEngineAvailability(
       return (
         readStructuredStatus(payload) ?? {
           ok: false,
-          reason: "unusable",
-          hint: REPAIR_HINT,
+          reason: "contract",
+          hint: CONTRACT_HINT,
         }
       );
     }

--- a/raycast/src/lib/kesha-bin.ts
+++ b/raycast/src/lib/kesha-bin.ts
@@ -200,9 +200,9 @@ function proseSaysEngineMissing(stdout: string): boolean {
   return binaryLine !== undefined && binaryLine.includes(MISSING_ENGINE_MARKER);
 }
 
-// Non-null is too weak a bar for "the engine can describe itself": the CLI
-// forwards whatever the engine's capabilities JSON parsed to, without shape
-// validation, so `false`, `[]` and `{}` would otherwise pass as healthy.
+// The CLI validates this shape too, but the extension ships through the Raycast
+// Store against whatever CLI version is on the machine — including ones that
+// predate that validation and forward `{}` or `[]` as capabilities.
 function capabilitiesAreReadable(capabilities: unknown): boolean {
   return (
     typeof capabilities === "object" &&
@@ -214,11 +214,16 @@ function capabilitiesAreReadable(capabilities: unknown): boolean {
 
 function readStructuredStatus(
   payload: Record<string, unknown>,
-): EnginePreflightResult | null {
+): EnginePreflightResult {
+  const contractError: EnginePreflightResult = {
+    ok: false,
+    reason: "contract",
+    hint: CONTRACT_HINT,
+  };
   const engine = payload.engine;
-  if (!engine || typeof engine !== "object") return null;
+  if (!engine || typeof engine !== "object") return contractError;
   const { installed, capabilities } = engine as Record<string, unknown>;
-  if (typeof installed !== "boolean") return null;
+  if (typeof installed !== "boolean") return contractError;
 
   if (!installed) {
     const hint = typeof payload.hint === "string" ? payload.hint.trim() : "";
@@ -254,15 +259,7 @@ export async function probeEngineAvailability(
       deps,
     );
     const payload = parseStatusObject(stdout);
-    if (payload) {
-      return (
-        readStructuredStatus(payload) ?? {
-          ok: false,
-          reason: "contract",
-          hint: CONTRACT_HINT,
-        }
-      );
-    }
+    if (payload) return readStructuredStatus(payload);
     if (proseSaysEngineMissing(stdout)) {
       return { ok: false, reason: "missing", hint: stderr.trim() || undefined };
     }

--- a/raycast/src/lib/kesha-bin.ts
+++ b/raycast/src/lib/kesha-bin.ts
@@ -155,9 +155,13 @@ export interface EnginePreflightResult {
 
 const MISSING_ENGINE_MARKER = "not installed";
 // A corrupt binary is not repaired by a plain `kesha install`: that hits the
-// cached-engine path and only re-trusts it. `--no-cache` forces the re-download
-// (`cacheValid = versionMatches && (!noCache || !canWriteEngineDir)`).
-const REPAIR_HINT = "Run `kesha install --no-cache` to re-download the engine.";
+// cached-engine path and only re-trusts it. `--no-cache` forces the re-download,
+// except on a read-only engine dir (Nix store), where it is deliberately a no-op
+// (`cacheValid = versionMatches && (!noCache || !canWriteEngineDir)`). The probe
+// cannot tell the two installs apart, so the hint names both rather than
+// promising a fix that would silently skip.
+const REPAIR_HINT =
+  "Run `kesha install --no-cache` to re-download the engine. On a read-only (Nix) install, repair it through your package manager instead.";
 
 function runKesha(spawn: KeshaSpawn, args: string[], deps: ProbeDeps) {
   const run = deps.execFile ?? execFileAsync;

--- a/raycast/tests/dictation-controller.test.ts
+++ b/raycast/tests/dictation-controller.test.ts
@@ -159,6 +159,25 @@ describe("dictation controller", () => {
     });
   });
 
+  it("does not blame the engine for a CLI/extension version skew (#647)", async () => {
+    const deps = createDeps({
+      preflight: vi.fn(async () => ({
+        ok: false,
+        reason: "contract" as const,
+        hint: "Update the kesha CLI and this extension to matching versions.",
+      })),
+    });
+    const { states } = deps;
+
+    const session = startDictationSession({}, deps.setState, deps);
+    await session.done;
+
+    expect(deps.startRecorder).not.toHaveBeenCalled();
+    const last = states.at(-1);
+    expect(last?.message).toBe("Kesha CLI and this extension are out of sync.");
+    expect(last?.message).not.toContain("engine");
+  });
+
   it("falls back to the not-found hint when preflight fails without one", async () => {
     const deps = createDeps({
       preflight: vi.fn(async () => ({ ok: false })),

--- a/raycast/tests/dictation-controller.test.ts
+++ b/raycast/tests/dictation-controller.test.ts
@@ -138,6 +138,27 @@ describe("dictation controller", () => {
     });
   });
 
+  it("names a broken install differently from a missing one (#647)", async () => {
+    const deps = createDeps({
+      preflight: vi.fn(async () => ({
+        ok: false,
+        reason: "unusable" as const,
+        hint: "Run `kesha install --no-cache` to re-download the engine.",
+      })),
+    });
+    const { states } = deps;
+
+    const session = startDictationSession({}, deps.setState, deps);
+    await session.done;
+
+    expect(deps.startRecorder).not.toHaveBeenCalled();
+    expect(states.at(-1)).toEqual({
+      status: "error",
+      message: "Kesha's engine is installed but not working.",
+      hint: "Run `kesha install --no-cache` to re-download the engine.",
+    });
+  });
+
   it("falls back to the not-found hint when preflight fails without one", async () => {
     const deps = createDeps({
       preflight: vi.fn(async () => ({ ok: false })),

--- a/raycast/tests/kesha-bin-status-json.test.ts
+++ b/raycast/tests/kesha-bin-status-json.test.ts
@@ -73,12 +73,28 @@ describe("probeEngineAvailability — structured status (#647)", () => {
     const execFile = jsonStdout({ ok: true, engine: { path: "/x" }, hint: "setup" });
     const result = await probeEngineAvailability(kesha, { execFile });
     expect(result.ok).toBe(false);
-    expect(result.reason).toBe("unusable");
+    // Version skew is not a broken engine — re-downloading would fix nothing.
+    expect(result.reason).toBe("contract");
+    expect(result.hint).not.toContain("--no-cache");
   });
 
   it("fails closed when installed is present but not a boolean", async () => {
     const execFile = jsonStdout({ engine: { installed: "yes", capabilities: null } });
-    expect((await probeEngineAvailability(kesha, { execFile })).ok).toBe(false);
+    const result = await probeEngineAvailability(kesha, { execFile });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("contract");
+  });
+
+  it("does not accept junk in place of capabilities", async () => {
+    for (const capabilities of [{}, [], false, "", "coreml", 0]) {
+      const execFile = jsonStdout({
+        engine: { installed: true, path: "/x", capabilities },
+        hint: null,
+      });
+      const result = await probeEngineAvailability(kesha, { execFile });
+      expect(result.ok).toBe(false);
+      expect(result.reason).toBe("unusable");
+    }
   });
 
   it("falls back to prose for an older CLI reporting a missing engine", async () => {
@@ -108,7 +124,9 @@ describe("probeEngineAvailability — structured status (#647)", () => {
   });
 
   it("fails open on empty or garbage stdout", async () => {
-    for (const stdout of ["", "   ", " garbage", "{not json at all"]) {
+    // `{not installed` is the trap: it opens like JSON, fails to parse, and
+    // carries the marker — matching loose text would flip it closed.
+    for (const stdout of ["", "   ", " garbage", "{not json at all", "{not installed"]) {
       expect(await probeEngineAvailability(kesha, { execFile: textStdout(stdout) })).toEqual({
         ok: true,
       });

--- a/raycast/tests/kesha-bin-status-json.test.ts
+++ b/raycast/tests/kesha-bin-status-json.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from "vitest";
+import { probeEngineAvailability } from "../src/lib/kesha-bin";
+import type { ProbeDeps } from "../src/lib/kesha-bin";
+
+// One case per row of the probe matrix in
+// openspec/changes/status-json-output/design.md.
+describe("probeEngineAvailability — structured status (#647)", () => {
+  const kesha = { command: "/opt/homebrew/bin/kesha", prefixArgs: [] };
+
+  function jsonStdout(payload: unknown): ProbeDeps["execFile"] {
+    return vi.fn(async () => ({
+      stdout: JSON.stringify(payload, null, 2),
+      stderr: "",
+    }));
+  }
+
+  function textStdout(stdout: string, stderr = ""): ProbeDeps["execFile"] {
+    return vi.fn(async () => ({ stdout, stderr }));
+  }
+
+  it("asks the CLI for machine-readable status", async () => {
+    const execFile = jsonStdout({
+      engine: { installed: true, path: "/x", capabilities: { backend: "coreml" } },
+    });
+    await probeEngineAvailability(kesha, { execFile });
+    expect(execFile).toHaveBeenCalledWith(
+      "/opt/homebrew/bin/kesha",
+      ["status", "--json"],
+      expect.anything(),
+    );
+  });
+
+  it("reports ok for an installed engine with readable capabilities", async () => {
+    const execFile = jsonStdout({
+      engine: {
+        installed: true,
+        path: "/x",
+        capabilities: { protocolVersion: 3, backend: "coreml", features: ["tts"] },
+      },
+      hint: null,
+    });
+    expect(await probeEngineAvailability(kesha, { execFile })).toEqual({ ok: true });
+  });
+
+  it("takes the hint from the payload when the engine is missing", async () => {
+    const execFile = jsonStdout({
+      engine: { installed: false, path: "/x", capabilities: null },
+      hint: "Run `kesha install` to download the engine and models.",
+    });
+    expect(await probeEngineAvailability(kesha, { execFile })).toEqual({
+      ok: false,
+      reason: "missing",
+      hint: "Run `kesha install` to download the engine and models.",
+    });
+  });
+
+  it("rejects an engine that is present but cannot report capabilities", async () => {
+    const execFile = jsonStdout({
+      engine: { installed: true, path: "/x", capabilities: null },
+      hint: null,
+    });
+    const result = await probeEngineAvailability(kesha, { execFile });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("unusable");
+    expect(result.hint).toContain("--no-cache");
+  });
+
+  it("fails closed on JSON that breaks the contract instead of matching prose", async () => {
+    // Parses fine and misses the prose marker: the old rule called this healthy.
+    const execFile = jsonStdout({ ok: true, engine: { path: "/x" }, hint: "setup" });
+    const result = await probeEngineAvailability(kesha, { execFile });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("unusable");
+  });
+
+  it("fails closed when installed is present but not a boolean", async () => {
+    const execFile = jsonStdout({ engine: { installed: "yes", capabilities: null } });
+    expect((await probeEngineAvailability(kesha, { execFile })).ok).toBe(false);
+  });
+
+  it("falls back to prose for an older CLI reporting a missing engine", async () => {
+    const execFile = textStdout(
+      "Engine:\n  ✗ Binary: not installed\n\n  ✓ Runtime: Bun 1.3.13\n",
+      "Run `kesha install` to download the engine and models.",
+    );
+    expect(await probeEngineAvailability(kesha, { execFile })).toEqual({
+      ok: false,
+      reason: "missing",
+      hint: "Run `kesha install` to download the engine and models.",
+    });
+  });
+
+  it("falls back to prose for an older CLI reporting a healthy engine", async () => {
+    const execFile = textStdout(
+      "Engine:\n  ✓ Binary: /opt/homebrew/bin/kesha-engine\n  ✓ Backend: coreml\n",
+    );
+    expect(await probeEngineAvailability(kesha, { execFile })).toEqual({ ok: true });
+  });
+
+  it("does not read the marker off a line other than Binary", async () => {
+    const execFile = textStdout(
+      "Engine:\n  ✓ Binary: /opt/homebrew/bin/kesha-engine\n  ✗ Diarization: not installed\n",
+    );
+    expect(await probeEngineAvailability(kesha, { execFile })).toEqual({ ok: true });
+  });
+
+  it("fails open on empty or garbage stdout", async () => {
+    for (const stdout of ["", "   ", " garbage", "{not json at all"]) {
+      expect(await probeEngineAvailability(kesha, { execFile: textStdout(stdout) })).toEqual({
+        ok: true,
+      });
+    }
+  });
+
+  it("fails open on a JSON array", async () => {
+    expect(await probeEngineAvailability(kesha, { execFile: textStdout("[1,2,3]") })).toEqual({
+      ok: true,
+    });
+  });
+});

--- a/raycast/tests/kesha-bin-status-json.test.ts
+++ b/raycast/tests/kesha-bin-status-json.test.ts
@@ -63,6 +63,9 @@ describe("probeEngineAvailability — structured status (#647)", () => {
     expect(result.ok).toBe(false);
     expect(result.reason).toBe("unusable");
     expect(result.hint).toContain("--no-cache");
+    // A read-only (Nix) install ignores --no-cache for the engine, so the hint
+    // must not promise a fix those users cannot get.
+    expect(result.hint).toContain("read-only");
   });
 
   it("fails closed on JSON that breaks the contract instead of matching prose", async () => {

--- a/raycast/tests/kesha-bin.test.ts
+++ b/raycast/tests/kesha-bin.test.ts
@@ -203,6 +203,7 @@ describe("probeEngineAvailability", () => {
     }));
     expect(await probeEngineAvailability(kesha, { execFile })).toEqual({
       ok: false,
+      reason: "missing",
       hint: "Run `kesha install` to download the engine and models.",
     });
   });
@@ -224,6 +225,7 @@ describe("probeEngineAvailability", () => {
     });
     expect(await probeEngineAvailability(kesha, { execFile })).toEqual({
       ok: false,
+      reason: "missing",
       hint: "Run `kesha install` to download the engine and models.",
     });
   });

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -1,8 +1,9 @@
 import { defineCommand } from "citty";
-import { showStatus } from "../status";
+import { collectStatus, renderStatus } from "../status";
 
 interface StatusCommandArgs {
   disk: boolean;
+  json: boolean;
 }
 
 export const statusCommand = defineCommand({
@@ -16,8 +17,20 @@ export const statusCommand = defineCommand({
       description: "Include recursive cache disk usage",
       default: false,
     },
+    json: {
+      type: "boolean",
+      description: "Output status as JSON",
+      default: false,
+    },
   },
   async run({ args }: { args: StatusCommandArgs }) {
-    await showStatus({ disk: args.disk });
+    const report = await collectStatus({ disk: args.disk });
+    if (args.json) {
+      // `log.*` writes to stdout, so the payload must be the only thing printed —
+      // the setup hint ships inside it instead of on stderr (#647).
+      console.log(JSON.stringify(report, null, 2));
+      return;
+    }
+    renderStatus(report);
   },
 });

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -364,10 +364,23 @@ export async function getEngineCapabilities(): Promise<EngineCapabilities | null
   const { stdout, exitCode } = await runEngine(["--capabilities-json"]);
   if (exitCode !== 0) return null;
   try {
-    const capabilities = JSON.parse(stdout) as EngineCapabilities;
+    const capabilities = parseCapabilities(JSON.parse(stdout));
+    if (!capabilities) return null;
     cachedEngineCapabilities = { binPath, mtime, capabilities };
     return capabilities;
   } catch {
     return null;
   }
+}
+
+// A non-null return has to mean "the engine described itself" — callers reach
+// straight for `.features.join()` and `.backend` (#647). Only the fields those
+// callers consume are checked, so a newer engine adding fields still validates.
+function parseCapabilities(parsed: unknown): EngineCapabilities | null {
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  const { protocolVersion, backend, features } = parsed as Record<string, unknown>;
+  if (typeof protocolVersion !== "number") return null;
+  if (typeof backend !== "string") return null;
+  if (!Array.isArray(features) || features.some((f) => typeof f !== "string")) return null;
+  return parsed as EngineCapabilities;
 }

--- a/src/status.ts
+++ b/src/status.ts
@@ -1,8 +1,14 @@
 import { readdirSync, statSync } from "fs";
 import { join } from "path";
-import { isEngineInstalled, getEngineBinPath, getEngineCapabilities } from "./engine";
+import {
+  isEngineInstalled,
+  getEngineBinPath,
+  getEngineCapabilities,
+  type EngineCapabilities,
+} from "./engine";
 import { installHint } from "./install-hint";
 import { log } from "./log";
+import { packageVersion } from "./package-info";
 import { keshaCacheDir } from "./paths";
 import { fluidKokoroCacheInfo } from "./fluid-kokoro-cache";
 import { dirSizeBytes } from "./diagnostic-paths";
@@ -35,8 +41,60 @@ export interface ShowStatusOptions {
   disk?: boolean;
 }
 
-async function logEngineCapabilities(): Promise<void> {
-  const caps = await getEngineCapabilities().catch(() => null);
+export interface StatusDiskComponent {
+  label: string;
+  sizeBytes: number;
+}
+
+export interface StatusDiskUsage {
+  cachePath: string;
+  components: StatusDiskComponent[];
+  componentTotalBytes: number;
+  totalBytes: number;
+  fluidKokoro: { path: string; sizeBytes: number } | null;
+}
+
+/**
+ * Machine-readable `kesha status` payload (#647). Contract: every key is always
+ * present — absent values are null (or `[]` for voices), never omitted, so a
+ * consumer never distinguishes a missing key from a null value. `engine.installed`
+ * reports only that a binary exists; usability additionally requires
+ * `engine.capabilities` to be non-null.
+ */
+export interface StatusReport {
+  cliVersion: string;
+  engine: {
+    installed: boolean;
+    path: string;
+    capabilities: EngineCapabilities | null;
+  };
+  voices: string[];
+  runtime: { bun: string; platform: string; arch: string };
+  modelMirror: string | null;
+  hint: string | null;
+  disk: StatusDiskUsage | null;
+}
+
+export async function collectStatus(options: ShowStatusOptions = {}): Promise<StatusReport> {
+  const path = getEngineBinPath();
+  const installed = isEngineInstalled();
+  const capabilities = installed ? await getEngineCapabilities().catch(() => null) : null;
+
+  return {
+    cliVersion: packageVersion,
+    engine: { installed, path, capabilities },
+    voices: installed ? listInstalledVoices() : [],
+    runtime: { bun: Bun.version, platform: process.platform, arch: process.arch },
+    modelMirror: activeModelMirror(),
+    hint: installed
+      ? null
+      : `Run \`${installHint()}\` to download the engine and models.`,
+    // Absent engine means no disk walk, matching the human path (#647).
+    disk: installed && options.disk ? collectDiskUsage(path) : null,
+  };
+}
+
+function logEngineCapabilities(caps: EngineCapabilities | null): void {
   if (caps) {
     log.info(formatStatusLine("Backend", caps.backend, true));
     log.info(formatStatusLine("Protocol", `v${caps.protocolVersion}`, true));
@@ -46,8 +104,7 @@ async function logEngineCapabilities(): Promise<void> {
   }
 }
 
-function logInstalledVoices(): void {
-  const voices = listInstalledVoices();
+function logInstalledVoices(voices: string[]): void {
   if (voices.length === 0) return;
   log.info("TTS voices:");
   for (const v of voices) {
@@ -56,38 +113,38 @@ function logInstalledVoices(): void {
   log.info("");
 }
 
-export async function showStatus(options: ShowStatusOptions = {}): Promise<void> {
-  const binPath = getEngineBinPath();
-  const installed = isEngineInstalled();
+export function renderStatus(report: StatusReport): void {
+  const { installed, path, capabilities } = report.engine;
 
   log.info("Engine:");
-  log.info(formatStatusLine("Binary", installed ? binPath : null, installed));
+  log.info(formatStatusLine("Binary", installed ? path : null, installed));
 
   if (installed) {
-    await logEngineCapabilities();
+    logEngineCapabilities(capabilities);
   }
   log.info("");
 
-  log.info(formatStatusLine("Runtime", `Bun ${Bun.version}`, true));
-  log.info(formatStatusLine("Platform", `${process.platform} ${process.arch}`, true));
-  const mirror = activeModelMirror();
-  if (mirror) {
-    log.info(formatStatusLine("Mirror", mirror, true));
+  log.info(formatStatusLine("Runtime", `Bun ${report.runtime.bun}`, true));
+  log.info(
+    formatStatusLine("Platform", `${report.runtime.platform} ${report.runtime.arch}`, true),
+  );
+  if (report.modelMirror) {
+    log.info(formatStatusLine("Mirror", report.modelMirror, true));
   }
   log.info("");
 
   if (installed) {
-    logInstalledVoices();
-
-    if (options.disk) {
-      showDiskUsage(binPath);
-    }
+    logInstalledVoices(report.voices);
+    if (report.disk) showDiskUsage(report.disk);
   }
 
-  if (!installed) {
-    log.warn(`Run \`${installHint()}\` to download the engine and models.`);
-    return;
+  if (report.hint) {
+    log.warn(report.hint);
   }
+}
+
+export async function showStatus(options: ShowStatusOptions = {}): Promise<void> {
+  renderStatus(await collectStatus(options));
 }
 
 function buildDiskComponents(cache: string, engineDir: string): Array<{ label: string; path: string }> {
@@ -101,11 +158,11 @@ function buildDiskComponents(cache: string, engineDir: string): Array<{ label: s
   ];
 }
 
-function logDiskRows(rows: Array<{ label: string; size: number }>, total: number, componentTotal: number): void {
+function logDiskRows(rows: StatusDiskComponent[], total: number, componentTotal: number): void {
   const labelWidth = Math.max(...rows.map((r) => r.label.length), "Total".length);
   for (const r of rows) {
     const pad = " ".repeat(labelWidth - r.label.length + 2);
-    log.info(`  ${r.label}:${pad}${humanBytes(r.size)}`);
+    log.info(`  ${r.label}:${pad}${humanBytes(r.sizeBytes)}`);
   }
   const totalPad = " ".repeat(labelWidth - "Total".length + 2);
   log.info(`  ${pc.bold("Total")}:${totalPad}${pc.bold(humanBytes(total))}`);
@@ -115,42 +172,51 @@ function logDiskRows(rows: Array<{ label: string; size: number }>, total: number
   }
 }
 
-function logFluidKokoroCache(): void {
-  const fluidKokoro = fluidKokoroCacheInfo();
-  if (!fluidKokoro.exists || fluidKokoro.sizeBytes <= 0) return;
+function logFluidKokoroCache(fluidKokoro: StatusDiskUsage["fluidKokoro"]): void {
+  if (!fluidKokoro) return;
   log.info("");
   log.info(`External caches (not included in Kesha total):`);
   log.info(`  FluidAudio Kokoro: ${humanBytes(fluidKokoro.sizeBytes)} (${fluidKokoro.path})`);
 }
 
-function showDiskUsage(binPath: string): void {
+function collectDiskUsage(binPath: string): StatusDiskUsage {
   const cache = keshaCacheDir();
   // Two levels up from the binary (`<cache>/engine/bin/`) so future engine-root siblings are counted.
   const engineDir = join(binPath, "..", "..");
 
-  const components = buildDiskComponents(cache, engineDir);
-
-  const rows: Array<{ label: string; size: number }> = [];
-  for (const c of components) {
-    const size = dirSizeBytes(c.path);
-    if (size > 0) rows.push({ label: c.label, size });
+  const components: StatusDiskComponent[] = [];
+  for (const c of buildDiskComponents(cache, engineDir)) {
+    const sizeBytes = dirSizeBytes(c.path);
+    if (sizeBytes > 0) components.push({ label: c.label, sizeBytes });
   }
 
-  if (rows.length === 0) return;
-
   // Sum cache root + engine dir separately so `KESHA_ENGINE_BIN` overrides outside the cache are still counted.
-  const componentTotal = rows.reduce((n, r) => n + r.size, 0);
   const cacheTotal = dirSizeBytes(cache);
-  const engineOutsideCache = engineDir.startsWith(cache)
-    ? 0
-    : dirSizeBytes(engineDir);
-  const total = cacheTotal + engineOutsideCache;
+  const engineOutsideCache = engineDir.startsWith(cache) ? 0 : dirSizeBytes(engineDir);
+  const fluidKokoro = fluidKokoroCacheInfo();
 
-  log.info(`Disk usage (${cache}):`);
-  logDiskRows(rows, total, componentTotal);
-  logFluidKokoroCache();
+  return {
+    cachePath: cache,
+    components,
+    componentTotalBytes: components.reduce((n, c) => n + c.sizeBytes, 0),
+    totalBytes: cacheTotal + engineOutsideCache,
+    fluidKokoro:
+      fluidKokoro.exists && fluidKokoro.sizeBytes > 0
+        ? { path: fluidKokoro.path, sizeBytes: fluidKokoro.sizeBytes }
+        : null,
+  };
+}
+
+function showDiskUsage(disk: StatusDiskUsage): void {
+  if (disk.components.length === 0) return;
+
+  log.info(`Disk usage (${disk.cachePath}):`);
+  logDiskRows(disk.components, disk.totalBytes, disk.componentTotalBytes);
+  logFluidKokoroCache(disk.fluidKokoro);
   log.info("");
-  log.info(pc.dim(`  To reset cache: rm -rf ${cache} — next \`kesha install\` re-downloads.`));
+  log.info(
+    pc.dim(`  To reset cache: rm -rf ${disk.cachePath} — next \`kesha install\` re-downloads.`),
+  );
   log.info("");
 }
 

--- a/src/status.ts
+++ b/src/status.ts
@@ -143,9 +143,6 @@ export function renderStatus(report: StatusReport): void {
   }
 }
 
-export async function showStatus(options: ShowStatusOptions = {}): Promise<void> {
-  renderStatus(await collectStatus(options));
-}
 
 function buildDiskComponents(cache: string, engineDir: string): Array<{ label: string; path: string }> {
   return [

--- a/tests/helpers/fake-engine.ts
+++ b/tests/helpers/fake-engine.ts
@@ -1,0 +1,37 @@
+import { chmodSync, mkdirSync, writeFileSync } from "fs";
+import { join } from "path";
+
+const ENGINE_ENV = ["KESHA_ENGINE_BIN", "KESHA_CACHE_DIR", "HOME", "KESHA_MODEL_MIRROR"] as const;
+
+/** Snapshots the engine-related env so a test can point them at a temp dir and restore afterwards. */
+export function saveEngineEnv(): () => void {
+  const saved = ENGINE_ENV.map((key) => [key, process.env[key]] as const);
+  return () => {
+    for (const [key, value] of saved) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  };
+}
+
+/**
+ * Writes an executable stub that answers `--capabilities-json` and exits 2 otherwise.
+ * Pass `capabilities: null` for a binary that exists but cannot describe itself.
+ */
+export function writeFakeEngine(
+  binDir: string,
+  capabilities: Record<string, unknown> | null = {
+    protocolVersion: 3,
+    backend: "fake-coreml",
+    features: ["tts"],
+  },
+): string {
+  mkdirSync(binDir, { recursive: true });
+  const binPath = join(binDir, "kesha-engine");
+  const body = capabilities
+    ? `if [ "$1" = "--capabilities-json" ]; then\n  printf '%s\\n' '${JSON.stringify(capabilities)}'\n  exit 0\nfi\n`
+    : "";
+  writeFileSync(binPath, `#!/bin/sh\n${body}exit 2\n`);
+  chmodSync(binPath, 0o755);
+  return binPath;
+}

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -290,7 +290,8 @@ USAGE status [OPTIONS]
 
 OPTIONS
 
-  --disk    Include recursive cache disk usage (Default: false)`);
+  --disk    Include recursive cache disk usage (Default: false)
+  --json    Output status as JSON (Default: false)`);
   });
 
   test("say help matches the normalized golden output", async () => {

--- a/tests/unit/status.test.ts
+++ b/tests/unit/status.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import { formatStatusLine, activeModelMirror, showStatus } from "../../src/status";
+import { formatStatusLine, activeModelMirror, showStatus, collectStatus } from "../../src/status";
 import { starSeenPath } from "../../src/star";
 
 const posixEngineTest = process.platform === "win32" ? test.skip : test;
@@ -224,6 +224,232 @@ exit 2
     } finally {
       console.log = originalLog;
       console.error = originalError;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("collectStatus --json payload (#647)", () => {
+  const savedEngineBin = process.env.KESHA_ENGINE_BIN;
+  const savedCacheDir = process.env.KESHA_CACHE_DIR;
+  const savedHome = process.env.HOME;
+  const savedMirror = process.env.KESHA_MODEL_MIRROR;
+
+  function restoreEnv() {
+    if (savedEngineBin === undefined) delete process.env.KESHA_ENGINE_BIN;
+    else process.env.KESHA_ENGINE_BIN = savedEngineBin;
+    if (savedCacheDir === undefined) delete process.env.KESHA_CACHE_DIR;
+    else process.env.KESHA_CACHE_DIR = savedCacheDir;
+    if (savedHome === undefined) delete process.env.HOME;
+    else process.env.HOME = savedHome;
+    if (savedMirror === undefined) delete process.env.KESHA_MODEL_MIRROR;
+    else process.env.KESHA_MODEL_MIRROR = savedMirror;
+  }
+
+  beforeEach(restoreEnv);
+  afterEach(restoreEnv);
+
+  function healthyEngine(): { dir: string; cache: string; binPath: string } {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-status-json-"));
+    const cache = join(dir, ".cache", "kesha");
+    const binDir = join(cache, "engine", "bin");
+    mkdirSync(binDir, { recursive: true });
+    const binPath = join(binDir, "kesha-engine");
+    writeFileSync(
+      binPath,
+      `#!/bin/sh
+if [ "$1" = "--capabilities-json" ]; then
+  printf '%s\\n' '{"protocolVersion":3,"backend":"fake-coreml","features":["tts"]}'
+  exit 0
+fi
+exit 2
+`,
+    );
+    chmodSync(binPath, 0o755);
+    process.env.KESHA_ENGINE_BIN = binPath;
+    process.env.KESHA_CACHE_DIR = cache;
+    process.env.HOME = dir;
+    return { dir, cache, binPath };
+  }
+
+  posixEngineTest("engine installed: presence, path, capabilities, voices", async () => {
+    const { dir, cache, binPath } = healthyEngine();
+    mkdirSync(join(cache, "models", "kokoro-82m", "voices"), { recursive: true });
+    writeFileSync(join(cache, "models", "kokoro-82m", "voices", "am_michael.bin"), "voice");
+    try {
+      const report = await collectStatus();
+      expect(report.engine.installed).toBe(true);
+      expect(report.engine.path).toBe(binPath);
+      expect(report.engine.capabilities).toEqual({
+        protocolVersion: 3,
+        backend: "fake-coreml",
+        features: ["tts"],
+      });
+      expect(report.voices).toEqual(["en-am_michael"]);
+      expect(report.hint).toBeNull();
+      expect(report.disk).toBeNull();
+      expect(report.cliVersion).toBeString();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("engine absent: presence false, hint carried in the payload", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-status-json-missing-"));
+    process.env.KESHA_ENGINE_BIN = join(dir, "nope", "kesha-engine");
+    process.env.KESHA_CACHE_DIR = join(dir, ".cache", "kesha");
+    process.env.HOME = dir;
+    try {
+      const report = await collectStatus();
+      expect(report.engine.installed).toBe(false);
+      expect(report.engine.capabilities).toBeNull();
+      expect(report.hint).toContain("kesha ins");
+      expect(report.voices).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  posixEngineTest("binary present but capabilities unreadable: installed, caps null", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-status-json-broken-"));
+    const cache = join(dir, ".cache", "kesha");
+    const binDir = join(cache, "engine", "bin");
+    mkdirSync(binDir, { recursive: true });
+    const binPath = join(binDir, "kesha-engine");
+    writeFileSync(binPath, "#!/bin/sh\nexit 3\n");
+    chmodSync(binPath, 0o755);
+    process.env.KESHA_ENGINE_BIN = binPath;
+    process.env.KESHA_CACHE_DIR = cache;
+    process.env.HOME = dir;
+    try {
+      const report = await collectStatus();
+      expect(report.engine.installed).toBe(true);
+      expect(report.engine.capabilities).toBeNull();
+      expect(report.hint).toBeNull();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("--disk with no engine reports null without walking the cache", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-status-json-nodisk-"));
+    const cache = join(dir, ".cache", "kesha");
+    mkdirSync(join(cache, "models", "parakeet-tdt-v3"), { recursive: true });
+    writeFileSync(join(cache, "models", "parakeet-tdt-v3", "model.onnx"), "model");
+    process.env.KESHA_ENGINE_BIN = join(dir, "nope", "kesha-engine");
+    process.env.KESHA_CACHE_DIR = cache;
+    process.env.HOME = dir;
+    try {
+      const report = await collectStatus({ disk: true });
+      expect(report.engine.installed).toBe(false);
+      expect(report.disk).toBeNull();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  posixEngineTest("--disk toggles the disk section", async () => {
+    const { dir, cache } = healthyEngine();
+    mkdirSync(join(cache, "models", "parakeet-tdt-v3"), { recursive: true });
+    writeFileSync(join(cache, "models", "parakeet-tdt-v3", "model.onnx"), "model");
+    try {
+      expect((await collectStatus()).disk).toBeNull();
+      const withDisk = await collectStatus({ disk: true });
+      expect(withDisk.disk).not.toBeNull();
+      expect(withDisk.disk!.components.length).toBeGreaterThan(0);
+      expect(withDisk.disk!.totalBytes).toBeGreaterThan(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("every documented key is present, never omitted", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-status-json-keys-"));
+    process.env.KESHA_ENGINE_BIN = join(dir, "nope", "kesha-engine");
+    process.env.KESHA_CACHE_DIR = join(dir, ".cache", "kesha");
+    process.env.HOME = dir;
+    try {
+      const report = await collectStatus();
+      const roundTripped = JSON.parse(JSON.stringify(report));
+      expect(Object.keys(roundTripped).sort()).toEqual([
+        "cliVersion",
+        "disk",
+        "engine",
+        "hint",
+        "modelMirror",
+        "runtime",
+        "voices",
+      ]);
+      expect(Object.keys(roundTripped.engine).sort()).toEqual([
+        "capabilities",
+        "installed",
+        "path",
+      ]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("kesha status --json stdout discipline (#647)", () => {
+  test("stdout is exactly one JSON object and the hint stays off stderr", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-status-json-cli-"));
+    const proc = Bun.spawn([process.execPath, "bin/kesha.js", "status", "--json"], {
+      stdout: "pipe",
+      stderr: "pipe",
+      cwd: `${import.meta.dir}/../..`,
+      env: {
+        ...process.env,
+        KESHA_ENGINE_BIN: join(dir, "nope", "kesha-engine"),
+        KESHA_CACHE_DIR: join(dir, ".cache", "kesha"),
+        HOME: dir,
+        NO_COLOR: "1",
+      },
+    });
+    try {
+      const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+      ]);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.engine.installed).toBe(false);
+      expect(parsed.hint).toContain("kesha ins");
+      // The hint ships in the payload, so stderr must not repeat it.
+      expect(stderr).not.toContain("kesha ins");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("human status output is a load-bearing contract (#647)", () => {
+  // The Raycast extension's probe falls back to matching "not installed" on the
+  // Binary line when it meets a CLI too old to emit `--json`
+  // (raycast/src/lib/kesha-bin.ts). Rewording this line breaks Store users on
+  // those CLIs, so the marker is frozen here rather than in the extension.
+  test("the Binary line still carries the `not installed` marker", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-status-marker-"));
+    const proc = Bun.spawn([process.execPath, "bin/kesha.js", "status"], {
+      stdout: "pipe",
+      stderr: "pipe",
+      cwd: `${import.meta.dir}/../..`,
+      env: {
+        ...process.env,
+        KESHA_ENGINE_BIN: join(dir, "nope", "kesha-engine"),
+        KESHA_CACHE_DIR: join(dir, ".cache", "kesha"),
+        HOME: dir,
+        NO_COLOR: "1",
+      },
+    });
+    try {
+      const stdout = await new Response(proc.stdout).text();
+      await proc.exited;
+      const binaryLine = stdout.split("\n").find((l) => l.includes("Binary:"));
+      expect(binaryLine).toBeDefined();
+      expect(binaryLine!).toContain("not installed");
+    } finally {
       rmSync(dir, { recursive: true, force: true });
     }
   });

--- a/tests/unit/status.test.ts
+++ b/tests/unit/status.test.ts
@@ -2,8 +2,9 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import { formatStatusLine, activeModelMirror, showStatus, collectStatus } from "../../src/status";
+import { formatStatusLine, activeModelMirror, collectStatus, renderStatus } from "../../src/status";
 import { starSeenPath } from "../../src/star";
+import { saveEngineEnv, writeFakeEngine } from "../helpers/fake-engine";
 
 const posixEngineTest = process.platform === "win32" ? test.skip : test;
 
@@ -73,22 +74,8 @@ describe("activeModelMirror (#121)", () => {
   });
 });
 
-describe("showStatus", () => {
-  const savedEngineBin = process.env.KESHA_ENGINE_BIN;
-  const savedCacheDir = process.env.KESHA_CACHE_DIR;
-  const savedHome = process.env.HOME;
-  const savedMirror = process.env.KESHA_MODEL_MIRROR;
-
-  function restoreEnv() {
-    if (savedEngineBin === undefined) delete process.env.KESHA_ENGINE_BIN;
-    else process.env.KESHA_ENGINE_BIN = savedEngineBin;
-    if (savedCacheDir === undefined) delete process.env.KESHA_CACHE_DIR;
-    else process.env.KESHA_CACHE_DIR = savedCacheDir;
-    if (savedHome === undefined) delete process.env.HOME;
-    else process.env.HOME = savedHome;
-    if (savedMirror === undefined) delete process.env.KESHA_MODEL_MIRROR;
-    else process.env.KESHA_MODEL_MIRROR = savedMirror;
-  }
+describe("collectStatus + renderStatus", () => {
+  const restoreEnv = saveEngineEnv();
 
   beforeEach(restoreEnv);
   afterEach(restoreEnv);
@@ -109,7 +96,7 @@ describe("showStatus", () => {
     console.log = () => {};
     console.error = () => {};
     try {
-      await showStatus();
+      renderStatus(await collectStatus());
       expect(existsSync(starSeenPath(binPath))).toBe(false);
     } finally {
       console.log = originalLog;
@@ -154,11 +141,11 @@ describe("showStatus", () => {
     };
     console.error = () => {};
     try {
-      await showStatus();
+      renderStatus(await collectStatus());
       expect(lines.join("\n")).not.toContain("Disk usage");
 
       lines.length = 0;
-      await showStatus({ disk: true });
+      renderStatus(await collectStatus({ disk: true }));
       expect(lines.join("\n")).toContain("Disk usage");
       if (process.platform === "darwin" && process.arch === "arm64") {
         expect(lines.join("\n")).toContain("External caches (not included in Kesha total):");
@@ -211,7 +198,7 @@ exit 2
     };
     console.error = () => {};
     try {
-      await showStatus();
+      renderStatus(await collectStatus());
       const output = lines.join("\n");
       expect(output).toContain("Backend: fake-coreml");
       expect(output).toContain("Protocol: v2");
@@ -230,21 +217,7 @@ exit 2
 });
 
 describe("collectStatus --json payload (#647)", () => {
-  const savedEngineBin = process.env.KESHA_ENGINE_BIN;
-  const savedCacheDir = process.env.KESHA_CACHE_DIR;
-  const savedHome = process.env.HOME;
-  const savedMirror = process.env.KESHA_MODEL_MIRROR;
-
-  function restoreEnv() {
-    if (savedEngineBin === undefined) delete process.env.KESHA_ENGINE_BIN;
-    else process.env.KESHA_ENGINE_BIN = savedEngineBin;
-    if (savedCacheDir === undefined) delete process.env.KESHA_CACHE_DIR;
-    else process.env.KESHA_CACHE_DIR = savedCacheDir;
-    if (savedHome === undefined) delete process.env.HOME;
-    else process.env.HOME = savedHome;
-    if (savedMirror === undefined) delete process.env.KESHA_MODEL_MIRROR;
-    else process.env.KESHA_MODEL_MIRROR = savedMirror;
-  }
+  const restoreEnv = saveEngineEnv();
 
   beforeEach(restoreEnv);
   afterEach(restoreEnv);
@@ -252,20 +225,7 @@ describe("collectStatus --json payload (#647)", () => {
   function healthyEngine(): { dir: string; cache: string; binPath: string } {
     const dir = mkdtempSync(join(tmpdir(), "kesha-status-json-"));
     const cache = join(dir, ".cache", "kesha");
-    const binDir = join(cache, "engine", "bin");
-    mkdirSync(binDir, { recursive: true });
-    const binPath = join(binDir, "kesha-engine");
-    writeFileSync(
-      binPath,
-      `#!/bin/sh
-if [ "$1" = "--capabilities-json" ]; then
-  printf '%s\\n' '{"protocolVersion":3,"backend":"fake-coreml","features":["tts"]}'
-  exit 0
-fi
-exit 2
-`,
-    );
-    chmodSync(binPath, 0o755);
+    const binPath = writeFakeEngine(join(cache, "engine", "bin"));
     process.env.KESHA_ENGINE_BIN = binPath;
     process.env.KESHA_CACHE_DIR = cache;
     process.env.HOME = dir;
@@ -313,11 +273,7 @@ exit 2
   posixEngineTest("binary present but capabilities unreadable: installed, caps null", async () => {
     const dir = mkdtempSync(join(tmpdir(), "kesha-status-json-broken-"));
     const cache = join(dir, ".cache", "kesha");
-    const binDir = join(cache, "engine", "bin");
-    mkdirSync(binDir, { recursive: true });
-    const binPath = join(binDir, "kesha-engine");
-    writeFileSync(binPath, "#!/bin/sh\nexit 3\n");
-    chmodSync(binPath, 0o755);
+    const binPath = writeFakeEngine(join(cache, "engine", "bin"), null);
     process.env.KESHA_ENGINE_BIN = binPath;
     process.env.KESHA_CACHE_DIR = cache;
     process.env.HOME = dir;
@@ -326,6 +282,28 @@ exit 2
       expect(report.engine.installed).toBe(true);
       expect(report.engine.capabilities).toBeNull();
       expect(report.hint).toBeNull();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  posixEngineTest("capabilities of the wrong shape are rejected, not forwarded", async () => {
+    // A non-null capabilities value must mean the engine described itself:
+    // `renderStatus` reaches straight for `features.join` (#647).
+    const dir = mkdtempSync(join(tmpdir(), "kesha-status-json-shape-"));
+    const cache = join(dir, ".cache", "kesha");
+    const binPath = writeFakeEngine(join(cache, "engine", "bin"), {
+      protocolVersion: "three",
+      backend: 42,
+    });
+    process.env.KESHA_ENGINE_BIN = binPath;
+    process.env.KESHA_CACHE_DIR = cache;
+    process.env.HOME = dir;
+    try {
+      const report = await collectStatus();
+      expect(report.engine.installed).toBe(true);
+      expect(report.engine.capabilities).toBeNull();
+      expect(() => renderStatus(report)).not.toThrow();
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
Closes #647

The Raycast extension decided whether the engine was installed by string-matching `"not installed"` in `kesha status` stdout. `raycast/` is mirrored into `raycast/extensions`, so rewording that line ships to Store users before we notice.

Spec first (3 commits), then the implementation. `openspec/changes/status-json-output/` carries the proposal, design, delta specs and task list; both delta specs are synced into `openspec/specs/`.

## CLI

`showStatus` splits into `collectStatus()` + `renderStatus()` — one source of truth, so the two renderings cannot drift. `--json` prints the payload and nothing else; the setup hint ships inside it rather than on stderr.

```json
{
  "cliVersion": "1.24.7",
  "engine": { "installed": true, "path": "…/kesha-engine",
              "capabilities": { "protocolVersion": 3, "backend": "coreml", "features": ["tts"] } },
  "voices": ["en-am_michael"],
  "runtime": { "bun": "1.3.13", "platform": "darwin", "arch": "arm64" },
  "modelMirror": null, "hint": null, "disk": null
}
```

Every key is always present — absent values are `null` (or `[]`), never omitted. Capabilities are nested so a binary that cannot describe itself yields **one** null instead of three, making "can it run" a single check. Names follow `DoctorReport` (`path`, `installed`, `capabilities`). `--json --disk` reports `null` with no engine instead of walking the cache, matching the human path.

## Raycast probe

Branches on stdout **kind**, not parse outcome:

| stdout | verdict |
|---|---|
| JSON object, `installed` boolean | use it |
| JSON object, contract broken | **unavailable** — never prose |
| not JSON | prose fallback (old CLI) |
| empty / garbage / spawn throws | fail open, as before |

That middle row is the bug the naive rule would have shipped: valid JSON without the contract field parses fine, misses the `"not installed"` match, and reports a *missing* engine as healthy. Field-name drift produces exactly that shape. Failing closed costs a dismissible setup view; failing open costs a recording.

The prose match is anchored to the Binary line — `"not installed"` is `formatStatusLine`'s default missing label, so a future missing line would otherwise read as the engine being absent.

An engine that is present but cannot report capabilities is now unavailable rather than a doomed session, and `dictation-controller` varies the **message**, not just the hint. The remedy was verified, not guessed: a plain `kesha install` takes the cached path and only re-trusts the binary, so repairing one needs `kesha install --no-cache` (`cacheValid = versionMatches && (!noCache || !canWriteEngineDir)`, `engine-install.ts:522`).

## Verification

- `bun test` — 530 pass, 0 fail; `bunx tsc --noEmit` clean
- `raycast`: `npm test` 89 pass, `npm run lint` clean
- Probe matrix has one test per row of the table above
- Shell completions + manpage regenerated for the new flag

**Not done:** the engine-present path was never run against a real install — no engine on this machine — so it rests on unit tests driving a fake `--capabilities-json` binary. Recorded in `tasks.md`; worth one real run before the mirror sync.

## Follow-ups

- `raycast/extensions` mirror sync. Until it lands, Store users stay on the fallback path — which is why the fallback is not optional.
- Recorded as Open Issues rather than fixed: the prose marker stays load-bearing while old CLIs exist (a test freezes it); the fallback cannot detect a broken engine on those CLIs (today's behaviour, not a regression); `getEngineCapabilities` casts without shape validation, so "readable capabilities" is weaker than "dictation will succeed".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdkbgPP5f4UtscN6Kz7hi9