### PR TITLE
feat(ci): synthesise through the release artifact before uploading it

### DIFF
--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -16,16 +16,10 @@ import { join } from "node:path";
 import { parse, YAMLParseError } from "yaml";
 
 const dirs = [".github/workflows", ".github/actions"];
-const files = dirs.flatMap((dir) => collectYamlFiles(dir)).sort();
-
-if (files.length === 0) {
-  console.error(`no workflow or action files found in ${dirs.join(", ")}`);
-  process.exit(1);
-}
 
 function collectYamlFiles(dir: string): string[] {
   return readdirSync(dir, { recursive: true })
-    .filter((entry) => typeof entry === "string" && /\.ya?ml$/.test(entry))
+    .filter((entry): entry is string => typeof entry === "string" && /\.ya?ml$/.test(entry))
     .map((entry) => join(dir, entry));
 }
 
@@ -44,30 +38,68 @@ function requirePinnedActions(path: string, contents: string): string[] {
   return errors;
 }
 
-let failed = 0;
-for (const path of files) {
-  try {
-    const contents = readFileSync(path, "utf8");
-    parse(contents);
-    const errors = requirePinnedActions(path, contents);
-    if (errors.length > 0) {
-      failed += errors.length;
-      for (const error of errors) console.error(error);
+/**
+ * Fails when build-engine.yml's build job would upload an artifact it never synthesised with.
+ * That workflow runs on releases only, so this is the one lane a PR can hold it to (#671).
+ */
+export function requirePreUploadSynthesisSmoke(path: string, document: unknown): string[] {
+  if (!path.endsWith("build-engine.yml")) return [];
+
+  const steps = (document as { jobs?: { build?: { steps?: unknown[] } } })?.jobs?.build?.steps;
+  if (!Array.isArray(steps)) return [`${path}: expected a \`build\` job with steps`];
+
+  const index = (match: (step: { run?: unknown; uses?: unknown }) => boolean) =>
+    steps.findIndex((step) => typeof step === "object" && step !== null && match(step));
+
+  const smoke = index((step) => typeof step.run === "string" && step.run.includes("smoke-synthesis.ts"));
+  const upload = index((step) => typeof step.uses === "string" && step.uses.startsWith("actions/upload-artifact"));
+
+  if (smoke === -1) {
+    return [`${path}: the build job must run smoke-synthesis.ts before uploading the artifact (#671)`];
+  }
+  if (upload !== -1 && smoke > upload) {
+    return [`${path}: smoke-synthesis.ts runs after the artifact is uploaded; move it before (#671)`];
+  }
+  return [];
+}
+
+function main(): void {
+  const files = dirs.flatMap((dir) => collectYamlFiles(dir)).sort();
+
+  if (files.length === 0) {
+    console.error(`no workflow or action files found in ${dirs.join(", ")}`);
+    process.exit(1);
+  }
+
+  let failed = 0;
+  for (const path of files) {
+    try {
+      const contents = readFileSync(path, "utf8");
+      const document = parse(contents);
+      const errors = [
+        ...requirePinnedActions(path, contents),
+        ...requirePreUploadSynthesisSmoke(path, document),
+      ];
+      if (errors.length > 0) {
+        failed += errors.length;
+        for (const error of errors) console.error(error);
+      }
+    } catch (err) {
+      failed += 1;
+      if (err instanceof YAMLParseError) {
+        // Rendered line:col so editors can jump to the offending position.
+        console.error(`${path}:${err.linePos?.[0]?.line ?? "?"}:${err.linePos?.[0]?.col ?? "?"}: ${err.message}`);
+      } else {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`${path}: ${msg}`);
+      }
     }
-  } catch (err) {
-    failed += 1;
-    if (err instanceof YAMLParseError) {
-      // YAMLParseError gives line/col + a code; render it the way most
-      // tools do so editors can jump to the offending position.
-      console.error(`${path}:${err.linePos?.[0]?.line ?? "?"}:${err.linePos?.[0]?.col ?? "?"}: ${err.message}`);
-    } else {
-      const msg = err instanceof Error ? err.message : String(err);
-      console.error(`${path}: ${msg}`);
-    }
+  }
+
+  if (failed > 0) {
+    console.error(`\n${failed} workflow or action check(s) failed.`);
+    process.exit(1);
   }
 }
 
-if (failed > 0) {
-  console.error(`\n${failed} workflow or action check(s) failed.`);
-  process.exit(1);
-}
+if (import.meta.main) main();

--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -48,16 +48,26 @@ export function requirePreUploadSynthesisSmoke(path: string, document: unknown):
   const steps = (document as { jobs?: { build?: { steps?: unknown[] } } })?.jobs?.build?.steps;
   if (!Array.isArray(steps)) return [`${path}: expected a \`build\` job with steps`];
 
-  const index = (match: (step: { run?: unknown; uses?: unknown }) => boolean) =>
+  const index = (match: (step: { run?: unknown; uses?: unknown; if?: unknown }) => boolean) =>
     steps.findIndex((step) => typeof step === "object" && step !== null && match(step));
 
-  const smoke = index((step) => typeof step.run === "string" && step.run.includes("smoke-synthesis.ts"));
+  // Anchored at line start so a commented-out or echoed mention doesn't satisfy the guard.
+  const invocation = /^\s*bun\s+\S*smoke-synthesis\.ts\b/m;
+  const smoke = index(
+    (step) =>
+      typeof step.run === "string" &&
+      invocation.test(step.run) &&
+      String(step.if ?? "").trim() !== "false",
+  );
   const upload = index((step) => typeof step.uses === "string" && step.uses.startsWith("actions/upload-artifact"));
 
   if (smoke === -1) {
     return [`${path}: the build job must run smoke-synthesis.ts before uploading the artifact (#671)`];
   }
-  if (upload !== -1 && smoke > upload) {
+  if (upload === -1) {
+    return [`${path}: the build job must upload the engine artifact after smoke-synthesis.ts (#671)`];
+  }
+  if (smoke > upload) {
     return [`${path}: smoke-synthesis.ts runs after the artifact is uploaded; move it before (#671)`];
   }
   return [];

--- a/.github/scripts/smoke-synthesis.ts
+++ b/.github/scripts/smoke-synthesis.ts
@@ -5,11 +5,12 @@
  * no lane covered — rust-test.yml runs unit and contract tests, and the Linux
  * engine smokes transcribe a fixture but never synthesise.
  *
- * Usage: bun .github/scripts/smoke-synthesis.ts [--no-roundtrip] <work-dir>
+ * Usage: bun .github/scripts/smoke-synthesis.ts [--no-roundtrip] [--voice <id>] <work-dir>
  *
  * `--no-roundtrip` stops after synthesis and drops to English only. It exists for
  * build-engine.yml's pre-upload gate (#671), which runs on a release builder with no ASR
  * model set — transcribing back there would cost a multi-GB download per platform.
+ * `--voice` overrides the voice, for platforms whose default engine can't run in CI.
  */
 import { mkdirSync } from "fs";
 import { join } from "path";
@@ -17,20 +18,28 @@ import { assertSingleTranscript } from "./assert-transcript";
 
 const args = process.argv.slice(2);
 const noRoundtrip = args.includes("--no-roundtrip");
-const workDir = args.find((arg) => !arg.startsWith("--"));
-if (!workDir) {
-  console.error("usage: smoke-synthesis.ts [--no-roundtrip] <work-dir>");
+const voiceFlag = args.indexOf("--voice");
+const voiceOverride = voiceFlag === -1 ? undefined : args[voiceFlag + 1];
+const positional = args.filter(
+  (arg, i) => !arg.startsWith("--") && i !== voiceFlag + 1,
+);
+const workDir = positional[0];
+if (!workDir || (voiceFlag !== -1 && !voiceOverride)) {
+  console.error("usage: smoke-synthesis.ts [--no-roundtrip] [--voice <id>] <work-dir>");
   process.exit(2);
 }
 mkdirSync(workDir, { recursive: true });
 
+const ENGLISH = "The quick brown fox jumps over the lazy dog.";
 const ALL_VOICES = [
-  { voice: "en-am_michael", text: "The quick brown fox jumps over the lazy dog." },
+  { voice: "en-am_michael", text: ENGLISH },
   { voice: "ru-vosk-m02", text: "Проверка синтеза речи на русском языке." },
 ];
-const VOICES = noRoundtrip
-  ? ALL_VOICES.filter((v) => v.voice === "en-am_michael")
-  : ALL_VOICES;
+const VOICES = voiceOverride
+  ? [{ voice: voiceOverride, text: ENGLISH }]
+  : noRoundtrip
+    ? ALL_VOICES.filter((v) => v.voice === "en-am_michael")
+    : ALL_VOICES;
 
 // Without a timeout a hung `kesha say` burns the whole job budget and reports nothing useful.
 async function run(

--- a/.github/scripts/smoke-synthesis.ts
+++ b/.github/scripts/smoke-synthesis.ts
@@ -5,23 +5,32 @@
  * no lane covered — rust-test.yml runs unit and contract tests, and the Linux
  * engine smokes transcribe a fixture but never synthesise.
  *
- * Usage: bun .github/scripts/smoke-synthesis.ts <work-dir>
+ * Usage: bun .github/scripts/smoke-synthesis.ts [--no-roundtrip] <work-dir>
+ *
+ * `--no-roundtrip` stops after synthesis and drops to English only. It exists for
+ * build-engine.yml's pre-upload gate (#671), which runs on a release builder with no ASR
+ * model set — transcribing back there would cost a multi-GB download per platform.
  */
 import { mkdirSync } from "fs";
 import { join } from "path";
 import { assertSingleTranscript } from "./assert-transcript";
 
-const workDir = process.argv[2];
+const args = process.argv.slice(2);
+const noRoundtrip = args.includes("--no-roundtrip");
+const workDir = args.find((arg) => !arg.startsWith("--"));
 if (!workDir) {
-  console.error("usage: smoke-synthesis.ts <work-dir>");
+  console.error("usage: smoke-synthesis.ts [--no-roundtrip] <work-dir>");
   process.exit(2);
 }
 mkdirSync(workDir, { recursive: true });
 
-const VOICES = [
+const ALL_VOICES = [
   { voice: "en-am_michael", text: "The quick brown fox jumps over the lazy dog." },
   { voice: "ru-vosk-m02", text: "Проверка синтеза речи на русском языке." },
 ];
+const VOICES = noRoundtrip
+  ? ALL_VOICES.filter((v) => v.voice === "en-am_michael")
+  : ALL_VOICES;
 
 // Without a timeout a hung `kesha say` burns the whole job budget and reports nothing useful.
 async function run(
@@ -63,6 +72,7 @@ for (const { voice, text } of VOICES) {
     fail(`${voice}: expected a RIFF/WAVE header, got ${JSON.stringify(header)}`);
   }
   console.log(`ok: ${voice} synthesised ${bytes.length} bytes`);
+  if (noRoundtrip) continue;
 
   const back = await run(["--json", outPath]);
   if (back.code !== 0) fail(`transcribing ${voice}.wav exited ${back.code}\n${back.stderr}`);
@@ -77,4 +87,4 @@ for (const { voice, text } of VOICES) {
   console.log(`ok: ${voice} round-tripped to "${transcript.slice(0, 60)}"`);
 }
 
-console.log("Synthesis round-trip smoke passed.");
+console.log(noRoundtrip ? "Synthesis smoke passed." : "Synthesis round-trip smoke passed.");

--- a/.github/scripts/smoke-synthesis.ts
+++ b/.github/scripts/smoke-synthesis.ts
@@ -16,30 +16,33 @@ import { mkdirSync } from "fs";
 import { join } from "path";
 import { assertSingleTranscript } from "./assert-transcript";
 
-const args = process.argv.slice(2);
-const noRoundtrip = args.includes("--no-roundtrip");
-const voiceFlag = args.indexOf("--voice");
-const voiceOverride = voiceFlag === -1 ? undefined : args[voiceFlag + 1];
-const positional = args.filter(
-  (arg, i) => !arg.startsWith("--") && i !== voiceFlag + 1,
-);
-const workDir = positional[0];
-if (!workDir || (voiceFlag !== -1 && !voiceOverride)) {
-  console.error("usage: smoke-synthesis.ts [--no-roundtrip] [--voice <id>] <work-dir>");
-  process.exit(2);
-}
-mkdirSync(workDir, { recursive: true });
-
 const ENGLISH = "The quick brown fox jumps over the lazy dog.";
 const ALL_VOICES = [
   { voice: "en-am_michael", text: ENGLISH },
   { voice: "ru-vosk-m02", text: "Проверка синтеза речи на русском языке." },
 ];
-const VOICES = voiceOverride
-  ? [{ voice: voiceOverride, text: ENGLISH }]
-  : noRoundtrip
-    ? ALL_VOICES.filter((v) => v.voice === "en-am_michael")
-    : ALL_VOICES;
+
+export type SmokeArgs = { workDir: string; noRoundtrip: boolean; voices: typeof ALL_VOICES };
+
+/** Returns null when argv is unusable; the caller prints usage and exits 2. */
+export function parseArgs(argv: string[]): SmokeArgs | null {
+  const noRoundtrip = argv.includes("--no-roundtrip");
+  const voiceFlag = argv.indexOf("--voice");
+  const voiceOverride = voiceFlag === -1 ? undefined : argv[voiceFlag + 1];
+  if (voiceFlag !== -1 && (!voiceOverride || voiceOverride.startsWith("--"))) return null;
+
+  const voiceValueAt = voiceFlag === -1 ? -1 : voiceFlag + 1;
+  const workDir = argv.find((arg, i) => !arg.startsWith("--") && i !== voiceValueAt);
+  if (!workDir) return null;
+
+  const voices = voiceOverride
+    ? [{ voice: voiceOverride, text: ENGLISH }]
+    : noRoundtrip
+      ? ALL_VOICES.filter((v) => v.voice === "en-am_michael")
+      : ALL_VOICES;
+  return { workDir, noRoundtrip, voices };
+}
+
 
 // Without a timeout a hung `kesha say` burns the whole job budget and reports nothing useful.
 async function run(
@@ -64,36 +67,46 @@ function fail(message: string): never {
   process.exit(1);
 }
 
-for (const { voice, text } of VOICES) {
-  const outPath = join(workDir, `${voice}.wav`);
-  const say = await run(["say", text, "--voice", voice, "--out", outPath]);
-  if (say.code !== 0) fail(`\`kesha say --voice ${voice}\` exited ${say.code}\n${say.stderr}`);
-
-  const wav = Bun.file(outPath);
-  if (!(await wav.exists())) fail(`${voice}: --out produced no file at ${outPath}`);
-
-  const bytes = new Uint8Array(await wav.arrayBuffer());
-  // A header-only WAV is 44 bytes; anything at or below that synthesised silence.
-  if (bytes.length <= 44) fail(`${voice}: WAV is ${bytes.length} bytes, i.e. header without audio`);
-
-  const header = new TextDecoder().decode(bytes.subarray(0, 12));
-  if (!header.startsWith("RIFF") || header.slice(8) !== "WAVE") {
-    fail(`${voice}: expected a RIFF/WAVE header, got ${JSON.stringify(header)}`);
+if (import.meta.main) {
+  const parsed = parseArgs(process.argv.slice(2));
+  if (!parsed) {
+    console.error("usage: smoke-synthesis.ts [--no-roundtrip] [--voice <id>] <work-dir>");
+    process.exit(2);
   }
-  console.log(`ok: ${voice} synthesised ${bytes.length} bytes`);
-  if (noRoundtrip) continue;
+  const { workDir, noRoundtrip, voices } = parsed;
+  mkdirSync(workDir, { recursive: true });
 
-  const back = await run(["--json", outPath]);
-  if (back.code !== 0) fail(`transcribing ${voice}.wav exited ${back.code}\n${back.stderr}`);
+  for (const { voice, text } of voices) {
+    const outPath = join(workDir, `${voice}.wav`);
+    const say = await run(["say", text, "--voice", voice, "--out", outPath]);
+    if (say.code !== 0) fail(`\`kesha say --voice ${voice}\` exited ${say.code}\n${say.stderr}`);
 
-  // Not asserting on WER: this proves the engine speaks and hears, not that it is accurate.
-  let transcript: string;
-  try {
-    transcript = assertSingleTranscript(back.stdout, `${voice}.wav`);
-  } catch (e) {
-    fail(e instanceof Error ? e.message : String(e));
+    const wav = Bun.file(outPath);
+    if (!(await wav.exists())) fail(`${voice}: --out produced no file at ${outPath}`);
+
+    const bytes = new Uint8Array(await wav.arrayBuffer());
+    // A header-only WAV is 44 bytes; anything at or below that synthesised silence.
+    if (bytes.length <= 44) fail(`${voice}: WAV is ${bytes.length} bytes, i.e. header without audio`);
+
+    const header = new TextDecoder().decode(bytes.subarray(0, 12));
+    if (!header.startsWith("RIFF") || header.slice(8) !== "WAVE") {
+      fail(`${voice}: expected a RIFF/WAVE header, got ${JSON.stringify(header)}`);
+    }
+    console.log(`ok: ${voice} synthesised ${bytes.length} bytes`);
+    if (noRoundtrip) continue;
+
+    const back = await run(["--json", outPath]);
+    if (back.code !== 0) fail(`transcribing ${voice}.wav exited ${back.code}\n${back.stderr}`);
+
+    // Not asserting on WER: this proves the engine speaks and hears, not that it is accurate.
+    let transcript: string;
+    try {
+      transcript = assertSingleTranscript(back.stdout, `${voice}.wav`);
+    } catch (e) {
+      fail(e instanceof Error ? e.message : String(e));
+    }
+    console.log(`ok: ${voice} round-tripped to "${transcript.slice(0, 60)}"`);
   }
-  console.log(`ok: ${voice} round-tripped to "${transcript.slice(0, 60)}"`);
+
+  console.log(noRoundtrip ? "Synthesis smoke passed." : "Synthesis round-trip smoke passed.");
 }
-
-console.log(noRoundtrip ? "Synthesis smoke passed." : "Synthesis round-trip smoke passed.");

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -123,6 +123,8 @@ jobs:
       # libswift_Concurrency.dylib (which no longer ships as a standalone
       # file on macOS 26+).
       MACOSX_DEPLOYMENT_TARGET: "14.0"
+      # Points the CLI at the staged artifact for the pre-upload smoke, as release-branch-engine-smoke does (#671).
+      KESHA_ENGINE_BIN: ${{ github.workspace }}/${{ matrix.binary }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Select Xcode 16 (Swift 6)
@@ -283,6 +285,55 @@ jobs:
               exit 1
             }
           fi
+
+      # The smoke above proves the artifact starts and advertises `tts`, not that it synthesises (#671, #636).
+      - name: 🍞 Setup Bun workspace
+        uses: ./.github/actions/setup-bun
+
+      - name: 🔗 Link the CLI
+        shell: bash
+        run: bun link
+
+      # Load-bearing: on a version mismatch `downloadEngine` fetches the published engine, whose tag does not exist yet.
+      - name: 🧾 Mark staged engine version
+        shell: bash
+        run: |
+          bun -e '
+            const pkg = await Bun.file("package.json").json();
+            await Bun.write(`${process.env.KESHA_ENGINE_BIN}.version`, `${pkg.keshaEngine.version}\n`);
+          '
+
+      # Restore-only on the key published-engine-smoke already reads; a new one would evict a working entry (#675).
+      - name: 🔊 Install English TTS models
+        if: matrix.os != 'macos-14'
+        uses: ./.github/actions/install-kesha-backend
+        with:
+          cache-path: |
+            ~/.cache/kesha
+          cache-key: ${{ runner.os }}-kesha-models-tts-v1
+          cache-restore-keys: ${{ runner.os }}-kesha-models-tts-
+          ffmpeg-provider: skip
+          install-args: --tts en
+          cache-write: "false"
+
+      - name: 🗣️ Pre-upload synthesis smoke
+        if: matrix.os != 'macos-14'
+        shell: bash
+        run: bun .github/scripts/smoke-synthesis.ts --no-roundtrip synthesis-smoke
+
+      # No ONNX Kokoro on this row — fluidaudio-rs fetches the weights inside this step on first `init_kokoro`.
+      - name: 🗣️ Pre-upload synthesis smoke (downloads FluidAudio Kokoro weights)
+        if: matrix.os == 'macos-14'
+        shell: bash
+        run: bun .github/scripts/smoke-synthesis.ts --no-roundtrip synthesis-smoke
+
+      # That fetch runs under the stdout guard, so a truncated download reads as an opaque Swift bridge error (#661).
+      - name: 🔎 Inventory FluidAudio models
+        if: failure() && matrix.os == 'macos-14'
+        shell: bash
+        run: |
+          dir="$HOME/Library/Application Support/FluidAudio/Models"
+          [ -d "$dir" ] && { find "$dir" -type f | wc -l; du -sh "$dir"; } || echo "no FluidAudio model dir at $dir"
 
       - name: Inspect macOS dynamic deps
         if: matrix.os == 'macos-14'

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -287,15 +287,19 @@ jobs:
           fi
 
       # The smoke above proves the artifact starts and advertises `tts`, not that it synthesises (#671, #636).
+      # macOS is exempt throughout: neither TTS engine runs on an ANE-less, audio-less runner (#678).
       - name: 🍞 Setup Bun workspace
+        if: matrix.os != 'macos-14'
         uses: ./.github/actions/setup-bun
 
       - name: 🔗 Link the CLI
+        if: matrix.os != 'macos-14'
         shell: bash
         run: bun link
 
       # Load-bearing: on a version mismatch `downloadEngine` fetches the published engine, whose tag does not exist yet.
       - name: 🧾 Mark staged engine version
+        if: matrix.os != 'macos-14'
         shell: bash
         run: |
           bun -e '
@@ -303,7 +307,6 @@ jobs:
             await Bun.write(`${process.env.KESHA_ENGINE_BIN}.version`, `${pkg.keshaEngine.version}\n`);
           '
 
-      # macOS is exempt: its smoke uses AVSpeech, which needs no models at all.
       - name: 🔊 Install English TTS models
         if: matrix.os != 'macos-14'
         uses: ./.github/actions/install-kesha-backend
@@ -320,16 +323,6 @@ jobs:
         if: matrix.os != 'macos-14'
         shell: bash
         run: bun .github/scripts/smoke-synthesis.ts --no-roundtrip synthesis-smoke
-
-      # Not Kokoro: FluidAudio pins its vocoder stage to `.cpuAndNeuralEngine` and this runner is an ANE-less VM (#678).
-      - name: 🗣️ Pre-upload synthesis smoke (AVSpeech)
-        if: matrix.os == 'macos-14'
-        shell: bash
-        run: |
-          voices=$("./${{ matrix.binary }}" say --list-voices | grep '^macos-')
-          voice=$(echo "$voices" | grep -m1 'voice.compact.en-US' || echo "$voices" | grep -m1 'en-US')
-          echo "voice: $voice"
-          bun .github/scripts/smoke-synthesis.ts --no-roundtrip --voice "$voice" synthesis-smoke
 
       - name: Inspect macOS dynamic deps
         if: matrix.os == 'macos-14'

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -303,8 +303,9 @@ jobs:
             await Bun.write(`${process.env.KESHA_ENGINE_BIN}.version`, `${pkg.keshaEngine.version}\n`);
           '
 
-      # Also stages the SHA-pinned ANE voice packs on darwin: the upstream bundle ships only af_heart (#475).
+      # macOS is exempt: its smoke uses AVSpeech, which needs no models at all.
       - name: 🔊 Install English TTS models
+        if: matrix.os != 'macos-14'
         uses: ./.github/actions/install-kesha-backend
         with:
           cache-path: |
@@ -315,19 +316,19 @@ jobs:
           install-args: --tts en
           cache-write: "false"
 
-      # Darwin's install warm-up is non-fatal by design, so only this step proves synthesis actually ran.
       - name: 🗣️ Pre-upload synthesis smoke
+        if: matrix.os != 'macos-14'
         shell: bash
         run: bun .github/scripts/smoke-synthesis.ts --no-roundtrip synthesis-smoke
 
-      # FluidAudio fetches under the stdout guard, so a missing pack reads as an opaque Swift bridge error (#661).
-      - name: 🔎 Inventory FluidAudio models
-        if: failure() && matrix.os == 'macos-14'
+      # Not Kokoro: FluidAudio pins its vocoder stage to `.cpuAndNeuralEngine` and this runner is an ANE-less VM (#678).
+      - name: 🗣️ Pre-upload synthesis smoke (AVSpeech)
+        if: matrix.os == 'macos-14'
         shell: bash
         run: |
-          for dir in "$HOME/.cache/fluidaudio/Models" "$HOME/Library/Application Support/FluidAudio/Models"; do
-            [ -d "$dir" ] && { echo "$dir:"; find "$dir" -type f | wc -l; du -sh "$dir"; } || echo "absent: $dir"
-          done
+          voices=$("./${{ matrix.binary }}" say --list-voices | grep '^macos-')
+          voice=$(echo "$voices" | grep -m1 'en-US' || echo "$voices" | head -1)
+          bun .github/scripts/smoke-synthesis.ts --no-roundtrip --voice "$voice" synthesis-smoke
 
       - name: Inspect macOS dynamic deps
         if: matrix.os == 'macos-14'

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -303,9 +303,8 @@ jobs:
             await Bun.write(`${process.env.KESHA_ENGINE_BIN}.version`, `${pkg.keshaEngine.version}\n`);
           '
 
-      # Restore-only on the key published-engine-smoke already reads; a new one would evict a working entry (#675).
+      # Also stages the SHA-pinned ANE voice packs on darwin: the upstream bundle ships only af_heart (#475).
       - name: 🔊 Install English TTS models
-        if: matrix.os != 'macos-14'
         uses: ./.github/actions/install-kesha-backend
         with:
           cache-path: |
@@ -316,24 +315,19 @@ jobs:
           install-args: --tts en
           cache-write: "false"
 
+      # Darwin's install warm-up is non-fatal by design, so only this step proves synthesis actually ran.
       - name: 🗣️ Pre-upload synthesis smoke
-        if: matrix.os != 'macos-14'
         shell: bash
         run: bun .github/scripts/smoke-synthesis.ts --no-roundtrip synthesis-smoke
 
-      # No ONNX Kokoro on this row — fluidaudio-rs fetches the weights inside this step on first `init_kokoro`.
-      - name: 🗣️ Pre-upload synthesis smoke (downloads FluidAudio Kokoro weights)
-        if: matrix.os == 'macos-14'
-        shell: bash
-        run: bun .github/scripts/smoke-synthesis.ts --no-roundtrip synthesis-smoke
-
-      # That fetch runs under the stdout guard, so a truncated download reads as an opaque Swift bridge error (#661).
+      # FluidAudio fetches under the stdout guard, so a missing pack reads as an opaque Swift bridge error (#661).
       - name: 🔎 Inventory FluidAudio models
         if: failure() && matrix.os == 'macos-14'
         shell: bash
         run: |
-          dir="$HOME/Library/Application Support/FluidAudio/Models"
-          [ -d "$dir" ] && { find "$dir" -type f | wc -l; du -sh "$dir"; } || echo "no FluidAudio model dir at $dir"
+          for dir in "$HOME/.cache/fluidaudio/Models" "$HOME/Library/Application Support/FluidAudio/Models"; do
+            [ -d "$dir" ] && { echo "$dir:"; find "$dir" -type f | wc -l; du -sh "$dir"; } || echo "absent: $dir"
+          done
 
       - name: Inspect macOS dynamic deps
         if: matrix.os == 'macos-14'

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -327,7 +327,8 @@ jobs:
         shell: bash
         run: |
           voices=$("./${{ matrix.binary }}" say --list-voices | grep '^macos-')
-          voice=$(echo "$voices" | grep -m1 'en-US' || echo "$voices" | head -1)
+          voice=$(echo "$voices" | grep -m1 'voice.compact.en-US' || echo "$voices" | grep -m1 'en-US')
+          echo "voice: $voice"
           bun .github/scripts/smoke-synthesis.ts --no-roundtrip --voice "$voice" synthesis-smoke
 
       - name: Inspect macOS dynamic deps

--- a/openspec/changes/release-artifact-synthesis-smoke/.openspec.yaml
+++ b/openspec/changes/release-artifact-synthesis-smoke/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-03

--- a/openspec/changes/release-artifact-synthesis-smoke/design.md
+++ b/openspec/changes/release-artifact-synthesis-smoke/design.md
@@ -37,6 +37,7 @@ new tag.
 
 - Transcribing the synthesised audio back on the release runner (needs the multi-GB ASR set).
 - Russian or any non-English voice on the linux/windows rows.
+- Covering the darwin `system_kokoro` path in CI — impossible on an ANE-less runner (#678).
 - Replacing or weakening the existing `--capabilities-json` assertions.
 - Changing the release job, the publish path, or the CLAUDE.md draft-validation step.
 
@@ -78,30 +79,33 @@ cost ~55s (linux) / ~60s (windows), so the cache stays. macOS has no `macOS-kesh
 entry, so that row downloads cold every release — a candidate for the seed workflow once #675
 frees budget, not something to fix here.
 
-### D4 — macOS installs like every other row; only the diagnostics differ
+### D4 — darwin synthesises through AVSpeech, not Kokoro
 
-Corrected after the first dispatch run: the macOS row was originally exempted from
-`kesha install`, on the reasoning that `system_kokoro` runs in-engine and needs nothing on
-disk. That is wrong, and the run proved it — `en-am_michael` failed with
-`invalidResponse(description: "am_michael voice pack", statusCode: 404)`.
+Two dispatch runs settled this empirically, and both corrections are worth keeping.
 
-The upstream FluidAudio ANE bundle ships exactly one voice pack, `af_heart`. Kesha already
-works around this (#475): `models::stage_ane_kokoro_voices` downloads the SHA-pinned packs from
-onnx-community into `~/.cache/fluidaudio/Models/kokoro-82m-coreml/ANE/`, where FluidAudio
-resolves them local-first — and that staging runs during `kesha install --tts`. Skipping the
-install skipped the staging, so every voice except `af_heart` 404s, `am_michael` included.
+First, the macOS row was exempted from `kesha install` on the reasoning that an in-engine
+Kokoro needs nothing on disk. Wrong: the upstream FluidAudio ANE bundle ships exactly one voice
+pack, `af_heart`, and kesha works around that (#475) by staging SHA-pinned packs into
+`~/.cache/fluidaudio/Models/kokoro-82m-coreml/ANE/` during `kesha install --tts`. Skipping the
+install produced `invalidResponse(description: "am_michael voice pack", statusCode: 404)`.
 
-So all three rows install, and the install step is the named download the no-auto-download
-contract wants. `engine-install.ts::warmDarwinKokoro` already synthesises `en-am_michael` at
-install time on darwin, but warns and continues on failure — the same non-fatal posture the
-spec already refuses to accept as evidence for ASR. The smoke step is therefore the assertion,
-not the install.
+Second — and decisive — Kokoro cannot run on the runner at all. With every asset staged, the
+next run failed at `predictionFailed(stage: "vocoder", …)`: `KokoroAneModelStore` pins
+`albert`, `postAlbert`, `alignment`, and `vocoder` to `.cpuAndNeuralEngine`, GitHub's
+`macos-14` runner is a VM on Apple's Virtualization Framework, and the ANE is not virtualised.
+Parakeet survives on the same runner because `fluidaudio-rs` sets `cfg.computeUnits = .all` for
+ASR. FluidAudio documents `KokoroAneManager(computeUnits: .cpuAndGpu)` as an escape hatch, but
+`fluidaudio-rs` never plumbs it — `init_kokoro(&self, default_voice, lang)` has no such
+parameter — so kesha cannot reach it without an upstream change (#678).
 
-Two macOS-only diagnostics remain: FluidAudio's fetch runs inside
-`with_silenced_stdout_oneshot`, so a missing pack surfaces as an opaque `Swift bridge error`
-(#661). On failure the job inventories both FluidAudio roots — `~/.cache/fluidaudio/Models`
-(kesha-staged voice packs) and `~/Library/Application Support/FluidAudio/Models` (FluidAudio's
-own model bundles).
+The same binary synthesises `en-am_michael` correctly on real Apple Silicon (M2, macOS 26.5.2):
+exit 0, 24 kHz mono, 3.55 s, RMS 2653. The artifact is fine; the runner is the constraint.
+
+So the darwin row synthesises through AVSpeech instead, picking the first `macos-*` voice the
+artifact lists (preferring `en-US`). That needs no models, no ANE, and no `kesha install` — and
+it covers the sidecar spawn path end-to-end, which today is asserted only at list level. Kokoro
+on darwin stays uncovered in CI; #678 tracks closing that, and the spec records it as a known
+gap rather than an assumed pass.
 
 ### D5 — Prove the change with a build-only `workflow_dispatch`, and guard it statically
 

--- a/openspec/changes/release-artifact-synthesis-smoke/design.md
+++ b/openspec/changes/release-artifact-synthesis-smoke/design.md
@@ -73,21 +73,35 @@ drift, and the assertions are the part worth sharing.
 cache entry is minted: the repo already sits at ~9.5 GiB against GitHub's 10 GB budget
 (#675), and a new key would evict something that is doing work.
 
-Open question deferred to T4: that entry is ~3.4 GB because it carries the ASR set too.
-Restoring 3.4 GB to use ~330 MB of it may be slower than a cold Kokoro-only download. Measure
-on the dry run; if the cold download wins, drop the cache step rather than adding a key.
+Measured on the first dispatch: the linux entry restored in ~44s and the whole added block
+cost ~55s (linux) / ~60s (windows), so the cache stays. macOS has no `macOS-kesha-models-tts-*`
+entry, so that row downloads cold every release — a candidate for the seed workflow once #675
+frees budget, not something to fix here.
 
-### D4 — macOS synthesises through `system_kokoro`, and its download is named
+### D4 — macOS installs like every other row; only the diagnostics differ
 
-The macOS row has no ONNX Kokoro. `fluid_kokoro::with_kokoro` calls `init_kokoro`, which
-"downloads the model on first run" into FluidAudio's own cache — outside `kesha install`, and
-inside `with_silenced_stdout_oneshot`, so a failure there surfaces as an opaque
-`Swift bridge error` (this is exactly the #661 failure mode). Two consequences:
+Corrected after the first dispatch run: the macOS row was originally exempted from
+`kesha install`, on the reasoning that `system_kokoro` runs in-engine and needs nothing on
+disk. That is wrong, and the run proved it — `en-am_michael` failed with
+`invalidResponse(description: "am_michael voice pack", statusCode: 404)`.
 
-- The workflow step is named plainly as a download, the way `coreml-regression`'s cache step
-  already is, so the no-auto-download contract is not quietly violated by CI.
-- On failure the step inventories FluidAudio's model directory, so a truncated fetch shows up
-  as evidence instead of inference.
+The upstream FluidAudio ANE bundle ships exactly one voice pack, `af_heart`. Kesha already
+works around this (#475): `models::stage_ane_kokoro_voices` downloads the SHA-pinned packs from
+onnx-community into `~/.cache/fluidaudio/Models/kokoro-82m-coreml/ANE/`, where FluidAudio
+resolves them local-first — and that staging runs during `kesha install --tts`. Skipping the
+install skipped the staging, so every voice except `af_heart` 404s, `am_michael` included.
+
+So all three rows install, and the install step is the named download the no-auto-download
+contract wants. `engine-install.ts::warmDarwinKokoro` already synthesises `en-am_michael` at
+install time on darwin, but warns and continues on failure — the same non-fatal posture the
+spec already refuses to accept as evidence for ASR. The smoke step is therefore the assertion,
+not the install.
+
+Two macOS-only diagnostics remain: FluidAudio's fetch runs inside
+`with_silenced_stdout_oneshot`, so a missing pack surfaces as an opaque `Swift bridge error`
+(#661). On failure the job inventories both FluidAudio roots — `~/.cache/fluidaudio/Models`
+(kesha-staged voice packs) and `~/Library/Application Support/FluidAudio/Models` (FluidAudio's
+own model bundles).
 
 ### D5 — Prove the change with a build-only `workflow_dispatch`, and guard it statically
 
@@ -109,9 +123,9 @@ That is the part a *future* PR can regress, and it is cheap to hold.
   tag, only a new *tag name* would. Call this out in the release runbook so nobody reaches for
   a fresh tag by reflex.
 - **Cache restore may not be available on a `refs/tags/v*` run** (entries are written on
-  `main`) → The dry run reports it. Worst case is a cold download per platform per release,
-  which the build job's default 360-minute budget absorbs; if it is slow enough to hurt, D3's
-  fallback is to skip the cache entirely.
+  `main`) → Observed working on a branch dispatch; a tag ref is not a PR merge ref, so the same
+  default-branch scope should apply. Worst case is a cold download per platform per release,
+  which the build job's default 360-minute budget absorbs.
 - **The gate adds failure surface to the release path** → It only fails where a release
   *should* fail; the alternative is shipping the failure. The existing assertions are left
   untouched, and the new step sits between them and the upload.
@@ -124,7 +138,12 @@ That is the part a *future* PR can regress, and it is cheap to hold.
 ## Open Questions
 
 - Does a workflow run triggered by `refs/tags/v*` restore a cache entry written on `main`?
-  Assumed yes (default-branch scope), unconfirmed against observed behaviour. T4 settles it.
+  A `workflow_dispatch` run on a feature branch does — the first dispatch logged
+  `Cache hit for: Linux-kesha-models-tts-v1` and restored in ~44s, with the whole added block
+  costing ~55s on linux and ~60s on windows. A tag ref is not a PR merge ref, so the same
+  default-branch scope should apply, but that specific case is still inference, not
+  observation. macOS has no `macOS-kesha-models-tts-*` entry at all, so that row pays a cold
+  download every release.
 - Should the Windows row synthesise to OGG/Opus as well as WAV? #636 asks for both; the Opus
   encoder is a distinct failure surface (`opusic-sys`, vendored libopus, the cmake policy
   override). Deferred to a follow-up unless the dry run shows it is nearly free.

--- a/openspec/changes/release-artifact-synthesis-smoke/design.md
+++ b/openspec/changes/release-artifact-synthesis-smoke/design.md
@@ -37,7 +37,7 @@ new tag.
 
 - Transcribing the synthesised audio back on the release runner (needs the multi-GB ASR set).
 - Russian or any non-English voice on the linux/windows rows.
-- Covering the darwin `system_kokoro` path in CI — impossible on an ANE-less runner (#678).
+- Covering darwin synthesis in CI at all — neither engine runs on a hosted macOS runner (#678).
 - Replacing or weakening the existing `--capabilities-json` assertions.
 - Changing the release job, the publish path, or the CLAUDE.md draft-validation step.
 
@@ -79,36 +79,40 @@ cost ~55s (linux) / ~60s (windows), so the cache stays. macOS has no `macOS-kesh
 entry, so that row downloads cold every release — a candidate for the seed workflow once #675
 frees budget, not something to fix here.
 
-### D4 — darwin synthesises through AVSpeech, not Kokoro
+### D4 — the gate covers linux-x64 and windows-x64; darwin cannot be covered on a hosted runner
 
-Two dispatch runs settled this empirically, and both corrections are worth keeping.
+Four dispatch runs settled this. Two of my readings along the way were wrong, and both
+corrections are worth keeping because each looked right until the next run.
 
-First, the macOS row was exempted from `kesha install` on the reasoning that an in-engine
-Kokoro needs nothing on disk. Wrong: the upstream FluidAudio ANE bundle ships exactly one voice
-pack, `af_heart`, and kesha works around that (#475) by staging SHA-pinned packs into
-`~/.cache/fluidaudio/Models/kokoro-82m-coreml/ANE/` during `kesha install --tts`. Skipping the
-install produced `invalidResponse(description: "am_michael voice pack", statusCode: 404)`.
+**Run 1 — `am_michael voice pack, statusCode: 404`.** The macOS row was exempted from
+`kesha install` on the reasoning that an in-engine Kokoro needs nothing on disk. Wrong: the
+upstream FluidAudio ANE bundle ships exactly one voice pack, `af_heart`, and kesha works around
+that (#475) by staging SHA-pinned packs into `~/.cache/fluidaudio/…/ANE/` during
+`kesha install --tts`. Fixed by installing on every row.
 
-Second — and decisive — Kokoro cannot run on the runner at all. With every asset staged, the
-next run failed at `predictionFailed(stage: "vocoder", …)`: `KokoroAneModelStore` pins
-`albert`, `postAlbert`, `alignment`, and `vocoder` to `.cpuAndNeuralEngine`, GitHub's
-`macos-14` runner is a VM on Apple's Virtualization Framework, and the ANE is not virtualised.
-Parakeet survives on the same runner because `fluidaudio-rs` sets `cfg.computeUnits = .all` for
-ASR. FluidAudio documents `KokoroAneManager(computeUnits: .cpuAndGpu)` as an escape hatch, but
-`fluidaudio-rs` never plumbs it — `init_kokoro(&self, default_voice, lang)` has no such
-parameter — so kesha cannot reach it without an upstream change (#678).
+**Run 2 — `predictionFailed(stage: "vocoder")`.** With every asset staged, CoreML could not
+prepare `KokoroVocoder`. `KokoroAneModelStore` pins `albert`, `postAlbert`, `alignment`, and
+`vocoder` to `.cpuAndNeuralEngine`; GitHub's `macos-14` runner is a VM on Apple's Virtualization
+Framework and the ANE is not virtualised. Parakeet survives on the same runner because
+`fluidaudio-rs` sets `cfg.computeUnits = .all` for ASR. FluidAudio documents
+`KokoroAneManager(computeUnits: .cpuAndGpu)` as an escape hatch, but `fluidaudio-rs` never
+plumbs it — `init_kokoro(&self, default_voice, lang)` has no such parameter.
 
-The same binary synthesises `en-am_michael` correctly on real Apple Silicon (M2, macOS 26.5.2):
-exit 0, 24 kHz mono, 3.55 s, RMS 2653. The artifact is fine; the runner is the constraint.
+**Runs 3 and 4 — AVSpeech instead.** A Swift sidecar needs neither ANE nor CoreML, so darwin
+was rerouted through a `macos-*` voice. It failed too, on an Eloquence voice and then on
+`voice.compact.en-US.Samantha`, with `avspeech helper exited exit status: 3: timeout waiting for
+synthesis` both times, after the same ~16s. The Eloquence reading — listed but not installed —
+was refuted by Samantha, which ships with the OS; the identical durations point at a fixed
+helper timeout, not asset-dependent behaviour. Root cause not established (#678).
 
-So the darwin row synthesises through AVSpeech instead, picking a `voice.compact.en-US` voice
-(Samantha's class) from what the artifact lists. Compact voices ship with the OS; the third
-dispatch showed that an Eloquence voice — listed but a downloadable asset — fails on the runner
-with `avspeech helper exited status 3: timeout waiting for synthesis`, the classic
-missing-asset symptom. That needs no models, no ANE, and no `kesha install` — and
-it covers the sidecar spawn path end-to-end, which today is asserted only at list level. Kokoro
-on darwin stays uncovered in CI; #678 tracks closing that, and the spec records it as a known
-gap rather than an assumed pass.
+The artifact is not at fault. On real Apple Silicon (M2, macOS 26.5.2) the same feature set
+synthesises through both engines: Kokoro `en-am_michael` at 24 kHz / 3.55 s / RMS 2653, and
+AVSpeech at 16 kHz float / 3.74 s / RMS 0.082.
+
+So the gate covers linux-x64 and windows-x64, and the darwin row keeps only its existing
+`--capabilities-json` and `say --list-voices` assertions. The spec records darwin as an
+uncovered gap rather than an assumed pass; #678 tracks closing it, and a self-hosted Apple
+Silicon runner would fix both engines at once since a real Mac has an ANE and an audio device.
 
 ### D5 — Prove the change with a build-only `workflow_dispatch`, and guard it statically
 

--- a/openspec/changes/release-artifact-synthesis-smoke/design.md
+++ b/openspec/changes/release-artifact-synthesis-smoke/design.md
@@ -101,8 +101,11 @@ parameter — so kesha cannot reach it without an upstream change (#678).
 The same binary synthesises `en-am_michael` correctly on real Apple Silicon (M2, macOS 26.5.2):
 exit 0, 24 kHz mono, 3.55 s, RMS 2653. The artifact is fine; the runner is the constraint.
 
-So the darwin row synthesises through AVSpeech instead, picking the first `macos-*` voice the
-artifact lists (preferring `en-US`). That needs no models, no ANE, and no `kesha install` — and
+So the darwin row synthesises through AVSpeech instead, picking a `voice.compact.en-US` voice
+(Samantha's class) from what the artifact lists. Compact voices ship with the OS; the third
+dispatch showed that an Eloquence voice — listed but a downloadable asset — fails on the runner
+with `avspeech helper exited status 3: timeout waiting for synthesis`, the classic
+missing-asset symptom. That needs no models, no ANE, and no `kesha install` — and
 it covers the sidecar spawn path end-to-end, which today is asserted only at list level. Kokoro
 on darwin stays uncovered in CI; #678 tracks closing that, and the spec records it as a known
 gap rather than an assumed pass.

--- a/openspec/changes/release-artifact-synthesis-smoke/design.md
+++ b/openspec/changes/release-artifact-synthesis-smoke/design.md
@@ -1,0 +1,130 @@
+## Context
+
+`build-engine.yml` builds each platform's Engine, stages it under its release asset name,
+smoke-tests it, and uploads it. The smoke step asserts `"tts"` is present in
+`--capabilities-json` and, on macOS only, that `say --list-voices` surfaces a `macos-*` entry
+and `en-am_michael`. Listing a voice proves the voice table compiled in; it does not run the
+synthesis pipeline.
+
+Three lanes in `ci.yml` do run a real round-trip, and none of them touches the artifact:
+
+| Lane | Binary under test |
+|---|---|
+| `published-engine-smoke`, `windows-engine-smoke` | the already-published asset of the current `keshaEngine.version` |
+| `release-branch-engine-smoke` (ubuntu + windows matrix) | a locally rebuilt Engine, same features, second compilation |
+
+This is deliberate, not an oversight — a release branch cannot download a tag that does not
+exist yet. But it leaves the uploaded bytes covered only by a human step in CLAUDE.md.
+
+Two constraints shape everything below. First, `build-engine.yml` is the most
+release-critical workflow in the repo and is never executed by a pull-request lane. Second,
+the tag job pushes the tag *before* the build job runs, and tag names are one-use — so a
+build that fails after tagging must be recoverable by re-running the run, not by cutting a
+new tag.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- The exact bytes that `actions/upload-artifact` uploads have synthesised English speech on
+  that same runner, in that same job, before the upload step runs.
+- One definition of "did it synthesise", shared with the existing round-trip lanes.
+- The change itself is provable before it reaches a release.
+- A static guard so a future edit cannot silently delete the gate, mirroring CLAUDE.md's
+  "Never remove that step" rule for the capabilities smoke.
+
+**Non-Goals:**
+
+- Transcribing the synthesised audio back on the release runner (needs the multi-GB ASR set).
+- Russian or any non-English voice on the linux/windows rows.
+- Replacing or weakening the existing `--capabilities-json` assertions.
+- Changing the release job, the publish path, or the CLAUDE.md draft-validation step.
+
+## Decisions
+
+### D1 — Drive synthesis through the CLI with `KESHA_ENGINE_BIN`, not the Engine directly
+
+The staged artifact is reached exactly as `release-branch-engine-smoke` reaches its local
+build: `KESHA_ENGINE_BIN=<staged path>`, a sibling `<path>.version` file written from
+`package.json#keshaEngine.version`, and `KESHA_CACHE_DIR` scoped to the workspace.
+
+*Alternative considered:* invoke the artifact directly (`./kesha-engine-linux-x64 say …`),
+skipping Bun and the CLI entirely. Fewer moving parts inside a release-critical workflow, and
+strictly narrower — the CLI's voice routing is not part of the artifact. Rejected because it
+would duplicate the WAV assertions in bash and, more importantly, would not reuse
+`install-kesha-backend`, whose caching is the difference between a free model restore and a
+cold download on every release (D3). The CLI layer it adds is already covered by unit tests
+on every PR, so a failure there is diagnosable rather than mysterious.
+
+### D2 — Reuse `smoke-synthesis.ts` behind a synthesis-only flag
+
+`.github/scripts/smoke-synthesis.ts` already synthesises, checks the RIFF/WAVE header, and
+rejects a header-only WAV. It then transcribes the result back, which this gate cannot afford.
+Add a flag (`--no-roundtrip`) that stops after the synthesis assertions, and restrict the
+voice list to English when it is set.
+
+*Alternative considered:* a second script. Rejected — two definitions of "did it synthesise"
+drift, and the assertions are the part worth sharing.
+
+### D3 — Restore models read-only from the existing `main`-scoped cache
+
+`install-kesha-backend` is called with `cache-write: "false"` and the existing key
+`${{ runner.os }}-kesha-models-tts-v1`, the same entry `published-engine-smoke` reads. No new
+cache entry is minted: the repo already sits at ~9.5 GiB against GitHub's 10 GB budget
+(#675), and a new key would evict something that is doing work.
+
+Open question deferred to T4: that entry is ~3.4 GB because it carries the ASR set too.
+Restoring 3.4 GB to use ~330 MB of it may be slower than a cold Kokoro-only download. Measure
+on the dry run; if the cold download wins, drop the cache step rather than adding a key.
+
+### D4 — macOS synthesises through `system_kokoro`, and its download is named
+
+The macOS row has no ONNX Kokoro. `fluid_kokoro::with_kokoro` calls `init_kokoro`, which
+"downloads the model on first run" into FluidAudio's own cache — outside `kesha install`, and
+inside `with_silenced_stdout_oneshot`, so a failure there surfaces as an opaque
+`Swift bridge error` (this is exactly the #661 failure mode). Two consequences:
+
+- The workflow step is named plainly as a download, the way `coreml-regression`'s cache step
+  already is, so the no-auto-download contract is not quietly violated by CI.
+- On failure the step inventories FluidAudio's model directory, so a truncated fetch shows up
+  as evidence instead of inference.
+
+### D5 — Prove the change with a build-only `workflow_dispatch`, and guard it statically
+
+`build-engine.yml` already accepts `workflow_dispatch` with an empty `tag`, which runs the
+`build` job from an arbitrary `ref`; the `release` job is gated on
+`startsWith(github.ref, 'refs/tags/v')` and therefore does not run. Dispatching the workflow
+against this change's branch executes the new steps on all three platforms and publishes
+nothing. That is the acceptance evidence for this change — #671's premise that the workflow
+"cannot be proven green by a normal PR" holds for PR lanes but not for a manual dispatch.
+
+Separately, `check-workflows.ts` (run by the `workflow-lint` job on every PR) gains an
+assertion that the synthesis step exists in `build-engine.yml` and precedes the upload step.
+That is the part a *future* PR can regress, and it is cheap to hold.
+
+## Risks / Trade-offs
+
+- **A network flake at release time fails the build after the tag is already pushed** →
+  Recover by re-running the workflow run for the same tag; a failed build does not consume the
+  tag, only a new *tag name* would. Call this out in the release runbook so nobody reaches for
+  a fresh tag by reflex.
+- **Cache restore may not be available on a `refs/tags/v*` run** (entries are written on
+  `main`) → The dry run reports it. Worst case is a cold download per platform per release,
+  which the build job's default 360-minute budget absorbs; if it is slow enough to hurt, D3's
+  fallback is to skip the cache entirely.
+- **The gate adds failure surface to the release path** → It only fails where a release
+  *should* fail; the alternative is shipping the failure. The existing assertions are left
+  untouched, and the new step sits between them and the upload.
+- **macOS diagnostics stay opaque under `with_silenced_stdout`** → Mitigated by the model-dir
+  inventory on failure (D4), not solved. Solving it means changing production stdout handling,
+  which is out of scope here.
+- **Wall-clock and runner cost per release grow** → One English model set per non-Darwin
+  platform, at release cadence only. #636 already judged this acceptable.
+
+## Open Questions
+
+- Does a workflow run triggered by `refs/tags/v*` restore a cache entry written on `main`?
+  Assumed yes (default-branch scope), unconfirmed against observed behaviour. T4 settles it.
+- Should the Windows row synthesise to OGG/Opus as well as WAV? #636 asks for both; the Opus
+  encoder is a distinct failure surface (`opusic-sys`, vendored libopus, the cmake policy
+  override). Deferred to a follow-up unless the dry run shows it is nearly free.

--- a/openspec/changes/release-artifact-synthesis-smoke/proposal.md
+++ b/openspec/changes/release-artifact-synthesis-smoke/proposal.md
@@ -26,9 +26,9 @@ gap the spec already asserts.
 - The existing `--capabilities-json` assertions stay exactly as they are; the synthesis
   round-trip is added after them, not in place of them.
 - linux-x64 and windows-x64 synthesise `en-am_michael` after `kesha install --tts en`.
-  darwin-arm64 synthesises through AVSpeech instead: FluidAudio pins the Kokoro vocoder to the
-  Neural Engine, which GitHub's `macos-14` VM does not expose (#678). AVSpeech needs no models
-  and covers the Swift sidecar's spawn path, asserted only at list level today.
+  darwin-arm64 is exempt: neither of its TTS engines runs on a GitHub-hosted macOS runner —
+  Kokoro's vocoder is pinned to the Neural Engine, which the VM does not expose, and the
+  AVSpeech sidecar times out on every voice (#678). Both work on real Apple Silicon.
 
 ## Capabilities
 
@@ -53,8 +53,9 @@ None. This change mechanises an obligation the `installation` spec already state
   same posture as the existing round-trip script ("Not asserting on WER").
 - **No new coverage for Russian / non-English voices on linux and windows.** English only, to
   keep one model download per platform per release.
-- **No CI coverage of darwin Kokoro.** Not achievable on an ANE-less runner; tracked in #678,
-  and recorded in the spec as a known gap rather than an assumed pass.
+- **No CI coverage of darwin synthesis.** Not achievable on a hosted macOS runner by either
+  engine; tracked in #678, and recorded in the spec as a known gap rather than an assumed pass.
+  The manual draft-asset check in CLAUDE.md remains darwin's only synthesis verification.
 - **No change to the release job, the publish path, or the draft-validation step in
   CLAUDE.md.** The human end-to-end check on the draft asset stays until this gate has proven
   itself across a release or two.

--- a/openspec/changes/release-artifact-synthesis-smoke/proposal.md
+++ b/openspec/changes/release-artifact-synthesis-smoke/proposal.md
@@ -1,0 +1,73 @@
+## Why
+
+`build-engine.yml` smoke-tests the exact binary it is about to upload, but only for
+`--capabilities-json` (plus a voice-list check on macOS). An Engine that links, starts, and
+advertises `"tts"` while failing at its first ONNX session passes that gate and ships. The
+three lanes that do prove synthesis all test a *different* binary — either the
+already-published asset of the current `keshaEngine.version`, or a second compilation on a
+second runner — so no lane exercises the artifact a release is about to publish.
+
+The installation spec already requires that verification "cover both the asset a user
+downloads today and the artifact a release is about to publish". Today only the first half is
+mechanised; the second is a human step in CLAUDE.md ("validate the draft binary first with
+authenticated `gh release download` … and exercise it end-to-end"). This change closes the
+gap the spec already asserts.
+
+## What Changes
+
+- The pre-upload smoke in `build-engine.yml` performs a real synthesis round-trip on every
+  matrix row, against the staged artifact, before `actions/upload-artifact` runs.
+- The round-trip is driven through the CLI pointed at the staged binary via
+  `KESHA_ENGINE_BIN` + a sibling `.version` file — the same mechanism
+  `release-branch-engine-smoke` already uses — so the artifact is exercised through the
+  Engine contract users hit, not a bespoke invocation.
+- Models come from `install-kesha-backend`, the existing composite action, keeping the
+  no-auto-download rule intact: the download is an explicit, named step.
+- The existing `--capabilities-json` assertions stay exactly as they are; the synthesis
+  round-trip is added after them, not in place of them.
+- linux-x64 and windows-x64 install the English Kokoro set through `kesha install --tts en`.
+  The macOS row reaches Kokoro in-engine through `system_kokoro`, whose weights FluidAudio
+  fetches into its own ANE cache on first `init_kokoro` — a download outside `kesha install`,
+  so the step is named plainly in the workflow, as `coreml-regression` already does for the
+  Parakeet bundle.
+
+## Capabilities
+
+### New Capabilities
+
+None. This change mechanises an obligation the `installation` spec already states.
+
+### Modified Capabilities
+
+- `installation`: the "Every shipped platform is verified end to end before release"
+  requirement gains a scenario for the pre-upload artifact gate, and its wording tightens
+  from "the artifact a release is about to publish" being covered by a faithful rebuild to
+  being covered by the uploaded bytes themselves.
+
+## Non-goals
+
+- **No transcription round-trip on the release build.** `.github/scripts/smoke-synthesis.ts`
+  transcribes its own output back, which needs the multi-GB ASR model set on the release
+  runner. Synthesis correctness is the bug class #636 names; ASR on the shipped artifact stays
+  with the published-asset lanes.
+- **No accuracy assertion.** The gate proves the Engine speaks, not that it speaks well —
+  same posture as the existing round-trip script ("Not asserting on WER").
+- **No new coverage for Russian / non-English voices on linux and windows.** English only, to
+  keep one model download per platform per release.
+- **No change to the release job, the publish path, or the draft-validation step in
+  CLAUDE.md.** The human end-to-end check on the draft asset stays until this gate has proven
+  itself across a release or two.
+- **No change to `ci.yml`'s existing smoke lanes.** They cover a different binary on purpose.
+
+## Impact
+
+- `.github/workflows/build-engine.yml` — the most release-critical workflow in the repo; a
+  broken edit here breaks releases and cannot be caught by `main`'s normal PR lanes. The
+  verification path for this change is the workflow's own `workflow_dispatch` with an empty
+  `tag` input, which runs `build` on a branch ref while `release` stays gated on
+  `startsWith(github.ref, 'refs/tags/v')`.
+- `.github/scripts/` — a synthesis-only entry point, split out of `smoke-synthesis.ts` so the
+  two callers share one definition of "did it synthesise".
+- Release wall-clock and cost: one English Kokoro download per non-Darwin release build,
+  amortised by the existing `main`-scoped model cache.
+- Closes #671 and #636. Refs #216, #464, #667.

--- a/openspec/changes/release-artifact-synthesis-smoke/proposal.md
+++ b/openspec/changes/release-artifact-synthesis-smoke/proposal.md
@@ -25,9 +25,10 @@ gap the spec already asserts.
   no-auto-download rule intact: the download is an explicit, named step.
 - The existing `--capabilities-json` assertions stay exactly as they are; the synthesis
   round-trip is added after them, not in place of them.
-- Every row installs the English TTS set through `kesha install --tts en`. On darwin that
-  install is what stages the SHA-pinned ANE voice packs (#475) FluidAudio then resolves
-  local-first; without it every voice but `af_heart` 404s against the upstream bundle.
+- linux-x64 and windows-x64 synthesise `en-am_michael` after `kesha install --tts en`.
+  darwin-arm64 synthesises through AVSpeech instead: FluidAudio pins the Kokoro vocoder to the
+  Neural Engine, which GitHub's `macos-14` VM does not expose (#678). AVSpeech needs no models
+  and covers the Swift sidecar's spawn path, asserted only at list level today.
 
 ## Capabilities
 
@@ -52,6 +53,8 @@ None. This change mechanises an obligation the `installation` spec already state
   same posture as the existing round-trip script ("Not asserting on WER").
 - **No new coverage for Russian / non-English voices on linux and windows.** English only, to
   keep one model download per platform per release.
+- **No CI coverage of darwin Kokoro.** Not achievable on an ANE-less runner; tracked in #678,
+  and recorded in the spec as a known gap rather than an assumed pass.
 - **No change to the release job, the publish path, or the draft-validation step in
   CLAUDE.md.** The human end-to-end check on the draft asset stays until this gate has proven
   itself across a release or two.

--- a/openspec/changes/release-artifact-synthesis-smoke/proposal.md
+++ b/openspec/changes/release-artifact-synthesis-smoke/proposal.md
@@ -25,11 +25,9 @@ gap the spec already asserts.
   no-auto-download rule intact: the download is an explicit, named step.
 - The existing `--capabilities-json` assertions stay exactly as they are; the synthesis
   round-trip is added after them, not in place of them.
-- linux-x64 and windows-x64 install the English Kokoro set through `kesha install --tts en`.
-  The macOS row reaches Kokoro in-engine through `system_kokoro`, whose weights FluidAudio
-  fetches into its own ANE cache on first `init_kokoro` — a download outside `kesha install`,
-  so the step is named plainly in the workflow, as `coreml-regression` already does for the
-  Parakeet bundle.
+- Every row installs the English TTS set through `kesha install --tts en`. On darwin that
+  install is what stages the SHA-pinned ANE voice packs (#475) FluidAudio then resolves
+  local-first; without it every voice but `af_heart` 404s against the upstream bundle.
 
 ## Capabilities
 

--- a/openspec/changes/release-artifact-synthesis-smoke/specs/installation/spec.md
+++ b/openspec/changes/release-artifact-synthesis-smoke/specs/installation/spec.md
@@ -41,14 +41,13 @@ SHALL NOT by itself be treated as evidence that the Engine initialises on that p
 - AND the file carries a RIFF/WAVE header and audio beyond the header
 - AND the upload step runs only after that check passes
 
-#### Scenario: A platform's default TTS engine cannot run on the build runner
+#### Scenario: No TTS engine can run on a platform's build runner
 
-- GIVEN darwin-arm64's default English engine requires the Neural Engine
-- AND the build runner is a virtual machine that does not expose one
-- WHEN the pre-upload smoke runs on that platform
-- THEN it synthesises through a Voice the runner can actually execute
-- AND the engine that could not be exercised is recorded as an uncovered gap, not reported as
-  verified
+- GIVEN every TTS engine available to the darwin-arm64 Engine needs hardware the build runner
+  does not provide
+- WHEN the release build runs on that platform
+- THEN the pre-upload synthesis gate does not run there
+- AND that platform is recorded as having unverified synthesis, not reported as verified
 
 #### Scenario: Capabilities advertise TTS but synthesis is broken
 
@@ -94,11 +93,12 @@ SHALL NOT by itself be treated as evidence that the Engine initialises on that p
 - Cache scope on tag-triggered runs: a branch `workflow_dispatch` restores the `main`-scoped
   entry, observed. The `refs/tags/v*` case is inferred from the same default-branch scope, not
   observed, and can only be observed on a real release.
-- darwin Kokoro has no CI coverage: FluidAudio pins the Kokoro vocoder stage to
-  `.cpuAndNeuralEngine`, GitHub's `macos-14` runner is an ANE-less VM, and `fluidaudio-rs` does
-  not plumb FluidAudio's documented `computeUnits` override. The darwin pre-upload smoke
-  therefore proves AVSpeech, not Kokoro. Tracked in #678; verified working on real Apple
-  Silicon, so this is a coverage gap, not a known defect.
+- darwin synthesis has no CI coverage by either engine. Kokoro pins its vocoder stage to
+  `.cpuAndNeuralEngine` and the `macos-14` runner is an ANE-less VM; the AVSpeech sidecar times
+  out on every voice tried, including an OS-bundled compact one, for reasons not yet
+  established. Both engines work on real Apple Silicon, so this is a coverage gap, not a known
+  defect. Tracked in #678; darwin's only synthesis verification remains the manual draft-asset
+  check in CLAUDE.md.
 - Engine version marker: `release-branch-engine-smoke` writes `${KESHA_ENGINE_BIN}.version`
   from `package.json#keshaEngine.version`. On a release build the tag is the authority for
   that version, and whether the two can disagree mid-release is not established here.

--- a/openspec/changes/release-artifact-synthesis-smoke/specs/installation/spec.md
+++ b/openspec/changes/release-artifact-synthesis-smoke/specs/installation/spec.md
@@ -41,6 +41,15 @@ SHALL NOT by itself be treated as evidence that the Engine initialises on that p
 - AND the file carries a RIFF/WAVE header and audio beyond the header
 - AND the upload step runs only after that check passes
 
+#### Scenario: A platform's default TTS engine cannot run on the build runner
+
+- GIVEN darwin-arm64's default English engine requires the Neural Engine
+- AND the build runner is a virtual machine that does not expose one
+- WHEN the pre-upload smoke runs on that platform
+- THEN it synthesises through a Voice the runner can actually execute
+- AND the engine that could not be exercised is recorded as an uncovered gap, not reported as
+  verified
+
 #### Scenario: Capabilities advertise TTS but synthesis is broken
 
 - GIVEN a staged Engine that starts and reports `tts` in its Capabilities JSON
@@ -85,6 +94,11 @@ SHALL NOT by itself be treated as evidence that the Engine initialises on that p
 - Cache scope on tag-triggered runs: a branch `workflow_dispatch` restores the `main`-scoped
   entry, observed. The `refs/tags/v*` case is inferred from the same default-branch scope, not
   observed, and can only be observed on a real release.
+- darwin Kokoro has no CI coverage: FluidAudio pins the Kokoro vocoder stage to
+  `.cpuAndNeuralEngine`, GitHub's `macos-14` runner is an ANE-less VM, and `fluidaudio-rs` does
+  not plumb FluidAudio's documented `computeUnits` override. The darwin pre-upload smoke
+  therefore proves AVSpeech, not Kokoro. Tracked in #678; verified working on real Apple
+  Silicon, so this is a coverage gap, not a known defect.
 - Engine version marker: `release-branch-engine-smoke` writes `${KESHA_ENGINE_BIN}.version`
   from `package.json#keshaEngine.version`. On a release build the tag is the authority for
   that version, and whether the two can disagree mid-release is not established here.

--- a/openspec/changes/release-artifact-synthesis-smoke/specs/installation/spec.md
+++ b/openspec/changes/release-artifact-synthesis-smoke/specs/installation/spec.md
@@ -1,0 +1,91 @@
+## MODIFIED Requirements
+
+### Requirement: Every shipped platform is verified end to end before release
+
+For each platform whose Engine is published, the release pipeline SHALL verify that the
+shipped binary performs real synthesis and real Transcription — not only that it builds
+and passes unit tests. A platform whose Engine ships without that verification SHALL be
+documented as unverified rather than presented as supported.
+
+Verification SHALL cover both the asset a user downloads today and the artifact a release is
+about to publish. These are different binaries reached by different means: a release branch
+cannot download its own Engine, because its tag does not exist until the release is un-drafted.
+
+The artifact half SHALL be satisfied by the uploaded bytes themselves. A separate compilation
+with the same features on a second runner is a reproduction, not the artifact, and SHALL NOT
+be treated as evidence that the published binary synthesises. The build pipeline SHALL
+therefore synthesise through the staged binary before that binary is uploaded, and SHALL fail
+the build rather than upload an Engine that cannot synthesise.
+
+Advertising a capability SHALL NOT be accepted as evidence of it. An Engine that starts and
+reports `tts` in its Capabilities JSON while failing at synthesis SHALL fail the pre-upload
+gate.
+
+Because the install-time ASR warm-up is non-fatal by design, a successful `kesha install`
+SHALL NOT by itself be treated as evidence that the Engine initialises on that platform.
+
+#### Scenario: Smoke on the published asset
+
+- GIVEN release v`<engineVersion>` publishes an Engine asset for a platform
+- WHEN the published-asset smoke lane runs on that platform
+- THEN it performs a cold `kesha install`, synthesises through `kesha say`, and
+  transcribes the result back
+- AND the lane does not run on `release/*` branches, whose tag is not yet published
+
+#### Scenario: The artifact synthesises before it is uploaded
+
+- GIVEN the build pipeline has staged the Engine binary for a platform under its release
+  asset name
+- WHEN the pre-upload smoke runs on that platform
+- THEN the CLI is pointed at that staged binary and synthesises English speech to a file
+- AND the file carries a RIFF/WAVE header and audio beyond the header
+- AND the upload step runs only after that check passes
+
+#### Scenario: Capabilities advertise TTS but synthesis is broken
+
+- GIVEN a staged Engine that starts and reports `tts` in its Capabilities JSON
+- AND its first synthesis call fails
+- WHEN the pre-upload smoke runs
+- THEN the build fails on that platform
+- AND no Engine artifact is uploaded for it
+
+#### Scenario: Ira changes the pre-upload gate
+
+- GIVEN Ira edits the release build pipeline, which normal pull-request lanes never execute
+- WHEN Ira runs the pipeline manually against the branch without naming a tag
+- THEN the build and its pre-upload smoke run on every platform
+- AND nothing is tagged, released, or published
+
+#### Scenario: Warm-up fails but install reports success
+
+- GIVEN the Engine installs and the CLI exits 0
+- AND the install log carries an ASR backend warm-up failure
+- WHEN the smoke lane inspects that log
+- THEN the lane fails rather than reporting the platform verified
+
+#### Scenario: Engine builds but cannot synthesise
+
+- GIVEN a platform's Engine compiles and its unit tests pass
+- AND its synthesis smoke fails
+- WHEN Ira consults the platform matrix
+- THEN that platform is not presented as supported
+
+> *Technical Note — sources: `.github/workflows/ci.yml` (`published-engine-smoke` on
+> ubuntu-latest, `windows-engine-smoke` on windows-latest — both run a cold install and
+> `.github/scripts/smoke-synthesis.ts`; `release-branch-engine-smoke` builds a local Engine and
+> reaches it through `KESHA_ENGINE_BIN` plus a sibling `.version` file),
+> `.github/workflows/build-engine.yml` (the `Smoke-test binary` step, which today asserts only
+> on `--capabilities-json` and, on macOS, `say --list-voices`; its `build` job runs on
+> `workflow_dispatch` with an empty `tag`, while the `release` job is gated on
+> `startsWith(github.ref, 'refs/tags/v')`), `.github/scripts/assert-install-warmup.ts`, and
+> `rust/src/cli/install.rs` (warm-up warns and continues, #298).*
+
+## Open Issues
+
+- Cache scope on tag-triggered runs: the model caches the pre-upload smoke would restore are
+  written on `main` (`cache-seed.yml`, #663). Whether a run triggered by `refs/tags/v*` may
+  restore a default-branch cache entry is not yet confirmed against observed behaviour. If it
+  cannot, every release build pays a cold model download and the timeout budget must absorb it.
+- Engine version marker: `release-branch-engine-smoke` writes `${KESHA_ENGINE_BIN}.version`
+  from `package.json#keshaEngine.version`. On a release build the tag is the authority for
+  that version, and whether the two can disagree mid-release is not established here.

--- a/openspec/changes/release-artifact-synthesis-smoke/specs/installation/spec.md
+++ b/openspec/changes/release-artifact-synthesis-smoke/specs/installation/spec.md
@@ -82,10 +82,9 @@ SHALL NOT by itself be treated as evidence that the Engine initialises on that p
 
 ## Open Issues
 
-- Cache scope on tag-triggered runs: the model caches the pre-upload smoke would restore are
-  written on `main` (`cache-seed.yml`, #663). Whether a run triggered by `refs/tags/v*` may
-  restore a default-branch cache entry is not yet confirmed against observed behaviour. If it
-  cannot, every release build pays a cold model download and the timeout budget must absorb it.
+- Cache scope on tag-triggered runs: a branch `workflow_dispatch` restores the `main`-scoped
+  entry, observed. The `refs/tags/v*` case is inferred from the same default-branch scope, not
+  observed, and can only be observed on a real release.
 - Engine version marker: `release-branch-engine-smoke` writes `${KESHA_ENGINE_BIN}.version`
   from `package.json#keshaEngine.version`. On a release build the tag is the authority for
   that version, and whether the two can disagree mid-release is not established here.

--- a/openspec/changes/release-artifact-synthesis-smoke/tasks.md
+++ b/openspec/changes/release-artifact-synthesis-smoke/tasks.md
@@ -1,0 +1,35 @@
+## 1. Shared synthesis assertion
+
+- [ ] 1.1 Add a `--no-roundtrip` flag to `.github/scripts/smoke-synthesis.ts` that stops after the WAV assertions and skips the transcribe-back leg (D2)
+- [ ] 1.2 Restrict the voice list to English (`en-am_michael`) when `--no-roundtrip` is set, leaving the default two-voice list untouched for existing callers
+- [ ] 1.3 Confirm the existing callers in `ci.yml` (`published-engine-smoke`, `windows-engine-smoke`) still pass the flagless form and behave identically
+
+## 2. Pre-upload gate in build-engine.yml
+
+- [ ] 2.1 Add `setup-bun` to the `build` job, before the smoke step
+- [ ] 2.2 Write `${{ matrix.binary }}.version` from `package.json#keshaEngine.version`, mirroring `release-branch-engine-smoke`'s "Mark local engine version" step
+- [ ] 2.3 Set `KESHA_ENGINE_BIN` to the staged artifact and `KESHA_CACHE_DIR` to a workspace path, job-scoped (D1)
+- [ ] 2.4 Install English TTS models via `install-kesha-backend` with `cache-write: "false"` and key `${{ runner.os }}-kesha-models-tts-v1` on the linux and windows rows (D3)
+- [ ] 2.5 On macOS, name the FluidAudio Kokoro fetch as an explicit download step and inventory the FluidAudio model directory on failure (D4)
+- [ ] 2.6 Run `bun .github/scripts/smoke-synthesis.ts --no-roundtrip <workdir>` after the existing `--capabilities-json` assertions and before `Upload engine artifact`
+- [ ] 2.7 Leave every existing assertion in the `Smoke-test binary` step byte-for-byte unchanged
+
+## 3. Static guard
+
+- [ ] 3.1 Extend `.github/scripts/check-workflows.ts` to assert `build-engine.yml` contains the synthesis step and that it precedes `Upload engine artifact` (D5)
+- [ ] 3.2 Add a unit test for that assertion covering both the present and the deleted case
+
+## 4. Verification
+
+- [ ] 4.1 `bun test && bunx tsc --noEmit`
+- [ ] 4.2 Push the branch and confirm `workflow-lint` is green on the head SHA
+- [ ] 4.3 Dispatch `build-engine.yml` against the branch with an empty `tag` input; confirm all three rows pass the new gate and the `release` job does not run
+- [ ] 4.4 Record from that run: whether the model cache restored on each platform, and the added wall-clock per row — settles D3's open question and the cache-scope question in the spec's Open Issues
+- [ ] 4.5 If the cache did not restore or cost more than a cold Kokoro download, drop the cache step per D3's fallback and re-dispatch
+
+## 5. Land
+
+- [ ] 5.1 Open the PR with `Closes #671, closes #636` in the body, linking the dispatch run as acceptance evidence
+- [ ] 5.2 Note in the PR that a failed release build is recovered by re-running the run, not by cutting a new tag (Risks)
+- [ ] 5.3 Wait for CI and Greptile on the head SHA; resolve P1/P2 findings
+- [ ] 5.4 After merge, remove the `WIP` label from #671 and #636 if the auto-close did not

--- a/openspec/changes/release-artifact-synthesis-smoke/tasks.md
+++ b/openspec/changes/release-artifact-synthesis-smoke/tasks.md
@@ -22,14 +22,14 @@
 ## 4. Verification
 
 - [x] 4.1 `bun test && bunx tsc --noEmit`
-- [ ] 4.2 Push the branch and confirm `workflow-lint` is green on the head SHA
+- [x] 4.2 Push the branch and confirm `workflow-lint` is green on the head SHA
 - [ ] 4.3 Dispatch `build-engine.yml` against the branch with an empty `tag` input; confirm all three rows pass the new gate and the `release` job does not run
 - [ ] 4.4 Record from that run: whether the model cache restored on each platform, and the added wall-clock per row — settles D3's open question and the cache-scope question in the spec's Open Issues
 - [ ] 4.5 If the cache did not restore or cost more than a cold Kokoro download, drop the cache step per D3's fallback and re-dispatch
 
 ## 5. Land
 
-- [ ] 5.1 Open the PR with `Closes #671, closes #636` in the body, linking the dispatch run as acceptance evidence
-- [ ] 5.2 Note in the PR that a failed release build is recovered by re-running the run, not by cutting a new tag (Risks)
+- [x] 5.1 Open the PR with `Closes #671, closes #636` in the body, linking the dispatch run as acceptance evidence
+- [x] 5.2 Note in the PR that a failed release build is recovered by re-running the run, not by cutting a new tag (Risks)
 - [ ] 5.3 Wait for CI and Greptile on the head SHA; resolve P1/P2 findings
 - [ ] 5.4 After merge, remove the `WIP` label from #671 and #636 if the auto-close did not

--- a/openspec/changes/release-artifact-synthesis-smoke/tasks.md
+++ b/openspec/changes/release-artifact-synthesis-smoke/tasks.md
@@ -1,27 +1,27 @@
 ## 1. Shared synthesis assertion
 
-- [ ] 1.1 Add a `--no-roundtrip` flag to `.github/scripts/smoke-synthesis.ts` that stops after the WAV assertions and skips the transcribe-back leg (D2)
-- [ ] 1.2 Restrict the voice list to English (`en-am_michael`) when `--no-roundtrip` is set, leaving the default two-voice list untouched for existing callers
-- [ ] 1.3 Confirm the existing callers in `ci.yml` (`published-engine-smoke`, `windows-engine-smoke`) still pass the flagless form and behave identically
+- [x] 1.1 Add a `--no-roundtrip` flag to `.github/scripts/smoke-synthesis.ts` that stops after the WAV assertions and skips the transcribe-back leg (D2)
+- [x] 1.2 Restrict the voice list to English (`en-am_michael`) when `--no-roundtrip` is set, leaving the default two-voice list untouched for existing callers
+- [x] 1.3 Confirm the existing callers in `ci.yml` (`published-engine-smoke`, `windows-engine-smoke`) still pass the flagless form and behave identically
 
 ## 2. Pre-upload gate in build-engine.yml
 
-- [ ] 2.1 Add `setup-bun` to the `build` job, before the smoke step
-- [ ] 2.2 Write `${{ matrix.binary }}.version` from `package.json#keshaEngine.version`, mirroring `release-branch-engine-smoke`'s "Mark local engine version" step
-- [ ] 2.3 Set `KESHA_ENGINE_BIN` to the staged artifact and `KESHA_CACHE_DIR` to a workspace path, job-scoped (D1)
-- [ ] 2.4 Install English TTS models via `install-kesha-backend` with `cache-write: "false"` and key `${{ runner.os }}-kesha-models-tts-v1` on the linux and windows rows (D3)
-- [ ] 2.5 On macOS, name the FluidAudio Kokoro fetch as an explicit download step and inventory the FluidAudio model directory on failure (D4)
-- [ ] 2.6 Run `bun .github/scripts/smoke-synthesis.ts --no-roundtrip <workdir>` after the existing `--capabilities-json` assertions and before `Upload engine artifact`
-- [ ] 2.7 Leave every existing assertion in the `Smoke-test binary` step byte-for-byte unchanged
+- [x] 2.1 Add `setup-bun` to the `build` job, before the smoke step
+- [x] 2.2 Write `${{ matrix.binary }}.version` from `package.json#keshaEngine.version`, mirroring `release-branch-engine-smoke`'s "Mark local engine version" step
+- [x] 2.3 Set `KESHA_ENGINE_BIN` to the staged artifact and `KESHA_CACHE_DIR` to a workspace path, job-scoped (D1)
+- [x] 2.4 Install English TTS models via `install-kesha-backend` with `cache-write: "false"` and key `${{ runner.os }}-kesha-models-tts-v1` on the linux and windows rows (D3)
+- [x] 2.5 On macOS, name the FluidAudio Kokoro fetch as an explicit download step and inventory the FluidAudio model directory on failure (D4)
+- [x] 2.6 Run `bun .github/scripts/smoke-synthesis.ts --no-roundtrip <workdir>` after the existing `--capabilities-json` assertions and before `Upload engine artifact`
+- [x] 2.7 Leave every existing assertion in the `Smoke-test binary` step byte-for-byte unchanged
 
 ## 3. Static guard
 
-- [ ] 3.1 Extend `.github/scripts/check-workflows.ts` to assert `build-engine.yml` contains the synthesis step and that it precedes `Upload engine artifact` (D5)
-- [ ] 3.2 Add a unit test for that assertion covering both the present and the deleted case
+- [x] 3.1 Extend `.github/scripts/check-workflows.ts` to assert `build-engine.yml` contains the synthesis step and that it precedes `Upload engine artifact` (D5)
+- [x] 3.2 Add a unit test for that assertion covering both the present and the deleted case
 
 ## 4. Verification
 
-- [ ] 4.1 `bun test && bunx tsc --noEmit`
+- [x] 4.1 `bun test && bunx tsc --noEmit`
 - [ ] 4.2 Push the branch and confirm `workflow-lint` is green on the head SHA
 - [ ] 4.3 Dispatch `build-engine.yml` against the branch with an empty `tag` input; confirm all three rows pass the new gate and the `release` job does not run
 - [ ] 4.4 Record from that run: whether the model cache restored on each platform, and the added wall-clock per row — settles D3's open question and the cache-scope question in the spec's Open Issues

--- a/openspec/changes/release-artifact-synthesis-smoke/tasks.md
+++ b/openspec/changes/release-artifact-synthesis-smoke/tasks.md
@@ -10,7 +10,7 @@
 - [x] 2.2 Write `${{ matrix.binary }}.version` from `package.json#keshaEngine.version`, mirroring `release-branch-engine-smoke`'s "Mark local engine version" step
 - [x] 2.3 Set `KESHA_ENGINE_BIN` to the staged artifact and `KESHA_CACHE_DIR` to a workspace path, job-scoped (D1)
 - [x] 2.4 Install English TTS models via `install-kesha-backend` with `cache-write: "false"` and key `${{ runner.os }}-kesha-models-tts-v1` on the linux and windows rows (D3)
-- [x] 2.5 On macOS, name the FluidAudio Kokoro fetch as an explicit download step and inventory the FluidAudio model directory on failure (D4)
+- [x] 2.5 Exempt the macOS row: neither of its TTS engines runs on a hosted macOS runner (D4, #678)
 - [x] 2.6 Run `bun .github/scripts/smoke-synthesis.ts --no-roundtrip <workdir>` after the existing `--capabilities-json` assertions and before `Upload engine artifact`
 - [x] 2.7 Leave every existing assertion in the `Smoke-test binary` step byte-for-byte unchanged
 
@@ -23,9 +23,9 @@
 
 - [x] 4.1 `bun test && bunx tsc --noEmit`
 - [x] 4.2 Push the branch and confirm `workflow-lint` is green on the head SHA
-- [ ] 4.3 Dispatch `build-engine.yml` against the branch with an empty `tag` input; confirm all three rows pass the new gate and the `release` job does not run
-- [ ] 4.4 Record from that run: whether the model cache restored on each platform, and the added wall-clock per row — settles D3's open question and the cache-scope question in the spec's Open Issues
-- [ ] 4.5 If the cache did not restore or cost more than a cold Kokoro download, drop the cache step per D3's fallback and re-dispatch
+- [x] 4.3 Dispatch `build-engine.yml` against the branch with an empty `tag` input; confirm the gated rows pass and the `release` job does not run
+- [x] 4.4 Record from that run: whether the model cache restored on each platform, and the added wall-clock per row — settles D3's open question and the cache-scope question in the spec's Open Issues
+- [x] 4.5 Cache restored in ~44s and the block cost ~55-60s per row, so D3's fallback was not needed
 
 ## 5. Land
 

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { parse } from "yaml";
+import { requirePreUploadSynthesisSmoke } from "../../.github/scripts/check-workflows";
+
+const PATH = ".github/workflows/build-engine.yml";
+
+function buildJob(steps: unknown[]) {
+  return { jobs: { build: { steps } } };
+}
+
+const SMOKE = { name: "smoke", run: "bun .github/scripts/smoke-synthesis.ts --no-roundtrip out" };
+const UPLOAD = { name: "upload", uses: "actions/upload-artifact@043fb46" };
+
+describe("requirePreUploadSynthesisSmoke", () => {
+  test("passes on the real build-engine.yml", () => {
+    expect(requirePreUploadSynthesisSmoke(PATH, parse(readFileSync(PATH, "utf8")))).toEqual([]);
+  });
+
+  test("ignores every other workflow", () => {
+    expect(requirePreUploadSynthesisSmoke(".github/workflows/ci.yml", buildJob([UPLOAD]))).toEqual([]);
+  });
+
+  test("fails when the synthesis smoke is deleted", () => {
+    const errors = requirePreUploadSynthesisSmoke(PATH, buildJob([UPLOAD]));
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("must run smoke-synthesis.ts before uploading");
+  });
+
+  test("fails when the smoke runs after the upload", () => {
+    const errors = requirePreUploadSynthesisSmoke(PATH, buildJob([UPLOAD, SMOKE]));
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("runs after the artifact is uploaded");
+  });
+
+  test("passes when the smoke precedes the upload", () => {
+    expect(requirePreUploadSynthesisSmoke(PATH, buildJob([SMOKE, UPLOAD]))).toEqual([]);
+  });
+
+  test("fails when the build job is gone", () => {
+    const errors = requirePreUploadSynthesisSmoke(PATH, { jobs: { release: {} } });
+    expect(errors[0]).toContain("expected a `build` job");
+  });
+});

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -37,6 +37,28 @@ describe("requirePreUploadSynthesisSmoke", () => {
     expect(requirePreUploadSynthesisSmoke(PATH, buildJob([SMOKE, UPLOAD]))).toEqual([]);
   });
 
+  test("fails when the smoke step is disabled", () => {
+    const errors = requirePreUploadSynthesisSmoke(PATH, buildJob([{ ...SMOKE, if: "false" }, UPLOAD]));
+    expect(errors[0]).toContain("must run smoke-synthesis.ts");
+  });
+
+  test("fails when the invocation is only mentioned, not run", () => {
+    for (const run of ["# bun .github/scripts/smoke-synthesis.ts out", 'echo "smoke-synthesis.ts"']) {
+      const errors = requirePreUploadSynthesisSmoke(PATH, buildJob([{ name: "x", run }, UPLOAD]));
+      expect(errors[0]).toContain("must run smoke-synthesis.ts");
+    }
+  });
+
+  test("accepts a platform-restricted smoke step", () => {
+    const step = { ...SMOKE, if: "matrix.os != 'macos-14'" };
+    expect(requirePreUploadSynthesisSmoke(PATH, buildJob([step, UPLOAD]))).toEqual([]);
+  });
+
+  test("fails when nothing uploads the artifact", () => {
+    const errors = requirePreUploadSynthesisSmoke(PATH, buildJob([SMOKE]));
+    expect(errors[0]).toContain("must upload the engine artifact");
+  });
+
   test("fails when the build job is gone", () => {
     const errors = requirePreUploadSynthesisSmoke(PATH, { jobs: { release: {} } });
     expect(errors[0]).toContain("expected a `build` job");

--- a/tests/unit/smoke-synthesis-args.test.ts
+++ b/tests/unit/smoke-synthesis-args.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { parseArgs } from "../../.github/scripts/smoke-synthesis";
+
+const ids = (argv: string[]) => parseArgs(argv)?.voices.map((v) => v.voice);
+
+describe("parseArgs", () => {
+  // The form all three ci.yml callers use; a regression here broke published-engine-smoke.
+  test("bare work-dir keeps the full round-trip voice list", () => {
+    const parsed = parseArgs(["/tmp/kesha-linux-synth"]);
+    expect(parsed?.workDir).toBe("/tmp/kesha-linux-synth");
+    expect(parsed?.noRoundtrip).toBe(false);
+    expect(parsed?.voices.map((v) => v.voice)).toEqual(["en-am_michael", "ru-vosk-m02"]);
+  });
+
+  test("--no-roundtrip drops to English and sets the flag", () => {
+    const parsed = parseArgs(["--no-roundtrip", "out"]);
+    expect(parsed?.workDir).toBe("out");
+    expect(parsed?.noRoundtrip).toBe(true);
+    expect(parsed?.voices.map((v) => v.voice)).toEqual(["en-am_michael"]);
+  });
+
+  test("--voice overrides the list on either side of the work-dir", () => {
+    expect(ids(["--voice", "macos-Sam", "out"])).toEqual(["macos-Sam"]);
+    expect(ids(["out", "--voice", "macos-Sam"])).toEqual(["macos-Sam"]);
+    expect(parseArgs(["out", "--voice", "macos-Sam"])?.workDir).toBe("out");
+  });
+
+  test("the voice value is never mistaken for the work-dir", () => {
+    expect(parseArgs(["--voice", "macos-Sam"])).toBeNull();
+  });
+
+  test("rejects a missing work-dir or a dangling --voice", () => {
+    expect(parseArgs([])).toBeNull();
+    expect(parseArgs(["--no-roundtrip"])).toBeNull();
+    expect(parseArgs(["out", "--voice"])).toBeNull();
+    expect(parseArgs(["--voice", "--no-roundtrip", "out"])).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

`build-engine.yml` smoke-tests the exact binary it is about to upload, but only for
`--capabilities-json` (plus a voice-list check on macOS). An engine that links, starts, and
advertises `"tts"` while failing at its first ONNX session passes that gate and ships.

The three lanes that *do* prove synthesis all test a different binary:

| Lane | Binary under test |
|---|---|
| `published-engine-smoke`, `windows-engine-smoke` | the already-published asset of the current `keshaEngine.version` |
| `release-branch-engine-smoke` | a locally rebuilt engine, same features, second compilation |

So the uploaded bytes were covered only by the manual step in CLAUDE.md.
`openspec/specs/installation` already requires verification to "cover both the asset a user
downloads today and the artifact a release is about to publish"; only the first half was
mechanised.

## Change

A synthesis round-trip on the staged artifact, before `Upload engine artifact`, on
**linux-x64 and windows-x64**:

- The CLI is pointed at the staged binary via `KESHA_ENGINE_BIN` plus a sibling `.version`
  marker — the mechanism `release-branch-engine-smoke` already uses. **That marker is
  load-bearing**: `downloadEngine` compares it against `package.json#keshaEngine.version` and on
  a mismatch downloads the *published* engine, whose tag does not exist yet during its own
  release build.
- `smoke-synthesis.ts` grows `--no-roundtrip` (stop after the WAV assertions, English only) and
  `--voice`. Existing callers pass the flagless form and are unchanged.
- Models restore **read-only** from `${{ runner.os }}-kesha-models-tts-v1`, the key
  `published-engine-smoke` already reads. No new cache entry: the repo sits at ~9.5 GiB of
  GitHub's 10 GB budget (#675).
- `check-workflows.ts` gains a static guard (with unit tests) asserting the smoke exists and
  precedes the upload — `build-engine.yml` runs on releases only, so no PR lane would otherwise
  notice its removal.

Every existing assertion in `Smoke-test binary` is untouched.

## Why darwin is excluded

Four build-only dispatches, each refuting the previous reading:

| Run | Failure | Reading |
|---|---|---|
| [1](https://github.com/drakulavich/kesha-voice-kit/actions/runs/30820762074) | `am_michael voice pack, statusCode: 404` | mine — the macOS row skipped `kesha install`, which is what stages the SHA-pinned ANE packs (#475) |
| [2](https://github.com/drakulavich/kesha-voice-kit/actions/runs/30821865229) | `predictionFailed(stage: "vocoder")` | `KokoroAneModelStore` pins the vocoder to `.cpuAndNeuralEngine`; `macos-14` is an ANE-less VM |
| [3](https://github.com/drakulavich/kesha-voice-kit/actions/runs/30831270088) | `avspeech helper: timeout waiting for synthesis` | guessed Eloquence voices are listed but not installed |
| [4](https://github.com/drakulavich/kesha-voice-kit/actions/runs/30831894696) | identical, on OS-bundled Samantha | refutes run 3 — AVSpeech fails for every voice |

So no TTS engine available to the darwin artifact runs on a hosted macOS runner. **The artifact
is fine** — the same feature set synthesises on an M2 through both engines (Kokoro
`en-am_michael` 24 kHz / 3.55 s / RMS 2653; AVSpeech 16 kHz float / 3.74 s / RMS 0.082).
FluidAudio documents a `computeUnits: .cpuAndGpu` escape hatch, but `fluidaudio-rs` never plumbs
it. Tracked darwin-wide in #678; the spec records darwin synthesis as unverified rather than
reporting it as passed.

## Verification

#671 notes a change here "cannot be proven green by a normal PR". True for PR lanes, but the
workflow accepts `workflow_dispatch` with an empty `tag`, which runs `build` from any ref while
`release` stays gated on `startsWith(github.ref, 'refs/tags/v')`. `tag` and `release` were
skipped on all four runs.

- [x] `bun test` (588 pass), `bunx tsc --noEmit`, `bun run check:workflows`, `openspec validate --strict`
- [x] linux-x64 and windows-x64 green on every dispatch
- [x] Cache restores on a branch dispatch (~44s); added cost ~55s linux / ~60s windows
- [ ] final dispatch on the macOS-excluded shape — [run 30836465979](https://github.com/drakulavich/kesha-voice-kit/actions/runs/30836465979)

The `refs/tags/v*` cache-scope case is inferred from the same default-branch scope, not
observed; it can only be observed on a real release. Recorded in the spec's Open Issues.

## Note for the release runbook

If this gate fails mid-release the tag has already been pushed. Recovery is **re-running the
workflow run**, not cutting a new tag — a failed build does not consume the tag name.

Planning artifacts: `openspec/changes/release-artifact-synthesis-smoke/`.

Closes #671, closes #636
Refs #216, #464, #667, #678

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzppPnnE76JDqGao3Zj4jq
