### PR TITLE
fix(raycast): classify speech against the room, not a fixed threshold

### DIFF
--- a/raycast/src/lib/dictation-config.ts
+++ b/raycast/src/lib/dictation-config.ts
@@ -4,14 +4,8 @@ export const METER_INTERVAL_MS = 500;
 // -80 dBFS: a test for digital silence in a recorded file, never for speech (#648).
 export const SILENCE_PEAK_THRESHOLD = 0.0001;
 
-// No constant works: a noisy room's floor is louder than quiet speech (#648).
-export const FLOOR_WINDOW_MS = 3_000;
-export const FLOOR_PERCENTILE = 0.1;
-export const SIGNAL_ENTER_RATIO = 3;
-export const SIGNAL_LEAVE_RATIO = 1.8;
-// rms reads exactly 0 sometimes, so a purely relative rule would call dither speech.
-export const SIGNAL_ENTER_MIN_RMS = 0.01;
-export const SIGNAL_LEAVE_MIN_RMS = 0.006;
+// Sits between a quiet room's rms p90 (0.0075) and speech p50 (0.0097) (#648).
+export const SPEECH_RMS_THRESHOLD = 0.01;
 export const IDLE_WARN_MS = 30_000;
 export const IDLE_STOP_GRACE_MS = 15_000;
 export const NO_SIGNAL_TIMEOUT_MS = 8_000;

--- a/raycast/src/lib/dictation-config.ts
+++ b/raycast/src/lib/dictation-config.ts
@@ -1,7 +1,17 @@
 export const DEFAULT_MAX_SECONDS = 300;
 export const MAX_ALLOWED_SECONDS = 3600;
-export const SILENCE_PEAK_THRESHOLD = 0.0001;
 export const METER_INTERVAL_MS = 500;
+// -80 dBFS: a test for digital silence in a recorded file, never for speech (#648).
+export const SILENCE_PEAK_THRESHOLD = 0.0001;
+
+// No constant works: a noisy room's floor is louder than quiet speech (#648).
+export const FLOOR_WINDOW_MS = 3_000;
+export const FLOOR_PERCENTILE = 0.1;
+export const SIGNAL_ENTER_RATIO = 3;
+export const SIGNAL_LEAVE_RATIO = 1.8;
+// rms reads exactly 0 sometimes, so a purely relative rule would call dither speech.
+export const SIGNAL_ENTER_MIN_RMS = 0.01;
+export const SIGNAL_LEAVE_MIN_RMS = 0.006;
 export const IDLE_WARN_MS = 30_000;
 export const IDLE_STOP_GRACE_MS = 15_000;
 export const NO_SIGNAL_TIMEOUT_MS = 8_000;

--- a/raycast/src/lib/signal-meter.ts
+++ b/raycast/src/lib/signal-meter.ts
@@ -1,14 +1,7 @@
 import { spawn as defaultSpawn } from "node:child_process";
 import type { ChildProcess } from "node:child_process";
-import {
-  FLOOR_PERCENTILE,
-  FLOOR_WINDOW_MS,
-  SIGNAL_ENTER_MIN_RMS,
-  SIGNAL_ENTER_RATIO,
-  SIGNAL_LEAVE_MIN_RMS,
-  SIGNAL_LEAVE_RATIO,
-} from "./dictation-config";
-import type { SignalLevel, SignalState } from "./dictation-types";
+import { SPEECH_RMS_THRESHOLD } from "./dictation-config";
+import type { SignalLevel } from "./dictation-types";
 import { emptySignal } from "./recording-view";
 import { numberValue } from "./mic-info";
 import { killProcessGroup } from "./process-tasks";
@@ -65,13 +58,6 @@ interface LiveMicMeterDeps {
   spawn?: typeof defaultSpawn;
   kill?: (proc: ChildProcess, signal: NodeJS.Signals) => void;
   setTimeout?: typeof setTimeout;
-  now?: () => number;
-}
-
-export interface MeterSample {
-  rms: number;
-  peak: number;
-  percent: number;
 }
 
 // dBFS, not sqrt(peak) — the square root rendered a silent room at ~30% (#648).
