### PR TITLE
fix(install): stream model-install output instead of buffering it

### DIFF
--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -4,6 +4,7 @@ use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
 
 use crate::coded_bail;
 use crate::errors::{CodedContext, ErrorCode};
@@ -1523,7 +1524,7 @@ fn download_verified(cache: &Path, f: &ModelFile, no_cache: bool) -> Result<()> 
     if target.exists() {
         if verify_sha256(&target, f.sha256)? {
             if !no_cache {
-                eprintln!("OK  {} (cached)", f.rel_path);
+                with_stderr(|| eprintln!("OK  {} (cached)", f.rel_path));
                 return Ok(());
             }
             // no_cache over a valid file: keep it in place until a verified
@@ -1538,7 +1539,10 @@ fn download_verified(cache: &Path, f: &ModelFile, no_cache: bool) -> Result<()> 
     if let Some(parent) = target.parent() {
         fs::create_dir_all(parent)?;
     }
-    eprintln!("GET {}", f.rel_path);
+    // Claim in-flight before announcing: the request below blocks on headers, and a
+    // sibling's bar must stop repainting over this row first (Greptile P1 on #681).
+    let _in_flight = InFlight::new();
+    with_stderr(|| eprintln!("GET {}", f.rel_path));
     let url = apply_mirror(f.url);
     // Include the resolved URL in the error chain (#275 D11). On
     // `KESHA_MODEL_MIRROR`-redirected downloads, the user otherwise has no
@@ -1555,14 +1559,13 @@ fn download_verified(cache: &Path, f: &ModelFile, no_cache: bool) -> Result<()> 
         .and_then(|v| v.parse::<u64>().ok())
         .unwrap_or(0);
     let mut reader = response.into_body().into_reader();
-    let _in_flight = InFlight::new();
     if total >= PROGRESS_MIN_BYTES && io::IsTerminal::is_terminal(&io::stderr()) {
         let mut reader = ProgressReader::new(&mut reader, total);
         write_verified(&mut reader, &target, f.rel_path, f.sha256)?;
     } else {
         write_verified(&mut reader, &target, f.rel_path, f.sha256)?;
     }
-    eprintln!("OK  {}", f.rel_path);
+    with_stderr(|| eprintln!("OK  {}", f.rel_path));
     Ok(())
 }
 
@@ -1572,6 +1575,14 @@ const PROGRESS_INTERVAL: std::time::Duration = std::time::Duration::from_millis(
 const PROGRESS_BAR_WIDTH: usize = 20;
 
 static DOWNLOADS_IN_FLIGHT: AtomicUsize = AtomicUsize::new(0);
+static STDERR_LINE: Mutex<()> = Mutex::new(());
+
+/// Serializes install-progress writes. A bar repaint reads the in-flight count under
+/// this lock, so a worker that claimed a slot can't have its `GET` painted over.
+fn with_stderr<T>(write: impl FnOnce() -> T) -> T {
+    let _guard = STDERR_LINE.lock().unwrap_or_else(|e| e.into_inner());
+    write()
+}
 
 /// Counts concurrent `download_verified` network phases so the bar can tell whether it owns stderr.
 struct InFlight;
@@ -1626,24 +1637,26 @@ impl<R: io::Read> ProgressReader<R> {
     }
 
     fn draw(&mut self) {
-        if DOWNLOADS_IN_FLIGHT.load(Ordering::SeqCst) != 1 {
-            self.close_line();
-            return;
-        }
-        let pct = ((self.read.min(self.total) as f64 / self.total as f64) * 100.0) as usize;
-        let filled = pct * PROGRESS_BAR_WIDTH / 100;
-        // No file name — a deep path wraps the line, and then `\r` can't repaint it (Greptile P2 on #681).
-        let line = format!(
-            "    [{}{}] {:>3}%  {:.1}/{:.1}MB",
-            "█".repeat(filled),
-            "░".repeat(PROGRESS_BAR_WIDTH - filled),
-            pct,
-            self.read as f64 / 1_048_576.0,
-            self.total as f64 / 1_048_576.0,
-        );
-        eprint!("\r{line}");
-        let _ = io::Write::flush(&mut io::stderr());
-        self.line_len = line.chars().count();
+        with_stderr(|| {
+            if DOWNLOADS_IN_FLIGHT.load(Ordering::SeqCst) != 1 {
+                self.close_line();
+                return;
+            }
+            let pct = ((self.read.min(self.total) as f64 / self.total as f64) * 100.0) as usize;
+            let filled = pct * PROGRESS_BAR_WIDTH / 100;
+            // No file name — a deep path wraps the line, and then `\r` can't repaint it (Greptile P2 on #681).
+            let line = format!(
+                "    [{}{}] {:>3}%  {:.1}/{:.1}MB",
+                "█".repeat(filled),
+                "░".repeat(PROGRESS_BAR_WIDTH - filled),
+                pct,
+                self.read as f64 / 1_048_576.0,
+                self.total as f64 / 1_048_576.0,
+            );
+            eprint!("\r{line}");
+            let _ = io::Write::flush(&mut io::stderr());
+            self.line_len = line.chars().count();
+        });
     }
 }
 
@@ -1662,9 +1675,12 @@ impl<R: io::Read> io::Read for ProgressReader<R> {
 /// End the line here, not at EOF, so a mid-download bail prints its error on a fresh row.
 impl<R> Drop for ProgressReader<R> {
     fn drop(&mut self) {
-        if self.line_len > 0 {
-            eprintln!();
-        }
+        let line_len = self.line_len;
+        with_stderr(|| {
+            if line_len > 0 {
+                eprintln!();
+            }
+        });
     }
 }
 

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -1552,12 +1552,8 @@ fn download_verified(cache: &Path, f: &ModelFile, no_cache: bool) -> Result<()> 
         .call()
         .with_context(|| format!("GET {url} ({})", f.rel_path))
         .coded(ErrorCode::ModelDownload)?;
-    let total = response
-        .headers()
-        .get("content-length")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|v| v.parse::<u64>().ok())
-        .unwrap_or(0);
+    // Not the raw header — that one reports the compressed size when decompression is active.
+    let total = response.body().content_length().unwrap_or(0);
     let mut reader = response.into_body().into_reader();
     if total >= PROGRESS_MIN_BYTES && io::IsTerminal::is_terminal(&io::stderr()) {
         let mut reader = ProgressReader::new(&mut reader, total);
@@ -1575,12 +1571,26 @@ const PROGRESS_INTERVAL: std::time::Duration = std::time::Duration::from_millis(
 const PROGRESS_BAR_WIDTH: usize = 20;
 
 static DOWNLOADS_IN_FLIGHT: AtomicUsize = AtomicUsize::new(0);
-static STDERR_LINE: Mutex<()> = Mutex::new(());
+/// `true` while a bar repaint has left the cursor mid-row. Guarded by the same lock
+/// as the writes themselves, so ownership of the row transfers atomically.
+static BAR_LINE_OPEN: Mutex<bool> = Mutex::new(false);
 
-/// Serializes install-progress writes. A bar repaint reads the in-flight count under
-/// this lock, so a worker that claimed a slot can't have its `GET` painted over.
+fn lock_stderr() -> std::sync::MutexGuard<'static, bool> {
+    BAR_LINE_OPEN.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+fn end_open_bar_line(open: &mut bool) {
+    if *open {
+        eprintln!();
+        *open = false;
+    }
+}
+
+/// Serializes install-progress writes and ends any open bar row first: the bar paints
+/// with `\r` and no newline, so an `eprintln!` would otherwise land inside that row.
 fn with_stderr<T>(write: impl FnOnce() -> T) -> T {
-    let _guard = STDERR_LINE.lock().unwrap_or_else(|e| e.into_inner());
+    let mut open = lock_stderr();
+    end_open_bar_line(&mut open);
     write()
 }
 
@@ -1613,7 +1623,6 @@ struct ProgressReader<R> {
     total: u64,
     read: u64,
     last_draw: std::time::Instant,
-    line_len: usize,
 }
 
 impl<R: io::Read> ProgressReader<R> {
@@ -1623,40 +1632,28 @@ impl<R: io::Read> ProgressReader<R> {
             total,
             read: 0,
             last_draw: std::time::Instant::now(),
-            line_len: 0,
-        }
-    }
-
-    /// End the line instead of blanking it: once another worker has printed, the
-    /// cursor may have left our row, and an erase would eat that worker's output.
-    fn close_line(&mut self) {
-        if self.line_len > 0 {
-            eprintln!();
-            self.line_len = 0;
         }
     }
 
     fn draw(&mut self) {
-        with_stderr(|| {
-            if DOWNLOADS_IN_FLIGHT.load(Ordering::SeqCst) != 1 {
-                self.close_line();
-                return;
-            }
-            let pct = ((self.read.min(self.total) as f64 / self.total as f64) * 100.0) as usize;
-            let filled = pct * PROGRESS_BAR_WIDTH / 100;
-            // No file name — a deep path wraps the line, and then `\r` can't repaint it (Greptile P2 on #681).
-            let line = format!(
-                "    [{}{}] {:>3}%  {:.1}/{:.1}MB",
-                "█".repeat(filled),
-                "░".repeat(PROGRESS_BAR_WIDTH - filled),
-                pct,
-                self.read as f64 / 1_048_576.0,
-                self.total as f64 / 1_048_576.0,
-            );
-            eprint!("\r{line}");
-            let _ = io::Write::flush(&mut io::stderr());
-            self.line_len = line.chars().count();
-        });
+        let mut open = lock_stderr();
+        if DOWNLOADS_IN_FLIGHT.load(Ordering::SeqCst) != 1 {
+            end_open_bar_line(&mut open);
+            return;
+        }
+        let pct = ((self.read.min(self.total) as f64 / self.total as f64) * 100.0) as usize;
+        let filled = pct * PROGRESS_BAR_WIDTH / 100;
+        // No file name — a deep path wraps the line, and then `\r` can't repaint it (Greptile P2 on #681).
+        eprint!(
+            "\r    [{}{}] {:>3}%  {:.1}/{:.1}MB",
+            "█".repeat(filled),
+            "░".repeat(PROGRESS_BAR_WIDTH - filled),
+            pct,
+            self.read as f64 / 1_048_576.0,
+            self.total as f64 / 1_048_576.0,
+        );
+        let _ = io::Write::flush(&mut io::stderr());
+        *open = true;
     }
 }
 
@@ -1675,12 +1672,7 @@ impl<R: io::Read> io::Read for ProgressReader<R> {
 /// End the line here, not at EOF, so a mid-download bail prints its error on a fresh row.
 impl<R> Drop for ProgressReader<R> {
     fn drop(&mut self) {
-        let line_len = self.line_len;
-        with_stderr(|| {
-            if line_len > 0 {
-                eprintln!();
-            }
-        });
+        end_open_bar_line(&mut lock_stderr());
     }
 }
 
@@ -2008,14 +2000,36 @@ mod progress_tests {
         let _a = InFlight::new();
         let _b = InFlight::new();
         reader.draw();
-        assert_eq!(reader.line_len, 0, "must not draw beside another download");
+        assert!(!*lock_stderr(), "must not draw beside another download");
 
         drop(_b);
         reader.read = payload.len() as u64;
         reader.draw();
-        assert!(
-            reader.line_len > 0,
-            "must draw when it is the only download"
-        );
+        assert!(*lock_stderr(), "must draw when it is the only download");
+    }
+
+    /// A sibling's `GET`/`OK` must not land inside the bar's open `\r` row (grok review on #681).
+    #[test]
+    fn sibling_write_ends_the_open_bar_row() {
+        let payload = vec![7u8; 512];
+        let mut reader = ProgressReader::new(payload.as_slice(), payload.len() as u64);
+        let _alone = InFlight::new();
+        reader.draw();
+        assert!(*lock_stderr(), "bar row is open");
+
+        with_stderr(|| {});
+        assert!(!*lock_stderr(), "a non-bar write must close the row first");
+    }
+
+    #[test]
+    fn dropping_the_reader_ends_the_open_bar_row() {
+        let payload = vec![7u8; 512];
+        let _alone = InFlight::new();
+        {
+            let mut reader = ProgressReader::new(payload.as_slice(), payload.len() as u64);
+            reader.draw();
+            assert!(*lock_stderr(), "bar row is open");
+        }
+        assert!(!*lock_stderr(), "drop must close the row");
     }
 }

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -1547,10 +1547,84 @@ fn download_verified(cache: &Path, f: &ModelFile, no_cache: bool) -> Result<()> 
         .call()
         .with_context(|| format!("GET {url} ({})", f.rel_path))
         .coded(ErrorCode::ModelDownload)?;
+    let total = response
+        .headers()
+        .get("content-length")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(0);
     let mut reader = response.into_body().into_reader();
-    write_verified(&mut reader, &target, f.rel_path, f.sha256)?;
+    if total >= PROGRESS_MIN_BYTES && io::IsTerminal::is_terminal(&io::stderr()) {
+        let mut reader = ProgressReader::new(&mut reader, f.rel_path, total);
+        write_verified(&mut reader, &target, f.rel_path, f.sha256)?;
+    } else {
+        write_verified(&mut reader, &target, f.rel_path, f.sha256)?;
+    }
     eprintln!("OK  {}", f.rel_path);
     Ok(())
+}
+
+/// Below this a download finishes fast enough that a bar is noise, not feedback.
+const PROGRESS_MIN_BYTES: u64 = 16 * 1024 * 1024;
+const PROGRESS_INTERVAL: std::time::Duration = std::time::Duration::from_millis(200);
+const PROGRESS_BAR_WIDTH: usize = 20;
+
+/// Redraws a single `\r` line as bytes arrive (#680). Silent unless stderr is a
+/// terminal, so redirected installs and CI logs keep the plain `GET`/`OK` lines.
+struct ProgressReader<'a, R> {
+    inner: R,
+    rel_path: &'a str,
+    total: u64,
+    read: u64,
+    last_draw: std::time::Instant,
+}
+
+impl<'a, R: io::Read> ProgressReader<'a, R> {
+    fn new(inner: R, rel_path: &'a str, total: u64) -> Self {
+        Self {
+            inner,
+            rel_path,
+            total,
+            read: 0,
+            last_draw: std::time::Instant::now(),
+        }
+    }
+
+    fn draw(&self) {
+        let pct = ((self.read.min(self.total) as f64 / self.total as f64) * 100.0) as usize;
+        let filled = pct * PROGRESS_BAR_WIDTH / 100;
+        eprint!(
+            "\r    [{}{}] {:>3}%  {:.1}/{:.1}MB  {}",
+            "█".repeat(filled),
+            "░".repeat(PROGRESS_BAR_WIDTH - filled),
+            pct,
+            self.read as f64 / 1_048_576.0,
+            self.total as f64 / 1_048_576.0,
+            self.rel_path
+        );
+        let _ = io::Write::flush(&mut io::stderr());
+    }
+}
+
+impl<R: io::Read> io::Read for ProgressReader<'_, R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let n = self.inner.read(buf)?;
+        self.read += n as u64;
+        if n == 0 || self.last_draw.elapsed() >= PROGRESS_INTERVAL {
+            self.draw();
+            self.last_draw = std::time::Instant::now();
+        }
+        Ok(n)
+    }
+}
+
+/// Close the `\r` line here, not at EOF, so a mid-download bail doesn't print its error onto the bar.
+impl<R> Drop for ProgressReader<'_, R> {
+    fn drop(&mut self) {
+        if self.read > 0 {
+            eprintln!();
+        }
+    }
 }
 
 /// Stream `reader` into `target` atomically: bytes land in a per-process

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -3,6 +3,7 @@ use std::ffi::OsString;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::coded_bail;
 use crate::errors::{CodedContext, ErrorCode};
