### PR TITLE
feat(install): unblock Windows x64

### DIFF
--- a/.github/actions/install-kesha-backend/action.yml
+++ b/.github/actions/install-kesha-backend/action.yml
@@ -22,17 +22,49 @@ inputs:
     description: Additional arguments for `kesha install`
     required: false
     default: ""
+  engine-dir:
+    description: When set, delete this engine dir after cache restore so the install really downloads
+    required: false
+    default: ""
+  install-log:
+    description: When set, tee the install output to this file so a job can assert on it
+    required: false
+    default: ""
+  cache-write:
+    description: Set false so PR runs only read the cache; cache-seed.yml owns writing on main (#661)
+    required: false
+    default: "true"
 
 runs:
   using: composite
   steps:
     - name: 💾 Cache backend
-      if: ${{ inputs.cache-path != '' }}
+      if: ${{ inputs.cache-path != '' && inputs.cache-write == 'true' }}
       uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
       with:
         path: ${{ inputs.cache-path }}
         key: ${{ inputs.cache-key }}
         restore-keys: ${{ inputs.cache-restore-keys }}
+
+    - name: 💾 Restore backend cache
+      if: ${{ inputs.cache-path != '' && inputs.cache-write != 'true' }}
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ inputs.cache-path }}
+        key: ${{ inputs.cache-key }}
+        restore-keys: ${{ inputs.cache-restore-keys }}
+
+    # `!dir/sub` does NOT exclude children of an included dir (actions/toolkit#713), so purge explicitly.
+    - name: 🧊 Force a cold engine download
+      if: ${{ inputs.engine-dir != '' }}
+      shell: bash
+      env:
+        ENGINE_DIR: ${{ inputs.engine-dir }}
+      run: |
+        # A quoted "~/…" is a literal path, so the rm would no-op and the assert would still pass.
+        dir="${ENGINE_DIR/#\~/$HOME}"
+        rm -rf "$dir"
+        test ! -e "$dir"
 
     - name: 🎬 Install ffmpeg
       shell: bash
@@ -50,4 +82,19 @@ runs:
       shell: bash
       env:
         INSTALL_ARGS: ${{ inputs.install-args }}
-      run: bun link && kesha install $INSTALL_ARGS
+        INSTALL_LOG: ${{ inputs.install-log }}
+      run: |
+        bun link
+        if [ -n "$INSTALL_LOG" ]; then
+          kesha install $INSTALL_ARGS 2>&1 | tee "$INSTALL_LOG"
+        else
+          kesha install $INSTALL_ARGS
+        fi
+
+    # A cold install that silently reused a cached binary would green while testing nothing.
+    - name: 🧊 Assert the engine really downloaded
+      if: ${{ inputs.engine-dir != '' && inputs.install-log != '' }}
+      shell: bash
+      env:
+        INSTALL_LOG: ${{ inputs.install-log }}
+      run: grep -q "Engine binary downloaded" "$INSTALL_LOG"

--- a/.github/scripts/assert-install-warmup.ts
+++ b/.github/scripts/assert-install-warmup.ts
@@ -1,0 +1,36 @@
+#!/usr/bin/env bun
+/**
+ * The ASR warm-up is deliberately non-fatal (`rust/src/cli/install.rs`, #298):
+ * install already succeeded, so a failed warm-up only warns and the first real
+ * run pays the cold start. That means a green `kesha install` is NOT evidence
+ * the ORT session initialises — on a platform whose runtime behaviour is what
+ * we are trying to establish, that distinction is the whole point.
+ *
+ * Usage: bun .github/scripts/assert-install-warmup.ts <install-log>
+ */
+const logPath = process.argv[2];
+if (!logPath) {
+  console.error("usage: assert-install-warmup.ts <install-log>");
+  process.exit(2);
+}
+
+const log = await Bun.file(logPath).text();
+
+if (/ASR backend warm-up failed/.test(log)) {
+  console.error(
+    "FAIL: install reported success but the ASR warm-up failed — the engine cannot " +
+      "initialise an ORT session on this platform.\n" +
+      log.split("\n").filter((l) => /warm/i.test(l)).join("\n"),
+  );
+  process.exit(1);
+}
+
+if (!/ASR backend warmed up/.test(log)) {
+  console.error(
+    "FAIL: no warm-up outcome in the install log. Either warm-up was skipped " +
+      "(--no-warmup) or the log was not captured — both leave the platform unverified.",
+  );
+  process.exit(1);
+}
+
+console.log("ok: ASR backend warmed up during install");

--- a/.github/scripts/assert-transcript.ts
+++ b/.github/scripts/assert-transcript.ts
@@ -1,0 +1,39 @@
+#!/usr/bin/env bun
+/**
+ * Asserts `kesha --json <audio>` produced exactly one result with usable text.
+ *
+ * Usage: bun .github/scripts/assert-transcript.ts <json-file>
+ */
+export function assertSingleTranscript(raw: string, label: string): string {
+  let results: Array<{ text?: string }>;
+  try {
+    results = JSON.parse(raw);
+  } catch {
+    throw new Error(`${label}: expected JSON on stdout, got ${raw.slice(0, 200)}`);
+  }
+  if (!Array.isArray(results) || results.length !== 1) {
+    throw new Error(
+      `${label}: expected exactly one transcription result, got ${JSON.stringify(results).slice(0, 200)}`,
+    );
+  }
+  const text = results[0]?.text?.trim() ?? "";
+  if (text.length < 5) {
+    throw new Error(`${label}: expected non-empty transcription text, got ${JSON.stringify(text)}`);
+  }
+  return text;
+}
+
+if (import.meta.main) {
+  const path = process.argv[2];
+  if (!path) {
+    console.error("usage: assert-transcript.ts <json-file>");
+    process.exit(2);
+  }
+  try {
+    const text = assertSingleTranscript(await Bun.file(path).text(), path);
+    console.log(`ok: transcribed "${text.slice(0, 60)}"`);
+  } catch (e) {
+    console.error(`FAIL: ${e instanceof Error ? e.message : String(e)}`);
+    process.exit(1);
+  }
+}

--- a/.github/scripts/smoke-synthesis.ts
+++ b/.github/scripts/smoke-synthesis.ts
@@ -9,6 +9,7 @@
  */
 import { mkdirSync } from "fs";
 import { join } from "path";
