### PR TITLE
fix(raycast): fail closed on valid JSON that is not a status object

### DIFF
--- a/openspec/specs/raycast-extension/spec.md
+++ b/openspec/specs/raycast-extension/spec.md
@@ -463,6 +463,13 @@ guards report the real problem with a better message than the probe could.
 - **AND** the setup view names a CLI/extension version mismatch, not a broken Engine
 - **AND** no recording starts
 
+#### Scenario: Machine-readable output that is not a status object
+
+- **GIVEN** the resolved CLI emits valid JSON whose top-level value is an array or a scalar
+- **WHEN** Maks starts a Dictation session
+- **THEN** the probe treats it as a contract failure, not as an older CLI's output
+- **AND** no recording starts
+
 #### Scenario: Probe cannot run
 
 - **WHEN** the resolved CLI cannot be spawned or exits unexpectedly during the probe

--- a/raycast/src/lib/dictation-controller.ts
+++ b/raycast/src/lib/dictation-controller.ts
@@ -248,9 +248,7 @@ export function startDictationSession(
   }
 }
 
-// Each reason has its own remedy, so the headline tracks it: re-downloading a
-// broken engine, finishing a first install, and upgrading a version-skewed CLI
-// are three different instructions (#647).
+// Each reason has a different remedy, so the headline tracks it, not just the hint (#647).
 function preflightMessage(reason: EnginePreflightResult["reason"]): string {
   switch (reason) {
     case "unusable":

--- a/raycast/src/lib/kesha-bin.ts
+++ b/raycast/src/lib/kesha-bin.ts
@@ -158,12 +158,7 @@ export interface EnginePreflightResult {
 }
 
 const MISSING_ENGINE_MARKER = "not installed";
-// A corrupt binary is not repaired by a plain `kesha install`: that hits the
-// cached-engine path and only re-trusts it. `--no-cache` forces the re-download,
-// except on a read-only engine dir (Nix store), where it is deliberately a no-op
-// (`cacheValid = versionMatches && (!noCache || !canWriteEngineDir)`). The probe
-// cannot tell the two installs apart, so the hint names both rather than
-// promising a fix that would silently skip.
+// Plain `kesha install` only re-trusts a cached binary; `--no-cache` re-downloads, except on a read-only (Nix) dir.
 const REPAIR_HINT =
   "Run `kesha install --no-cache` to re-download the engine. On a read-only (Nix) install, repair it through your package manager instead.";
 const CONTRACT_HINT =
@@ -176,23 +171,28 @@ function runKesha(spawn: KeshaSpawn, args: string[], deps: ProbeDeps) {
   });
 }
 
-function parseStatusObject(stdout: string): Record<string, unknown> | null {
+type StatusStdout =
+  | { kind: "payload"; value: Record<string, unknown> }
+  | { kind: "contract" }
+  | { kind: "prose" };
+
+// An older CLI prints human text, never JSON — so a non-object is a broken contract, not a fallback.
+function classifyStatusStdout(stdout: string): StatusStdout {
   const trimmed = stdout.trim();
-  if (!trimmed.startsWith("{")) return null;
+  if (!trimmed) return { kind: "prose" };
+  let parsed: unknown;
   try {
-    const parsed: unknown = JSON.parse(trimmed);
-    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
-      ? (parsed as Record<string, unknown>)
-      : null;
+    parsed = JSON.parse(trimmed);
   } catch {
-    return null;
+    return { kind: "prose" };
   }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { kind: "contract" };
+  }
+  return { kind: "payload", value: parsed as Record<string, unknown> };
 }
 
