### PR TITLE
fix(install): apply download backpressure instead of buffering

### DIFF
--- a/src/progress.ts
+++ b/src/progress.ts
@@ -105,6 +105,27 @@ export function createPercentProgress(
   };
 }
 
+type SinkWrite = ReturnType<Bun.FileSink["write"]>;
+
+/**
+ * Waits for the sink whenever a write did not complete inline.
+ *
+ * Bun's FileSink reports a pending write as a Promise and backpressure as the negative
+ * sentinel `-(bytes + 1)`; discarding either buffers the whole download in memory instead
+ * of throttling to disk speed, which for the engine is ~63 MB and for the Vosk voice ~937 MB
+ * (#669). Exported for the test — the sentinel is not reproducible on demand.
+ */
+export async function applyBackpressure(
+  writer: Pick<Bun.FileSink, "flush">,
+  written: SinkWrite,
+): Promise<void> {
+  if (typeof written !== "number") {
+    await written;
+    return;
+  }
+  if (written < 0) await writer.flush();
+}
+
 export async function streamResponseToFile(
   res: Response,
   destPath: string,
@@ -123,7 +144,7 @@ export async function streamResponseToFile(
   let bytes = 0;
   try {
     for await (const chunk of res.body) {
-      writer.write(chunk);
+      await applyBackpressure(writer, writer.write(chunk));
       bytes += chunk.length;
       progress.update(chunk.length);
     }

--- a/tests/unit/progress-stream.test.ts
+++ b/tests/unit/progress-stream.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync, statSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import { streamResponseToFile } from "../../src/progress";
+import { applyBackpressure, streamResponseToFile } from "../../src/progress";
 
 // #216: `writer.end()` went unawaited, so the write handle outlived the call. Whether an
 // OS then lets you spawn the file is nondeterministic — that half is covered by
@@ -27,5 +27,79 @@ describe("streamResponseToFile flushes before resolving", () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+
+  // Backpressure handling sits in the write loop, so a mishandled sentinel could drop or
+  // reorder a chunk without changing the byte count — compare content, not just length.
+  test("a multi-chunk body round-trips byte for byte", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-stream-large-"));
+    try {
+      const dest = join(dir, "payload.bin");
+      const source = new Uint8Array(8 * 1024 * 1024);
+      for (let i = 0; i < source.length; i++) source[i] = i % 251;
+
+      const written = await streamResponseToFile(
+        new Response(source, { headers: { "content-length": String(source.length) } }),
+        dest,
+        "payload",
+      );
+
+      expect(written).toBe(source.length);
+      const back = new Uint8Array(await Bun.file(dest).arrayBuffer());
+      expect(back.length).toBe(source.length);
+      expect(Bun.SHA256.hash(back, "hex")).toBe(Bun.SHA256.hash(source, "hex"));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("applyBackpressure honours the FileSink contract (#669)", () => {
+  function fakeSink() {
+    let flushes = 0;
+    return {
+      flush: () => {
+        flushes += 1;
+        return 0;
+      },
+      get flushes() {
+        return flushes;
+      },
+    };
+  }
+
+  test("an inline write needs no flush", async () => {
+    const sink = fakeSink();
+    await applyBackpressure(sink, 4096);
+    expect(sink.flushes).toBe(0);
+  });
+
+  // Bun encodes backpressure as -(bytes + 1); ignoring it buffers the whole download.
+  test("the negative sentinel drains the sink", async () => {
+    const sink = fakeSink();
+    await applyBackpressure(sink, -(65_536 + 1));
+    expect(sink.flushes).toBe(1);
+  });
+
+  test("a pending write is awaited rather than dropped", async () => {
+    const sink = fakeSink();
+    let settled = false;
+    const pending = new Promise<number>((resolve) =>
+      setTimeout(() => {
+        settled = true;
+        resolve(4096);
+      }, 10),
+    );
+
+    await applyBackpressure(sink, pending);
+
+    expect(settled).toBe(true);
+    expect(sink.flushes).toBe(0);
+  });
+
+  test("zero bytes written is not mistaken for backpressure", async () => {
+    const sink = fakeSink();
+    await applyBackpressure(sink, 0);
+    expect(sink.flushes).toBe(0);
   });
 });


### PR DESCRIPTION
## Problem

`streamResponseToFile` discarded the return value of `writer.write(chunk)`:

```ts
for await (const chunk of res.body) {
  writer.write(chunk);   // return value dropped
  bytes += chunk.length;
  progress.update(chunk.length);
}
```

Per Bun's documented `FileSink` contract, that return value is the backpressure channel:

- `write()` returns `number | Promise<number>`
- a **pending** write comes back as a `Promise`
- **backpressure** comes back as the negative sentinel `-(bytes + 1)`
- the JSDoc is explicit: *"If the file descriptor is not writable yet, the data is buffered."*

Dropping it means we never wait for a pending write and never drain on backpressure, so a slow or contended disk makes the download accumulate in memory instead of throttling.

## Impact

**Correctness was never at risk** — `await writer.end()` (added in #667) flushes whatever is still buffered before the download reports success. This is a memory-profile fix, and it scales with the payload: ~63 MB for the engine, ~937 MB for the Russian Vosk voice, on whatever machine the user has. Every CLI download goes through this function — the engine binary and both darwin sidecars.

## Fix

```ts
await applyBackpressure(writer, writer.write(chunk));
```

which awaits a Promise result and flushes on a negative sentinel.

`applyBackpressure` is exported rather than inlined because the sentinel cannot be produced on demand — the tests drive it through a fake sink, covering the inline write, the sentinel, a genuinely pending write, and `0` bytes written (which must not be mistaken for backpressure, since `0 < 0` is false but the boundary is worth pinning).

The round-trip test compares **SHA-256 over 8 MB** rather than just the byte count: a mishandled sentinel could drop or reorder a chunk without changing the length, which a size assertion would not catch.

## Context

Found while verifying the `FileSink` contract against Bun's docs during #667, and deliberately kept out of that PR to hold its diff to the Windows install path. The unawaited `end()` was fixed there because it was an actual crash — `EBUSY` on Windows, `ETXTBSY` on Linux, from spawning a file whose write handle was still open. This one is latent, which is why it was filed rather than bundled.

Closes #669

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhPvkHRyjGTP6octKHuS5T
