### PR TITLE
fix(cli): drive every init prompt through clack

### DIFF
--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1,7 +1,5 @@
 import { defineCommand } from "citty";
-import { createInterface } from "node:readline/promises";
-import { stdin as input, stdout as output } from "node:process";
-import { multiselect, isCancel, cancel } from "@clack/prompts";
+import { confirm, multiselect, isCancel, cancel } from "@clack/prompts";
 import { renderInstallPlan } from "../install-plan";
 import { log } from "../log";
 import { getEngineCapabilities } from "../engine";
@@ -23,6 +21,18 @@ const TTS_LANG_LABELS: Record<string, string> = {
 /** Signature of the interactive TTS-language picker (injectable for tests). */
 export type TtsLangPrompt = (preselect: string[]) => Promise<string[]>;
 
+/** Signature of the interactive yes/no prompt (injectable for tests). */
+export type ConfirmPrompt = (message: string, initialValue: boolean) => Promise<boolean>;
+
+/** Ctrl-C at any prompt ends init without downloading, rather than falling through with a default. */
+function exitIfCancelled<T>(answer: T | symbol): T {
+  if (isCancel(answer)) {
+    cancel("Init cancelled.");
+    process.exit(0);
+  }
+  return answer as T;
+}
+
 async function promptTtsLangs(preselect: string[]): Promise<string[]> {
   const caps = await getEngineCapabilities();
   const supported = caps?.tts?.languages.map((l) => l.code) ?? TTS_LANG_FALLBACK;
@@ -33,11 +43,12 @@ async function promptTtsLangs(preselect: string[]): Promise<string[]> {
     initialValues: preselect.filter((l) => supported.includes(l)),
     required: false,
   });
-  if (isCancel(selected)) {
-    cancel("Init cancelled.");
-    process.exit(0);
-  }
-  return selected as string[];
+  return exitIfCancelled(selected);
+}
+
+/** #677: keep every prompt on clack — its close() unpipes stdin, deadlocking any readline sharing it. */
+async function promptConfirm(message: string, initialValue: boolean): Promise<boolean> {
+  return exitIfCancelled(await confirm({ message, initialValue }));
 }
 
 export interface InitCommandArgs extends SharedInstallArgs {
@@ -50,10 +61,6 @@ export interface InitSelection {
   ttsLangs: string[];
   vad: boolean;
   diarize: boolean;
-}
-
-interface PromptApi {
-  question(prompt: string): Promise<string>;
 }
 
 export function canInstallDiarizeOnPlatform(
@@ -140,17 +147,17 @@ export function renderInitOverview(canDiarize = canInstallDiarizeOnPlatform()): 
 
 export async function promptInitSelection(
   args: InitCommandArgs,
-  prompt: PromptApi,
+  prompt: ConfirmPrompt,
   backend = resolveBackendFlag(args.coreml, args.onnx),
   canDiarize = canInstallDiarizeOnPlatform(),
   noCache = resolveNoCacheFlag(args),
   promptTts: TtsLangPrompt = promptTtsLangs,
 ): Promise<InitSelection> {
   const ttsLangs = await promptTts(args.tts ? ["en"] : []);
-  const vad = await askYesNo(prompt, "Install VAD for long or silence-heavy audio?", args.vad);
+  const vad = await prompt("Install VAD for long or silence-heavy audio?", args.vad);
   let diarize = false;
   if (canDiarize) {
-    diarize = await askYesNo(prompt, "Install speaker diarization for `--speakers`?", args.diarize);
+    diarize = await prompt("Install speaker diarization for `--speakers`?", args.diarize);
   } else if (args.diarize) {
     log.warn("--diarize is currently darwin-arm64 only; omitting it from the interactive install.");
   }
@@ -162,17 +169,6 @@ export async function promptInitSelection(
     vad,
     diarize,
   };
-}
-
-async function askYesNo(prompt: PromptApi, message: string, defaultValue: boolean): Promise<boolean> {
-  const suffix = defaultValue ? "Y/n" : "y/N";
-  for (;;) {
-    const answer = (await prompt.question(`${message} [${suffix}] `)).trim().toLowerCase();
-    if (answer === "") return defaultValue;
-    if (answer === "y" || answer === "yes") return true;
-    if (answer === "n" || answer === "no") return false;
-    log.warn("Please answer yes or no.");
-  }
 }
 
 async function printPlan(selection: InitSelection): Promise<void> {
@@ -282,33 +278,36 @@ export const initCommand = defineCommand({
     }
 
     log.info(renderInitOverview());
-    const rl = createInterface({ input, output });
-    try {
-      const prompted = await promptInitSelection(args, rl, backend, canInstallDiarizeOnPlatform(), noCache);
-      log.info("");
-      await printPlan(prompted);
-      const confirmed = await askYesNo(rl, `Run \`${initInstallArgs(prompted).join(" ")}\` now?`, true);
-      if (!confirmed) {
-        log.info(`Skipped install. Run later: ${initInstallArgs(prompted).join(" ")}`);
-        return;
-      }
-      await performInstall(
-        prompted.noCache,
-        prompted.backend,
-        prompted.ttsLangs,
-        prompted.vad,
-        prompted.diarize,
-      );
-      // Next-steps hint (#523): leave the user with something runnable rather
-      // than ending on the install log.
-      log.info("");
-      log.success("Kesha is ready. Try:");
-      log.info("  kesha path/to/audio.ogg     Transcribe a file.");
-      if (prompted.ttsLangs.length > 0) {
-        log.info('  kesha say "hello"           Speak text (TTS).');
-      }
-    } finally {
-      rl.close();
+    const prompted = await promptInitSelection(
+      args,
+      promptConfirm,
+      backend,
+      canInstallDiarizeOnPlatform(),
+      noCache,
+    );
+    log.info("");
+    await printPlan(prompted);
+    const confirmed = await promptConfirm(
+      `Run \`${initInstallArgs(prompted).join(" ")}\` now?`,
+      true,
+    );
+    if (!confirmed) {
+      log.info(`Skipped install. Run later: ${initInstallArgs(prompted).join(" ")}`);
+      return;
+    }
+    await performInstall(
+      prompted.noCache,
+      prompted.backend,
+      prompted.ttsLangs,
+      prompted.vad,
+      prompted.diarize,
+    );
+    // #523: end on something runnable, not on the install log.
+    log.info("");
+    log.success("Kesha is ready. Try:");
+    log.info("  kesha path/to/audio.ogg     Transcribe a file.");
+    if (prompted.ttsLangs.length > 0) {
+      log.info('  kesha say "hello"           Speak text (TTS).');
     }
   },
 });

--- a/tests/unit/init.test.ts
+++ b/tests/unit/init.test.ts
@@ -76,11 +76,9 @@ describe("init onboarding", () => {
     try {
       const selection = await promptInitSelection(
         initArgs({ diarize: true }),
-        {
-          async question(prompt: string) {
-            prompts.push(prompt);
-            return "";
-          },
+        async (message, initialValue) => {
+          prompts.push(message);
+          return initialValue;
         },
         undefined,
         false,
@@ -94,8 +92,7 @@ describe("init onboarding", () => {
       expect(selection.diarize).toBe(false);
       expect(selection.ttsLangs).toEqual([]);
       expect(initInstallArgs(selection)).toEqual(["kesha", "install"]);
-      // TTS is now a multiselect handled outside the yes/no PromptApi, so only
-      // the VAD question flows through `question` (diarize skipped off darwin).
+      // TTS is a multiselect, diarize is skipped off darwin — only VAD is a yes/no here.
       expect(prompts).toHaveLength(1);
       expect(prompts.join("\n")).not.toContain("diarization");
       expect(ttsPreselects).toEqual([[]]);
@@ -110,11 +107,7 @@ describe("init onboarding", () => {
     try {
       const selection = await promptInitSelection(
         initArgs({ tts: true }),
-        {
-          async question() {
-            return "";
-          },
-        },
+        async (_message, initialValue) => initialValue,
         undefined,
         false,
         false,
@@ -125,6 +118,33 @@ describe("init onboarding", () => {
     } finally {
       console.error = savedError;
     }
+  });
+
+  test("preselect flags arrive as the confirm prompt's initial value", async () => {
+    const initialValues: boolean[] = [];
+    const selection = await promptInitSelection(
+      initArgs({ vad: true }),
+      async (_message, initialValue) => {
+        initialValues.push(initialValue);
+        return initialValue;
+      },
+      undefined,
+      false,
+      false,
+      async () => [],
+    );
+
+    expect(initialValues).toEqual([true]);
+    expect(selection.vad).toBe(true);
+  });
+
+  test("init drives every prompt through @clack/prompts", async () => {
+    // #677: a node:readline interface sharing stdin with clack deadlocks after clack closes.
+    const source = await Bun.file(new URL("../../src/cli/init.ts", import.meta.url)).text();
+    const imported = [...source.matchAll(/^import .*?from "(.+?)";$/gm)].map((m) => m[1]);
+
+    expect(imported).toContain("@clack/prompts");
+    expect(imported.filter((m) => m.startsWith("node:readline"))).toEqual([]);
   });
 
   test("non-interactive suggestions preserve backend and cache flags", () => {


### PR DESCRIPTION
Closes #677

`kesha init` hung at the first yes/no question — the prompt rendered, the terminal echoed typed characters, and Enter never returned.

## Cause

`src/cli/init.ts` drove one stdin with two prompt libraries. A `node:readline/promises` interface was created up front, then the TTS multiselect from `@clack/prompts` ran on that same stdin. `@clack/core`s `Prompt.close()` calls `input.unpipe()`, removes its keypress listener, and closes its own readline interface — after which the outer `rl` never receives another line and `rl.question()` never resolves.

Ordering is what made it visible. Readline was fine while the clack prompt came last; #519 put the multiselect *first*, ahead of the three readline questions (VAD, diarization, final confirm).

## Change

`askYesNo` and the `PromptApi` interface are gone. Yes/no prompts now go through clacks `confirm()` behind a `ConfirmPrompt` type alias, mirroring the existing `TtsLangPrompt` injection point, so tests still pass a fake. `node:readline/promises` is no longer imported, and the shared cancel handling collapses into `exitIfCancelled`.

This removes the failure mode instead of reordering around it, and drops the visual mismatch where the multiselect rendered in clack chrome while the questions were bare text.

Interaction is preserved: clacks confirm accepts `y`/`n` keypresses, and Enter still takes the preselected default (`--vad`, `--diarize` still preselect).

## Verification

- `bun test` — 561 pass, 28 skip, 0 fail
- `bunx tsc --noEmit` — clean
- End-to-end under a real pty (`expect`, 120-column tty), same harness against both trees:

| tree | result |
| --- | --- |
| `main` | **HUNG at VAD question** |
| this branch | multiselect → VAD → diarization → final confirm → `Skipped install` |

Nothing was downloaded — the final confirm was declined.

New regression tests: the confirm prompt receives the preselect as its initial value, and `src/cli/init.ts` imports `@clack/prompts` and no `node:readline` (the deadlock itself needs a pty, so the import is the guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FkpxF1agJV6kpBdWpYo4YH