+import { assertSingleTranscript } from "./assert-transcript";
 
 const workDir = process.argv[2];
 if (!workDir) {
@@ -22,13 +23,22 @@ const VOICES = [
   { voice: "ru-vosk-m02", text: "Проверка синтеза речи на русском языке." },
 ];
 
-async function run(args: string[]): Promise<{ stdout: string; stderr: string; code: number }> {
+// Without a timeout a hung `kesha say` burns the whole job budget and reports nothing useful.
+async function run(
+  args: string[],
+  timeoutMs = 300_000,
+): Promise<{ stdout: string; stderr: string; code: number }> {
   const proc = Bun.spawn(["kesha", ...args], { stdout: "pipe", stderr: "pipe" });
-  const [stdout, stderr] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-  ]);
-  return { stdout, stderr, code: await proc.exited };
+  const timer = setTimeout(() => proc.kill(), timeoutMs);
+  try {
+    const [stdout, stderr] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ]);
+    return { stdout, stderr, code: await proc.exited };
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 function fail(message: string): never {
@@ -48,30 +58,21 @@ for (const { voice, text } of VOICES) {
   // A header-only WAV is 44 bytes; anything at or below that synthesised silence.
   if (bytes.length <= 44) fail(`${voice}: WAV is ${bytes.length} bytes, i.e. header without audio`);
 
-  const riff = new TextDecoder().decode(bytes.subarray(0, 4));
-  const wave = new TextDecoder().decode(bytes.subarray(8, 12));
-  if (riff !== "RIFF" || wave !== "WAVE") {
-    fail(`${voice}: expected a RIFF/WAVE header, got "${riff}"/"${wave}"`);
+  const header = new TextDecoder().decode(bytes.subarray(0, 12));
+  if (!header.startsWith("RIFF") || header.slice(8) !== "WAVE") {
+    fail(`${voice}: expected a RIFF/WAVE header, got ${JSON.stringify(header)}`);
   }
   console.log(`ok: ${voice} synthesised ${bytes.length} bytes`);
 
   const back = await run(["--json", outPath]);
   if (back.code !== 0) fail(`transcribing ${voice}.wav exited ${back.code}\n${back.stderr}`);
 
-  let results: Array<{ text?: string }>;
+  // Not asserting on WER: this proves the engine speaks and hears, not that it is accurate.
+  let transcript: string;
   try {
-    results = JSON.parse(back.stdout);
+    transcript = assertSingleTranscript(back.stdout, `${voice}.wav`);
   } catch (e) {
-    fail(`transcribing ${voice}.wav returned non-JSON stdout: ${back.stdout.slice(0, 200)}`);
-  }
-  if (!Array.isArray(results) || results.length !== 1) {
-    fail(`transcribing ${voice}.wav: expected exactly one result, got ${JSON.stringify(results).slice(0, 200)}`);
-  }
-  // Not asserting on WER: this proves the engine speaks and hears, not that it
-  // is accurate. Accuracy has its own benchmark lane.
-  const transcript = results[0]?.text?.trim() ?? "";
-  if (transcript.length < 5) {
-    fail(`transcribing ${voice}.wav produced no usable text (got ${JSON.stringify(transcript)})`);
+    fail(e instanceof Error ? e.message : String(e));
   }
   console.log(`ok: ${voice} round-tripped to "${transcript.slice(0, 60)}"`);
 }

--- a/.github/scripts/smoke-synthesis.ts
+++ b/.github/scripts/smoke-synthesis.ts
@@ -1,0 +1,79 @@
+#!/usr/bin/env bun
+/**
+ * Round-trip smoke for a shipped engine: synthesise with both TTS engines, then
+ * transcribe the result back. Closes the last #216 acceptance criterion, which
+ * no lane covered — rust-test.yml runs unit and contract tests, and the Linux
+ * engine smokes transcribe a fixture but never synthesise.
+ *
+ * Usage: bun .github/scripts/smoke-synthesis.ts <work-dir>
+ */
+import { mkdirSync } from "fs";
+import { join } from "path";
+
+const workDir = process.argv[2];
+if (!workDir) {
+  console.error("usage: smoke-synthesis.ts <work-dir>");
+  process.exit(2);
+}
+mkdirSync(workDir, { recursive: true });
+
+const VOICES = [
+  { voice: "en-am_michael", text: "The quick brown fox jumps over the lazy dog." },
+  { voice: "ru-vosk-m02", text: "Проверка синтеза речи на русском языке." },
+];
+
+async function run(args: string[]): Promise<{ stdout: string; stderr: string; code: number }> {
+  const proc = Bun.spawn(["kesha", ...args], { stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  return { stdout, stderr, code: await proc.exited };
+}
+
+function fail(message: string): never {
+  console.error(`FAIL: ${message}`);
+  process.exit(1);
+}
+
+for (const { voice, text } of VOICES) {
+  const outPath = join(workDir, `${voice}.wav`);
+  const say = await run(["say", text, "--voice", voice, "--out", outPath]);
+  if (say.code !== 0) fail(`\`kesha say --voice ${voice}\` exited ${say.code}\n${say.stderr}`);
+
+  const wav = Bun.file(outPath);
+  if (!(await wav.exists())) fail(`${voice}: --out produced no file at ${outPath}`);
+
+  const bytes = new Uint8Array(await wav.arrayBuffer());
+  // A header-only WAV is 44 bytes; anything at or below that synthesised silence.
+  if (bytes.length <= 44) fail(`${voice}: WAV is ${bytes.length} bytes, i.e. header without audio`);
+
+  const riff = new TextDecoder().decode(bytes.subarray(0, 4));
+  const wave = new TextDecoder().decode(bytes.subarray(8, 12));
+  if (riff !== "RIFF" || wave !== "WAVE") {
+    fail(`${voice}: expected a RIFF/WAVE header, got "${riff}"/"${wave}"`);
+  }
+  console.log(`ok: ${voice} synthesised ${bytes.length} bytes`);
+
+  const back = await run(["--json", outPath]);
+  if (back.code !== 0) fail(`transcribing ${voice}.wav exited ${back.code}\n${back.stderr}`);
+
+  let results: Array<{ text?: string }>;
+  try {
+    results = JSON.parse(back.stdout);
+  } catch (e) {
+    fail(`transcribing ${voice}.wav returned non-JSON stdout: ${back.stdout.slice(0, 200)}`);
+  }
+  if (!Array.isArray(results) || results.length !== 1) {
+    fail(`transcribing ${voice}.wav: expected exactly one result, got ${JSON.stringify(results).slice(0, 200)}`);
+  }
+  // Not asserting on WER: this proves the engine speaks and hears, not that it
+  // is accurate. Accuracy has its own benchmark lane.
+  const transcript = results[0]?.text?.trim() ?? "";
+  if (transcript.length < 5) {
+    fail(`transcribing ${voice}.wav produced no usable text (got ${JSON.stringify(transcript)})`);
+  }
+  console.log(`ok: ${voice} round-tripped to "${transcript.slice(0, 60)}"`);
+}
+
+console.log("Synthesis round-trip smoke passed.");

--- a/.github/workflows/cache-seed.yml
+++ b/.github/workflows/cache-seed.yml
@@ -22,7 +22,7 @@ on:
     # The key hashes rust/ci/download-kokoro.sh, so only a change to that file can
     # make a re-seed necessary. Without this filter every push to main — up to 26
     # a day here — spun three runners to probe a guaranteed hit.
-    paths: ["rust/ci/download-kokoro.sh"]
+    paths: ["rust/ci/download-kokoro.sh", "rust/src/models.rs", ".github/workflows/cache-seed.yml"]
   # Eviction does not wait for pushes. Without this, a bundle evicted under budget
   # pressure stays gone until someone happens to touch the download script, and
   # every PR job in between pays a full cold download.
@@ -87,3 +87,43 @@ jobs:
         with:
           path: ${{ env.KOKORO_CACHE }}
           key: kokoro-models-v1-${{ runner.os }}-${{ hashFiles('rust/ci/download-kokoro.sh') }}
+
+  kesha-models:
+    name: Kesha models (${{ matrix.os }})
+    # The smoke lanes read `${{ runner.os }}-kesha-models-tts-v1` restore-only, so without this
+    # seed they cold-download ~3.5 GB every run; with it, one main-scoped copy serves every PR.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 40
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Probe cache
+        id: probe
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/kesha
+          key: ${{ runner.os }}-kesha-models-tts-v1
+          lookup-only: true
+
+      - name: 🍞 Setup Bun workspace
+        if: steps.probe.outputs.cache-hit != 'true'
+        uses: ./.github/actions/setup-bun
+
+      - name: Populate models
+        if: steps.probe.outputs.cache-hit != 'true'
+        uses: ./.github/actions/install-kesha-backend
+        with:
+          ffmpeg-provider: skip
+          install-args: --tts en ru
+
+      - name: Save models
+        if: steps.probe.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/kesha
+          key: ${{ runner.os }}-kesha-models-tts-v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -649,6 +649,98 @@ jobs:
         shell: bash
         run: bun .github/scripts/smoke-synthesis.ts /tmp/kesha-release-synth
 
+  release-branch-windows-smoke:
+    # The win32 half of P1.11: windows-engine-smoke is guarded off release branches, whose tag is unpublished (#216, #464).
+    needs: [changes, unit-tests]
+    if: |
+      needs.changes.outputs.integration == 'true' &&
+      (
+        startsWith(github.head_ref, 'release/') ||
+        startsWith(github.event.head_commit.message, 'chore(release):')
+      ) &&
+      needs.unit-tests.result == 'success'
+    runs-on: windows-latest
+    # Higher than the Linux lane's 35: a cold MSVC build of the engine dominates this job.
+    timeout-minutes: 50
+    env:
+      KESHA_CACHE_DIR: ${{ github.workspace }}\.kesha-release-smoke
+      # Cargo emits kesha-engine.exe — the Linux lane's extensionless path does not carry over.
+      KESHA_ENGINE_BIN: ${{ github.workspace }}\rust\target\release\kesha-engine.exe
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          lfs: true
+
+      - name: 🍞 Setup Bun workspace
+        uses: ./.github/actions/setup-bun
+
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with:
+          toolchain: stable
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: rust
+
+      - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+
+      - name: 🔗 Pin MSVC linker
+        shell: pwsh
+        # Git for Windows ships a GNU link.exe that shadows MSVC's under `shell: bash` (rust-test.yml).
+        run: |
+          $linkPath = (Get-Command link.exe |
+            Where-Object { $_.Source -notlike "*Git*usr*" } |
+            Select-Object -First 1).Source
+          if (-not $linkPath) { Write-Error "MSVC link.exe not found"; exit 1 }
+          Add-Content -Path $env:GITHUB_ENV -Value "CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=$linkPath"
+
+      - name: 🎧 Allow legacy cmake_minimum_required
+        shell: pwsh
+        # opusic-sys falls back to a cmake build of vendored libopus whose CMakeLists predates cmake 4.
+        run: Add-Content -Path $env:GITHUB_ENV -Value "CMAKE_POLICY_VERSION_MINIMUM=3.5"
+
+      - name: 🦀 Build local Windows engine
+        shell: bash
+        run: cd rust && cargo build --release --features onnx,tts --no-default-features
+
+      - name: 🧾 Mark local engine version
+        shell: bash
+        run: |
+          bun -e '
+            const pkg = await Bun.file("package.json").json();
+            await Bun.write(`${process.env.KESHA_ENGINE_BIN}.version`, `${pkg.keshaEngine.version}\n`);
+          '
+
+      - name: 🔊 Install models through local backend
+        uses: ./.github/actions/install-kesha-backend
+        with:
+          cache-path: |
+            ${{ github.workspace }}\.kesha-release-smoke
+          cache-key: ${{ runner.os }}-kesha-release-smoke-v1
+          cache-restore-keys: ${{ runner.os }}-kesha-release-smoke-
+          ffmpeg-provider: skip
+          install-args: --onnx --tts en ru
+
+      - name: 🚬 Smoke release branch local engine
+        shell: bash
+        run: |
+          kesha status
+          kesha --json tests/fixtures/benchmark-en/01-check-email.ogg > kesha-release-smoke.json
+          bun -e '
+            const output = await Bun.file("kesha-release-smoke.json").json();
+            if (!Array.isArray(output) || output.length !== 1) {
+              throw new Error("expected exactly one transcription result");
+            }
+            if (!output[0].text || output[0].text.length < 5) {
+              throw new Error("expected non-empty transcription text");
+            }
+          '
+
+      - name: 🗣️ Synthesis round-trip
+        shell: bash
+        run: bun .github/scripts/smoke-synthesis.ts kesha-release-synth
+
   tts-e2e:
     # Runs whenever rust engine code, the TS CLI that drives `kesha say`,
     # or the say-e2e test itself changes. Wait for `unit-tests` so a red
@@ -873,6 +965,7 @@ jobs:
       - published-engine-smoke
       - windows-engine-smoke
       - release-branch-engine-smoke
+      - release-branch-windows-smoke
       - tts-e2e
       - raycast-lint
       - openspec-validate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,10 @@ jobs:
               - 'src/engine.ts'
               - 'src/lib.ts'
               - 'src/paths.ts'
+              # The download path itself: a revert of the awaited `writer.end()` must re-fire
+              # these lanes, and `install.ts` carries the backend pre-flight (#216).
+              - 'src/progress.ts'
+              - 'src/cli/install.ts'
               - 'src/transcribe.ts'
               - 'src/cli/dispatch.ts'
               - 'src/cli/main.ts'
@@ -106,6 +110,9 @@ jobs:
               - 'tests/integration/say-e2e.test.ts'
               - '.github/workflows/ci.yml'
               - '.github/actions/**'
+              - '.github/scripts/smoke-synthesis.ts'
+              - '.github/scripts/assert-transcript.ts'
+              - '.github/scripts/assert-install-warmup.ts'
             tts_e2e:
               - 'rust/**'
               - 'package.json'
@@ -445,29 +452,22 @@ jobs:
       - name: 🔊 Install published Linux backend
         uses: ./.github/actions/install-kesha-backend
         with:
-          # Models only, same reason as the Windows lane: a cached engine skips the download path.
           cache-path: |
             ~/.cache/kesha
-            !~/.cache/kesha/engine
           cache-key: ${{ runner.os }}-kesha-models-tts-v1
           cache-restore-keys: ${{ runner.os }}-kesha-models-tts-
           ffmpeg-provider: apt
           install-args: --tts en ru
+          engine-dir: ~/.cache/kesha/engine
+          install-log: kesha-install.log
+          cache-write: "false"
 
       - name: 🚬 Smoke published Linux engine
         shell: bash
         run: |
           kesha status
           kesha --json tests/fixtures/benchmark-en/01-check-email.ogg > /tmp/kesha-linux-smoke.json
-          bun -e '
-            const output = await Bun.file("/tmp/kesha-linux-smoke.json").json();
-            if (!Array.isArray(output) || output.length !== 1) {
-              throw new Error("expected exactly one transcription result");
-            }
-            if (!output[0].text || output[0].text.length < 5) {
-              throw new Error("expected non-empty transcription text");
-            }
-          '
+          bun .github/scripts/assert-transcript.ts /tmp/kesha-linux-smoke.json
 
       # Synthesis was unproven on every non-Darwin platform (#464).
       - name: 🗣️ Synthesis round-trip
@@ -503,33 +503,18 @@ jobs:
       - name: 🍞 Setup Bun workspace
         uses: ./.github/actions/setup-bun
 
-      - name: 💾 Cache backend
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
-        with:
-          # Models only: a cached engine + version marker sends downloadEngine down its cacheValid branch, skipping fetchEngineBinary (#216).
-          path: |
-            ~/.cache/kesha
-            !~/.cache/kesha/engine
-          key: ${{ runner.os }}-kesha-models-tts-v1
-          restore-keys: ${{ runner.os }}-kesha-models-tts-
-
-      # Belt-and-braces against the exclusion above silently regressing: the cold path is the point.
-      - name: 🧊 Assert no engine is present before install
-        shell: bash
-        run: |
-          rm -rf ~/.cache/kesha/engine
-          test ! -e ~/.cache/kesha/engine
-
-      # Not the composite action: this lane keeps the install log to assert on warm-up.
       - name: 🔊 Cold install the published Windows engine
-        shell: bash
-        run: |
-          bun link
-          kesha install --tts en ru 2>&1 | tee kesha-install.log
-
-      - name: 🧊 Assert the engine really downloaded
-        shell: bash
-        run: grep -q "Engine binary downloaded" kesha-install.log
+        uses: ./.github/actions/install-kesha-backend
+        with:
+          cache-path: |
+            ~/.cache/kesha
+          cache-key: ${{ runner.os }}-kesha-models-tts-v1
+          cache-restore-keys: ${{ runner.os }}-kesha-models-tts-
+          ffmpeg-provider: skip
+          install-args: --tts en ru
+          engine-dir: ~/.cache/kesha/engine
+          install-log: kesha-install.log
+          cache-write: "false"
 
       - name: 🔥 Assert the ASR warm-up actually ran
         shell: bash
@@ -540,15 +525,7 @@ jobs:
         run: |
           kesha status
           kesha --json tests/fixtures/benchmark-en/01-check-email.ogg > kesha-win-smoke.json
-          bun -e '
-            const output = await Bun.file("kesha-win-smoke.json").json();
-            if (!Array.isArray(output) || output.length !== 1) {
-              throw new Error("expected exactly one transcription result");
-            }
-            if (!output[0].text || output[0].text.length < 5) {
-              throw new Error("expected non-empty transcription text");
-            }
-          '
+          bun .github/scripts/assert-transcript.ts kesha-win-smoke.json
 
       - name: 🗣️ Synthesis round-trip
         shell: bash
@@ -634,15 +611,7 @@ jobs:
         run: |
           kesha status
           kesha --json tests/fixtures/benchmark-en/01-check-email.ogg > /tmp/kesha-release-smoke.json
-          bun -e '
-            const output = await Bun.file("/tmp/kesha-release-smoke.json").json();
-            if (!Array.isArray(output) || output.length !== 1) {
-              throw new Error("expected exactly one transcription result");
-            }
-            if (!output[0].text || output[0].text.length < 5) {
-              throw new Error("expected non-empty transcription text");
-            }
-          '
+          bun .github/scripts/assert-transcript.ts /tmp/kesha-release-smoke.json
 
       # The about-to-ship artifact needs the same synthesis proof as the published one (#464).
       - name: 🗣️ Synthesis round-trip
@@ -727,15 +696,7 @@ jobs:
         run: |
           kesha status
           kesha --json tests/fixtures/benchmark-en/01-check-email.ogg > kesha-release-smoke.json
-          bun -e '
-            const output = await Bun.file("kesha-release-smoke.json").json();
-            if (!Array.isArray(output) || output.length !== 1) {
-              throw new Error("expected exactly one transcription result");
-            }
-            if (!output[0].text || output[0].text.length < 5) {
-              throw new Error("expected non-empty transcription text");
-            }
-          '
+          bun .github/scripts/assert-transcript.ts kesha-release-smoke.json
 
       - name: 🗣️ Synthesis round-trip
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -445,10 +445,12 @@ jobs:
       - name: 🔊 Install published Linux backend
         uses: ./.github/actions/install-kesha-backend
         with:
+          # Models only, same reason as the Windows lane: a cached engine skips the download path.
           cache-path: |
             ~/.cache/kesha
-          cache-key: ${{ runner.os }}-kesha-engine-tts-v1
-          cache-restore-keys: ${{ runner.os }}-kesha-engine-tts-
+            !~/.cache/kesha/engine
+          cache-key: ${{ runner.os }}-kesha-models-tts-v1
+          cache-restore-keys: ${{ runner.os }}-kesha-models-tts-
           ffmpeg-provider: apt
           install-args: --tts en ru
 
@@ -504,9 +506,19 @@ jobs:
       - name: 💾 Cache backend
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
-          path: ~/.cache/kesha
-          key: ${{ runner.os }}-kesha-engine-tts-v1
-          restore-keys: ${{ runner.os }}-kesha-engine-tts-
+          # Models only: a cached engine + version marker sends downloadEngine down its cacheValid branch, skipping fetchEngineBinary (#216).
+          path: |
+            ~/.cache/kesha
+            !~/.cache/kesha/engine
+          key: ${{ runner.os }}-kesha-models-tts-v1
+          restore-keys: ${{ runner.os }}-kesha-models-tts-
+
+      # Belt-and-braces against the exclusion above silently regressing: the cold path is the point.
+      - name: 🧊 Assert no engine is present before install
+        shell: bash
+        run: |
+          rm -rf ~/.cache/kesha/engine
+          test ! -e ~/.cache/kesha/engine
 
       # Not the composite action: this lane keeps the install log to assert on warm-up.
       - name: 🔊 Cold install the published Windows engine
@@ -514,6 +526,10 @@ jobs:
         run: |
           bun link
           kesha install --tts en ru 2>&1 | tee kesha-install.log
+
+      - name: 🧊 Assert the engine really downloaded
+        shell: bash
+        run: grep -q "Engine binary downloaded" kesha-install.log
 
       - name: 🔥 Assert the ASR warm-up actually ran
         shell: bash
@@ -566,7 +582,8 @@ jobs:
       ) &&
       needs.unit-tests.result == 'success'
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    # 25 before the TTS models were added to this lane.
+    timeout-minutes: 35
     env:
       KESHA_CACHE_DIR: ${{ github.workspace }}/.kesha-release-smoke
       KESHA_ENGINE_BIN: ${{ github.workspace }}/rust/target/release/kesha-engine
@@ -610,7 +627,7 @@ jobs:
           cache-key: ${{ runner.os }}-kesha-release-smoke-v1
           cache-restore-keys: ${{ runner.os }}-kesha-release-smoke-
           ffmpeg-provider: apt
-          install-args: --onnx
+          install-args: --onnx --tts en ru
 
       - name: 🚬 Smoke release branch local engine
         shell: bash
@@ -626,6 +643,11 @@ jobs:
               throw new Error("expected non-empty transcription text");
             }
           '
+
+      # The about-to-ship artifact needs the same synthesis proof as the published one (#464).
+      - name: 🗣️ Synthesis round-trip
+        shell: bash
+        run: bun .github/scripts/smoke-synthesis.ts /tmp/kesha-release-synth
 
   tts-e2e:
     # Runs whenever rust engine code, the TS CLI that drives `kesha say`,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -411,10 +411,7 @@ jobs:
             --category bun --flakiness-project Laputa/kesha-voice-kit
 
   published-engine-smoke:
-    # P1.10: keep at least one non-Darwin lane exercising the published
-    # engine install path. Windows is intentionally omitted while
-    # `src/engine-install.ts` still reports win32 x64 as unsupported; this
-    # Linux x64 lane covers the currently supported non-Darwin release asset.
+    # P1.10: one non-Darwin lane on the published engine; `windows-engine-smoke` is the win32 half (#216).
     needs: [changes, unit-tests]
     # `always()` so a SKIPPED `unit-tests` (rust-only PRs have `code == 'false'`)
     # doesn't skip-propagate and drop the heavy lane — `real_engine_e2e` includes
@@ -450,9 +447,10 @@ jobs:
         with:
           cache-path: |
             ~/.cache/kesha
-          cache-key: ${{ runner.os }}-kesha-engine-v1
-          cache-restore-keys: ${{ runner.os }}-kesha-engine-
+          cache-key: ${{ runner.os }}-kesha-engine-tts-v1
+          cache-restore-keys: ${{ runner.os }}-kesha-engine-tts-
           ffmpeg-provider: apt
+          install-args: --tts en ru
 
       - name: 🚬 Smoke published Linux engine
         shell: bash
@@ -468,6 +466,91 @@ jobs:
               throw new Error("expected non-empty transcription text");
             }
           '
+
+      # Synthesis was unproven on every non-Darwin platform (#464).
+      - name: 🗣️ Synthesis round-trip
+        shell: bash
+        run: bun .github/scripts/smoke-synthesis.ts /tmp/kesha-linux-synth
+
+  windows-engine-smoke:
+    # Cold `kesha install` on purpose: pre-seeding the engine skips `fetchEngineBinary`, where the #216 refusal lived.
+    needs: [changes, unit-tests]
+    # `always()` so a legitimately skipped `unit-tests` on a rust-only PR doesn't skip-propagate (#274).
+    if: |
+      always() &&
+      needs.changes.result == 'success' &&
+      needs.unit-tests.result != 'failure' &&
+      needs.unit-tests.result != 'cancelled' &&
+      (
+        github.event_name == 'schedule' ||
+        (
+          needs.changes.outputs.real_engine_e2e == 'true' &&
+          !startsWith(github.head_ref, 'release/') &&
+          !startsWith(github.event.head_commit.message, 'chore(release):')
+        )
+      )
+    runs-on: windows-latest
+    # Higher than the Linux lane's 12: slower model downloads, and the ru voice doubles the payload.
+    timeout-minutes: 30
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          lfs: true
+
+      - name: 🍞 Setup Bun workspace
+        uses: ./.github/actions/setup-bun
+
+      - name: 💾 Cache backend
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: ~/.cache/kesha
+          key: ${{ runner.os }}-kesha-engine-tts-v1
+          restore-keys: ${{ runner.os }}-kesha-engine-tts-
+
+      # Not the composite action: this lane keeps the install log to assert on warm-up.
+      - name: 🔊 Cold install the published Windows engine
+        shell: bash
+        run: |
+          bun link
+          kesha install --tts en ru 2>&1 | tee kesha-install.log
+
+      - name: 🔥 Assert the ASR warm-up actually ran
+        shell: bash
+        run: bun .github/scripts/assert-install-warmup.ts kesha-install.log
+
+      - name: 🚬 Smoke the installed engine
+        shell: bash
+        run: |
+          kesha status
+          kesha --json tests/fixtures/benchmark-en/01-check-email.ogg > kesha-win-smoke.json
+          bun -e '
+            const output = await Bun.file("kesha-win-smoke.json").json();
+            if (!Array.isArray(output) || output.length !== 1) {
+              throw new Error("expected exactly one transcription result");
+            }
+            if (!output[0].text || output[0].text.length < 5) {
+              throw new Error("expected non-empty transcription text");
+            }
+          '
+
+      - name: 🗣️ Synthesis round-trip
+        shell: bash
+        run: bun .github/scripts/smoke-synthesis.ts kesha-win-synth
+
+      # Only meaningful without KESHA_ENGINE_BIN, which makes performInstall skip the pre-flight.
+      - name: 🚫 Reject --coreml on Windows
+        shell: bash
+        run: |
+          if kesha install --coreml 2> coreml-reject.log; then
+            echo "FAIL: \`kesha install --coreml\` succeeded on Windows" >&2
+            exit 1
+          fi
+          grep -qi onnx coreml-reject.log || {
+            echo "FAIL: rejection did not name the ONNX backend" >&2
+            cat coreml-reject.log >&2
+            exit 1
+          }
 
   release-branch-engine-smoke:
     # P1.11: release branches cannot download the not-yet-published engine
@@ -766,6 +849,7 @@ jobs:
       - integration-tests
       - integration-tests-full
       - published-engine-smoke
+      - windows-engine-smoke
       - release-branch-engine-smoke
       - tts-e2e
       - raycast-lint

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 ## Quick Start
 
-Runtime: **[Bun](https://bun.sh)** >= 1.3.0 · Platforms: macOS arm64, Linux x64. Windows x64 is currently blocked at install ([#216](https://github.com/drakulavich/kesha-voice-kit/issues/216)).
+Runtime: **[Bun](https://bun.sh)** >= 1.3.0 · Platforms: macOS arm64, Linux x64, Windows x64. Linux and Windows run the ONNX engine — everything except microphone capture (`kesha record`), macOS system voices, speaker diarization, and text language detection, which need Apple frameworks.
 
 ```bash
 # 1. Install Bun (skip if you have it) — Linux & macOS:

--- a/docs/product-positioning.md
+++ b/docs/product-positioning.md
@@ -60,27 +60,29 @@ The product promise is not "one model for every audio problem." The promise is a
 
 | Capability | macOS arm64 | macOS x64 | Linux x64 | Windows x64 | Nix path |
 |---|---|---|---|---|---|
-| STT | Supported, CoreML path | Not shipped | Supported, ONNX CPU path | Blocked at install (#216) | `aarch64-darwin`, `x86_64-linux` |
-| Audio language detection | Supported | Not shipped | Supported | Blocked at install (#216) | Supported where the flake builds |
-| VAD | Supported with `kesha install --vad` | Not shipped | Supported with `kesha install --vad` | Blocked at install (#216) | Supported where the engine path includes VAD assets |
-| TTS: English Kokoro | Supported, FluidAudio/CoreML in release builds | Not shipped | Supported, ONNX path | Blocked at install (#216) | Supported except where noted in `docs/nix-install.md` |
-| TTS: Russian Vosk-TTS | Supported | Not shipped | Supported | Blocked at install (#216) | Supported except where noted in `docs/nix-install.md` |
+| STT | Supported, CoreML path | Not shipped | Supported, ONNX CPU path | Supported, ONNX CPU path | `aarch64-darwin`, `x86_64-linux` |
+| Audio language detection | Supported | Not shipped | Supported | Supported | Supported where the flake builds |
+| VAD | Supported with `kesha install --vad` | Not shipped | Supported with `kesha install --vad` | Supported with `kesha install --vad` | Supported where the engine path includes VAD assets |
+| TTS: English Kokoro | Supported, FluidAudio/CoreML in release builds | Not shipped | Supported, ONNX path | Supported, ONNX path | Supported except where noted in `docs/nix-install.md` |
+| TTS: Russian Vosk-TTS | Supported | Not shipped | Supported | Supported | Supported except where noted in `docs/nix-install.md` |
 | macOS system voices | Supported | Not shipped | Not applicable | Not applicable | Supported on `aarch64-darwin` |
 | Speaker diarization | Preview, darwin-arm64 only | Not supported | Not supported | Not supported | Not wired into the Nix build yet |
 | Raycast extension | Supported | Not shipped | Not applicable | Not applicable | Not applicable |
-| OpenClaw integration | Supported through CLI route | Not shipped | Supported through CLI route | Blocked at install (#216) | Use the installed `kesha` command from the chosen path |
-| Hermes Agent integration | Supported through command providers | Not shipped | Supported through command providers | Blocked at install (#216) | Use the installed `kesha` command from the chosen path |
+| OpenClaw integration | Supported through CLI route | Not shipped | Supported through CLI route | Supported through CLI route | Use the installed `kesha` command from the chosen path |
+| Hermes Agent integration | Supported through command providers | Not shipped | Supported through command providers | Supported through command providers | Use the installed `kesha` command from the chosen path |
 
 `macOS x64` means Intel Macs. Kesha does not currently publish a `darwin-x64` engine binary, so Intel Macs are intentionally marked as not shipped rather than implied to use the ONNX fallback.
 
-`Windows x64` shows "Blocked at install" because the CLI's install step
-refuses to run on Windows, not because no binary exists — `build-engine.yml`
-builds and publishes `kesha-engine-windows-x64.exe` with every release. The
-Vosk-TTS native dependency trips MSVC at link time, so the CLI blocks the
-install client-side rather than shipping a broken engine. See
-[issue #216](https://github.com/drakulavich/kesha-voice-kit/issues/216) for
-the underlying failure and the v1.4.x workaround; the toolkit is unusable on
-Windows until that lands.
+`Windows x64` runs the same ONNX engine as Linux. The MSVC link failure behind
+[issue #216](https://github.com/drakulavich/kesha-voice-kit/issues/216) was fixed by
+vendoring the Vosk-TTS runtime under `rust/vendor/vosk-tts/`, and the CLI's install
+refusal — which outlived that fix by about twenty minor versions — is gone. CI now runs
+a cold `kesha install` on `windows-latest`, synthesises with both the Kokoro and Vosk
+engines, and transcribes the result back, so the platform's row reflects a tested path
+rather than a published binary nobody had run.
+
+Microphone capture is the one Linux/Windows gap that is not about Apple frameworks:
+`kesha record` is macOS-only, so pass an existing audio file instead.
 
 ## When to choose something else
 

--- a/openspec/changes/2026-08-01-windows-x64-unblock/.openspec.yaml
+++ b/openspec/changes/2026-08-01-windows-x64-unblock/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-01

--- a/openspec/changes/2026-08-01-windows-x64-unblock/proposal.md
+++ b/openspec/changes/2026-08-01-windows-x64-unblock/proposal.md
@@ -14,7 +14,7 @@ vendoring plan it proposed. Three of its four acceptance criteria are demonstrab
 - `rust/vendor/vosk-tts/` exists and builds — the vendored crate compiles in every Rust lane.
 - `build-engine.yml` carries the `windows-latest` / `x86_64-pc-windows-msvc` row with
   `--features onnx,tts`, and release **v1.24.7 publishes `kesha-engine-windows-x64.exe`
-  (61 MB) with a sigstore attestation**.
+  (63,447,040 bytes) with a sigstore attestation**.
 - The Windows row is back in `rust-test.yml`; `test (windows-latest)` runs 393 tests green.
 
 The fourth — "`kesha say --voice ru-vosk-m02` produces a valid WAV on Windows" — was never
@@ -42,7 +42,7 @@ false negative with an unverified promise.
   `kesha say` and feeds it back through Transcription. This closes the last #216 acceptance
   criterion and the `Linux/Windows real-synth release smoke` item already tracked in ROADMAP
   under [#464](https://github.com/drakulavich/kesha-voice-kit/issues/464).
-- **Docs**: README platform line, the four "Blocked at install (#216)" rows and the
+- **Docs**: README platform line, the seven "Blocked at install (#216)" rows and the
   explanatory paragraph in `docs/product-positioning.md`, and the installation spec's Open
   Issue entry.
 

--- a/openspec/changes/2026-08-01-windows-x64-unblock/proposal.md
+++ b/openspec/changes/2026-08-01-windows-x64-unblock/proposal.md
@@ -30,7 +30,10 @@ false negative with an unverified promise.
 
 - **CLI platform gate**: `getEngineBinaryName` stops throwing for `win32`/`x64` and returns
   the released asset name. Backend auto-detection learns `win32-x64 → onnx`; today it returns
-  `undefined`, which would fail the install a second time even with the throw removed.
+  `undefined`, and the pre-flight check is written `platformBackend && backend !== platformBackend`,
+  so `undefined` *skips* validation rather than failing it. Lifting the throw alone would let
+  `kesha install --coreml` past the pre-flight on Windows and only reject it after the 63 MB
+  download, when `validateBackend` compares the Capabilities JSON.
 - **Install plan**: the Windows note claiming the platform is blocked is dropped, so
   `kesha install --plan` stops contradicting itself (it already lists the Windows asset and
   its size).

--- a/openspec/changes/2026-08-01-windows-x64-unblock/proposal.md
+++ b/openspec/changes/2026-08-01-windows-x64-unblock/proposal.md
@@ -1,0 +1,80 @@
+# Proposal: windows-x64-unblock
+
+## Why
+
+The CLI refuses to install on Windows x64 with an error naming **v1.5.0** and recommending
+"use v1.4.x as a workaround". The repository is on v1.24.7 — the refusal has outlived its
+cause by roughly twenty minor versions.
+
+The cause was [issue #216](https://github.com/drakulavich/kesha-voice-kit/issues/216): the
+`vosk-tts-rs` transitive native stack mixed static and dynamic MSVC CRTs, so the Engine
+would not link on `x86_64-pc-windows-msvc`. That issue was **closed on 2026-04-30** by the
+vendoring plan it proposed. Three of its four acceptance criteria are demonstrably met:
+
+- `rust/vendor/vosk-tts/` exists and builds — the vendored crate compiles in every Rust lane.
+- `build-engine.yml` carries the `windows-latest` / `x86_64-pc-windows-msvc` row with
+  `--features onnx,tts`, and release **v1.24.7 publishes `kesha-engine-windows-x64.exe`
+  (61 MB) with a sigstore attestation**.
+- The Windows row is back in `rust-test.yml`; `test (windows-latest)` runs 393 tests green.
+
+The fourth — "`kesha say --voice ru-vosk-m02` produces a valid WAV on Windows" — was never
+verified, and no lane verifies it today: the Windows CI job runs unit and contract tests, not
+real synthesis or Transcription. So the Engine ships, the CLI refuses to fetch it, and nobody
+knows whether the shipped binary actually speaks.
+
+This proposal removes the stale refusal **and** adds the verification whose absence is the
+only honest reason left to keep a gate. Shipping the unblock without it would replace a
+false negative with an unverified promise.
+
+## What Changes
+
+- **CLI platform gate**: `getEngineBinaryName` stops throwing for `win32`/`x64` and returns
+  the released asset name. Backend auto-detection learns `win32-x64 → onnx`; today it returns
+  `undefined`, which would fail the install a second time even with the throw removed.
+- **Install plan**: the Windows note claiming the platform is blocked is dropped, so
+  `kesha install --plan` stops contradicting itself (it already lists the Windows asset and
+  its size).
+- **Release verification**: a real-synthesis and real-Transcription smoke lane on
+  `windows-latest` (and `ubuntu-latest`, which has the same gap) that synthesises a WAV via
+  `kesha say` and feeds it back through Transcription. This closes the last #216 acceptance
+  criterion and the `Linux/Windows real-synth release smoke` item already tracked in ROADMAP
+  under [#464](https://github.com/drakulavich/kesha-voice-kit/issues/464).
+- **Docs**: README platform line, the four "Blocked at install (#216)" rows and the
+  explanatory paragraph in `docs/product-positioning.md`, and the installation spec's Open
+  Issue entry.
+
+## Capabilities
+
+### New Capabilities
+
+(none — the change modifies behavior already covered by the `installation` capability)
+
+### Modified Capabilities
+
+- `installation`: Windows x64 becomes a supported install target; Backend auto-detection
+  covers it; the platform matrix a reader consults stops describing a block that the
+  release artifacts contradict.
+
+## Non-goals
+
+- **No new platform capabilities.** Windows gets exactly what the ONNX Engine already
+  compiles: Transcription, Language detection (audio), VAD, and TTS via Kokoro, Vosk, and
+  CharsiuG2P. CoreML, `macos-*` voices, Diarization, and Language detection (text) stay
+  macOS-only, and this change must not blur those rows.
+- **No microphone capture on Windows.** `kesha record` remains macOS-only; Windows users
+  pass an existing audio file, as the README already instructs.
+- **No Intel-Mac (`darwin-x64`) revival.** That platform has no published Engine and stays
+  "not shipped".
+- **No change to the Never-auto-download rule.** Unblocking install does not make anything
+  download outside an explicit `kesha install`.
+- **No engine (Rust) changes.** The Windows Engine already builds and ships; this is a CLI,
+  CI, and documentation change.
+
+## Impact
+
+- TS CLI: `src/engine-install.ts::getEngineBinaryName`, `src/cli/install.ts::defaultBackendForPlatform`,
+  `src/install-plan.ts::buildEngineComponent` + unit tests.
+- CI: a new release-smoke lane; no change to the existing rust-test or build-engine matrices.
+- Docs: `README.md`, `docs/product-positioning.md`, `openspec/specs/installation/spec.md`.
+- No breaking changes for macOS or Linux: every touched branch is guarded on
+  `process.platform === "win32"` and is unreachable elsewhere.

--- a/openspec/changes/2026-08-01-windows-x64-unblock/specs/installation/spec.md
+++ b/openspec/changes/2026-08-01-windows-x64-unblock/specs/installation/spec.md
@@ -45,10 +45,13 @@ other platform is unsupported and fails.
 - AND the process exits 1
 
 > *Technical Note — sources: `src/cli/install.ts::resolveBackendFlag`,
-> `src/cli/install.ts::defaultBackendForPlatform` (returns `undefined` for win32 today,
-> so Windows fails backend resolution even once the download refusal is lifted),
-> `src/engine-install.ts::downloadEngine` (post-download backend mismatch check via
-> Capabilities JSON).*
+> `src/cli/install.ts::defaultBackendForPlatform` (returns `undefined` for win32 today; the
+> caller guards on `platformBackend && backend !== platformBackend`, so `undefined` skips the
+> pre-flight rather than failing it — `--coreml` on Windows is currently caught only after the
+> Engine downloads), `src/engine-install.ts::validateBackend` (that post-download mismatch check,
+> via Capabilities JSON). The scenario above requires the pre-flight to reject, so
+> `defaultBackendForPlatform` must return `onnx` for win32-x64, not merely stop returning
+> `undefined`.*
 
 ## ADDED Requirements
 
@@ -103,12 +106,24 @@ shipped binary performs real synthesis and real Transcription — not only that 
 and passes unit tests. A platform whose Engine ships without that verification SHALL be
 documented as unverified rather than presented as supported.
 
+Verification SHALL cover both the asset a user downloads today and the artifact a release is
+about to publish. These are different binaries reached by different means: a release branch
+cannot download its own Engine, because its tag does not exist until the release is un-drafted.
+
 #### Scenario: Release smoke on a shipped platform
 
-- GIVEN the release pipeline has produced the Windows and Linux Engine binaries
-- WHEN the smoke lane runs
-- THEN each binary synthesises audio through `kesha say` and transcribes the result back
+- GIVEN the release pipeline has built the Windows and Linux Engine binaries from source
+- WHEN the smoke lane runs on the release branch
+- THEN each locally built binary synthesises audio through `kesha say` and transcribes the
+  result back
 - AND a failure in either direction fails the release
+
+#### Scenario: Smoke on the published asset
+
+- GIVEN release v`<engineVersion>` publishes an Engine asset for a platform
+- WHEN the published-asset smoke lane runs on that platform
+- THEN it downloads that asset, synthesises through `kesha say`, and transcribes the result back
+- AND the lane does not run on `release/*` branches, whose tag is not yet published
 
 #### Scenario: Engine builds but cannot synthesise
 

--- a/openspec/changes/2026-08-01-windows-x64-unblock/specs/installation/spec.md
+++ b/openspec/changes/2026-08-01-windows-x64-unblock/specs/installation/spec.md
@@ -1,0 +1,140 @@
+## MODIFIED Requirements
+
+### Requirement: Backend selection is mutex and platform-validated
+
+The CLI SHALL accept `--coreml` and `--onnx` flags to override the auto-detected
+backend. Passing both SHALL fail immediately with exit 1. Requesting a backend that
+does not match the platform's release Engine (e.g. `--coreml` on Linux) SHALL also
+fail with exit 1.
+
+Auto-detection defaults: darwin-arm64 → CoreML; linux-x64 → ONNX; win32-x64 → ONNX. Any
+other platform is unsupported and fails.
+
+#### Scenario: Both flags given
+
+- WHEN Ira runs `kesha install --coreml --onnx`
+- THEN the CLI prints `Choose only one backend: "--coreml" or "--onnx".` to stderr
+- AND the process exits 1 without downloading anything
+
+#### Scenario: Wrong backend for platform
+
+- GIVEN the machine is linux-x64 (ONNX release)
+- WHEN Ira runs `kesha install --coreml`
+- THEN the CLI prints an error explaining the platform uses the ONNX backend
+- AND the process exits 1
+
+#### Scenario: Auto-detection on darwin-arm64
+
+- GIVEN the machine is darwin-arm64 and `--coreml`/`--onnx` are not passed
+- WHEN Maks runs `kesha install`
+- THEN the CoreML Engine binary is downloaded
+- AND no backend error is emitted
+
+#### Scenario: Auto-detection on win32-x64
+
+- GIVEN the machine is win32-x64 and `--coreml`/`--onnx` are not passed
+- WHEN Ira runs `kesha install` on a Windows build agent
+- THEN the ONNX Engine binary is downloaded
+- AND no backend error is emitted
+
+#### Scenario: CoreML requested on Windows
+
+- GIVEN the machine is win32-x64
+- WHEN Ira runs `kesha install --coreml`
+- THEN the CLI prints an error explaining the platform uses the ONNX backend
+- AND the process exits 1
+
+> *Technical Note — sources: `src/cli/install.ts::resolveBackendFlag`,
+> `src/cli/install.ts::defaultBackendForPlatform` (returns `undefined` for win32 today,
+> so Windows fails backend resolution even once the download refusal is lifted),
+> `src/engine-install.ts::downloadEngine` (post-download backend mismatch check via
+> Capabilities JSON).*
+
+## ADDED Requirements
+
+### Requirement: Windows x64 installs the released ONNX Engine
+
+`kesha install` on win32-x64 SHALL download the published Windows Engine asset and
+complete the same install flow as linux-x64, with no platform-specific refusal. The
+Install plan SHALL describe that platform in the same terms it uses for the platforms
+it installs on, so a reader is never told a platform is blocked while the same output
+lists its Engine asset and size.
+
+The capability set Windows receives is the ONNX one: Transcription, Language detection
+(audio), VAD, and TTS through the Kokoro, Vosk, and CharsiuG2P TTS engines. Capabilities
+that require Apple frameworks — CoreML, `macos-*` Voice ids, Diarization, and Language
+detection (text) — remain unavailable there and SHALL keep failing with their existing
+platform errors.
+
+#### Scenario: Installing on a Windows build agent
+
+- GIVEN the machine is win32-x64 with no Engine in the Model cache
+- WHEN Ira runs `kesha install --tts en`
+- THEN the Windows Engine binary and the requested TTS models are downloaded
+- AND `kesha say "hello"` writes a playable WAV
+
+#### Scenario: Requesting a macOS-only capability on Windows
+
+- GIVEN the machine is win32-x64 with the Engine installed
+- WHEN Ira runs `kesha install --diarize`
+- THEN the CLI prints an error stating Diarization requires darwin-arm64
+- AND the process exits 1
+
+#### Scenario: Previewing the install before downloading
+
+- GIVEN the machine is win32-x64
+- WHEN Ira runs `kesha install --plan`
+- THEN the plan lists the Windows Engine asset with its size and cache status
+- AND the plan contains no statement that the platform is blocked
+
+> *Technical Note — sources: `src/engine-install.ts::getEngineBinaryName` (throws for
+> win32-x64 today, naming v1.5.0 while the repository is on v1.24.7),
+> `src/engine-install.ts::downloadEngine:386` (its only caller),
+> `src/install-plan.ts::engineAssetForPlatform` (already returns
+> `kesha-engine-windows-x64.exe`) and `src/install-plan.ts::buildEngineComponent` (attaches
+> the "blocked" note). The asset is published: release v1.24.7 carries
+> `kesha-engine-windows-x64.exe` (61 MB) plus its sigstore attestation, built by
+> `.github/workflows/build-engine.yml` with `--features onnx,tts`.*
+
+### Requirement: Every shipped platform is verified end to end before release
+
+For each platform whose Engine is published, the release pipeline SHALL verify that the
+shipped binary performs real synthesis and real Transcription — not only that it builds
+and passes unit tests. A platform whose Engine ships without that verification SHALL be
+documented as unverified rather than presented as supported.
+
+#### Scenario: Release smoke on a shipped platform
+
+- GIVEN the release pipeline has produced the Windows and Linux Engine binaries
+- WHEN the smoke lane runs
+- THEN each binary synthesises audio through `kesha say` and transcribes the result back
+- AND a failure in either direction fails the release
+
+#### Scenario: Engine builds but cannot synthesise
+
+- GIVEN a platform's Engine compiles and its unit tests pass
+- AND its synthesis smoke fails
+- WHEN Ira consults the platform matrix
+- THEN that platform is not presented as supported
+
+> *Technical Note — sources: `.github/workflows/rust-test.yml` (the `test` matrix covers
+> macos-14 and windows-latest with unit and contract tests only; the Kokoro and Vosk model
+> caches feed gated tests that do not assert audio output),
+> `.github/workflows/build-engine.yml` (builds and publishes all three assets). The gap is
+> already tracked as `Linux/Windows real-synth release smoke` in `ROADMAP.md` under
+> [#464](https://github.com/drakulavich/kesha-voice-kit/issues/464).*
+
+## Open Issues
+
+- The last acceptance criterion of closed issue #216 — `kesha say --voice ru-vosk-m02`
+  producing a valid WAV on Windows — has never been demonstrated. The Windows Engine has
+  shipped in every release since the vendoring landed, but no lane exercises synthesis or
+  Transcription there, so its runtime behavior is unknown rather than known-good. This
+  change proposes the verification; until it passes, the install unblock should not merge.
+- Whether `kesha record` should gain Windows microphone capture is out of scope here and
+  unresolved: `record.rs` gates capture on macOS, and the README directs Linux and Windows
+  users to pass an existing audio file. The platform matrix and this spec both continue to
+  treat recording as macOS-only.
+- The install-time warm-up step's behavior on Windows is undocumented. `InstallArgs::no_warmup`
+  describes warm-up as "~500 ms on the ONNX path (Linux/Windows)", which implies Windows was
+  considered, but no run has confirmed it.

--- a/openspec/changes/2026-08-01-windows-x64-unblock/specs/installation/spec.md
+++ b/openspec/changes/2026-08-01-windows-x64-unblock/specs/installation/spec.md
@@ -69,11 +69,17 @@ that require Apple frameworks — CoreML, `macos-*` Voice ids, Diarization, and 
 detection (text) — remain unavailable there and SHALL keep failing with their existing
 platform errors.
 
+The Engine SHALL be installed at a path the CLI can spawn on Windows. `defaultEngineBinPath`
+returns an extensionless `kesha-engine`, and the Windows release asset is a `.exe`; the install
+SHALL NOT depend on an unverified assumption that an extensionless PE is spawnable.
+
 #### Scenario: Installing on a Windows build agent
 
 - GIVEN the machine is win32-x64 with no Engine in the Model cache
+- AND `KESHA_ENGINE_BIN` is not set, so the download path is the one under test
 - WHEN Ira runs `kesha install --tts en`
 - THEN the Windows Engine binary and the requested TTS models are downloaded
+- AND the installed binary is spawnable at the path the CLI resolves
 - AND `kesha say "hello"` writes a playable WAV
 
 #### Scenario: Requesting a macOS-only capability on Windows
@@ -92,11 +98,13 @@ platform errors.
 
 > *Technical Note — sources: `src/engine-install.ts::getEngineBinaryName` (throws for
 > win32-x64 today, naming v1.5.0 while the repository is on v1.24.7),
-> `src/engine-install.ts::downloadEngine:386` (its only caller),
+> `src/engine-install.ts::fetchEngineBinary:386` (its only caller — reached from
+> `downloadEngine:527` only when the cached-version check fails, so an Engine already present
+> with a matching `.version` marker never touches the gate),
 > `src/install-plan.ts::engineAssetForPlatform` (already returns
 > `kesha-engine-windows-x64.exe`) and `src/install-plan.ts::buildEngineComponent` (attaches
 > the "blocked" note). The asset is published: release v1.24.7 carries
-> `kesha-engine-windows-x64.exe` (61 MB) plus its sigstore attestation, built by
+> `kesha-engine-windows-x64.exe` (63,447,040 bytes) plus its sigstore attestation, built by
 > `.github/workflows/build-engine.yml` with `--features onnx,tts`.*
 
 ### Requirement: Every shipped platform is verified end to end before release
@@ -152,4 +160,9 @@ cannot download its own Engine, because its tag does not exist until the release
   treat recording as macOS-only.
 - The install-time warm-up step's behavior on Windows is undocumented. `InstallArgs::no_warmup`
   describes warm-up as "~500 ms on the ONNX path (Linux/Windows)", which implies Windows was
-  considered, but no run has confirmed it.
+  considered, but no run has confirmed it. Note that warm-up runs by default yet is deliberately
+  non-fatal (`rust/src/cli/install.rs:74-84` warns and continues), so a green install on Windows
+  is not evidence the warm-up succeeded — the smoke lane has to assert on the warning line.
+- Whether an extensionless `kesha-engine` written by `fetchEngineBinary` is spawnable on Windows
+  is unverified, and no smoke lane that sets `KESHA_ENGINE_BIN` can answer it, because that
+  override points at a real `.exe`. Only the cold-install job settles it.

--- a/openspec/changes/2026-08-01-windows-x64-unblock/tasks.md
+++ b/openspec/changes/2026-08-01-windows-x64-unblock/tasks.md
@@ -4,6 +4,13 @@ Ordered so the verification exists before the gate opens. Lane 1 is the one that
 whether the rest may proceed: if the shipped Windows Engine cannot synthesise or transcribe,
 the block was accidentally protecting users and the proposal needs rethinking, not merging.
 
+**Lane 1 proves the Engine runs, not that the install works.** Its provisioning deliberately
+routes around `fetchEngineBinary` — which is where the gate lives — so it cannot exercise the
+download path that lane 2 opens. That path gets its own gate in section 2 (task 2.5), and
+section 3 is blocked on *that*, not on lane 1. Keeping the two claims apart is the point:
+"the shipped binary speaks" and "Windows is a supported install target" are different
+statements needing different evidence.
+
 ## 1. Prove the shipped Windows Engine works (PR lane 1 — `ci-real-synth-smoke`)
 
 Two lanes, not one, mirroring the split `ci.yml` already draws on Linux: `published-engine-smoke`
@@ -22,21 +29,40 @@ lane sets `KESHA_ENGINE_BIN`, places the Engine there, writes the marker — the
 Engine's own `install` subcommand. No gate is in the path, and no darwin assets are fetched:
 `downloadSidecar` returns early on `!isDarwinArm64()`.
 
+Two costs of that trick, both accepted here and paid back in 2.5. Setting `KESHA_ENGINE_BIN`
+also disables the backend pre-flight (`install.ts:156` guards on `!process.env.KESHA_ENGINE_BIN`),
+so lane 1 cannot exercise `--coreml` rejection end to end. And pointing it at a `.exe` sidesteps
+the extensionless default path (see 2.5).
+
 - [ ] 1.1 Windows published-asset lane on `windows-latest`: `gh release download v<engineVersion>`
-      for `kesha-engine-windows-x64.exe`, provision as above, then `--capabilities-json` asserting
+      for `kesha-engine-windows-x64.exe` (pass `GH_TOKEN: ${{ github.token }}`), provision as
+      above with `KESHA_ENGINE_BIN` ending in `.exe`, then `--capabilities-json` asserting
       protocol version 3 and the ONNX feature set
 - [ ] 1.2 Extend it to synthesise: `kesha say --voice en-am_michael` and
       `--voice ru-vosk-m02` each produce a non-empty WAV with a valid RIFF header
 - [ ] 1.3 Feed the synthesised WAV back through Transcription and assert non-empty text
-- [ ] 1.4 Add synthesis (1.2 + 1.3) to the existing `published-engine-smoke` job — it transcribes
-      a fixture today but never synthesises, so Linux carries the same gap
-- [ ] 1.5 Cover the pre-publication artifact: add synthesis to `release-branch-engine-smoke` and
+- [ ] 1.4 Assert the install's ASR warm-up succeeded. It runs by default but is deliberately
+      non-fatal (`rust/src/cli/install.rs:74-84` warns and continues), so a Windows ORT session
+      failure would leave install reporting success. Fail the lane on that `warning:` line —
+      otherwise the warm-up Open Issue survives a green lane 1
+- [ ] 1.5 Add synthesis (1.2 + 1.3) to the existing `published-engine-smoke` job — it transcribes
+      a fixture today but never synthesises, so Linux carries the same gap. Windows must not reuse
+      its `ffmpeg-provider: apt` input (`ci.yml:455`); the Engine needs no ffmpeg, so pass `skip`
+- [ ] 1.6 Cover the pre-publication artifact: add synthesis to `release-branch-engine-smoke` and
       give it a `windows-latest` counterpart that builds the Engine locally
       (`cargo build --release --features onnx,tts --no-default-features`) rather than downloading a
-      tag that does not exist yet
-- [ ] 1.6 Reuse the `release/*` guard from `integration-tests-full` on the published lane, so it
+      tag that does not exist yet. Carry over the three Windows build prerequisites from
+      `rust-test.yml:117-155` — `ilammy/msvc-dev-cmd`, the `CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER`
+      pin that stops Git's GNU `link.exe` shadowing MSVC's, and `CMAKE_POLICY_VERSION_MINIMUM=3.5`
+      for the vendored opus cmake fallback — or the lane fails at link time for reasons unrelated
+      to this change. Cargo emits `kesha-engine.exe`, so the Linux job's extensionless
+      `KESHA_ENGINE_BIN` (`ci.yml:489`) cannot be copied verbatim
+- [ ] 1.7 Reuse the `release/*` guard from `integration-tests-full` on the published lane, so it
       never tries to download an unpublished tag on a release PR
-- [ ] 1.7 Record the outcome in this change's Open Issues (pass, or the exact failure)
+- [ ] 1.8 Give the Windows lanes their own timeouts and model cache. Linux
+      `release-branch-engine-smoke` is already 25 minutes (`ci.yml:486`); a Windows cargo build plus
+      dual-voice model download will exceed that
+- [ ] 1.9 Record the outcome in this change's Open Issues (pass, or the exact failure)
 
 ## 2. Remove the stale platform gate (PR lane 2 — `fix-windows-install-gate`)
 
@@ -48,13 +74,31 @@ Blocked by lane 1.
       It is module-private today — export it, as `resolveBackendFlag` and `resolveTtsLangs`
       already are, so the unit test can cover auto-detection and `--coreml` rejection
       directly rather than through `performInstall`'s `process.exit`
-- [ ] 2.3 `src/install-plan.ts::buildEngineComponent` drops the "blocked by the install
-      path" note; unit test asserting the plan carries no block statement
-- [ ] 2.4 Gate `bun test && bunx tsc --noEmit`, commit
+- [ ] 2.3 Both functions read `process.platform`/`process.arch` with no parameters, and
+      unit-tests run on ubuntu — so their win32 branches are untestable as written. Take optional
+      `platform`/`arch` parameters, the shape `isDarwinArm64(platform?, arch?)` already uses in
+      `src/fluid-kokoro-cache.ts`. Without this, 2.1 and 2.2's tests assert nothing on CI
+- [ ] 2.4 Decide the Windows binary path. `defaultEngineBinPath` (`src/paths.ts:8-10`) returns an
+      extensionless `kesha-engine`, and `fetchEngineBinary` writes the `.exe` asset straight to it
+      (`engine-install.ts:416`). Whether Bun can spawn an extensionless PE on Windows is unverified
+      — and lane 1 cannot tell us, because it points `KESHA_ENGINE_BIN` at a real `.exe`. Either
+      append `.exe` on win32 or prove the extensionless path spawns; do not leave it to the first
+      user. `chmodSync(binPath, 0o755)` on the same line is a Windows no-op and is fine
+- [ ] 2.5 **Cold-install gate.** A `windows-latest` job with no `KESHA_ENGINE_BIN` and no
+      pre-placed binary or marker, running bare `kesha install --tts en ru` so `fetchEngineBinary`
+      really downloads the asset to the default path, then synthesis + Transcription. This is the
+      job that earns the word "supported", and section 3 is blocked on it — lane 1 deliberately
+      cannot reach this path. Also assert `kesha install --coreml` exits 1 here, since the
+      pre-flight only engages without `KESHA_ENGINE_BIN`
+- [ ] 2.6 `src/install-plan.ts::buildEngineComponent` drops the "blocked by the install
+      path" note; unit test asserting the plan carries no block statement. While here, refresh the
+      stale `63_126_528` size at `install-plan.ts:115` — v1.24.7's asset is 63,447,040 bytes
+- [ ] 2.7 Gate `bun test && bunx tsc --noEmit`, commit
 
 ## 3. Make the docs match the artifacts (PR lane 3 — `docs-windows-supported`)
 
-Blocked by lane 2.
+Blocked by task 2.5 specifically, not merely by lane 2 landing. Docs may not call Windows
+supported until a cold `kesha install` has been shown to work there.
 
 - [ ] 3.1 `README.md` platform line: Windows x64 supported with the ONNX capability set,
       minus recording and the macOS-only capabilities

--- a/openspec/changes/2026-08-01-windows-x64-unblock/tasks.md
+++ b/openspec/changes/2026-08-01-windows-x64-unblock/tasks.md
@@ -33,7 +33,14 @@ is just enforced by CI on this PR instead of by PR ordering.
       meaningful without `KESHA_ENGINE_BIN`, which makes `performInstall` skip the pre-flight
 - [x] 1.7 Carry the `release/*` guard so the lane never chases an unpublished tag, and add
       `windows-engine-smoke` to the `ci` aggregator's `needs` so a failure actually blocks
-- [ ] 1.8 Record the outcome here (pass, or the exact failure)
+- [x] 1.8 Keep the lane cold across runs: the model cache excludes `~/.cache/kesha/engine`,
+      because restoring the binary and its version marker sends `downloadEngine` down the
+      cacheValid branch and the download path stops being tested from run two onward
+      (Greptile P1). The lane asserts the engine is absent before install and that the install
+      log says it downloaded
+- [x] 1.9 `release-branch-engine-smoke` gains `--tts en ru` and the same synthesis script, so
+      the about-to-ship artifact is covered too, not only the published one
+- [ ] 1.10 Record the outcome here (pass, or the exact failure)
 
 ## 2. Remove the stale platform gate
 

--- a/openspec/changes/2026-08-01-windows-x64-unblock/tasks.md
+++ b/openspec/changes/2026-08-01-windows-x64-unblock/tasks.md
@@ -6,14 +6,37 @@ the block was accidentally protecting users and the proposal needs rethinking, n
 
 ## 1. Prove the shipped Windows Engine works (PR lane 1 — `ci-real-synth-smoke`)
 
-- [ ] 1.1 Add a release-smoke job on `windows-latest` that downloads the published
-      `kesha-engine-windows-x64.exe`, runs `--capabilities-json`, and asserts protocol
-      version 3 plus the expected ONNX feature set
+Two lanes, not one, mirroring the split `ci.yml` already draws on Linux: `published-engine-smoke`
+covers the asset users actually download, and `release-branch-engine-smoke` covers the artifact a
+release is about to ship (which cannot be downloaded — its tag does not exist yet). Only the
+published lane gates section 2: it is the one that answers "does the binary the CLI would fetch
+today actually speak".
+
+**Provisioning (applies to both lanes).** `kesha install` cannot fetch the Engine on Windows while
+`getEngineBinaryName` throws — but it does not have to. `downloadEngine` reaches that throw only
+via `fetchEngineBinary`, which is skipped when `getEngineBinPath()` already holds a binary whose
+`.version` marker matches `package.json#keshaEngine.version` (`engine-install.ts:519-528`). So each
+lane sets `KESHA_ENGINE_BIN`, places the Engine there, writes the marker — the pattern
+`release-branch-engine-smoke` already uses at `ci.yml:515-520` — and only then runs
+`kesha install --onnx --tts en ru`, which provisions the ASR, Kokoro, and Vosk models through the
+Engine's own `install` subcommand. No gate is in the path, and no darwin assets are fetched:
+`downloadSidecar` returns early on `!isDarwinArm64()`.
+
+- [ ] 1.1 Windows published-asset lane on `windows-latest`: `gh release download v<engineVersion>`
+      for `kesha-engine-windows-x64.exe`, provision as above, then `--capabilities-json` asserting
+      protocol version 3 and the ONNX feature set
 - [ ] 1.2 Extend it to synthesise: `kesha say --voice en-am_michael` and
       `--voice ru-vosk-m02` each produce a non-empty WAV with a valid RIFF header
 - [ ] 1.3 Feed the synthesised WAV back through Transcription and assert non-empty text
-- [ ] 1.4 Mirror the lane on `ubuntu-latest` — the same verification gap exists there
-- [ ] 1.5 Record the outcome in this change's Open Issues (pass, or the exact failure)
+- [ ] 1.4 Add synthesis (1.2 + 1.3) to the existing `published-engine-smoke` job — it transcribes
+      a fixture today but never synthesises, so Linux carries the same gap
+- [ ] 1.5 Cover the pre-publication artifact: add synthesis to `release-branch-engine-smoke` and
+      give it a `windows-latest` counterpart that builds the Engine locally
+      (`cargo build --release --features onnx,tts --no-default-features`) rather than downloading a
+      tag that does not exist yet
+- [ ] 1.6 Reuse the `release/*` guard from `integration-tests-full` on the published lane, so it
+      never tries to download an unpublished tag on a release PR
+- [ ] 1.7 Record the outcome in this change's Open Issues (pass, or the exact failure)
 
 ## 2. Remove the stale platform gate (PR lane 2 — `fix-windows-install-gate`)
 
@@ -21,8 +44,10 @@ Blocked by lane 1.
 
 - [ ] 2.1 `src/engine-install.ts::getEngineBinaryName` returns
       `kesha-engine-windows-x64.exe` for win32-x64 instead of throwing; unit test
-- [ ] 2.2 `src/cli/install.ts::defaultBackendForPlatform` returns `onnx` for win32-x64;
-      unit test covering auto-detection and `--coreml` rejection on Windows
+- [ ] 2.2 `src/cli/install.ts::defaultBackendForPlatform` returns `onnx` for win32-x64.
+      It is module-private today — export it, as `resolveBackendFlag` and `resolveTtsLangs`
+      already are, so the unit test can cover auto-detection and `--coreml` rejection
+      directly rather than through `performInstall`'s `process.exit`
 - [ ] 2.3 `src/install-plan.ts::buildEngineComponent` drops the "blocked by the install
       path" note; unit test asserting the plan carries no block statement
 - [ ] 2.4 Gate `bun test && bunx tsc --noEmit`, commit
@@ -33,13 +58,19 @@ Blocked by lane 2.
 
 - [ ] 3.1 `README.md` platform line: Windows x64 supported with the ONNX capability set,
       minus recording and the macOS-only capabilities
-- [ ] 3.2 `docs/product-positioning.md`: replace the four "Blocked at install (#216)" cells
-      and rewrite the paragraph below the matrix
+- [ ] 3.2 `docs/product-positioning.md`: replace the seven "Blocked at install (#216)" cells
+      (STT, audio language detection, VAD, Kokoro, Vosk-TTS, OpenClaw, Hermes) and rewrite the
+      paragraph below the matrix, which still names the v1.4.x workaround and calls the toolkit
+      "unusable on Windows". Leave the "Not applicable" rows alone
 - [ ] 3.3 `openspec/specs/installation/spec.md`: drop the Windows entry from Open Issues and
       the "temporarily unsupported" clause from the backend Technical Note
-- [ ] 3.4 Check `docs/tts.md`, `docs/languages.md`, and `docs/errors.md` for statements that
-      assumed the block; leave the macOS-only rows untouched
-- [ ] 3.5 Gate `bun run check:specs`, commit
+- [ ] 3.4 `.github/workflows/ci.yml:414-417`: the `published-engine-smoke` P1.10 comment
+      justifies omitting Windows by citing the very gate lane 2 removes — rewrite it once the
+      Windows lane from 1.1 exists
+- [ ] 3.5 Check `docs/tts.md`, `docs/languages.md`, and `docs/errors.md` for statements that
+      assumed the block; leave the macOS-only rows untouched. `NOTICES.md`'s #216 reference is
+      historical (it records the vendoring) and stays as written
+- [ ] 3.6 Gate `bun run check:specs`, commit
 
 ## 4. Archive
 

--- a/openspec/changes/2026-08-01-windows-x64-unblock/tasks.md
+++ b/openspec/changes/2026-08-01-windows-x64-unblock/tasks.md
@@ -40,7 +40,7 @@ is just enforced by CI on this PR instead of by PR ordering.
       log says it downloaded
 - [x] 1.9 `release-branch-engine-smoke` gains `--tts en ru` and the same synthesis script, so
       the about-to-ship artifact is covered too, not only the published one
-- [ ] 1.10 Record the outcome here (pass, or the exact failure)
+- [x] 1.10 Outcome recorded below
 
 ## 2. Remove the stale platform gate
 
@@ -74,3 +74,36 @@ is just enforced by CI on this PR instead of by PR ordering.
 ## 4. Archive
 
 - [ ] 4.1 Move this change to `openspec/changes/archive/` once CI is green on the Windows lane
+
+## Outcome
+
+`windows-engine-smoke` passed on 2026-08-01 (run 30707424619, 3m38s), against the published
+v1.24.7 `kesha-engine-windows-x64.exe` fetched by a cold `kesha install`:
+
+```
+Waiting for the engine binary to be released by the system...
+Engine binary downloaded (v1.24.7).
+ok: ASR backend warmed up during install
+ok: en-am_michael synthesised 355258 bytes
+ok: en-am_michael round-tripped to ", The quick brown fox jumps over the lazy dog."
+ok: ru-vosk-m02 synthesised 219194 bytes
+ok: ru-vosk-m02 round-tripped to "Проверка синтеза речи на русском языке."
+```
+
+**Issue #216's last acceptance criterion is met**: `kesha say --voice ru-vosk-m02` produces a
+valid WAV on Windows — demonstrated rather than assumed, for the first time since the vendoring
+landed on 2026-04-30. `published-engine-smoke` passed the same round-trip on Linux.
+
+The lane paid for itself before it went green. Three defects it found, none of which any
+existing test could have:
+
+1. `streamResponseToFile` never awaited `writer.end()`, so the write handle outlived the
+   download and the engine could not be spawned — `EBUSY` 15 ms later. Latent on Linux too, as
+   `ETXTBSY`.
+2. A security scanner holds a newly written 60 MB PE; the `Waiting for...` line above is that
+   lock being waited out. Without it the first `kesha install` on a stock Windows machine fails.
+3. `defaultEngineBinPath` wrote the `.exe` asset to an extensionless path.
+
+Two Open Issues from the proposal are now closed by this evidence: the Windows synthesis
+criterion, and the install-time warm-up, which is asserted rather than assumed because it is
+non-fatal by design.

--- a/openspec/changes/2026-08-01-windows-x64-unblock/tasks.md
+++ b/openspec/changes/2026-08-01-windows-x64-unblock/tasks.md
@@ -1,0 +1,46 @@
+# Tasks: windows-x64-unblock
+
+Ordered so the verification exists before the gate opens. Lane 1 is the one that decides
+whether the rest may proceed: if the shipped Windows Engine cannot synthesise or transcribe,
+the block was accidentally protecting users and the proposal needs rethinking, not merging.
+
+## 1. Prove the shipped Windows Engine works (PR lane 1 — `ci-real-synth-smoke`)
+
+- [ ] 1.1 Add a release-smoke job on `windows-latest` that downloads the published
+      `kesha-engine-windows-x64.exe`, runs `--capabilities-json`, and asserts protocol
+      version 3 plus the expected ONNX feature set
+- [ ] 1.2 Extend it to synthesise: `kesha say --voice en-am_michael` and
+      `--voice ru-vosk-m02` each produce a non-empty WAV with a valid RIFF header
+- [ ] 1.3 Feed the synthesised WAV back through Transcription and assert non-empty text
+- [ ] 1.4 Mirror the lane on `ubuntu-latest` — the same verification gap exists there
+- [ ] 1.5 Record the outcome in this change's Open Issues (pass, or the exact failure)
+
+## 2. Remove the stale platform gate (PR lane 2 — `fix-windows-install-gate`)
+
+Blocked by lane 1.
+
+- [ ] 2.1 `src/engine-install.ts::getEngineBinaryName` returns
+      `kesha-engine-windows-x64.exe` for win32-x64 instead of throwing; unit test
+- [ ] 2.2 `src/cli/install.ts::defaultBackendForPlatform` returns `onnx` for win32-x64;
+      unit test covering auto-detection and `--coreml` rejection on Windows
+- [ ] 2.3 `src/install-plan.ts::buildEngineComponent` drops the "blocked by the install
+      path" note; unit test asserting the plan carries no block statement
+- [ ] 2.4 Gate `bun test && bunx tsc --noEmit`, commit
+
+## 3. Make the docs match the artifacts (PR lane 3 — `docs-windows-supported`)
+
+Blocked by lane 2.
+
+- [ ] 3.1 `README.md` platform line: Windows x64 supported with the ONNX capability set,
+      minus recording and the macOS-only capabilities
+- [ ] 3.2 `docs/product-positioning.md`: replace the four "Blocked at install (#216)" cells
+      and rewrite the paragraph below the matrix
+- [ ] 3.3 `openspec/specs/installation/spec.md`: drop the Windows entry from Open Issues and
+      the "temporarily unsupported" clause from the backend Technical Note
+- [ ] 3.4 Check `docs/tts.md`, `docs/languages.md`, and `docs/errors.md` for statements that
+      assumed the block; leave the macOS-only rows untouched
+- [ ] 3.5 Gate `bun run check:specs`, commit
+
+## 4. Archive
+
+- [ ] 4.1 Move this change to `openspec/changes/archive/` once lanes 1-3 have merged

--- a/openspec/changes/2026-08-01-windows-x64-unblock/tasks.md
+++ b/openspec/changes/2026-08-01-windows-x64-unblock/tasks.md
@@ -4,118 +4,66 @@ Ordered so the verification exists before the gate opens. Lane 1 is the one that
 whether the rest may proceed: if the shipped Windows Engine cannot synthesise or transcribe,
 the block was accidentally protecting users and the proposal needs rethinking, not merging.
 
-**Lane 1 proves the Engine runs, not that the install works.** Its provisioning deliberately
-routes around `fetchEngineBinary` — which is where the gate lives — so it cannot exercise the
-download path that lane 2 opens. That path gets its own gate in section 2 (task 2.5), and
-section 3 is blocked on *that*, not on lane 1. Keeping the two claims apart is the point:
-"the shipped binary speaks" and "Windows is a supported install target" are different
-statements needing different evidence.
+**Landed as one PR, which makes the verification stronger, not weaker.** The three-lane split
+existed to work around a chicken-and-egg problem: while the gate throws, no CI lane can run a
+real `kesha install` on Windows, so lane 1 had to pre-place the binary and route around
+`fetchEngineBinary` — the very function the gate lives in. Removing the gate in the same commit
+dissolves that: `windows-engine-smoke` runs a cold `kesha install` against the published
+v1.24.7 asset, which is exactly the path a user takes. The provisioning trick and the separate
+task 2.5 are therefore both gone, replaced by one lane that tests the real thing.
 
-## 1. Prove the shipped Windows Engine works (PR lane 1 — `ci-real-synth-smoke`)
+If that lane goes red, the unblock does not merge — the sequencing constraint is unchanged, it
+is just enforced by CI on this PR instead of by PR ordering.
 
-Two lanes, not one, mirroring the split `ci.yml` already draws on Linux: `published-engine-smoke`
-covers the asset users actually download, and `release-branch-engine-smoke` covers the artifact a
-release is about to ship (which cannot be downloaded — its tag does not exist yet). Only the
-published lane gates section 2: it is the one that answers "does the binary the CLI would fetch
-today actually speak".
+## 1. Prove the shipped Windows Engine works
 
-**Provisioning (applies to both lanes).** `kesha install` cannot fetch the Engine on Windows while
-`getEngineBinaryName` throws — but it does not have to. `downloadEngine` reaches that throw only
-via `fetchEngineBinary`, which is skipped when `getEngineBinPath()` already holds a binary whose
-`.version` marker matches `package.json#keshaEngine.version` (`engine-install.ts:519-528`). So each
-lane sets `KESHA_ENGINE_BIN`, places the Engine there, writes the marker — the pattern
-`release-branch-engine-smoke` already uses at `ci.yml:515-520` — and only then runs
-`kesha install --onnx --tts en ru`, which provisions the ASR, Kokoro, and Vosk models through the
-Engine's own `install` subcommand. No gate is in the path, and no darwin assets are fetched:
-`downloadSidecar` returns early on `!isDarwinArm64()`.
+- [x] 1.1 `windows-engine-smoke` on `windows-latest`: cold `kesha install --tts en ru`, no
+      `KESHA_ENGINE_BIN`, no pre-placed binary — so `fetchEngineBinary` really downloads the
+      published asset
+- [x] 1.2 Synthesise with both engines: `en-am_michael` (Kokoro) and `ru-vosk-m02` (Vosk) each
+      produce a WAV with a valid RIFF/WAVE header and more than a bare 44-byte header
+- [x] 1.3 Feed each synthesised WAV back through Transcription and assert non-empty text
+- [x] 1.4 Assert the install's ASR warm-up succeeded. It runs by default but is deliberately
+      non-fatal (`rust/src/cli/install.rs`), so a Windows ORT failure would otherwise leave
+      install reporting success — `.github/scripts/assert-install-warmup.ts`
+- [x] 1.5 Close the same gap on Linux: `published-engine-smoke` gains `--tts en ru` and the
+      shared `.github/scripts/smoke-synthesis.ts`, since it transcribed a fixture but never
+      synthesised
+- [x] 1.6 Assert `kesha install --coreml` exits 1 on Windows naming the ONNX backend — only
+      meaningful without `KESHA_ENGINE_BIN`, which makes `performInstall` skip the pre-flight
+- [x] 1.7 Carry the `release/*` guard so the lane never chases an unpublished tag, and add
+      `windows-engine-smoke` to the `ci` aggregator's `needs` so a failure actually blocks
+- [ ] 1.8 Record the outcome here (pass, or the exact failure)
 
-Two costs of that trick, both accepted here and paid back in 2.5. Setting `KESHA_ENGINE_BIN`
-also disables the backend pre-flight (`install.ts:156` guards on `!process.env.KESHA_ENGINE_BIN`),
-so lane 1 cannot exercise `--coreml` rejection end to end. And pointing it at a `.exe` sidesteps
-the extensionless default path (see 2.5).
+## 2. Remove the stale platform gate
 
-- [ ] 1.1 Windows published-asset lane on `windows-latest`: `gh release download v<engineVersion>`
-      for `kesha-engine-windows-x64.exe` (pass `GH_TOKEN: ${{ github.token }}`), provision as
-      above with `KESHA_ENGINE_BIN` ending in `.exe`, then `--capabilities-json` asserting
-      protocol version 3 and the ONNX feature set
-- [ ] 1.2 Extend it to synthesise: `kesha say --voice en-am_michael` and
-      `--voice ru-vosk-m02` each produce a non-empty WAV with a valid RIFF header
-- [ ] 1.3 Feed the synthesised WAV back through Transcription and assert non-empty text
-- [ ] 1.4 Assert the install's ASR warm-up succeeded. It runs by default but is deliberately
-      non-fatal (`rust/src/cli/install.rs:74-84` warns and continues), so a Windows ORT session
-      failure would leave install reporting success. Fail the lane on that `warning:` line —
-      otherwise the warm-up Open Issue survives a green lane 1
-- [ ] 1.5 Add synthesis (1.2 + 1.3) to the existing `published-engine-smoke` job — it transcribes
-      a fixture today but never synthesises, so Linux carries the same gap. Windows must not reuse
-      its `ffmpeg-provider: apt` input (`ci.yml:455`); the Engine needs no ffmpeg, so pass `skip`
-- [ ] 1.6 Cover the pre-publication artifact: add synthesis to `release-branch-engine-smoke` and
-      give it a `windows-latest` counterpart that builds the Engine locally
-      (`cargo build --release --features onnx,tts --no-default-features`) rather than downloading a
-      tag that does not exist yet. Carry over the three Windows build prerequisites from
-      `rust-test.yml:117-155` — `ilammy/msvc-dev-cmd`, the `CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER`
-      pin that stops Git's GNU `link.exe` shadowing MSVC's, and `CMAKE_POLICY_VERSION_MINIMUM=3.5`
-      for the vendored opus cmake fallback — or the lane fails at link time for reasons unrelated
-      to this change. Cargo emits `kesha-engine.exe`, so the Linux job's extensionless
-      `KESHA_ENGINE_BIN` (`ci.yml:489`) cannot be copied verbatim
-- [ ] 1.7 Reuse the `release/*` guard from `integration-tests-full` on the published lane, so it
-      never tries to download an unpublished tag on a release PR
-- [ ] 1.8 Give the Windows lanes their own timeouts and model cache. Linux
-      `release-branch-engine-smoke` is already 25 minutes (`ci.yml:486`); a Windows cargo build plus
-      dual-voice model download will exceed that
-- [ ] 1.9 Record the outcome in this change's Open Issues (pass, or the exact failure)
+- [x] 2.1 `src/engine-install.ts::getEngineBinaryName` returns `kesha-engine-windows-x64.exe`
+      for win32-x64 instead of throwing
+- [x] 2.2 `src/cli/install.ts::defaultBackendForPlatform` returns `onnx` for win32-x64, and is
+      exported. `undefined` would have skipped the pre-flight rather than failing it, letting
+      `--coreml` through until the post-download `validateBackend`
+- [x] 2.3 Both take optional `platform`/`arch` parameters — the shape
+      `isDarwinArm64(platform?, arch?)` already uses — so their win32 branches are testable on
+      the ubuntu unit lane
+- [x] 2.4 `src/paths.ts::defaultEngineBinPath` keeps the `.exe` suffix on win32. The release
+      asset is a PE and `fetchEngineBinary` wrote it to an extensionless path; no lane setting
+      `KESHA_ENGINE_BIN` could have caught that, since the override points at a real `.exe`
+- [x] 2.5 `src/install-plan.ts::buildEngineComponent` drops the "blocked" note; the stale
+      `63_126_528` asset size is refreshed to v1.24.7's 63,447,040 bytes
+- [x] 2.6 Unit tests for all of the above; `bun test && bunx tsc --noEmit` green
 
-## 2. Remove the stale platform gate (PR lane 2 — `fix-windows-install-gate`)
+## 3. Make the docs match the artifacts
 
-Blocked by lane 1.
-
-- [ ] 2.1 `src/engine-install.ts::getEngineBinaryName` returns
-      `kesha-engine-windows-x64.exe` for win32-x64 instead of throwing; unit test
-- [ ] 2.2 `src/cli/install.ts::defaultBackendForPlatform` returns `onnx` for win32-x64.
-      It is module-private today — export it, as `resolveBackendFlag` and `resolveTtsLangs`
-      already are, so the unit test can cover auto-detection and `--coreml` rejection
-      directly rather than through `performInstall`'s `process.exit`
-- [ ] 2.3 Both functions read `process.platform`/`process.arch` with no parameters, and
-      unit-tests run on ubuntu — so their win32 branches are untestable as written. Take optional
-      `platform`/`arch` parameters, the shape `isDarwinArm64(platform?, arch?)` already uses in
-      `src/fluid-kokoro-cache.ts`. Without this, 2.1 and 2.2's tests assert nothing on CI
-- [ ] 2.4 Decide the Windows binary path. `defaultEngineBinPath` (`src/paths.ts:8-10`) returns an
-      extensionless `kesha-engine`, and `fetchEngineBinary` writes the `.exe` asset straight to it
-      (`engine-install.ts:416`). Whether Bun can spawn an extensionless PE on Windows is unverified
-      — and lane 1 cannot tell us, because it points `KESHA_ENGINE_BIN` at a real `.exe`. Either
-      append `.exe` on win32 or prove the extensionless path spawns; do not leave it to the first
-      user. `chmodSync(binPath, 0o755)` on the same line is a Windows no-op and is fine
-- [ ] 2.5 **Cold-install gate.** A `windows-latest` job with no `KESHA_ENGINE_BIN` and no
-      pre-placed binary or marker, running bare `kesha install --tts en ru` so `fetchEngineBinary`
-      really downloads the asset to the default path, then synthesis + Transcription. This is the
-      job that earns the word "supported", and section 3 is blocked on it — lane 1 deliberately
-      cannot reach this path. Also assert `kesha install --coreml` exits 1 here, since the
-      pre-flight only engages without `KESHA_ENGINE_BIN`
-- [ ] 2.6 `src/install-plan.ts::buildEngineComponent` drops the "blocked by the install
-      path" note; unit test asserting the plan carries no block statement. While here, refresh the
-      stale `63_126_528` size at `install-plan.ts:115` — v1.24.7's asset is 63,447,040 bytes
-- [ ] 2.7 Gate `bun test && bunx tsc --noEmit`, commit
-
-## 3. Make the docs match the artifacts (PR lane 3 — `docs-windows-supported`)
-
-Blocked by task 2.5 specifically, not merely by lane 2 landing. Docs may not call Windows
-supported until a cold `kesha install` has been shown to work there.
-
-- [ ] 3.1 `README.md` platform line: Windows x64 supported with the ONNX capability set,
-      minus recording and the macOS-only capabilities
-- [ ] 3.2 `docs/product-positioning.md`: replace the seven "Blocked at install (#216)" cells
-      (STT, audio language detection, VAD, Kokoro, Vosk-TTS, OpenClaw, Hermes) and rewrite the
-      paragraph below the matrix, which still names the v1.4.x workaround and calls the toolkit
-      "unusable on Windows". Leave the "Not applicable" rows alone
-- [ ] 3.3 `openspec/specs/installation/spec.md`: drop the Windows entry from Open Issues and
-      the "temporarily unsupported" clause from the backend Technical Note
-- [ ] 3.4 `.github/workflows/ci.yml:414-417`: the `published-engine-smoke` P1.10 comment
-      justifies omitting Windows by citing the very gate lane 2 removes — rewrite it once the
-      Windows lane from 1.1 exists
-- [ ] 3.5 Check `docs/tts.md`, `docs/languages.md`, and `docs/errors.md` for statements that
-      assumed the block; leave the macOS-only rows untouched. `NOTICES.md`'s #216 reference is
-      historical (it records the vendoring) and stays as written
-- [ ] 3.6 Gate `bun run check:specs`, commit
+- [x] 3.1 `README.md` platform line: Windows x64 supported, naming the macOS-only exclusions
+- [x] 3.2 `docs/product-positioning.md`: all seven "Blocked at install (#216)" cells, plus the
+      paragraph below the matrix that still recommended the v1.4.x workaround
+- [x] 3.3 `openspec/specs/installation/spec.md`: Windows dropped from Open Issues, backend
+      Technical Note rewritten, and both new requirements synced from the delta spec
+- [x] 3.4 `.github/workflows/ci.yml`: the `published-engine-smoke` P1.10 comment no longer
+      justifies omitting Windows by citing the gate this change removes
+- [x] 3.5 `docs/tts.md` and `docs/languages.md` already described Linux/Windows as working and
+      needed no change; `NOTICES.md`'s #216 reference is historical and stays
 
 ## 4. Archive
 
-- [ ] 4.1 Move this change to `openspec/changes/archive/` once lanes 1-3 have merged
+- [ ] 4.1 Move this change to `openspec/changes/archive/` once CI is green on the Windows lane

--- a/openspec/changes/2026-08-01-windows-x64-unblock/tasks.md
+++ b/openspec/changes/2026-08-01-windows-x64-unblock/tasks.md
@@ -38,8 +38,11 @@ is just enforced by CI on this PR instead of by PR ordering.
       cacheValid branch and the download path stops being tested from run two onward
       (Greptile P1). The lane asserts the engine is absent before install and that the install
       log says it downloaded
-- [x] 1.9 `release-branch-engine-smoke` gains `--tts en ru` and the same synthesis script, so
-      the about-to-ship artifact is covered too, not only the published one
+- [x] 1.9 `release-branch-engine-smoke` gains `--tts en ru` and the same synthesis script, and
+      `release-branch-windows-smoke` is its win32 counterpart — building the engine with MSVC
+      rather than downloading a tag that does not exist yet. Without it the Windows binary about
+      to ship would be the one published artifact with no synthesis proof, since
+      `windows-engine-smoke` is guarded off `release/*`
 - [x] 1.10 Outcome recorded below
 
 ## 2. Remove the stale platform gate

--- a/openspec/specs/installation/spec.md
+++ b/openspec/specs/installation/spec.md
@@ -56,8 +56,8 @@ backend. Passing both SHALL fail immediately with exit 1. Requesting a backend t
 does not match the platform's release Engine (e.g. `--coreml` on Linux) SHALL also
 fail with exit 1.
 
-Auto-detection defaults: darwin-arm64 → CoreML; linux-x64 → ONNX. Any other
-platform is unsupported and fails.
+Auto-detection defaults: darwin-arm64 → CoreML; linux-x64 → ONNX; win32-x64 → ONNX. Any
+other platform is unsupported and fails.
 
 #### Scenario: Both flags given
 
@@ -79,11 +79,115 @@ platform is unsupported and fails.
 - THEN the CoreML Engine binary is downloaded
 - AND no backend error is emitted
 
+#### Scenario: Auto-detection on win32-x64
+
+- GIVEN the machine is win32-x64 and `--coreml`/`--onnx` are not passed
+- WHEN Ira runs `kesha install` on a Windows build agent
+- THEN the ONNX Engine binary is downloaded
+- AND no backend error is emitted
+
+#### Scenario: CoreML requested on Windows
+
+- GIVEN the machine is win32-x64
+- WHEN Ira runs `kesha install --coreml`
+- THEN the CLI prints an error explaining the platform uses the ONNX backend
+- AND the process exits 1
+
 > *Technical Note — sources: `src/cli/install.ts::resolveBackendFlag`,
-> `src/cli/install.ts::defaultBackendForPlatform`,
-> `src/engine-install.ts::downloadEngine` (post-download backend mismatch check via
-> Capabilities JSON). Windows x64 is temporarily unsupported in the current release
-> (issue #216).*
+> `src/cli/install.ts::defaultBackendForPlatform` (darwin-arm64 → `coreml`, linux-x64 and
+> win32-x64 → `onnx`), `src/engine-install.ts::validateBackend` (post-download backend
+> mismatch check via Capabilities JSON). The pre-flight in `performInstall` only engages
+> when the platform backend is defined, so an unshipped platform defers to the
+> post-download check.*
+
+### Requirement: Windows x64 installs the released ONNX Engine
+
+`kesha install` on win32-x64 SHALL download the published Windows Engine asset and
+complete the same install flow as linux-x64, with no platform-specific refusal. The
+Install plan SHALL describe that platform in the same terms it uses for the platforms
+it installs on, so a reader is never told a platform is blocked while the same output
+lists its Engine asset and size.
+
+The capability set Windows receives is the ONNX one: Transcription, Language detection
+(audio), VAD, and TTS through the Kokoro, Vosk, and CharsiuG2P TTS engines. Capabilities
+that require Apple frameworks — CoreML, `macos-*` Voice ids, Diarization, and Language
+detection (text) — remain unavailable there and SHALL keep failing with their existing
+platform errors.
+
+The Engine SHALL be installed at a path the CLI can spawn on Windows. The release asset
+is a PE, so the installed binary keeps its `.exe` suffix rather than the extensionless
+name used on POSIX platforms.
+
+#### Scenario: Installing on a Windows build agent
+
+- GIVEN the machine is win32-x64 with no Engine in the Model cache
+- AND `KESHA_ENGINE_BIN` is not set, so the download path is the one under test
+- WHEN Ira runs `kesha install --tts en`
+- THEN the Windows Engine binary and the requested TTS models are downloaded
+- AND the installed binary is spawnable at the path the CLI resolves
+- AND `kesha say "hello"` writes a playable WAV
+
+#### Scenario: Requesting a macOS-only capability on Windows
+
+- GIVEN the machine is win32-x64 with the Engine installed
+- WHEN Ira runs `kesha install --diarize`
+- THEN the CLI prints an error stating Diarization requires darwin-arm64
+- AND the process exits 1
+
+#### Scenario: Previewing the install before downloading
+
+- GIVEN the machine is win32-x64
+- WHEN Ira runs `kesha install --plan`
+- THEN the plan lists the Windows Engine asset with its size and cache status
+- AND the plan contains no statement that the platform is blocked
+
+> *Technical Note — sources: `src/engine-install.ts::getEngineBinaryName`,
+> `src/engine-install.ts::fetchEngineBinary` (its only caller — reached from
+> `downloadEngine` only when the cached-version check fails), `src/paths.ts::defaultEngineBinPath`
+> (`.exe` on win32), `src/install-plan.ts::engineAssetForPlatform`. Built by
+> `.github/workflows/build-engine.yml` with `--features onnx,tts`; issue #216's MSVC link
+> failure was resolved by vendoring the Vosk-TTS runtime under `rust/vendor/vosk-tts/`.*
+
+### Requirement: Every shipped platform is verified end to end before release
+
+For each platform whose Engine is published, the release pipeline SHALL verify that the
+shipped binary performs real synthesis and real Transcription — not only that it builds
+and passes unit tests. A platform whose Engine ships without that verification SHALL be
+documented as unverified rather than presented as supported.
+
+Verification SHALL cover both the asset a user downloads today and the artifact a release is
+about to publish. These are different binaries reached by different means: a release branch
+cannot download its own Engine, because its tag does not exist until the release is un-drafted.
+
+Because the install-time ASR warm-up is non-fatal by design, a successful `kesha install`
+SHALL NOT by itself be treated as evidence that the Engine initialises on that platform.
+
+#### Scenario: Smoke on the published asset
+
+- GIVEN release v`<engineVersion>` publishes an Engine asset for a platform
+- WHEN the published-asset smoke lane runs on that platform
+- THEN it performs a cold `kesha install`, synthesises through `kesha say`, and
+  transcribes the result back
+- AND the lane does not run on `release/*` branches, whose tag is not yet published
+
+#### Scenario: Warm-up fails but install reports success
+
+- GIVEN the Engine installs and the CLI exits 0
+- AND the install log carries an ASR backend warm-up failure
+- WHEN the smoke lane inspects that log
+- THEN the lane fails rather than reporting the platform verified
+
+#### Scenario: Engine builds but cannot synthesise
+
+- GIVEN a platform's Engine compiles and its unit tests pass
+- AND its synthesis smoke fails
+- WHEN Ira consults the platform matrix
+- THEN that platform is not presented as supported
+
+> *Technical Note — sources: `.github/workflows/ci.yml` (`published-engine-smoke` on
+> ubuntu-latest, `windows-engine-smoke` on windows-latest — both run a cold install and
+> `.github/scripts/smoke-synthesis.ts`), `.github/scripts/assert-install-warmup.ts`, and
+> `rust/src/cli/install.rs` (warm-up warns and continues, #298).*
 
 ### Requirement: TTS install is opt-in and requires `--tts`
 
@@ -399,5 +503,5 @@ Interactive missing-model errors recommend `kesha init`; the Quick Start SHALL m
   falls back to `TTS_LANG_FALLBACK` (which excludes `zh`) and rejects the request;
   the error message says "unsupported" rather than "install the engine first to
   unlock platform-specific languages" — see the `resolveTtsLangs` fallback path.
-- Windows x64 is temporarily unsupported in the current release (issue #216) due to
-  native Vosk-TTS link-time issues; `kesha install` fails with an explanatory error.
+- `kesha record` has no Windows or Linux microphone capture; `record.rs` gates capture on
+  macOS and the README directs other platforms to pass an existing audio file.

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -90,9 +90,13 @@ export function resolveBackendFlag(coreml: boolean, onnx: boolean): string | und
   return selection.backend;
 }
 
-function defaultBackendForPlatform(): string | undefined {
-  if (process.platform === "darwin" && process.arch === "arm64") return "coreml";
-  if (process.platform === "linux" && process.arch === "x64") return "onnx";
+export function defaultBackendForPlatform(
+  platform = process.platform,
+  arch = process.arch,
+): string | undefined {
+  if (platform === "darwin" && arch === "arm64") return "coreml";
+  if (platform === "linux" && arch === "x64") return "onnx";
+  if (platform === "win32" && arch === "x64") return "onnx";
   return undefined;
 }
 

--- a/src/engine-install.ts
+++ b/src/engine-install.ts
@@ -365,29 +365,38 @@ async function refreshCachedEngine(
   }
 }
 
+/** EACCES/EPERM are deliberately absent: those are policy (noexec, ACL, AppLocker) and never clear. */
+export function isTransientSpawnLock(message: string): boolean {
+  return /\b(EBUSY|ETXTBSY)\b/.test(message) || /sharing violation/i.test(message);
+}
+
 /**
  * Blocks until the freshly-downloaded engine can actually be spawned.
  *
- * A security scanner (Windows Defender is the one this was found on) holds a
- * lock on a newly written 60 MB PE while it scans, and the first spawn fails
- * with EBUSY — 15 ms after the download reported success (#216). The lock is
- * transient, so probe until it clears rather than failing the install on it.
+ * A security scanner (Windows Defender is the one this was found on) holds a lock on a newly
+ * written 60 MB PE while it scans, so the first spawn fails with EBUSY 15 ms after the download
+ * reported success (#216). The lock is transient, so probe until it clears.
  */
-export function isTransientSpawnLock(message: string): boolean {
-  return /\b(EBUSY|ETXTBSY|EACCES|EPERM)\b/.test(message);
-}
-
 export async function waitUntilSpawnable(
   binPath: string,
   deadlineMs = 60_000,
+  probeTimeoutMs = 5_000,
 ): Promise<void> {
-  const startedAt = Date.now();
+  const deadline = Date.now() + deadlineMs;
   let lastError = "";
+  let warned = false;
+  let delay = 100;
 
-  for (let delay = 100; ; delay = Math.min(delay * 2, 2_000)) {
+  for (;;) {
     try {
-      // A non-zero exit still proves the file spawned; only a throw means it is locked.
-      Bun.spawnSync([binPath, "--version"], { stdout: "ignore", stderr: "ignore" });
+      // Only a throw means locked; the timeout is for a scanner that detains rather than refuses.
+      const proc = Bun.spawn([binPath, "--version"], { stdout: "ignore", stderr: "ignore" });
+      const timer = setTimeout(() => proc.kill(), probeTimeoutMs);
+      try {
+        await proc.exited;
+      } finally {
+        clearTimeout(timer);
+      }
       return;
     } catch (e) {
       lastError = errorMessage(e);
@@ -398,11 +407,13 @@ export async function waitUntilSpawnable(
             `  Fix: delete ${dirname(binPath)} and re-run \`kesha install\`.`,
         );
       }
-      if (Date.now() - startedAt + delay > deadlineMs) break;
-      if (delay === 100) {
+      if (Date.now() + delay > deadline) break;
+      if (!warned) {
+        warned = true;
         log.progress("Waiting for the engine binary to be released by the system...");
       }
       await Bun.sleep(delay);
+      delay = Math.min(delay * 2, 2_000);
     }
   }
 
@@ -458,8 +469,9 @@ async function fetchEngineBinary(
   await streamResponseToFile(res, binPath, "kesha-engine binary");
   chmodSync(binPath, 0o755);
   darwinTrustBinary(binPath, "kesha-engine binary");
-  writeInstalledEngineVersion(binPath, engineVersion);
+  // Marker last: writing it first sends the retry down the cacheValid branch, which never waits.
   await waitUntilSpawnable(binPath);
+  writeInstalledEngineVersion(binPath, engineVersion);
   log.success(`Engine binary downloaded (v${engineVersion}).`);
   await Promise.all(sidecarPromises);
 }

--- a/src/engine-install.ts
+++ b/src/engine-install.ts
@@ -365,6 +365,55 @@ async function refreshCachedEngine(
   }
 }
 
+/**
+ * Blocks until the freshly-downloaded engine can actually be spawned.
+ *
+ * A security scanner (Windows Defender is the one this was found on) holds a
+ * lock on a newly written 60 MB PE while it scans, and the first spawn fails
+ * with EBUSY — 15 ms after the download reported success (#216). The lock is
+ * transient, so probe until it clears rather than failing the install on it.
+ */
+export function isTransientSpawnLock(message: string): boolean {
+  return /\b(EBUSY|ETXTBSY|EACCES|EPERM)\b/.test(message);
+}
+
+export async function waitUntilSpawnable(
+  binPath: string,
+  deadlineMs = 60_000,
+): Promise<void> {
+  const startedAt = Date.now();
+  let lastError = "";
+
+  for (let delay = 100; ; delay = Math.min(delay * 2, 2_000)) {
+    try {
+      // A non-zero exit still proves the file spawned; only a throw means it is locked.
+      Bun.spawnSync([binPath, "--version"], { stdout: "ignore", stderr: "ignore" });
+      return;
+    } catch (e) {
+      lastError = errorMessage(e);
+      // Only a lock is worth waiting out — a missing or corrupt binary never becomes spawnable.
+      if (!isTransientSpawnLock(lastError)) {
+        throw new Error(
+          `Downloaded the engine to ${binPath} but it could not be started: ${lastError}\n` +
+            `  Fix: delete ${dirname(binPath)} and re-run \`kesha install\`.`,
+        );
+      }
+      if (Date.now() - startedAt + delay > deadlineMs) break;
+      if (delay === 100) {
+        log.progress("Waiting for the engine binary to be released by the system...");
+      }
+      await Bun.sleep(delay);
+    }
+  }
+
+  throw new Error(
+    `Downloaded the engine to ${binPath} but it is still locked after ` +
+      `${Math.round(deadlineMs / 1000)}s: ${lastError}\n` +
+      `  Fix: a security scanner is likely holding the file. Re-run \`kesha install\`, ` +
+      `or exclude ${dirname(binPath)} from real-time scanning.`,
+  );
+}
+
 /** Cold path: download the engine binary (and sidecars, concurrently). */
 async function fetchEngineBinary(
   binPath: string,
@@ -410,6 +459,7 @@ async function fetchEngineBinary(
   chmodSync(binPath, 0o755);
   darwinTrustBinary(binPath, "kesha-engine binary");
   writeInstalledEngineVersion(binPath, engineVersion);
+  await waitUntilSpawnable(binPath);
   log.success(`Engine binary downloaded (v${engineVersion}).`);
   await Promise.all(sidecarPromises);
 }

--- a/src/engine-install.ts
+++ b/src/engine-install.ts
@@ -25,20 +25,13 @@ export {
 
 const GITHUB_REPO = "drakulavich/kesha-voice-kit";
 
-function getEngineBinaryName(): string {
-  const platform = process.platform;
-  const arch = process.arch;
-
+export function getEngineBinaryName(
+  platform = process.platform,
+  arch = process.arch,
+): string {
   if (platform === "darwin" && arch === "arm64") return "kesha-engine-darwin-arm64";
   if (platform === "linux" && arch === "x64") return "kesha-engine-linux-x64";
-  if (platform === "win32" && arch === "x64") {
-    throw new Error(
-      "Windows x64 is temporarily unsupported in v1.5.0 — the Vosk-TTS engine has " +
-        "native deps that trip MSVC at link time. Tracked at " +
-        "https://github.com/drakulavich/kesha-voice-kit/issues/216. " +
-        "Use v1.4.x as a workaround until the fix lands.",
-    );
-  }
+  if (platform === "win32" && arch === "x64") return "kesha-engine-windows-x64.exe";
 
   throw new Error(`Unsupported platform: ${platform} ${arch}`);
 }

--- a/src/install-plan.ts
+++ b/src/install-plan.ts
@@ -112,7 +112,7 @@ function engineAssetForPlatform(): ReleaseAssetSpec | null {
     return { assetName: "kesha-engine-linux-x64", sizeBytes: 62_897_808 };
   }
   if (process.platform === "win32" && process.arch === "x64") {
-    return { assetName: "kesha-engine-windows-x64.exe", sizeBytes: 63_126_528 };
+    return { assetName: "kesha-engine-windows-x64.exe", sizeBytes: 63_447_040 };
   }
   return null;
 }
@@ -153,10 +153,6 @@ function buildEngineComponent(binPath: string, noCache: boolean): PlanComponent 
       sizeBytes: engineAsset.sizeBytes,
       cached: engineCached,
       refresh: noCache,
-      note:
-        process.platform === "win32"
-          ? "Windows x64 is currently blocked by the install path; see issue #216."
-          : undefined,
     };
   }
   return {

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -5,6 +5,8 @@ export function keshaCacheDir(): string {
   return process.env.KESHA_CACHE_DIR ?? join(homedir(), ".cache", "kesha");
 }
 
-export function defaultEngineBinPath(): string {
-  return join(keshaCacheDir(), "engine", "bin", "kesha-engine");
+/** Windows needs the `.exe` suffix: the release asset is a PE, and an extensionless copy is not reliably spawnable. */
+export function defaultEngineBinPath(platform = process.platform): string {
+  const basename = platform === "win32" ? "kesha-engine.exe" : "kesha-engine";
+  return join(keshaCacheDir(), "engine", "bin", basename);
 }

--- a/src/progress.ts
+++ b/src/progress.ts
@@ -128,7 +128,8 @@ export async function streamResponseToFile(
       progress.update(chunk.length);
     }
   } finally {
-    writer.end();
+    // Must await: an open write handle makes the freshly-downloaded engine unspawnable — EBUSY on Windows, ETXTBSY on Linux.
+    await writer.end();
   }
 
   progress.finish();

--- a/tests/unit/engine-install.test.ts
+++ b/tests/unit/engine-install.test.ts
@@ -4,10 +4,12 @@ import {
   cleanupRetiredSidecars,
   getVersionMarkerPath,
   getEngineBinaryName,
+  isTransientSpawnLock,
+  waitUntilSpawnable,
   readInstalledEngineVersion,
   writeInstalledEngineVersion,
 } from "../../src/engine-install";
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync, rmSync } from "fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, writeFileSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { defaultEngineBinPath } from "../../src/paths";
@@ -172,5 +174,41 @@ describe("defaultEngineBinPath extension (#216)", () => {
     expect(getVersionMarkerPath(defaultEngineBinPath("win32"))).toMatch(
       /kesha-engine\.exe\.version$/,
     );
+  });
+});
+
+describe("waitUntilSpawnable (#216)", () => {
+  test("classifies lock errors as transient, everything else as fatal", () => {
+    expect(isTransientSpawnLock("EBUSY: resource busy or locked, uv_spawn")).toBe(true);
+    expect(isTransientSpawnLock("ETXTBSY: text file is busy, uv_spawn")).toBe(true);
+    expect(isTransientSpawnLock("ENOENT: no such file or directory")).toBe(false);
+    expect(isTransientSpawnLock("ENOEXEC: exec format error")).toBe(false);
+  });
+
+  test("returns once the binary spawns", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-spawnable-"));
+    try {
+      const binPath = join(dir, "engine");
+      writeFileSync(binPath, "#!/bin/sh\nexit 0\n");
+      chmodSync(binPath, 0o755);
+      expect(await waitUntilSpawnable(binPath)).toBeUndefined();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // A missing binary never becomes spawnable, so retrying it would just stall the
+  // install for the full deadline before failing anyway.
+  test("fails fast on a non-transient error instead of waiting out the deadline", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-spawnable-missing-"));
+    try {
+      const startedAt = Date.now();
+      await expect(
+        waitUntilSpawnable(join(dir, "does-not-exist"), 60_000),
+      ).rejects.toThrow(/could not be started/);
+      expect(Date.now() - startedAt).toBeLessThan(5_000);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/unit/engine-install.test.ts
+++ b/tests/unit/engine-install.test.ts
@@ -146,15 +146,6 @@ describe("getEngineBinaryName platform mapping (#216)", () => {
     expect(getEngineBinaryName("darwin", "arm64")).toBe("kesha-engine-darwin-arm64");
     expect(getEngineBinaryName("linux", "x64")).toBe("kesha-engine-linux-x64");
   });
-  test("no release asset mentions a version workaround", () => {
-    for (const [platform, arch] of [
-      ["win32", "x64"],
-      ["darwin", "arm64"],
-      ["linux", "x64"],
-    ] as const) {
-      expect(getEngineBinaryName(platform, arch)).not.toMatch(/v1\.[45]/);
-    }
-  });
   test("platforms without a published engine still throw", () => {
     expect(() => getEngineBinaryName("win32", "arm64")).toThrow(/Unsupported platform/);
     expect(() => getEngineBinaryName("darwin", "x64")).toThrow(/Unsupported platform/);
@@ -164,11 +155,11 @@ describe("getEngineBinaryName platform mapping (#216)", () => {
 
 describe("defaultEngineBinPath extension (#216)", () => {
   test("win32 keeps the .exe suffix so the downloaded PE is spawnable", () => {
-    expect(defaultEngineBinPath("win32").endsWith("kesha-engine.exe")).toBe(true);
+    expect(defaultEngineBinPath("win32")).toEndWith("kesha-engine.exe");
   });
   test("posix platforms stay extensionless", () => {
-    expect(defaultEngineBinPath("linux").endsWith("kesha-engine")).toBe(true);
-    expect(defaultEngineBinPath("darwin").endsWith("kesha-engine")).toBe(true);
+    expect(defaultEngineBinPath("linux")).toEndWith("kesha-engine");
+    expect(defaultEngineBinPath("darwin")).toEndWith("kesha-engine");
   });
   test("the version marker follows the binary name on win32", () => {
     expect(getVersionMarkerPath(defaultEngineBinPath("win32"))).toMatch(
@@ -183,6 +174,9 @@ describe("waitUntilSpawnable (#216)", () => {
     expect(isTransientSpawnLock("ETXTBSY: text file is busy, uv_spawn")).toBe(true);
     expect(isTransientSpawnLock("ENOENT: no such file or directory")).toBe(false);
     expect(isTransientSpawnLock("ENOEXEC: exec format error")).toBe(false);
+    // Policy, not a scanner: waiting these out would stall an install that can never succeed.
+    expect(isTransientSpawnLock("EACCES: permission denied")).toBe(false);
+    expect(isTransientSpawnLock("EPERM: operation not permitted")).toBe(false);
   });
 
   // The fixture is a shell script, which Windows cannot spawn — the lock-clearing
@@ -195,7 +189,7 @@ describe("waitUntilSpawnable (#216)", () => {
       const binPath = join(dir, "engine");
       writeFileSync(binPath, "#!/bin/sh\nexit 0\n");
       chmodSync(binPath, 0o755);
-      expect(await waitUntilSpawnable(binPath)).toBeUndefined();
+      await waitUntilSpawnable(binPath);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/tests/unit/engine-install.test.ts
+++ b/tests/unit/engine-install.test.ts
@@ -185,7 +185,11 @@ describe("waitUntilSpawnable (#216)", () => {
     expect(isTransientSpawnLock("ENOEXEC: exec format error")).toBe(false);
   });
 
-  test("returns once the binary spawns", async () => {
+  // The fixture is a shell script, which Windows cannot spawn — the lock-clearing
+  // behaviour itself is what `windows-engine-smoke` exercises against a real PE.
+  const spawnFixtureTest = process.platform === "win32" ? test.skip : test;
+
+  spawnFixtureTest("returns once the binary spawns", async () => {
     const dir = mkdtempSync(join(tmpdir(), "kesha-spawnable-"));
     try {
       const binPath = join(dir, "engine");

--- a/tests/unit/engine-install.test.ts
+++ b/tests/unit/engine-install.test.ts
@@ -3,12 +3,14 @@ import {
   buildEngineInstallArgs,
   cleanupRetiredSidecars,
   getVersionMarkerPath,
+  getEngineBinaryName,
   readInstalledEngineVersion,
   writeInstalledEngineVersion,
 } from "../../src/engine-install";
 import { existsSync, mkdirSync, mkdtempSync, writeFileSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
+import { defaultEngineBinPath } from "../../src/paths";
 
 function mkTmpBinPath(): string {
   const dir = mkdtempSync(join(tmpdir(), "kesha-install-test-"));
@@ -131,5 +133,44 @@ describe("engine-install retired sidecar cleanup (#438)", () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("getEngineBinaryName platform mapping (#216)", () => {
+  test("win32-x64 returns the published Windows asset", () => {
+    expect(getEngineBinaryName("win32", "x64")).toBe("kesha-engine-windows-x64.exe");
+  });
+  test("darwin-arm64 and linux-x64 are unchanged", () => {
+    expect(getEngineBinaryName("darwin", "arm64")).toBe("kesha-engine-darwin-arm64");
+    expect(getEngineBinaryName("linux", "x64")).toBe("kesha-engine-linux-x64");
+  });
+  test("no release asset mentions a version workaround", () => {
+    for (const [platform, arch] of [
+      ["win32", "x64"],
+      ["darwin", "arm64"],
+      ["linux", "x64"],
+    ] as const) {
+      expect(getEngineBinaryName(platform, arch)).not.toMatch(/v1\.[45]/);
+    }
+  });
+  test("platforms without a published engine still throw", () => {
+    expect(() => getEngineBinaryName("win32", "arm64")).toThrow(/Unsupported platform/);
+    expect(() => getEngineBinaryName("darwin", "x64")).toThrow(/Unsupported platform/);
+    expect(() => getEngineBinaryName("linux", "arm64")).toThrow(/Unsupported platform/);
+  });
+});
+
+describe("defaultEngineBinPath extension (#216)", () => {
+  test("win32 keeps the .exe suffix so the downloaded PE is spawnable", () => {
+    expect(defaultEngineBinPath("win32").endsWith("kesha-engine.exe")).toBe(true);
+  });
+  test("posix platforms stay extensionless", () => {
+    expect(defaultEngineBinPath("linux").endsWith("kesha-engine")).toBe(true);
+    expect(defaultEngineBinPath("darwin").endsWith("kesha-engine")).toBe(true);
+  });
+  test("the version marker follows the binary name on win32", () => {
+    expect(getVersionMarkerPath(defaultEngineBinPath("win32"))).toMatch(
+      /kesha-engine\.exe\.version$/,
+    );
   });
 });

--- a/tests/unit/engine.test.ts
+++ b/tests/unit/engine.test.ts
@@ -80,6 +80,8 @@ async function withEngineEnv<T>(
   }
 }
 
+const engineBasename = process.platform === "win32" ? "kesha-engine.exe" : "kesha-engine";
+
 describe("engine", () => {
   test("getEngineBinPath returns path under .cache kesha", () => {
     const path = getEngineBinPath();
@@ -93,7 +95,7 @@ describe("engine", () => {
     try {
       delete process.env.KESHA_ENGINE_BIN;
       process.env.KESHA_CACHE_DIR = "/tmp/kesha-cache";
-      expect(getEngineBinPath()).toBe(join("/tmp/kesha-cache", "engine", "bin", "kesha-engine"));
+      expect(getEngineBinPath()).toBe(join("/tmp/kesha-cache", "engine", "bin", engineBasename));
     } finally {
       if (savedCacheDir === undefined) delete process.env.KESHA_CACHE_DIR;
       else process.env.KESHA_CACHE_DIR = savedCacheDir;
@@ -108,7 +110,7 @@ describe("engine", () => {
     try {
       process.env.KESHA_CACHE_DIR = "/tmp/kesha-cache";
       process.env.KESHA_ENGINE_BIN = "";
-      expect(getEngineBinPath()).toBe(join("/tmp/kesha-cache", "engine", "bin", "kesha-engine"));
+      expect(getEngineBinPath()).toBe(join("/tmp/kesha-cache", "engine", "bin", engineBasename));
     } finally {
       if (savedCacheDir === undefined) delete process.env.KESHA_CACHE_DIR;
       else process.env.KESHA_CACHE_DIR = savedCacheDir;

--- a/tests/unit/install-plan.test.ts
+++ b/tests/unit/install-plan.test.ts
@@ -148,3 +148,21 @@ describe("renderInstallPlan", () => {
     }
   });
 });
+
+describe("install plan carries no platform block (#216)", () => {
+  test("the plan never tells a reader the platform is blocked", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-install-plan-block-"));
+    try {
+      process.env.HOME = dir;
+      process.env.KESHA_CACHE_DIR = join(dir, "cache");
+      process.env.KESHA_ENGINE_BIN = join(dir, "engine", "bin", "kesha-engine");
+
+      const output = await renderInstallPlan({ ttsLangs: ["en"] });
+
+      expect(output).not.toMatch(/blocked/i);
+      expect(output).not.toMatch(/#216/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/install.test.ts
+++ b/tests/unit/install.test.ts
@@ -25,6 +25,7 @@ describe("resolveTtsLangs", () => {
 });
 
 describe("defaultBackendForPlatform", () => {
+  // A defined backend is what lets performInstall reject `--coreml` before the download.
   test("win32-x64 auto-detects onnx", () => {
     expect(defaultBackendForPlatform("win32", "x64")).toBe("onnx");
   });
@@ -33,15 +34,6 @@ describe("defaultBackendForPlatform", () => {
   });
   test("linux-x64 auto-detects onnx", () => {
     expect(defaultBackendForPlatform("linux", "x64")).toBe("onnx");
-  });
-  // A defined win32 backend is what makes `--coreml` reject before downloading:
-  // performInstall guards on `platformBackend && backend !== platformBackend`,
-  // so `undefined` would skip the pre-flight and defer to validateBackend
-  // after the ~63 MB fetch.
-  test("win32-x64 disagrees with coreml, so the pre-flight can reject it", () => {
-    const platformBackend = defaultBackendForPlatform("win32", "x64");
-    expect(platformBackend).toBeDefined();
-    expect(platformBackend).not.toBe("coreml");
   });
   test("unshipped platforms stay undefined", () => {
     expect(defaultBackendForPlatform("darwin", "x64")).toBeUndefined();

--- a/tests/unit/install.test.ts
+++ b/tests/unit/install.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { resolveTtsLangs } from "../../src/cli/install";
+import { defaultBackendForPlatform, resolveTtsLangs } from "../../src/cli/install";
 
 const caps = ["en", "es", "fr", "it", "pt", "ru"];
 
@@ -21,5 +21,31 @@ describe("resolveTtsLangs", () => {
   });
   test("undefined supported set skips the unsupported check (engine validates)", () => {
     expect(resolveTtsLangs({ tts: true, positionals: ["ja"] }, undefined)).toEqual(["ja"]);
+  });
+});
+
+describe("defaultBackendForPlatform", () => {
+  test("win32-x64 auto-detects onnx", () => {
+    expect(defaultBackendForPlatform("win32", "x64")).toBe("onnx");
+  });
+  test("darwin-arm64 auto-detects coreml", () => {
+    expect(defaultBackendForPlatform("darwin", "arm64")).toBe("coreml");
+  });
+  test("linux-x64 auto-detects onnx", () => {
+    expect(defaultBackendForPlatform("linux", "x64")).toBe("onnx");
+  });
+  // A defined win32 backend is what makes `--coreml` reject before downloading:
+  // performInstall guards on `platformBackend && backend !== platformBackend`,
+  // so `undefined` would skip the pre-flight and defer to validateBackend
+  // after the ~63 MB fetch.
+  test("win32-x64 disagrees with coreml, so the pre-flight can reject it", () => {
+    const platformBackend = defaultBackendForPlatform("win32", "x64");
+    expect(platformBackend).toBeDefined();
+    expect(platformBackend).not.toBe("coreml");
+  });
+  test("unshipped platforms stay undefined", () => {
+    expect(defaultBackendForPlatform("darwin", "x64")).toBeUndefined();
+    expect(defaultBackendForPlatform("linux", "arm64")).toBeUndefined();
+    expect(defaultBackendForPlatform("freebsd", "x64")).toBeUndefined();
   });
 });

--- a/tests/unit/progress-stream.test.ts
+++ b/tests/unit/progress-stream.test.ts
@@ -1,13 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { chmodSync, mkdtempSync, rmSync, statSync } from "fs";
+import { mkdtempSync, rmSync, statSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { streamResponseToFile } from "../../src/progress";
 
-// #216: `writer.end()` went unawaited, so the write handle outlived the call and
-// the just-downloaded engine could not be spawned — EBUSY on Windows, ETXTBSY on
-// Linux. The contract is that the file is complete AND released once this resolves.
-const spawnTest = process.platform === "win32" ? test.skip : test;
+// #216: `writer.end()` went unawaited, so the write handle outlived the call. Whether an
+// OS then lets you spawn the file is nondeterministic — that half is covered by
+// windows-engine-smoke against a real PE and absorbed by `waitUntilSpawnable`.
 
 function responseOf(body: string): Response {
   const bytes = new TextEncoder().encode(body);
@@ -25,22 +24,6 @@ describe("streamResponseToFile releases the file before resolving", () => {
 
       expect(written).toBe(body.length);
       expect(statSync(dest).size).toBe(body.length);
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
-  spawnTest("a downloaded executable is spawnable immediately", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "kesha-stream-exec-"));
-    try {
-      const dest = join(dir, "helper");
-
-      await streamResponseToFile(responseOf("#!/bin/sh\nexit 0\n"), dest, "helper");
-      chmodSync(dest, 0o755);
-
-      const proc = Bun.spawn([dest], { stdout: "ignore", stderr: "pipe" });
-      const stderr = await new Response(proc.stderr).text();
-      expect({ code: await proc.exited, stderr }).toEqual({ code: 0, stderr: "" });
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/tests/unit/progress-stream.test.ts
+++ b/tests/unit/progress-stream.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, rmSync, statSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { streamResponseToFile } from "../../src/progress";
+
+// #216: `writer.end()` went unawaited, so the write handle outlived the call and
+// the just-downloaded engine could not be spawned — EBUSY on Windows, ETXTBSY on
+// Linux. The contract is that the file is complete AND released once this resolves.
+const spawnTest = process.platform === "win32" ? test.skip : test;
+
+function responseOf(body: string): Response {
+  const bytes = new TextEncoder().encode(body);
+  return new Response(bytes, { headers: { "content-length": String(bytes.length) } });
+}
+
+describe("streamResponseToFile releases the file before resolving", () => {
+  test("the full payload is on disk when the promise resolves", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-stream-"));
+    try {
+      const dest = join(dir, "payload.bin");
+      const body = "x".repeat(512 * 1024);
+
+      const written = await streamResponseToFile(responseOf(body), dest, "payload");
+
+      expect(written).toBe(body.length);
+      expect(statSync(dest).size).toBe(body.length);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  spawnTest("a downloaded executable is spawnable immediately", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-stream-exec-"));
+    try {
+      const dest = join(dir, "helper");
+
+      await streamResponseToFile(responseOf("#!/bin/sh\nexit 0\n"), dest, "helper");
+      chmodSync(dest, 0o755);
+
+      const proc = Bun.spawn([dest], { stdout: "ignore", stderr: "pipe" });
+      const stderr = await new Response(proc.stderr).text();
+      expect({ code: await proc.exited, stderr }).toEqual({ code: 0, stderr: "" });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/progress-stream.test.ts
+++ b/tests/unit/progress-stream.test.ts
@@ -13,7 +13,7 @@ function responseOf(body: string): Response {
   return new Response(bytes, { headers: { "content-length": String(bytes.length) } });
 }
 
-describe("streamResponseToFile releases the file before resolving", () => {
+describe("streamResponseToFile flushes before resolving", () => {
   test("the full payload is on disk when the promise resolves", async () => {
     const dir = mkdtempSync(join(tmpdir(), "kesha-stream-"));
     try {


### PR DESCRIPTION
Unblocks `kesha install` on Windows x64, and adds the end-to-end verification whose absence was the only honest reason left to keep a gate.

## Why

The CLI refused to install on Windows with an error naming **v1.5.0** and recommending "use v1.4.x as a workaround". The repo is on v1.24.7 — the refusal outlived its cause by about twenty minor versions. [#216](https://github.com/drakulavich/kesha-voice-kit/issues/216), the MSVC CRT link failure behind it, was closed on 2026-04-30 by vendoring the Vosk-TTS runtime under `rust/vendor/vosk-tts/`, and `build-engine.yml` has published `kesha-engine-windows-x64.exe` every release since.

So the engine shipped, the CLI refused to fetch it, and nobody had run it. #216's last acceptance criterion — `kesha say --voice ru-vosk-m02` producing a valid WAV on Windows — was never demonstrated.

## Verification and unblock land together, on purpose

While the gate throws, no CI lane can run a real `kesha install` on Windows. The proposal's earlier shape worked around that by pre-placing the binary so `downloadEngine` took its `cacheValid` branch — which skips `fetchEngineBinary`, which is exactly where the gate lives. That would have verified everything except the fix.

Removing the gate in the same commit dissolves the workaround. `windows-engine-smoke` runs a **cold** `kesha install --tts en ru` — no `KESHA_ENGINE_BIN`, no pre-placed binary — against the published v1.24.7 asset. That is the path a user takes. **If it goes red, this does not merge.**

## Two defects only the cold path can reach

- **`defaultEngineBinPath` returned an extensionless `kesha-engine`**, and `fetchEngineBinary` writes the Windows PE straight to it. Every smoke lane that sets `KESHA_ENGINE_BIN` points at a real `.exe`, so none of them could have caught this. Now `.exe` on win32.
- **`defaultBackendForPlatform` returned `undefined` for win32**, and `performInstall` guards on `platformBackend && backend !== platformBackend` — so `undefined` *skipped* the pre-flight rather than failing it. `kesha install --coreml` would have been rejected only after the 63 MB download. Now `onnx`, with the rejection asserted in CI where the pre-flight is live.

## Synthesis was unverified everywhere non-Darwin

`published-engine-smoke` transcribed a fixture but never synthesised, so Linux carried the same gap ([#464](https://github.com/drakulavich/kesha-voice-kit/issues/464)). Both lanes now share `.github/scripts/smoke-synthesis.ts`: say through Kokoro and Vosk, assert a real RIFF/WAVE payload rather than a bare 44-byte header, transcribe each result back.

And because the ASR warm-up is **non-fatal by design** (#298), a green install proves nothing about ORT init on a new platform — `assert-install-warmup.ts` reads the install log for it.

## Not in scope

No new platform capabilities: Windows gets what the ONNX engine already compiles. CoreML, `macos-*` voices, diarization, and text language detection stay macOS-only, as does `kesha record`. No engine (Rust) changes. No change to the never-auto-download rule.

Closes #216
Refs #464

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhPvkHRyjGTP6octKHuS5T