@@ -1554,8 +1555,9 @@ fn download_verified(cache: &Path, f: &ModelFile, no_cache: bool) -> Result<()> 
         .and_then(|v| v.parse::<u64>().ok())
         .unwrap_or(0);
     let mut reader = response.into_body().into_reader();
+    let _in_flight = InFlight::new();
     if total >= PROGRESS_MIN_BYTES && io::IsTerminal::is_terminal(&io::stderr()) {
-        let mut reader = ProgressReader::new(&mut reader, f.rel_path, total);
+        let mut reader = ProgressReader::new(&mut reader, total);
         write_verified(&mut reader, &target, f.rel_path, f.sha256)?;
     } else {
         write_verified(&mut reader, &target, f.rel_path, f.sha256)?;
@@ -1569,44 +1571,83 @@ const PROGRESS_MIN_BYTES: u64 = 16 * 1024 * 1024;
 const PROGRESS_INTERVAL: std::time::Duration = std::time::Duration::from_millis(200);
 const PROGRESS_BAR_WIDTH: usize = 20;
 
+static DOWNLOADS_IN_FLIGHT: AtomicUsize = AtomicUsize::new(0);
+
+/// Counts concurrent `download_verified` network phases so the bar can tell whether it owns stderr.
+struct InFlight;
+
+impl InFlight {
+    fn new() -> Self {
+        DOWNLOADS_IN_FLIGHT.fetch_add(1, Ordering::SeqCst);
+        Self
+    }
+}
+
+impl Drop for InFlight {
+    fn drop(&mut self) {
+        DOWNLOADS_IN_FLIGHT.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
 /// Redraws a single `\r` line as bytes arrive (#680). Silent unless stderr is a
 /// terminal, so redirected installs and CI logs keep the plain `GET`/`OK` lines.
-struct ProgressReader<'a, R> {
+///
+/// Draws only while it is the sole download in flight: `parallel_download` runs
+/// 4 rayon workers over one stderr, and concurrent bars plus other workers'
+/// `GET`/`OK` lines would overwrite each other (Greptile P1 on #681). That still
+/// covers the case this exists for — the 2.4GB encoder outlives every sibling by
+/// minutes, so the long silent stretch is exactly when the bar is alone.
+struct ProgressReader<R> {
     inner: R,
-    rel_path: &'a str,
     total: u64,
     read: u64,
     last_draw: std::time::Instant,
+    line_len: usize,
 }
 
-impl<'a, R: io::Read> ProgressReader<'a, R> {
-    fn new(inner: R, rel_path: &'a str, total: u64) -> Self {
+impl<R: io::Read> ProgressReader<R> {
+    fn new(inner: R, total: u64) -> Self {
         Self {
             inner,
-            rel_path,
             total,
             read: 0,
             last_draw: std::time::Instant::now(),
+            line_len: 0,
         }
     }
 
-    fn draw(&self) {
+    /// End the line instead of blanking it: once another worker has printed, the
+    /// cursor may have left our row, and an erase would eat that worker's output.
+    fn close_line(&mut self) {
+        if self.line_len > 0 {
+            eprintln!();
+            self.line_len = 0;
+        }
+    }
+
+    fn draw(&mut self) {
+        if DOWNLOADS_IN_FLIGHT.load(Ordering::SeqCst) != 1 {
+            self.close_line();
+            return;
+        }
         let pct = ((self.read.min(self.total) as f64 / self.total as f64) * 100.0) as usize;
         let filled = pct * PROGRESS_BAR_WIDTH / 100;
-        eprint!(
-            "\r    [{}{}] {:>3}%  {:.1}/{:.1}MB  {}",
+        // No file name — a deep path wraps the line, and then `\r` can't repaint it (Greptile P2 on #681).
+        let line = format!(
+            "    [{}{}] {:>3}%  {:.1}/{:.1}MB",
             "█".repeat(filled),
             "░".repeat(PROGRESS_BAR_WIDTH - filled),
             pct,
             self.read as f64 / 1_048_576.0,
             self.total as f64 / 1_048_576.0,
-            self.rel_path
         );
+        eprint!("\r{line}");
         let _ = io::Write::flush(&mut io::stderr());
+        self.line_len = line.chars().count();
     }
 }
 
-impl<R: io::Read> io::Read for ProgressReader<'_, R> {
+impl<R: io::Read> io::Read for ProgressReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let n = self.inner.read(buf)?;
         self.read += n as u64;
@@ -1618,10 +1659,10 @@ impl<R: io::Read> io::Read for ProgressReader<'_, R> {
     }
 }
 
-/// Close the `\r` line here, not at EOF, so a mid-download bail doesn't print its error onto the bar.
-impl<R> Drop for ProgressReader<'_, R> {
+/// End the line here, not at EOF, so a mid-download bail prints its error on a fresh row.
+impl<R> Drop for ProgressReader<R> {
     fn drop(&mut self) {
-        if self.read > 0 {
+        if self.line_len > 0 {
             eprintln!();
         }
     }
@@ -1914,5 +1955,51 @@ mod characterization_tests {
         assert_eq!(ane_voice_lang("zm_050.bin"), Some("zh"));
         assert_eq!(ane_voice_lang("xm_unknown.bin"), None);
         assert_eq!(ane_voice_lang(""), None);
+    }
+}
+
+#[cfg(test)]
+mod progress_tests {
+    use super::*;
+    use std::io::Read;
+
+    #[test]
+    fn progress_reader_is_byte_transparent() {
+        let payload: Vec<u8> = (0..4096u32).map(|i| (i % 251) as u8).collect();
+        let mut out = Vec::new();
+        let mut reader = ProgressReader::new(payload.as_slice(), payload.len() as u64);
+        reader.read_to_end(&mut out).expect("read");
+        assert_eq!(out, payload);
+    }
+
+    #[test]
+    fn in_flight_guard_balances() {
+        assert_eq!(DOWNLOADS_IN_FLIGHT.load(Ordering::SeqCst), 0);
+        {
+            let _outer = InFlight::new();
+            assert_eq!(DOWNLOADS_IN_FLIGHT.load(Ordering::SeqCst), 1);
+            let _inner = InFlight::new();
+            assert_eq!(DOWNLOADS_IN_FLIGHT.load(Ordering::SeqCst), 2);
+        }
+        assert_eq!(DOWNLOADS_IN_FLIGHT.load(Ordering::SeqCst), 0);
+    }
+
+    /// The bar must stay silent unless it owns stderr — 4 rayon workers share it (#681 P1).
+    #[test]
+    fn bar_draws_only_when_alone() {
+        let payload = vec![7u8; 512];
+        let mut reader = ProgressReader::new(payload.as_slice(), payload.len() as u64);
+        let _a = InFlight::new();
+        let _b = InFlight::new();
+        reader.draw();
+        assert_eq!(reader.line_len, 0, "must not draw beside another download");
+
+        drop(_b);
+        reader.read = payload.len() as u64;
+        reader.draw();
+        assert!(
+            reader.line_len > 0,
+            "must draw when it is the only download"
+        );
     }
 }

--- a/src/engine-install.ts
+++ b/src/engine-install.ts
@@ -528,7 +528,7 @@ function validateDiarize(caps: EngineCapabilities | null): void {
 
 /**
  * Runs `kesha-engine install` to download/verify models.
- * Streams stderr to the process and throws on non-zero exit.
+ * Inherits stdio so per-file progress reaches the user live, and throws on non-zero exit.
  */
 function runEngineModelInstall(
   binPath: string,
@@ -542,19 +542,17 @@ function runEngineModelInstall(
     vad: options.vad,
     diarize: options.diarize,
   });
+  // #680: piping buffers the child until exit, so multi-GB downloads looked hung.
   const proc = Bun.spawnSync([binPath, ...installArgs], {
-    stdout: "pipe",
-    stderr: "pipe",
+    stdout: "inherit",
+    stderr: "inherit",
   });
 
-  const stderr = proc.stderr.toString();
-  if (stderr) {
-    process.stderr.write(stderr);
-  }
-
   if (proc.exitCode !== 0) {
-    const detail = stderr.trim();
-    throw new Error(detail ? `Failed to install models: ${detail}` : "Failed to install models");
+    throw new Error(
+      `Failed to install models: kesha-engine install exited with code ${proc.exitCode}. ` +
+        "See the engine output above for the failing file.",
+    );
   }
 }
 


### PR DESCRIPTION
Closes #680

`kesha install` printed `Installing models...` and then went silent for minutes on a fresh install. Indistinguishable from a hang — and read as one.

## Cause

`runEngineModelInstall` (`src/engine-install.ts`) spawned the engine with both streams piped under `Bun.spawnSync`, which collects the whole stream and returns it only after the child exits. Every line was replayed at the end, exactly when it was no longer useful. The function's own doc comment claimed it streamed.

Everything `kesha-engine install` prints goes to stderr — the per-file `GET`/`OK` lines (`rust/src/models.rs`), `Warming up ASR backend...`, `Install complete.` — so all of it was withheld, not just some.

## Change

**TS** — inherit both streams. The failure message no longer embeds the child's stderr, since that output has already reached the terminal; it names the exit code and points at the output above.

**Rust** — streaming alone still leaves the 2.4GB Parakeet encoder as one `GET` and then silence, which is the bulk of the wait. `download_verified` now wraps the response reader in a `ProgressReader` that redraws a `\r` bar from Content-Length. It engages only above 16MB and only when stderr is a terminal, so redirected installs and CI logs keep the plain `GET`/`OK` lines they have today. The trailing newline comes from `Drop` rather than at EOF, so a mid-download bail cannot print its error onto the bar.

## Verification

Against a fake engine that sleeps 1.2s per file, timestamping each line as it arrives:

| | `main` | this branch |
|---|---|---|
| `Installing models...` | 0.34s | 0.35s |
| `GET encoder-model.onnx.data` | 4.05s | **0.56s** |
| `OK  encoder-model.onnx.data` | 4.05s | **1.77s** |
| `GET decoder_joint-model.onnx` | 4.05s | **1.77s** |
| `Install complete.` | 4.05s | 4.17s |

On `main` all eight lines land in one burst at the end; on this branch they arrive as they happen.

- `bun test` — 584 pass, 5 skip, 0 fail
- `bunx tsc --noEmit` — clean
- `make rust-test` — 396 passed, 0 skipped
- `cargo fmt`, `cargo clippy --all-targets -- -D warnings` — clean
- `cargo check --features coreml --no-default-features` — clean

## Rollout

The Rust half reaches users with the next engine release; the streaming fix ships with the CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FkpxF1agJV6kpBdWpYo4YH