### PR TITLE
chore(raycast): record the real date the setup-detection entry shipped

### DIFF
--- a/raycast/CHANGELOG.md
+++ b/raycast/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Kesha Voice Kit Changelog
 
-## [Sturdier setup detection] - {PR_MERGE_DATE}
+## [Sturdier setup detection] - 2026-08-03
 
 - Detect whether the engine is installed from the CLI's machine-readable status output instead of matching its wording, so a reworded CLI message can no longer be mistaken for a broken install. Older CLIs keep working through the previous check.
 - Refuse to start a session when the engine is installed but cannot run, instead of recording audio that could never be transcribed, and say how to repair it.


### PR DESCRIPTION
`{PR_MERGE_DATE}` is Raycast's placeholder — their bot replaces it when the Store PR merges. [raycast/extensions#29898](https://github.com/raycast/extensions/pull/29898) merged on 2026-08-03, so upstream's CHANGELOG now carries that date while ours still holds the placeholder.

Spotted while preparing the #648 mirror sync ([raycast/extensions#29936](https://github.com/raycast/extensions/pull/29936)): left alone, every future sync would carry the placeholder back and overwrite the real date upstream.

One line, no code.

Refs #647

🤖 Generated with [Claude Code](https://claude.com/claude-code)