-// Anchored to the Binary line rather than the whole output: "not installed" is
-// `formatStatusLine`'s default missing label, so a future missing line would
-// otherwise read as the engine being absent. No Binary line means this is not
-// status output at all — garbage fails open rather than matching loose text.
+// Anchored to the Binary line: "not installed" is the default missing label, so other lines would false-positive.
 function proseSaysEngineMissing(stdout: string): boolean {
   const binaryLine = stdout
     .split("\n")
@@ -200,9 +200,7 @@ function proseSaysEngineMissing(stdout: string): boolean {
   return binaryLine !== undefined && binaryLine.includes(MISSING_ENGINE_MARKER);
 }
 
-// The CLI validates this shape too, but the extension ships through the Raycast
-// Store against whatever CLI version is on the machine — including ones that
-// predate that validation and forward `{}` or `[]` as capabilities.
+// Re-checked here because the Store extension meets CLI versions predating the CLI-side validation.
 function capabilitiesAreReadable(capabilities: unknown): boolean {
   return (
     typeof capabilities === "object" &&
@@ -229,8 +227,7 @@ function readStructuredStatus(
     const hint = typeof payload.hint === "string" ? payload.hint.trim() : "";
     return { ok: false, reason: "missing", hint: hint || undefined };
   }
-  // Present is not usable: a binary that cannot report its capabilities would
-  // fail during transcription, after the recording is already gone (#647).
+  // Present is not usable: it would fail during transcription, after the recording is gone (#647).
   if (!capabilitiesAreReadable(capabilities)) {
     return { ok: false, reason: "unusable", hint: REPAIR_HINT };
   }
@@ -258,8 +255,12 @@ export async function probeEngineAvailability(
       ["status", "--json"],
       deps,
     );
-    const payload = parseStatusObject(stdout);
-    if (payload) return readStructuredStatus(payload);
+    const classified = classifyStatusStdout(stdout);
+    if (classified.kind === "payload")
+      return readStructuredStatus(classified.value);
+    if (classified.kind === "contract") {
+      return { ok: false, reason: "contract", hint: CONTRACT_HINT };
+    }
     if (proseSaysEngineMissing(stdout)) {
       return { ok: false, reason: "missing", hint: stderr.trim() || undefined };
     }

--- a/raycast/tests/kesha-bin-status-json.test.ts
+++ b/raycast/tests/kesha-bin-status-json.test.ts
@@ -2,8 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { probeEngineAvailability } from "../src/lib/kesha-bin";
 import type { ProbeDeps } from "../src/lib/kesha-bin";
 
-// One case per row of the probe matrix in
-// openspec/changes/status-json-output/design.md.
+// One case per row of the probe matrix in the status-json-output design.
 describe("probeEngineAvailability — structured status (#647)", () => {
   const kesha = { command: "/opt/homebrew/bin/kesha", prefixArgs: [] };
 
@@ -63,8 +62,7 @@ describe("probeEngineAvailability — structured status (#647)", () => {
     expect(result.ok).toBe(false);
     expect(result.reason).toBe("unusable");
     expect(result.hint).toContain("--no-cache");
-    // A read-only (Nix) install ignores --no-cache for the engine, so the hint
-    // must not promise a fix those users cannot get.
+    // A read-only (Nix) install ignores --no-cache, so the hint must not promise that fix alone.
     expect(result.hint).toContain("read-only");
   });
 
@@ -133,9 +131,12 @@ describe("probeEngineAvailability — structured status (#647)", () => {
     }
   });
 
-  it("fails open on a JSON array", async () => {
-    expect(await probeEngineAvailability(kesha, { execFile: textStdout("[1,2,3]") })).toEqual({
-      ok: true,
-    });
+  it("fails closed on valid JSON that is not an object", async () => {
+    // As prose this would miss the marker and report a missing engine as healthy.
+    for (const stdout of ["[1,2,3]", "42", '"ok"', "null", "true"]) {
+      const result = await probeEngineAvailability(kesha, { execFile: textStdout(stdout) });
+      expect(result.ok).toBe(false);
+      expect(result.reason).toBe("contract");
+    }
   });
 });

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -26,8 +26,7 @@ export const statusCommand = defineCommand({
   async run({ args }: { args: StatusCommandArgs }) {
     const report = await collectStatus({ disk: args.disk });
     if (args.json) {
-      // `log.*` writes to stdout, so the payload must be the only thing printed —
-      // the setup hint ships inside it instead of on stderr (#647).
+      // `log.*` writes to stdout, so the payload must be the only thing printed (#647).
       console.log(JSON.stringify(report, null, 2));
       return;
     }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -373,9 +373,7 @@ export async function getEngineCapabilities(): Promise<EngineCapabilities | null
   }
 }
 
-// A non-null return has to mean "the engine described itself" — callers reach
-// straight for `.features.join()` and `.backend` (#647). Only the fields those
-// callers consume are checked, so a newer engine adding fields still validates.
+// A non-null return must mean "it described itself" — callers reach straight for `.features.join()` (#647).
 function parseCapabilities(parsed: unknown): EngineCapabilities | null {
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
   const { protocolVersion, backend, features } = parsed as Record<string, unknown>;

--- a/tests/unit/status.test.ts
+++ b/tests/unit/status.test.ts
@@ -288,8 +288,7 @@ describe("collectStatus --json payload (#647)", () => {
   });
 
   posixEngineTest("capabilities of the wrong shape are rejected, not forwarded", async () => {
-    // A non-null capabilities value must mean the engine described itself:
-    // `renderStatus` reaches straight for `features.join` (#647).
+    // Non-null capabilities must mean it described itself: `renderStatus` calls `features.join` (#647).
     const dir = mkdtempSync(join(tmpdir(), "kesha-status-json-shape-"));
     const cache = join(dir, ".cache", "kesha");
     const binPath = writeFakeEngine(join(cache, "engine", "bin"), {
@@ -403,10 +402,7 @@ describe("kesha status --json stdout discipline (#647)", () => {
 });
 
 describe("human status output is a load-bearing contract (#647)", () => {
-  // The Raycast extension's probe falls back to matching "not installed" on the
-  // Binary line when it meets a CLI too old to emit `--json`
-  // (raycast/src/lib/kesha-bin.ts). Rewording this line breaks Store users on
-  // those CLIs, so the marker is frozen here rather than in the extension.
+  // Frozen for the Raycast probe's fallback on CLIs too old for `--json` — rewording breaks Store users.
   test("the Binary line still carries the `not installed` marker", async () => {
     const dir = mkdtempSync(join(tmpdir(), "kesha-status-marker-"));
     const proc = Bun.spawn([process.execPath, "bin/kesha.js", "status"], {


### PR DESCRIPTION
From the Greptile review on the upstream mirror PR [raycast/extensions#29898](https://github.com/raycast/extensions/pull/29898). Found upstream, fixed here first so the mirror never leads the source of record.

## The defect

`parseStatusObject` returned `null` for both "valid JSON of the wrong type" and "not JSON at all". Those are different situations and the probe treated them the same, so this reached the prose fallback:

```
stdout: [1,2,3]   →  parse ok, not an object  →  null  →  prose path
                  →  no "not installed" marker  →  { ok: true }
```

A CLI emitting an array for `status --json` is broken, yet the probe called the engine healthy and started a recording.

An older CLI prints human text and never JSON, so valid-JSON-but-not-an-object cannot be a version fallback — it is a contract failure and now fails closed like the others. `classifyStatusStdout` returns three outcomes instead of two.

## Worth noting: the spec was already right

`openspec/specs/raycast-extension/spec.md` says machine-readable output that does not satisfy the contract must be treated as unavailable and **never** passed to the prose fallback. An array is machine-readable and does not satisfy the contract. So this was implementation drifting from its own spec, not a gap in it — and my test asserting `{ ok: true }` for a JSON array had frozen the wrong behaviour. It now covers arrays, numbers, strings, `null` and booleans. Added a scenario to the spec so the case is explicit rather than implied.

## Also: the comment-style hook was dead

`.claude/hooks/check-new-comments.ts` enforces CLAUDE.md's one-line comment rule on `Edit|Write`. It had been failing with `Module not found` because it is declared with a **relative** path while its file is untracked (`.git/info/exclude` ignores `.claude/`), so `git worktree add` never materialises it — and all work happens in worktrees.

Consequence: it never ran over #664, and twelve multi-line comment blocks shipped in v1.25.0. Compressed here; the hook now passes on every touched file. The declaration itself is fixed in `settings.local.json` (untracked, machine-local).

## Verification

- `bun test` 533 pass / 0 fail, `bunx tsc --noEmit` clean
- `raycast`: `npm test` 91 pass, `npm run lint` clean
- `openspec validate --specs` 12/12
- `check-new-comments.ts` clean on all six touched files

## Follow-up

The same fix goes onto the upstream PR branch once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdkbgPP5f4UtscN6Kz7hi9