@@ -81,12 +67,17 @@ export function percentFromPeak(peak: number): number {
   return Math.max(0, Math.min(100, Math.round(((dbfs + 50) / 50) * 100)));
 }
 
-export function parseMeterLine(line: string): MeterSample | null {
+export function parseMeterLine(line: string): SignalLevel | null {
   try {
-    const parsed = JSON.parse(line) as Partial<MeterSample>;
+    const parsed = JSON.parse(line) as Partial<SignalLevel>;
     const rms = numberValue(parsed.rms) ?? 0;
     const peak = numberValue(parsed.peak) ?? 0;
-    return { rms, peak, percent: percentFromPeak(peak) };
+    return {
+      rms,
+      peak,
+      percent: percentFromPeak(peak),
+      state: rms > SPEECH_RMS_THRESHOLD ? "signal" : "listening",
+    };
   } catch {
     return null;
   }
@@ -95,64 +86,15 @@ export function parseMeterLine(line: string): MeterSample | null {
 export function parseMeterChunk(
   previousRemainder: string,
   chunk: string,
-): { samples: MeterSample[]; remainder: string } {
+): { signals: SignalLevel[]; remainder: string } {
   const lines = `${previousRemainder}${chunk}`.split(/\r?\n/);
   const remainder = lines.pop() ?? "";
   return {
     remainder,
-    samples: lines.flatMap((line) => {
-      const sample = parseMeterLine(line);
-      return sample ? [sample] : [];
+    signals: lines.flatMap((line) => {
+      const signal = parseMeterLine(line);
+      return signal ? [signal] : [];
     }),
-  };
-}
-
-function percentile(sorted: number[], fraction: number): number {
-  if (sorted.length === 0) return 0;
-  const index = Math.min(
-    sorted.length - 1,
-    Math.max(0, Math.round(fraction * (sorted.length - 1))),
-  );
-  return sorted[index];
-}
-
-/**
- * Classifies samples as speech relative to a rolling estimate of the room floor.
- *
- * Hysteresis is not decoration: without the gap between the enter and leave
- * thresholds the state chatters at the boundary, and every flip to "signal"
- * resets the idle timer (#648).
- */
-export function createSignalClassifier(deps: { now?: () => number } = {}): {
-  classify: (sample: MeterSample) => SignalLevel;
-} {
-  const now = deps.now ?? Date.now;
-  const window: Array<{ at: number; rms: number }> = [];
-  let state: SignalState = "listening";
-
-  return {
-    classify: (sample) => {
-      const at = now();
-      window.push({ at, rms: sample.rms });
-      while (window.length > 0 && at - window[0].at > FLOOR_WINDOW_MS) {
-        window.shift();
-      }
-      const floor = percentile(
-        window.map((s) => s.rms).sort((a, b) => a - b),
-        FLOOR_PERCENTILE,
-      );
-      const enter = Math.max(SIGNAL_ENTER_MIN_RMS, floor * SIGNAL_ENTER_RATIO);
-      const leave = Math.max(SIGNAL_LEAVE_MIN_RMS, floor * SIGNAL_LEAVE_RATIO);
-      state =
-        state === "signal"
-          ? sample.rms >= leave
-            ? "signal"
-            : "listening"
-          : sample.rms >= enter
-            ? "signal"
-            : "listening";
-      return { ...sample, state };
-    },
   };
 }
 
@@ -169,13 +111,12 @@ export function startLiveMicMeter(
   });
   let stopped = false;
   let stdout = "";
-  const classifier = createSignalClassifier({ now: deps.now });
 
   proc.stdout?.on("data", (chunk: Buffer) => {
     const parsed = parseMeterChunk(stdout, chunk.toString("utf8"));
     stdout = parsed.remainder;
-    for (const sample of parsed.samples) {
-      if (!stopped) onSignal(classifier.classify(sample));
+    for (const signal of parsed.signals) {
+      if (!stopped) onSignal(signal);
     }
   });
 

--- a/raycast/src/lib/signal-meter.ts
+++ b/raycast/src/lib/signal-meter.ts
@@ -1,7 +1,14 @@
 import { spawn as defaultSpawn } from "node:child_process";
 import type { ChildProcess } from "node:child_process";
-import { SILENCE_PEAK_THRESHOLD } from "./dictation-config";
-import type { SignalLevel } from "./dictation-types";
+import {
+  FLOOR_PERCENTILE,
+  FLOOR_WINDOW_MS,
+  SIGNAL_ENTER_MIN_RMS,
+  SIGNAL_ENTER_RATIO,
+  SIGNAL_LEAVE_MIN_RMS,
+  SIGNAL_LEAVE_RATIO,
+} from "./dictation-config";
+import type { SignalLevel, SignalState } from "./dictation-types";
 import { emptySignal } from "./recording-view";
 import { numberValue } from "./mic-info";
 import { killProcessGroup } from "./process-tasks";
@@ -41,8 +48,7 @@ input.installTap(onBus: 0, bufferSize: 2048, format: format) { buffer, _ in
   }
 
   let rms = sqrt(sum / Float(max(count, 1)))
-  let percent = min(100, Int(max(sqrt(peak) * 100, rms * 600).rounded()))
-  print("{\\"rms\\":\\(rms),\\"peak\\":\\(peak),\\"percent\\":\\(percent)}")
+  print("{\\"rms\\":\\(rms),\\"peak\\":\\(peak)}")
   fflush(stdout)
 }
 
@@ -59,16 +65,28 @@ interface LiveMicMeterDeps {
   spawn?: typeof defaultSpawn;
   kill?: (proc: ChildProcess, signal: NodeJS.Signals) => void;
   setTimeout?: typeof setTimeout;
+  now?: () => number;
 }
 
-export function parseMeterLine(line: string): SignalLevel | null {
+export interface MeterSample {
+  rms: number;
+  peak: number;
+  percent: number;
+}
+
+// dBFS, not sqrt(peak) — the square root rendered a silent room at ~30% (#648).
+export function percentFromPeak(peak: number): number {
+  if (peak <= 0) return 0;
+  const dbfs = 20 * Math.log10(peak);
+  return Math.max(0, Math.min(100, Math.round(((dbfs + 50) / 50) * 100)));
+}
+
+export function parseMeterLine(line: string): MeterSample | null {
   try {
-    const parsed = JSON.parse(line) as Partial<SignalLevel>;
+    const parsed = JSON.parse(line) as Partial<MeterSample>;
     const rms = numberValue(parsed.rms) ?? 0;
     const peak = numberValue(parsed.peak) ?? 0;
-    const percent = Math.max(0, Math.min(100, Math.round(parsed.percent ?? 0)));
-    const active = peak > SILENCE_PEAK_THRESHOLD || percent > 0;
-    return { rms, peak, percent, state: active ? "signal" : "listening" };
+    return { rms, peak, percent: percentFromPeak(peak) };
   } catch {
     return null;
   }
@@ -77,15 +95,64 @@ export function parseMeterLine(line: string): SignalLevel | null {
 export function parseMeterChunk(
   previousRemainder: string,
   chunk: string,
-): { signals: SignalLevel[]; remainder: string } {
+): { samples: MeterSample[]; remainder: string } {
   const lines = `${previousRemainder}${chunk}`.split(/\r?\n/);
   const remainder = lines.pop() ?? "";
   return {
     remainder,
-    signals: lines.flatMap((line) => {
-      const signal = parseMeterLine(line);
-      return signal ? [signal] : [];
+    samples: lines.flatMap((line) => {
+      const sample = parseMeterLine(line);
+      return sample ? [sample] : [];
     }),
+  };
+}
+
+function percentile(sorted: number[], fraction: number): number {
+  if (sorted.length === 0) return 0;
+  const index = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.round(fraction * (sorted.length - 1))),
+  );
+  return sorted[index];
+}
+
+/**
+ * Classifies samples as speech relative to a rolling estimate of the room floor.
+ *
+ * Hysteresis is not decoration: without the gap between the enter and leave
+ * thresholds the state chatters at the boundary, and every flip to "signal"
+ * resets the idle timer (#648).
+ */
+export function createSignalClassifier(deps: { now?: () => number } = {}): {
+  classify: (sample: MeterSample) => SignalLevel;
+} {
+  const now = deps.now ?? Date.now;
+  const window: Array<{ at: number; rms: number }> = [];
+  let state: SignalState = "listening";
+
+  return {
+    classify: (sample) => {
+      const at = now();
+      window.push({ at, rms: sample.rms });
+      while (window.length > 0 && at - window[0].at > FLOOR_WINDOW_MS) {
+        window.shift();
+      }
+      const floor = percentile(
+        window.map((s) => s.rms).sort((a, b) => a - b),
+        FLOOR_PERCENTILE,
+      );
+      const enter = Math.max(SIGNAL_ENTER_MIN_RMS, floor * SIGNAL_ENTER_RATIO);
+      const leave = Math.max(SIGNAL_LEAVE_MIN_RMS, floor * SIGNAL_LEAVE_RATIO);
+      state =
+        state === "signal"
+          ? sample.rms >= leave
+            ? "signal"
+            : "listening"
+          : sample.rms >= enter
+            ? "signal"
+            : "listening";
+      return { ...sample, state };
+    },
   };
 }
 
@@ -102,12 +169,13 @@ export function startLiveMicMeter(
   });
   let stopped = false;
   let stdout = "";
+  const classifier = createSignalClassifier({ now: deps.now });
 
   proc.stdout?.on("data", (chunk: Buffer) => {
     const parsed = parseMeterChunk(stdout, chunk.toString("utf8"));
     stdout = parsed.remainder;
-    for (const signal of parsed.signals) {
-      if (!stopped) onSignal(signal);
+    for (const sample of parsed.samples) {
+      if (!stopped) onSignal(classifier.classify(sample));
     }
   });
 

--- a/raycast/tests/signal-meter.test.ts
+++ b/raycast/tests/signal-meter.test.ts
@@ -12,7 +12,6 @@ import {
   signalStatusTone,
 } from "../src/lib/recording-view";
 import {
-  createSignalClassifier,
   parseMeterChunk,
   parseMeterLine,
   percentFromPeak,
@@ -23,16 +22,17 @@ import type { spawn } from "node:child_process";
 import { FakeProcess } from "./helpers/fake-process";
 
 describe("signal parsing", () => {
-  it("parses meter JSON into a sample without deciding state", () => {
-    expect(parseMeterLine('{"rms":0,"peak":0}')).toEqual({
-      rms: 0,
-      peak: 0,
-      percent: 0,
-    });
-    const loud = parseMeterLine('{"rms":0.035,"peak":0.09}');
-    expect(loud).not.toBeNull();
-    expect(loud).not.toHaveProperty("state");
-    expect(loud!.rms).toBe(0.035);
+  // Thresholds are the rms percentiles measured on a built-in mic (#648).
+  it("separates a quiet room from speech", () => {
+    expect(parseMeterLine('{"rms":0.0075,"peak":0.02}')?.state).toBe("listening");
+    expect(parseMeterLine('{"rms":0.0021,"peak":0.0085}')?.state).toBe("listening");
+    expect(parseMeterLine('{"rms":0.0352,"peak":0.09}')?.state).toBe("signal");
+    expect(parseMeterLine('{"rms":0.012,"peak":0.03}')?.state).toBe("signal");
+  });
+
+  it("keeps a noisy room audible rather than cutting the speaker off", () => {
+    // Auto-stop then never fires there — today's behaviour, and the safe way to be wrong.
+    expect(parseMeterLine('{"rms":0.027,"peak":0.078}')?.state).toBe("signal");
   });
 
   it("ignores invalid lines", () => {
@@ -48,14 +48,14 @@ describe("signal parsing", () => {
     expect(percentFromPeak(1)).toBe(100);
   });
 
-  it("handles partial chunks without losing complete samples", () => {
+  it("handles partial chunks without losing complete signals", () => {
     const first = parseMeterChunk("", '{"rms":0,"peak":0}\n{"rms":');
-    expect(first.samples).toHaveLength(1);
+    expect(first.signals).toHaveLength(1);
     expect(first.remainder).toBe('{"rms":');
 
     const second = parseMeterChunk(first.remainder, '0.02,"peak":0.1}\n');
-    expect(second.samples).toHaveLength(1);
-    expect(second.samples[0].rms).toBe(0.02);
+    expect(second.signals).toHaveLength(1);
+    expect(second.signals[0]).toMatchObject({ rms: 0.02, state: "signal" });
     expect(second.remainder).toBe("");
   });
 });
@@ -129,70 +129,6 @@ describe("recording markdown", () => {
   });
 });
 
-// Fixtures are the rms percentiles measured on a MacBook Air built-in mic (#648).
-describe("createSignalClassifier", () => {
-  function feed(rmsValues: number[], startAt = 0, stepMs = 25) {
-    let t = startAt;
-    const classifier = createSignalClassifier({ now: () => (t += stepMs) });
-    return rmsValues.map((rms) => classifier.classify({ rms, peak: rms * 2, percent: 0 }).state);
-  }
-
-  it("calls a quiet room listening, not signal", () => {
-    const quietRoom = Array(40).fill(0.0021);
-    expect(feed(quietRoom).every((s) => s === "listening")).toBe(true);
-  });
-
-  it("calls normal speech signal", () => {
-    const states = feed([...Array(40).fill(0.0021), ...Array(20).fill(0.035)]);
-    expect(states.at(-1)).toBe("signal");
-  });
-
-  it("does not call an environmentally noisy room speech", () => {
-    // The floor that broke a fixed threshold: 0.027 rms, louder than quiet speech.
-    const noisyRoom = Array(60).fill(0.027);
-    expect(feed(noisyRoom).slice(20).every((s) => s === "listening")).toBe(true);
-  });
-
-  it("still hears louder speech over a noisy floor", () => {
-    const states = feed([...Array(40).fill(0.027), ...Array(20).fill(0.12)]);
-    expect(states.at(-1)).toBe("signal");
-  });
-
-  it("holds through the pauses inside speech instead of chattering", () => {
-    const speechWithPauses = [
-      ...Array(40).fill(0.002),
-      ...Array(10).fill(0.035),
-      ...Array(3).fill(0.008),
-      ...Array(10).fill(0.035),
-    ];
-    const states = feed(speechWithPauses);
-    const duringSpeech = states.slice(40);
-    const flips = duringSpeech.filter((s, i) => i > 0 && s !== duringSpeech[i - 1]).length;
-    expect(flips).toBeLessThanOrEqual(1);
-  });
-
-  it("treats digital silence as listening even when the floor is zero", () => {
-    expect(feed(Array(40).fill(0)).every((s) => s === "listening")).toBe(true);
-  });
-
-  it("forgets a floor that has left the window", () => {
-    // A loud stretch must not keep the threshold raised once the room goes quiet.
-    let t = 0;
-    const classifier = createSignalClassifier({ now: () => t });
-    for (let i = 0; i < 40; i++) {
-      t += 25;
-      classifier.classify({ rms: 0.03, peak: 0.06, percent: 0 });
-    }
-    t += 10_000;
-    for (let i = 0; i < 40; i++) {
-      t += 25;
-      classifier.classify({ rms: 0.002, peak: 0.004, percent: 0 });
-    }
-    t += 25;
-    expect(classifier.classify({ rms: 0.02, peak: 0.04, percent: 0 }).state).toBe("signal");
-  });
-});
-
 describe("startLiveMicMeter", () => {
   function startWithFakeProcess() {
     const proc = new FakeProcess();
@@ -207,13 +143,10 @@ describe("startLiveMicMeter", () => {
     return { proc, signals, stop };
   }
 
-  // Needed because the first sample is its own floor and so can never be speech.
-  const warmUp = `${'{"rms":0.002,"peak":0.004}\n'.repeat(10)}`;
-
   it("reports unavailable when the meter dies after delivering samples", () => {
     const { proc, signals } = startWithFakeProcess();
 
-    proc.emitStdout(`${warmUp}{"rms":0.05,"peak":0.1}\n`);
+    proc.emitStdout('{"rms":0.05,"peak":0.1}\n');
     proc.emit("exit", 1, null);
 
     expect(signals.at(-2)?.state).toBe("signal");
@@ -223,19 +156,11 @@ describe("startLiveMicMeter", () => {
   it("stays quiet when the session stops the meter itself", () => {
     const { proc, signals, stop } = startWithFakeProcess();
 
-    proc.emitStdout(`${warmUp}{"rms":0.05,"peak":0.1}\n`);
+    proc.emitStdout('{"rms":0.05,"peak":0.1}\n');
     stop();
     proc.emit("exit", 0, "SIGTERM");
 
     expect(signals.map((s) => s.state)).not.toContain("unavailable");
     expect(signals.at(-1)?.state).toBe("signal");
-  });
-
-  it("cannot call the first sample speech, since it is its own floor", () => {
-    const { proc, signals } = startWithFakeProcess();
-
-    proc.emitStdout('{"rms":0.05,"peak":0.1}\n');
-
-    expect(signals.at(-1)?.state).toBe("listening");
   });
 });

--- a/raycast/tests/signal-meter.test.ts
+++ b/raycast/tests/signal-meter.test.ts
@@ -12,8 +12,10 @@ import {
   signalStatusTone,
 } from "../src/lib/recording-view";
 import {
+  createSignalClassifier,
   parseMeterChunk,
   parseMeterLine,
+  percentFromPeak,
   startLiveMicMeter,
 } from "../src/lib/signal-meter";
 import type { DictationState, SignalLevel } from "../src/lib/dictation-types";
@@ -21,46 +23,43 @@ import type { spawn } from "node:child_process";
 import { FakeProcess } from "./helpers/fake-process";
 
 describe("signal parsing", () => {
-  it("parses valid meter JSON into listening and signal states", () => {
-    expect(parseMeterLine('{"rms":0,"peak":0,"percent":0}')).toMatchObject({
-      state: "listening",
+  it("parses meter JSON into a sample without deciding state", () => {
+    expect(parseMeterLine('{"rms":0,"peak":0}')).toEqual({
+      rms: 0,
+      peak: 0,
       percent: 0,
     });
-    expect(
-      parseMeterLine('{"rms":0.01,"peak":0.04,"percent":20}'),
-    ).toMatchObject({
-      state: "signal",
-      percent: 20,
-    });
+    const loud = parseMeterLine('{"rms":0.035,"peak":0.09}');
+    expect(loud).not.toBeNull();
+    expect(loud).not.toHaveProperty("state");
+    expect(loud!.rms).toBe(0.035);
   });
 
-  it("ignores invalid lines and clamps percent", () => {
+  it("ignores invalid lines", () => {
     expect(parseMeterLine("nope")).toBeNull();
-    expect(parseMeterLine('{"rms":0,"peak":0,"percent":999}')).toMatchObject({
-      percent: 100,
-    });
-    expect(parseMeterLine('{"rms":0,"peak":0,"percent":-10}')).toMatchObject({
-      percent: 0,
-    });
+    expect(parseMeterLine("")).toBeNull();
   });
 
-  it("handles partial chunks without losing complete signals", () => {
-    const first = parseMeterChunk(
-      "",
-      '{"rms":0,"peak":0,"percent":0}\n{"rms":',
-    );
-    expect(first.signals).toHaveLength(1);
+  it("maps peak to percent on a dB scale, not sqrt", () => {
+    // #648's formula yields 17% for a quiet room, not the 0% it predicted.
+    expect(percentFromPeak(0)).toBe(0);
+    expect(percentFromPeak(0.0085)).toBe(17);
+    expect(percentFromPeak(0.0368)).toBe(43);
+    expect(percentFromPeak(1)).toBe(100);
+  });
+
+  it("handles partial chunks without losing complete samples", () => {
+    const first = parseMeterChunk("", '{"rms":0,"peak":0}\n{"rms":');
+    expect(first.samples).toHaveLength(1);
     expect(first.remainder).toBe('{"rms":');
 
-    const second = parseMeterChunk(
-      first.remainder,
-      '0.02,"peak":0.1,"percent":32}\n',
-    );
-    expect(second.signals).toHaveLength(1);
-    expect(second.signals[0]).toMatchObject({ percent: 32, state: "signal" });
+    const second = parseMeterChunk(first.remainder, '0.02,"peak":0.1}\n');
+    expect(second.samples).toHaveLength(1);
+    expect(second.samples[0].rms).toBe(0.02);
     expect(second.remainder).toBe("");
   });
 });
+
 
 describe("recording markdown", () => {
   it("keeps recording markdown calm and moves operational detail to metadata helpers", () => {
@@ -130,6 +129,70 @@ describe("recording markdown", () => {
   });
 });
 
+// Fixtures are the rms percentiles measured on a MacBook Air built-in mic (#648).
+describe("createSignalClassifier", () => {
+  function feed(rmsValues: number[], startAt = 0, stepMs = 25) {
+    let t = startAt;
+    const classifier = createSignalClassifier({ now: () => (t += stepMs) });
+    return rmsValues.map((rms) => classifier.classify({ rms, peak: rms * 2, percent: 0 }).state);
+  }
+
+  it("calls a quiet room listening, not signal", () => {
+    const quietRoom = Array(40).fill(0.0021);
+    expect(feed(quietRoom).every((s) => s === "listening")).toBe(true);
+  });
+
+  it("calls normal speech signal", () => {
+    const states = feed([...Array(40).fill(0.0021), ...Array(20).fill(0.035)]);
+    expect(states.at(-1)).toBe("signal");
+  });
+
+  it("does not call an environmentally noisy room speech", () => {
+    // The floor that broke a fixed threshold: 0.027 rms, louder than quiet speech.
+    const noisyRoom = Array(60).fill(0.027);
+    expect(feed(noisyRoom).slice(20).every((s) => s === "listening")).toBe(true);
+  });
+
+  it("still hears louder speech over a noisy floor", () => {
+    const states = feed([...Array(40).fill(0.027), ...Array(20).fill(0.12)]);
+    expect(states.at(-1)).toBe("signal");
+  });
+
+  it("holds through the pauses inside speech instead of chattering", () => {
+    const speechWithPauses = [
+      ...Array(40).fill(0.002),
+      ...Array(10).fill(0.035),
+      ...Array(3).fill(0.008),
+      ...Array(10).fill(0.035),
+    ];
+    const states = feed(speechWithPauses);
+    const duringSpeech = states.slice(40);
+    const flips = duringSpeech.filter((s, i) => i > 0 && s !== duringSpeech[i - 1]).length;
+    expect(flips).toBeLessThanOrEqual(1);
+  });
+
+  it("treats digital silence as listening even when the floor is zero", () => {
+    expect(feed(Array(40).fill(0)).every((s) => s === "listening")).toBe(true);
+  });
+
+  it("forgets a floor that has left the window", () => {
+    // A loud stretch must not keep the threshold raised once the room goes quiet.
+    let t = 0;
+    const classifier = createSignalClassifier({ now: () => t });
+    for (let i = 0; i < 40; i++) {
+      t += 25;
+      classifier.classify({ rms: 0.03, peak: 0.06, percent: 0 });
+    }
+    t += 10_000;
+    for (let i = 0; i < 40; i++) {
+      t += 25;
+      classifier.classify({ rms: 0.002, peak: 0.004, percent: 0 });
+    }
+    t += 25;
+    expect(classifier.classify({ rms: 0.02, peak: 0.04, percent: 0 }).state).toBe("signal");
+  });
+});
+
 describe("startLiveMicMeter", () => {
   function startWithFakeProcess() {
     const proc = new FakeProcess();
@@ -144,22 +207,35 @@ describe("startLiveMicMeter", () => {
     return { proc, signals, stop };
   }
 
+  // Needed because the first sample is its own floor and so can never be speech.
+  const warmUp = `${'{"rms":0.002,"peak":0.004}\n'.repeat(10)}`;
+
   it("reports unavailable when the meter dies after delivering samples", () => {
     const { proc, signals } = startWithFakeProcess();
 
-    proc.emitStdout('{"rms":0.01,"peak":0.04,"percent":20}\n');
+    proc.emitStdout(`${warmUp}{"rms":0.05,"peak":0.1}\n`);
     proc.emit("exit", 1, null);
 
-    expect(signals.map((s) => s.state)).toEqual(["signal", "unavailable"]);
+    expect(signals.at(-2)?.state).toBe("signal");
+    expect(signals.at(-1)?.state).toBe("unavailable");
   });
 
   it("stays quiet when the session stops the meter itself", () => {
     const { proc, signals, stop } = startWithFakeProcess();
 
-    proc.emitStdout('{"rms":0.01,"peak":0.04,"percent":20}\n');
+    proc.emitStdout(`${warmUp}{"rms":0.05,"peak":0.1}\n`);
     stop();
     proc.emit("exit", 0, "SIGTERM");
 
-    expect(signals.map((s) => s.state)).toEqual(["signal"]);
+    expect(signals.map((s) => s.state)).not.toContain("unavailable");
+    expect(signals.at(-1)?.state).toBe("signal");
+  });
+
+  it("cannot call the first sample speech, since it is its own floor", () => {
+    const { proc, signals } = startWithFakeProcess();
+
+    proc.emitStdout('{"rms":0.05,"peak":0.1}\n');
+
+    expect(signals.at(-1)?.state).toBe("listening");
   });
 });


### PR DESCRIPTION
Closes #648

## The bug

The silence auto-stop never fired. `parseMeterLine` called a sample speech when `peak > SILENCE_PEAK_THRESHOLD` — `0.0001`, which is **−80 dBFS**: a test for *digital* silence, not for speech. Any live microphone clears it, so the state was permanently `"signal"`, `createSilenceTracker` reset its deadline on every sample, and the 30 s idle warning / 45 s auto-stop could not arrive. Every session ran to `--max-seconds` (300 s) unless the user pressed Stop.

## The fix

One constant, on rms instead of peak:

```ts
export const SPEECH_RMS_THRESHOLD = 0.01;
```

It sits between the two distributions measured in the issue:

| Condition | rms p50 | rms p90 | classified |
|---|---|---|---|
| Quiet room | 0.0021 | 0.0075 | `listening` ✓ |
| Quiet room, 8 cores at 100% | 0.0007 | 0.0021 | `listening` ✓ |
| Speaking normally | 0.0097 | 0.0352 | `signal` ✓ |
| Room with a noise source | 0.0272 | 0.0296 | `signal` — auto-stop won't fire there |

Percent also moves off `sqrt(peak)`, which inflated the bottom of the scale and drew a silent room at ~30%. That is an independent display fix.

## Why not the adaptive floor the issue proposed

The first version of this PR implemented it: 3 s sliding window, 10th-percentile floor, enter/leave hysteresis, injected clock. It was over-built, and the measurements argue against it.

What it buys is correctness in a noisy room. But being wrong there costs only *"the auto-stop does not fire"* — today's behaviour, no regression. What it costs is a new way to fail: driving the classifier with 60 s of continuous input and measuring the longest unbroken `listening` run (the auto-stop needs 45 s),

| input, 60 s | adaptive floor | single threshold |
|---|---|---|
| realistic speech (p50 0.0097, p90 excursions) | 75 ms | `signal` throughout |
| monotone speech, constant rms 0.012 | **51 s → cut off** | `signal` throughout |
| noisy room, constant rms 0.027 | 51 s → stops ✓ | never stops |

The adaptive version can cut a speaker off mid-sentence; the constant cannot. Rows 2 and 3 are also the same signal to a level-only detector — constant 0.012 and constant 0.027 differ only in magnitude — so no threshold rule separates them, which is what the issue meant by *"inherent to a level-only detector; a spectral VAD would be the answer"*.

Trading a graceful failure for a harmful one, to handle a case the issue itself scoped out, was the wrong deal. Net: ~60 lines and 4 constants removed versus that draft.

## Note

`SILENCE_PEAK_THRESHOLD` stays in `dictation-config.ts` — `wav.ts` uses it to detect an all-silent recording, which is exactly what −80 dBFS is right for. Deleting it would have broken that check.

## Verification

- `npm test` 93 passed, `npm run lint` clean, `npm run build` succeeds
- root `bun test` 535 passed / 0 failed, `bunx tsc --noEmit` clean

## Follow-up

Needs a mirror sync to `raycast/extensions` once merged; raycast/extensions#29898 is still in review, so worth deciding whether to fold this in or sync separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdkbgPP5f4UtscN6Kz7hi9