### PR TITLE
refactor: one platform table, verified against the published release

### DIFF
--- a/.github/scripts/check-engine-targets.ts
+++ b/.github/scripts/check-engine-targets.ts
@@ -7,8 +7,9 @@
  * about disk cost and nothing fails. `install-plan.ts` carried a stale 63_126_528
  * against an actual 63_447_040 for exactly that reason (#216).
  *
- * Skips (exit 0) when the release is unreachable — offline dev and forked PRs
- * without a token must not fail on network, only on a real mismatch.
+ * A release branch bumps keshaEngine.version BEFORE the tag exists, so a 404 there is
+ * expected and skipped. Everywhere else a 404 means the pinned version was never published,
+ * which is a real problem — skipping it would make this check vacuous exactly when it matters.
  */
 import { engineTarget, engineTargetKeys } from "../../src/engine-targets";
 import { engineVersion } from "../../src/package-info";
@@ -22,8 +23,23 @@ if (process.env.GITHUB_TOKEN) headers.authorization = `Bearer ${process.env.GITH
 let assets: Array<{ name: string; size: number }>;
 try {
   const res = await fetch(url, { headers });
+  if (res.status === 404) {
+    const headRef = process.env.GITHUB_HEAD_REF ?? "";
+    if (headRef.startsWith("release/")) {
+      console.log(
+        `skip: v${engineVersion} is not published yet, which is expected on ${headRef}. ` +
+          `The scheduled run on main verifies the sizes once the release exists.`,
+      );
+      process.exit(0);
+    }
+    console.error(
+      `FAIL: package.json pins engine v${engineVersion}, but no such release exists.\n` +
+        `  Fix: publish it, or correct keshaEngine.version.`,
+    );
+    process.exit(1);
+  }
   if (!res.ok) {
-    console.log(`skip: release v${engineVersion} unreachable (HTTP ${res.status})`);
+    console.log(`skip: release API returned HTTP ${res.status}`);
     process.exit(0);
   }
   assets = (await res.json()).assets ?? [];

--- a/.github/scripts/check-engine-targets.ts
+++ b/.github/scripts/check-engine-targets.ts
@@ -7,11 +7,12 @@
  * about disk cost and nothing fails. `install-plan.ts` carried a stale 63_126_528
  * against an actual 63_447_040 for exactly that reason (#216).
  *
- * A release branch bumps keshaEngine.version BEFORE the tag exists, so a 404 there is
- * expected and skipped. Everywhere else a 404 means the pinned version was never published,
- * which is a real problem — skipping it would make this check vacuous exactly when it matters.
+ * Releases here merge first and tag second, so keshaEngine.version legitimately points at an
+ * unpublished tag on a `release/*` PR and on the `chore(release):` push to main that follows.
+ * A 404 anywhere else means the pinned version was never published, which is a real problem —
+ * skipping it would make this check vacuous exactly when it matters.
  */
-import { engineTarget, engineTargetKeys } from "../../src/engine-targets";
+import { engineTargetEntries } from "../../src/engine-targets";
 import { engineVersion } from "../../src/package-info";
 
 const REPO = "drakulavich/kesha-voice-kit";
@@ -25,10 +26,13 @@ try {
   const res = await fetch(url, { headers });
   if (res.status === 404) {
     const headRef = process.env.GITHUB_HEAD_REF ?? "";
-    if (headRef.startsWith("release/")) {
+    const headCommit = process.env.HEAD_COMMIT_MESSAGE ?? "";
+    const midRelease =
+      headRef.startsWith("release/") || headCommit.startsWith("chore(release):");
+    if (midRelease) {
       console.log(
-        `skip: v${engineVersion} is not published yet, which is expected on ${headRef}. ` +
-          `The scheduled run on main verifies the sizes once the release exists.`,
+        `skip: v${engineVersion} is not published yet, which is expected between the release ` +
+          `merge and its tag. The scheduled run verifies the sizes once the release exists.`,
       );
       process.exit(0);
     }
@@ -39,6 +43,11 @@ try {
     process.exit(1);
   }
   if (!res.ok) {
+    // A token means CI, where the API is reachable — skipping there would hide real drift.
+    if (process.env.GITHUB_TOKEN) {
+      console.error(`FAIL: release API returned HTTP ${res.status} for v${engineVersion}`);
+      process.exit(1);
+    }
     console.log(`skip: release API returned HTTP ${res.status}`);
     process.exit(0);
   }
@@ -51,9 +60,8 @@ try {
 const bySize = new Map(assets.map((a) => [a.name, a.size]));
 const problems: string[] = [];
 
-for (const key of engineTargetKeys()) {
-  const [platform, arch] = key.split("-");
-  const target = engineTarget(platform, arch)!;
+for (const { platform, arch, target } of engineTargetEntries()) {
+  const key = `${platform}-${arch}`;
   const published = bySize.get(target.assetName);
 
   if (published === undefined) {

--- a/.github/scripts/check-engine-targets.ts
+++ b/.github/scripts/check-engine-targets.ts
@@ -1,0 +1,65 @@
+#!/usr/bin/env bun
+/**
+ * Verifies every `ENGINE_TARGETS` row against the published release.
+ *
+ * Centralising the table removed the duplication but not the drift: the sizes are
+ * hand-written and only feed `kesha install --plan`, so a wrong one misleads a user
+ * about disk cost and nothing fails. `install-plan.ts` carried a stale 63_126_528
+ * against an actual 63_447_040 for exactly that reason (#216).
+ *
+ * Skips (exit 0) when the release is unreachable — offline dev and forked PRs
+ * without a token must not fail on network, only on a real mismatch.
+ */
+import { engineTarget, engineTargetKeys } from "../../src/engine-targets";
+import { engineVersion } from "../../src/package-info";
+
+const REPO = "drakulavich/kesha-voice-kit";
+const url = `https://api.github.com/repos/${REPO}/releases/tags/v${engineVersion}`;
+
+const headers: Record<string, string> = { accept: "application/vnd.github+json" };
+if (process.env.GITHUB_TOKEN) headers.authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+
+let assets: Array<{ name: string; size: number }>;
+try {
+  const res = await fetch(url, { headers });
+  if (!res.ok) {
+    console.log(`skip: release v${engineVersion} unreachable (HTTP ${res.status})`);
+    process.exit(0);
+  }
+  assets = (await res.json()).assets ?? [];
+} catch (e) {
+  console.log(`skip: could not reach the release API (${e instanceof Error ? e.message : e})`);
+  process.exit(0);
+}
+
+const bySize = new Map(assets.map((a) => [a.name, a.size]));
+const problems: string[] = [];
+
+for (const key of engineTargetKeys()) {
+  const [platform, arch] = key.split("-");
+  const target = engineTarget(platform, arch)!;
+  const published = bySize.get(target.assetName);
+
+  if (published === undefined) {
+    problems.push(
+      `${key}: release v${engineVersion} has no asset named ${target.assetName}` +
+        ` (published: ${assets.map((a) => a.name).join(", ") || "none"})`,
+    );
+    continue;
+  }
+  if (published !== target.sizeBytes) {
+    problems.push(
+      `${key}: ${target.assetName} is ${published} bytes in v${engineVersion}, ` +
+        `but ENGINE_TARGETS says ${target.sizeBytes}`,
+    );
+    continue;
+  }
+  console.log(`ok: ${key} → ${target.assetName} (${published} bytes)`);
+}
+
+if (problems.length > 0) {
+  console.error(`\nENGINE_TARGETS is out of date with release v${engineVersion}:`);
+  for (const p of problems) console.error(`  - ${p}`);
+  console.error(`\n  Fix: update src/engine-targets.ts to match the published assets.`);
+  process.exit(1);
+}

--- a/.github/scripts/release-manifest.mjs
+++ b/.github/scripts/release-manifest.mjs
@@ -29,9 +29,10 @@ const ENGINE_ASSETS = [
     id: "windows-x64",
     os: "win32",
     arch: "x64",
-    status: "release-artifact-only",
+    status: "supported",
     engineAsset: "kesha-engine-windows-x64.exe",
-    note: "Release workflow builds this artifact, but the Bun installer currently blocks Windows x64.",
+    // The installed name keeps the suffix: an extensionless PE is not reliably spawnable (#216).
+    install: { directory: "engine/bin", filename: "kesha-engine.exe" },
   },
 ];
 
@@ -175,11 +176,13 @@ function assertIncludes(source, needle, file) {
 
 function validateSourceConsistency(manifest) {
   const installer = readFileSync("src/engine-install.ts", "utf8");
+  // Asset names moved out of engine-install.ts into the one platform table (#216).
+  const targets = readFileSync("src/engine-targets.ts", "utf8");
   const workflow = readFileSync(".github/workflows/build-engine.yml", "utf8");
 
   for (const p of ENGINE_ASSETS) {
     if (p.status === "supported") {
-      assertIncludes(installer, p.engineAsset, "src/engine-install.ts");
+      assertIncludes(targets, p.engineAsset, "src/engine-targets.ts");
     }
     assertIncludes(workflow, p.engineAsset, ".github/workflows/build-engine.yml");
   }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,11 @@ jobs:
       - name: 🧾 Check release manifest metadata
         run: bun run check:release-manifest
 
+      - name: 🎯 Check engine targets match the published release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: bun run check:engine-targets
+
   homebrew-formula:
     needs: changes
     if: needs.changes.outputs.homebrew == 'true'
@@ -546,10 +551,8 @@ jobs:
           }
 
   release-branch-engine-smoke:
-    # P1.11: release branches cannot download the not-yet-published engine
-    # asset, but they still need an end-to-end CLI/backend gate. Build the
-    # Linux release-shaped engine locally, mark it as the package's engine
-    # version, install models through that binary, then smoke the wrapper.
+    # P1.11: a release branch cannot download its own engine — the tag does not exist until
+    # un-drafting — so build it locally and smoke that instead (#216, #464).
     needs: [changes, unit-tests]
     if: |
       needs.changes.outputs.integration == 'true' &&
@@ -558,12 +561,25 @@ jobs:
         startsWith(github.event.head_commit.message, 'chore(release):')
       ) &&
       needs.unit-tests.result == 'success'
-    runs-on: ubuntu-latest
-    # 25 before the TTS models were added to this lane.
-    timeout-minutes: 35
+    strategy:
+      # A network flake on one platform must not cancel the other's verification.
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            ffmpeg-provider: apt
+            engine-bin: kesha-engine
+            timeout: 35
+          # Cargo emits the .exe suffix, and a cold MSVC build dominates the job.
+          - os: windows-latest
+            ffmpeg-provider: skip
+            engine-bin: kesha-engine.exe
+            timeout: 50
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: ${{ matrix.timeout }}
     env:
       KESHA_CACHE_DIR: ${{ github.workspace }}/.kesha-release-smoke
-      KESHA_ENGINE_BIN: ${{ github.workspace }}/rust/target/release/kesha-engine
+      KESHA_ENGINE_BIN: ${{ github.workspace }}/rust/target/release/${{ matrix.engine-bin }}
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -582,14 +598,37 @@ jobs:
           workspaces: rust
 
       - name: 🎧 Install system audio deps
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends libopus-dev pkg-config
 
-      - name: 🦀 Build local Linux engine
+      - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+        if: runner.os == 'Windows'
+
+      - name: 🔗 Pin MSVC linker
+        if: runner.os == 'Windows'
+        shell: pwsh
+        # Git for Windows ships a GNU link.exe that shadows MSVC's under `shell: bash` (rust-test.yml).
+        run: |
+          $linkPath = (Get-Command link.exe |
+            Where-Object { $_.Source -notlike "*Git*usr*" } |
+            Select-Object -First 1).Source
+          if (-not $linkPath) { Write-Error "MSVC link.exe not found"; exit 1 }
+          Add-Content -Path $env:GITHUB_ENV -Value "CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=$linkPath"
+
+      - name: 🎧 Allow legacy cmake_minimum_required
+        if: runner.os == 'Windows'
+        shell: pwsh
+        # opusic-sys falls back to a cmake build of vendored libopus whose CMakeLists predates cmake 4.
+        run: Add-Content -Path $env:GITHUB_ENV -Value "CMAKE_POLICY_VERSION_MINIMUM=3.5"
+
+      - name: 🦀 Build local engine
+        shell: bash
         run: cd rust && cargo build --release --features onnx,tts --no-default-features
 
       - name: 🧾 Mark local engine version
+        shell: bash
         run: |
           bun -e '
             const pkg = await Bun.file("package.json").json();
@@ -603,93 +642,9 @@ jobs:
             ${{ github.workspace }}/.kesha-release-smoke
           cache-key: ${{ runner.os }}-kesha-release-smoke-v1
           cache-restore-keys: ${{ runner.os }}-kesha-release-smoke-
-          ffmpeg-provider: apt
+          ffmpeg-provider: ${{ matrix.ffmpeg-provider }}
           install-args: --onnx --tts en ru
-
-      - name: 🚬 Smoke release branch local engine
-        shell: bash
-        run: |
-          kesha status
-          kesha --json tests/fixtures/benchmark-en/01-check-email.ogg > /tmp/kesha-release-smoke.json
-          bun .github/scripts/assert-transcript.ts /tmp/kesha-release-smoke.json
-
-      # The about-to-ship artifact needs the same synthesis proof as the published one (#464).
-      - name: 🗣️ Synthesis round-trip
-        shell: bash
-        run: bun .github/scripts/smoke-synthesis.ts /tmp/kesha-release-synth
-
-  release-branch-windows-smoke:
-    # The win32 half of P1.11: windows-engine-smoke is guarded off release branches, whose tag is unpublished (#216, #464).
-    needs: [changes, unit-tests]
-    if: |
-      needs.changes.outputs.integration == 'true' &&
-      (
-        startsWith(github.head_ref, 'release/') ||
-        startsWith(github.event.head_commit.message, 'chore(release):')
-      ) &&
-      needs.unit-tests.result == 'success'
-    runs-on: windows-latest
-    # Higher than the Linux lane's 35: a cold MSVC build of the engine dominates this job.
-    timeout-minutes: 50
-    env:
-      KESHA_CACHE_DIR: ${{ github.workspace }}\.kesha-release-smoke
-      # Cargo emits kesha-engine.exe — the Linux lane's extensionless path does not carry over.
-      KESHA_ENGINE_BIN: ${{ github.workspace }}\rust\target\release\kesha-engine.exe
-    steps:
-      - name: 📥 Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          lfs: true
-
-      - name: 🍞 Setup Bun workspace
-        uses: ./.github/actions/setup-bun
-
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
-        with:
-          toolchain: stable
-
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          workspaces: rust
-
-      - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
-
-      - name: 🔗 Pin MSVC linker
-        shell: pwsh
-        # Git for Windows ships a GNU link.exe that shadows MSVC's under `shell: bash` (rust-test.yml).
-        run: |
-          $linkPath = (Get-Command link.exe |
-            Where-Object { $_.Source -notlike "*Git*usr*" } |
-            Select-Object -First 1).Source
-          if (-not $linkPath) { Write-Error "MSVC link.exe not found"; exit 1 }
-          Add-Content -Path $env:GITHUB_ENV -Value "CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=$linkPath"
-
-      - name: 🎧 Allow legacy cmake_minimum_required
-        shell: pwsh
-        # opusic-sys falls back to a cmake build of vendored libopus whose CMakeLists predates cmake 4.
-        run: Add-Content -Path $env:GITHUB_ENV -Value "CMAKE_POLICY_VERSION_MINIMUM=3.5"
-
-      - name: 🦀 Build local Windows engine
-        shell: bash
-        run: cd rust && cargo build --release --features onnx,tts --no-default-features
-
-      - name: 🧾 Mark local engine version
-        shell: bash
-        run: |
-          bun -e '
-            const pkg = await Bun.file("package.json").json();
-            await Bun.write(`${process.env.KESHA_ENGINE_BIN}.version`, `${pkg.keshaEngine.version}\n`);
-          '
-
-      - name: 🔊 Install models through local backend
-        uses: ./.github/actions/install-kesha-backend
-        with:
-          cache-path: |
-            ${{ github.workspace }}\.kesha-release-smoke
-          cache-key: ${{ runner.os }}-kesha-release-smoke-v1
-          cache-restore-keys: ${{ runner.os }}-kesha-release-smoke-
-          ffmpeg-provider: skip
-          install-args: --onnx --tts en ru
+          cache-write: "false"
 
       - name: 🚬 Smoke release branch local engine
         shell: bash
@@ -926,7 +881,6 @@ jobs:
       - published-engine-smoke
       - windows-engine-smoke
       - release-branch-engine-smoke
-      - release-branch-windows-smoke
       - tts-e2e
       - raycast-lint
       - openspec-validate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,9 @@ jobs:
 
   workflow-lint:
     needs: changes
-    if: needs.changes.outputs.workflows == 'true'
+    # `schedule` so a release published after the last workflow change still gets its assets
+    # verified within a day, rather than waiting for someone to touch a workflow file.
+    if: needs.changes.outputs.workflows == 'true' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout
@@ -170,6 +172,7 @@ jobs:
       - name: 🎯 Check engine targets match the published release
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_HEAD_REF: ${{ github.head_ref }}
         run: bun run check:engine-targets
 
   homebrew-formula:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,8 @@ jobs:
               - '.github/scripts/**'
               - 'package.json'
               - 'bun.lock'
+              # The file check:engine-targets guards; without it a size edit never runs the check.
+              - 'src/engine-targets.ts'
             homebrew:
               - 'packaging/homebrew/Formula/**'
               - 'docs/homebrew.md'
@@ -173,6 +175,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           GITHUB_HEAD_REF: ${{ github.head_ref }}
+          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: bun run check:engine-targets
 
   homebrew-formula:

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "check:workflows": "bun .github/scripts/check-workflows.ts",
     "check:specs": "bunx @fission-ai/openspec@1.4.1 validate --specs --strict",
     "check:release-manifest": "bun .github/scripts/release-manifest.mjs --check",
-    "check:versions": "bun .github/scripts/check-versions.ts"
+    "check:versions": "bun .github/scripts/check-versions.ts",
+    "check:engine-targets": "bun .github/scripts/check-engine-targets.ts"
   },
   "keywords": [
     "asr",

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -1,6 +1,7 @@
 import { defineCommand } from "citty";
 import { errorMessage } from "../error-utils";
 import { downloadEngine } from "../engine-install";
+import { engineTarget } from "../engine-targets";
 import { getEngineBinPath, getEngineCapabilities } from "../engine";
 import { renderInstallPlan } from "../install-plan";
 import { maybeAskForStar } from "../star";
@@ -91,13 +92,10 @@ export function resolveBackendFlag(coreml: boolean, onnx: boolean): string | und
 }
 
 export function defaultBackendForPlatform(
-  platform = process.platform,
-  arch = process.arch,
+  platform: string = process.platform,
+  arch: string = process.arch,
 ): string | undefined {
-  if (platform === "darwin" && arch === "arm64") return "coreml";
-  if (platform === "linux" && arch === "x64") return "onnx";
-  if (platform === "win32" && arch === "x64") return "onnx";
-  return undefined;
+  return engineTarget(platform, arch)?.backend;
 }
 
 type InstallDiagnosticErrorKind = "validation_failed" | "install_failed";

--- a/src/engine-install.ts
+++ b/src/engine-install.ts
@@ -8,6 +8,7 @@ import {
   TRANSCRIBE_DIARIZE_FEATURE,
   type EngineCapabilities,
 } from "./engine";
+import { engineTarget } from "./engine-targets";
 import { isDarwinArm64 } from "./fluid-kokoro-cache";
 import { log } from "./log";
 import { engineVersion } from "./package-info";
@@ -26,14 +27,12 @@ export {
 const GITHUB_REPO = "drakulavich/kesha-voice-kit";
 
 export function getEngineBinaryName(
-  platform = process.platform,
-  arch = process.arch,
+  platform: string = process.platform,
+  arch: string = process.arch,
 ): string {
-  if (platform === "darwin" && arch === "arm64") return "kesha-engine-darwin-arm64";
-  if (platform === "linux" && arch === "x64") return "kesha-engine-linux-x64";
-  if (platform === "win32" && arch === "x64") return "kesha-engine-windows-x64.exe";
-
-  throw new Error(`Unsupported platform: ${platform} ${arch}`);
+  const target = engineTarget(platform, arch);
+  if (!target) throw new Error(`Unsupported platform: ${platform} ${arch}`);
+  return target.assetName;
 }
 
 /** Sidecar spec — centralises AVSpeech (#141) and future sidecars so each is one entry. */

--- a/src/engine-targets.ts
+++ b/src/engine-targets.ts
@@ -1,0 +1,44 @@
+/**
+ * The one table of what each shipped platform gets.
+ *
+ * Kept import-free so any module can read it — `paths.ts` in particular must stay
+ * dependency-light. Adding a platform is one row here; #216 had to touch four
+ * separate switch chains, and nothing would have caught a missed one.
+ */
+export interface EngineTarget {
+  /** GitHub release asset name — suffixed for uniqueness across platforms. */
+  assetName: string;
+  backend: "coreml" | "onnx";
+  /** Published asset size, for `kesha install --plan`. Verified by `check:engine-targets`. */
+  sizeBytes: number;
+}
+
+const ENGINE_TARGETS: Record<string, EngineTarget> = {
+  "darwin-arm64": {
+    assetName: "kesha-engine-darwin-arm64",
+    backend: "coreml",
+    sizeBytes: 62_172_768,
+  },
+  "linux-x64": {
+    assetName: "kesha-engine-linux-x64",
+    backend: "onnx",
+    sizeBytes: 63_188_728,
+  },
+  "win32-x64": {
+    assetName: "kesha-engine-windows-x64.exe",
+    backend: "onnx",
+    sizeBytes: 63_447_040,
+  },
+};
+
+/** Returns null for a platform with no published engine — callers choose how loudly to fail. */
+export function engineTarget(
+  platform: string = process.platform,
+  arch: string = process.arch,
+): EngineTarget | null {
+  return ENGINE_TARGETS[`${platform}-${arch}`] ?? null;
+}
+
+export function engineTargetKeys(): string[] {
+  return Object.keys(ENGINE_TARGETS);
+}

--- a/src/engine-targets.ts
+++ b/src/engine-targets.ts
@@ -39,6 +39,10 @@ export function engineTarget(
   return ENGINE_TARGETS[`${platform}-${arch}`] ?? null;
 }
 
-export function engineTargetKeys(): string[] {
-  return Object.keys(ENGINE_TARGETS);
+export function engineTargetEntries(): Array<{ platform: string; arch: string; target: EngineTarget }> {
+  return Object.entries(ENGINE_TARGETS).map(([key, target]) => {
+    // Split once from the left: an arch token may itself contain a hyphen, a platform never does.
+    const sep = key.indexOf("-");
+    return { platform: key.slice(0, sep), arch: key.slice(sep + 1), target };
+  });
 }

--- a/src/install-plan.ts
+++ b/src/install-plan.ts
@@ -3,6 +3,7 @@ import { humanBytes } from "./format";
 import { dirname, join } from "path";
 import { getEngineBinPath } from "./engine";
 import { SIDECARS } from "./engine-install";
+import { engineTarget } from "./engine-targets";
 import { readInstalledEngineVersion } from "./engine-version-marker";
 import { keshaCacheDir } from "./paths";
 import { engineVersion, packageVersion } from "./package-info";
@@ -105,16 +106,8 @@ function sumFiles(files: PlanFile[]): number {
 }
 
 function engineAssetForPlatform(): ReleaseAssetSpec | null {
-  if (process.platform === "darwin" && process.arch === "arm64") {
-    return { assetName: "kesha-engine-darwin-arm64", sizeBytes: 59_621_264 };
-  }
-  if (process.platform === "linux" && process.arch === "x64") {
-    return { assetName: "kesha-engine-linux-x64", sizeBytes: 62_897_808 };
-  }
-  if (process.platform === "win32" && process.arch === "x64") {
-    return { assetName: "kesha-engine-windows-x64.exe", sizeBytes: 63_447_040 };
-  }
-  return null;
+  const target = engineTarget();
+  return target && { assetName: target.assetName, sizeBytes: target.sizeBytes };
 }
 
 function filesCached(cacheRoot: string, files: PlanFile[]): boolean {

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -5,7 +5,7 @@ export function keshaCacheDir(): string {
   return process.env.KESHA_CACHE_DIR ?? join(homedir(), ".cache", "kesha");
 }
 
-/** Windows needs the `.exe` suffix: the release asset is a PE, and an extensionless copy is not reliably spawnable. */
+/** The `.exe` suffix is a platform fact, not a per-target one: an extensionless PE is not reliably spawnable. */
 export function defaultEngineBinPath(platform = process.platform): string {
   const basename = platform === "win32" ? "kesha-engine.exe" : "kesha-engine";
   return join(keshaCacheDir(), "engine", "bin", basename);

--- a/tests/unit/engine-targets.test.ts
+++ b/tests/unit/engine-targets.test.ts
@@ -1,18 +1,25 @@
 import { describe, expect, test } from "bun:test";
-import { engineTarget, engineTargetKeys } from "../../src/engine-targets";
+import { engineTarget, engineTargetEntries } from "../../src/engine-targets";
 import { getEngineBinaryName } from "../../src/engine-install";
 import { defaultBackendForPlatform } from "../../src/cli/install";
 
 describe("engine targets are one table (#216)", () => {
-  test("every shipped platform is complete", () => {
-    for (const key of engineTargetKeys()) {
-      const [platform, arch] = key.split("-");
-      const target = engineTarget(platform, arch);
-      expect(target).not.toBeNull();
-      expect(target!.assetName).toMatch(/^kesha-engine-/);
-      expect(["coreml", "onnx"]).toContain(target!.backend);
-      expect(target!.sizeBytes).toBeGreaterThan(1_000_000);
-    }
+  // Pinned, not shape-checked: `backend` decides which release asset a platform installs, so a
+  // silent flip is the failure the four scattered tables made possible. Sizes are deliberately
+  // absent — check-engine-targets.ts verifies those against the release, which a literal cannot.
+  test("each platform is pinned to its backend and asset", () => {
+    expect(engineTarget("darwin", "arm64")).toMatchObject({
+      assetName: "kesha-engine-darwin-arm64",
+      backend: "coreml",
+    });
+    expect(engineTarget("linux", "x64")).toMatchObject({
+      assetName: "kesha-engine-linux-x64",
+      backend: "onnx",
+    });
+    expect(engineTarget("win32", "x64")).toMatchObject({
+      assetName: "kesha-engine-windows-x64.exe",
+      backend: "onnx",
+    });
   });
 
   test("unshipped platforms resolve to null", () => {
@@ -22,22 +29,20 @@ describe("engine targets are one table (#216)", () => {
     expect(engineTarget("freebsd", "x64")).toBeNull();
   });
 
-  // The four call sites disagreeing is the failure #216 hit: one platform, four hand-edited
-  // chains, and nothing asserting they agreed.
-  test("the consumers read the table rather than their own copy", () => {
-    for (const key of engineTargetKeys()) {
-      const [platform, arch] = key.split("-");
-      const target = engineTarget(platform, arch)!;
-      expect(getEngineBinaryName(platform, arch)).toBe(target.assetName);
-      expect(defaultBackendForPlatform(platform, arch)).toBe(target.backend);
+  test("entries round-trip back to the rows they came from", () => {
+    const entries = engineTargetEntries();
+    expect(entries).toHaveLength(3);
+    for (const { platform, arch, target } of entries) {
+      expect(engineTarget(platform, arch)).toBe(target);
     }
   });
 
-  test("only Windows assets carry an executable suffix", () => {
-    for (const key of engineTargetKeys()) {
-      const [platform, arch] = key.split("-");
-      const { assetName } = engineTarget(platform, arch)!;
-      expect(assetName.endsWith(".exe")).toBe(platform === "win32");
+  // Guards against someone re-introducing a divergent switch in a consumer, which is exactly
+  // how #216 ended up with four tables that nothing forced to agree.
+  test("the consumers read the table rather than their own copy", () => {
+    for (const { platform, arch, target } of engineTargetEntries()) {
+      expect(getEngineBinaryName(platform, arch)).toBe(target.assetName);
+      expect(defaultBackendForPlatform(platform, arch)).toBe(target.backend);
     }
   });
 });

--- a/tests/unit/engine-targets.test.ts
+++ b/tests/unit/engine-targets.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import { engineTarget, engineTargetKeys } from "../../src/engine-targets";
+import { getEngineBinaryName } from "../../src/engine-install";
+import { defaultBackendForPlatform } from "../../src/cli/install";
+
+describe("engine targets are one table (#216)", () => {
+  test("every shipped platform is complete", () => {
+    for (const key of engineTargetKeys()) {
+      const [platform, arch] = key.split("-");
+      const target = engineTarget(platform, arch);
+      expect(target).not.toBeNull();
+      expect(target!.assetName).toMatch(/^kesha-engine-/);
+      expect(["coreml", "onnx"]).toContain(target!.backend);
+      expect(target!.sizeBytes).toBeGreaterThan(1_000_000);
+    }
+  });
+
+  test("unshipped platforms resolve to null", () => {
+    expect(engineTarget("darwin", "x64")).toBeNull();
+    expect(engineTarget("linux", "arm64")).toBeNull();
+    expect(engineTarget("win32", "arm64")).toBeNull();
+    expect(engineTarget("freebsd", "x64")).toBeNull();
+  });
+
+  // The four call sites disagreeing is the failure #216 hit: one platform, four hand-edited
+  // chains, and nothing asserting they agreed.
+  test("the consumers read the table rather than their own copy", () => {
+    for (const key of engineTargetKeys()) {
+      const [platform, arch] = key.split("-");
+      const target = engineTarget(platform, arch)!;
+      expect(getEngineBinaryName(platform, arch)).toBe(target.assetName);
+      expect(defaultBackendForPlatform(platform, arch)).toBe(target.backend);
+    }
+  });
+
+  test("only Windows assets carry an executable suffix", () => {
+    for (const key of engineTargetKeys()) {
+      const [platform, arch] = key.split("-");
+      const { assetName } = engineTarget(platform, arch)!;
+      expect(assetName.endsWith(".exe")).toBe(platform === "win32");
+    }
+  });
+});


### PR DESCRIPTION
**Stacked on #667** — base is `spec/windows-x64-unblock`, so review that first. This PR is the follow-up its `/simplify` pass identified.

## Why

Unblocking one platform in #667 required four independent edits:

| Fact | Lived in |
|---|---|
| release asset name | `src/engine-install.ts::getEngineBinaryName` |
| default backend | `src/cli/install.ts::defaultBackendForPlatform` |
| asset size | `src/install-plan.ts::engineAssetForPlatform` |
| installed basename | `src/paths.ts::defaultEngineBinPath` |

Four hand-maintained chains over the same three platforms, with `kesha-engine-windows-x64.exe` spelled in two of them, and nothing — no type, no test — forcing them to agree. `ENGINE_TARGETS` is now one row per platform and the four functions are lookups over it.

## The executable suffix deliberately stayed out of the table

`.exe` is a property of **Windows**, not of a build target. Putting it in the table forced `defaultEngineBinPath` to take an `arch` it has no use for, and got it wrong for `win32-arm64` — a platform with no published engine whose executables still need the suffix. It stays a one-line platform branch in `paths.ts`.

## Centralising alone would have moved the problem, not fixed it

The sizes are hand-written and only feed `kesha install --plan`, so a wrong one misleads about disk cost and nothing fails. `check-engine-targets.ts` now verifies every row against the release API — and **its first run found two wrong, neither of them the one #667 touched**:

```
darwin-arm64  59_621_264 → 62_172_768   (off by 2.55 MB)
linux-x64     62_897_808 → 63_188_728   (off by 291 KB)
```

Only the Windows figure was correct, because it had been hand-fixed while writing the unblock. The other two had been misreporting disk cost for an unknown number of releases. The check skips when the release is unreachable, so offline work and forked PRs fail only on genuine drift.

## Release lanes merged into one matrix

Also collapses `release-branch-engine-smoke` and `release-branch-windows-smoke`, removing ~90 duplicated lines — including the load-bearing `release/*` guard that CLAUDE.md warns against carrying in two places.

I originally argued against merging these: a shared lane hides the MSVC linker pin and the cmake-policy workaround behind `if: runner.os`. That cost is real, and a `workflow_call` would have made it worse. A matrix keeps those steps visible inside the job that runs them, which is why it is the shape used here.

Refs #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhPvkHRyjGTP6octKHuS5T
