### PR TITLE
docs(openspec): propose an alpha release channel

### DIFF
--- a/openspec/changes/alpha-release-channel/.openspec.yaml
+++ b/openspec/changes/alpha-release-channel/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-04

--- a/openspec/changes/alpha-release-channel/design.md
+++ b/openspec/changes/alpha-release-channel/design.md
@@ -90,6 +90,19 @@ maintainer's intent, and the base can always be corrected by editing one field.
 The alpha version is written into `package.json` **in the runner** at publish time and never
 committed, exactly as Tolaria injects its computed version into the build.
 
+### The tag, not the npm registry, is the record of what was published
+
+Deriving from tags only works if each alpha leaves one. Publishing to npm alone would mean
+the next merge re-derives the same sequence, the prior-publish check skips it as already
+published, and release notes lose their commit boundary — a silent no-op rather than a
+failure. Tolaria avoids this implicitly because each of its alphas creates a GitHub Release,
+which creates the tag.
+
+So the alpha workflow tags the built commit as part of publishing, and a run whose artifact
+published but whose tag did not land fails rather than reporting success. This is also what
+makes "a published version identifier is never reissued" enforceable: the tag outlives the
+Release, so pruning old alpha Releases cannot free an identifier.
+
 ### npm dist-tags are the channel mechanism
 
 No `alpha-latest.json` analogue is needed. `bun add -g @drakulavich/kesha-voice-kit@alpha`

--- a/openspec/changes/alpha-release-channel/design.md
+++ b/openspec/changes/alpha-release-channel/design.md
@@ -87,8 +87,9 @@ suffix-drop rather than a guess.
 last tag. Rejected for now — it adds a second inference layer that can disagree with the
 maintainer's intent, and the base can always be corrected by editing one field.
 
-The alpha version is written into `package.json` **in the runner** at publish time and never
-committed, exactly as Tolaria injects its computed version into the build.
+The alpha version is written into `package.json` **in the runner** and never committed,
+exactly as Tolaria injects its computed version into the build. Which runner matters — see
+"The publish workflow owns version injection".
 
 ### The tag, not the npm registry, is the record of what was published
 
@@ -98,10 +99,10 @@ published, and release notes lose their commit boundary — a silent no-op rathe
 failure. Tolaria avoids this implicitly because each of its alphas creates a GitHub Release,
 which creates the tag.
 
-So the alpha workflow tags the built commit as part of publishing, and a run whose artifact
-published but whose tag did not land fails rather than reporting success. This is also what
-makes "a published version identifier is never reissued" enforceable: the tag outlives the
-Release, so pruning old alpha Releases cannot free an identifier.
+So every alpha leaves a tag at the commit it was built from — created *before* the publish,
+for the reason set out under "The tag is reserved before the artifact is published". This is
+also what makes "a published version identifier is never reissued" enforceable: the tag
+outlives the Release, so pruning old alpha Releases cannot free an identifier.
 
 ### npm dist-tags are the channel mechanism
 
@@ -117,6 +118,66 @@ enough to run per merge; a four-platform Rust build including the CoreML/Swift l
 and the Engine changes far less often. Engine alphas are dispatched manually and publish as
 non-draft Prereleases, changing `build-engine.yml:484` from an unconditional `draft: true`
 to a draft only for stable tags.
+
+### Tag grammar: `-cli` suffix for CLI, bare prerelease for the Engine
+
+`build-engine.yml:3-13` triggers on `v*` excluding `!v*-cli`, so a bare `v<base>-alpha.N`
+CLI tag would start the three-platform Engine build — and then fail its dispatch validator
+(`:56`) and the release manifest (`release-manifest.mjs:8`), both of which accept only
+`vX.Y.Z` or `-beta.N`.
+
+CLI alphas therefore extend the existing marker convention: `v1.26.0-alpha.1-cli`. The
+Engine trigger already excludes it, and `npm-publish.yml:80-81` already strips a `-cli`
+suffix when deriving the expected version. Engine alphas take the bare form
+`v1.24.8-alpha.1`, which needs the two `-beta.N` validators widened to accept `-alpha.N`.
+
+*Alternatives considered:* a `cli-` prefix isolates CLI tags from `v*` completely but breaks
+the existing `v1.25.0-cli` convention; leaving both artifacts on identical bare grammar
+makes a CLI tag and an Engine tag indistinguishable by shape, which is what causes the
+problem in the first place.
+
+### The publish workflow owns version injection
+
+Writing the derived version into `package.json` in the alpha workflow and then calling a
+reusable workflow does not work: a `workflow_call` job runs on its own runner and cannot see
+the caller's filesystem. The called workflow checks out a ref and validates
+`package.json#version` against the tag — and a ref on `main` carries the base version, not
+the injected alpha.
+
+So the reusable publish workflow takes the version as an input and applies it after its own
+checkout, and its version guard compares against that input rather than assuming the
+checkout already matches. `keshaEngine.version` must be correct in the same tarball.
+
+### The tag is reserved before the artifact is published
+
+Publishing first and tagging after leaves a window where npm has a version that no tag
+records. The next derivation then reuses that version for a different commit, and the
+prior-publish check turns the second publish into a silent skip rather than an error.
+
+The tag is therefore created at the source commit *before* the publish, and functions as the
+reservation. Failing to publish after a successful tag wastes an identifier, which is cheap;
+publishing without a tag corrupts the sequence, which is not.
+
+### `main`'s base must lead the Engine version
+
+`check-versions.ts:104` requires `package.json#version >= package.json#keshaEngine.version`,
+and a prerelease sorts *below* its own stable version. If the CLI base ever equals the
+current Engine version, every alpha of that base fails the gate: `1.25.0-alpha.1 < 1.25.0`.
+
+The convention that `main` carries the *next* CLI version keeps the base strictly ahead of
+the released Engine, which satisfies the rule — but this is a constraint on when the base is
+bumped, not an accident, and the derivation should fail loudly rather than emit a version
+that cannot pass the gate.
+
+### Privilege split across jobs
+
+The pipeline needs `contents: write` to create tags and `id-token: write` for npm
+provenance. Holding both in one continuously-running job means any merged change to a
+workflow, script, or lifecycle hook has a standing path to provenance-backed publication.
+
+The work is split: an unprivileged job checks out, classifies paths, derives and tests; a tag
+job holds `contents: write` and no OIDC; the publish job holds `id-token: write` and no tag
+write. New workflows pin actions by SHA, as the existing ones do.
 
 ### Extracting the publish path is prerequisite work, not a follow-up
 
@@ -154,19 +215,40 @@ from the new capability.
   a natural pause. → Alphas are opt-in and unversioned in documentation; nothing in the CLI
   or docs points a first-time reader at the alpha channel.
 
+- **A plain concurrency group drops merges.** GitHub keeps one pending run per group and
+  cancels an existing pending run when a newer one joins, so under three quick merges the
+  middle one disappears — which contradicts "every qualifying merge produces an alpha". →
+  Request queueing explicitly with `queue: max` (up to 100 pending); it cannot be combined
+  with `cancel-in-progress`.
+
+- **Derivation can see an incomplete tag set.** A shallow checkout without tags makes every
+  run derive sequence 1. → The derivation job fetches full history and tags, as
+  `build-engine.yml:44-45` already does for the same reason.
+
+- **A CLI alpha produces an npm version and a Git tag, but no GitHub Release**, while the
+  retention requirement talks about pruning alpha Releases. → Retention applies to Engine
+  alpha Releases and to any Release the CLI alpha workflow chooses to create; the npm version
+  and the tag are permanent either way. If CLI alphas do get Releases, publishing one fires
+  `release: published` and reaches the publish workflow, which must recognise its own tag and
+  decline rather than republish.
+
 - **Publishing on every merge multiplies npm versions.** Unpublishing on npm is restricted,
   so the alpha version list grows permanently. → Accepted: it is the cost of the property we
   want, and the `alpha` dist-tag keeps the list out of the default resolution path.
 
 ## Migration Plan
 
-1. Land the publish-path extraction with no behaviour change; verify by cutting the next
+1. Set `package.json#version` to the next unreleased version once the current release is
+   out. The derivation is invalid until the base leads the Engine version, so this comes
+   first, not last.
+2. Fix the tag grammar and widen the Engine-side validators, so no later step can push a tag
+   that starts an unwanted build.
+3. Land the publish-path extraction with no behaviour change; verify by cutting the next
    stable release through the reusable workflow.
-2. Set `package.json#version` to the next unreleased version once that release is out.
-3. Land the version-derivation script with its tests, exercised in CI but not yet wired to a
+4. Land the version-derivation script with its tests, exercised but not yet wired to a
    publish.
-4. Enable the alpha workflow on the default branch.
-5. Change Engine alpha publishing to non-draft Prerelease and dispatch one by hand.
+5. Enable the alpha workflow on the default branch.
+6. Change Engine alpha publishing to non-draft Prerelease and dispatch one by hand.
 
 Rollback: disabling the alpha workflow stops alpha production immediately and affects no
 stable artifact. The `alpha` dist-tag can be left in place pointing at the last alpha, or

--- a/openspec/changes/alpha-release-channel/design.md
+++ b/openspec/changes/alpha-release-channel/design.md
@@ -1,0 +1,172 @@
+## Context
+
+Kesha ships two artifacts on independent version lines: the CLI to npm, and the Engine as
+GitHub Release assets that the CLI resolves by URL. Both reach users only through a manual
+gate — bump versions, push a tag, wait for a draft, validate it, un-draft, which fires
+`npm publish --provenance`. Tag names are one-use and un-drafting is effectively permanent,
+so the gate is deliberately heavy.
+
+The reference implementation for the behaviour we want is `refactoringhq/tolaria`, which
+publishes an alpha on every push to `main` — 18 in a single day is normal there. Its scheme
+has four properties worth copying:
+
+1. `.github/workflows/release.yml` triggers on push to `main`, with `paths-ignore` for docs,
+   site, and the workflow itself.
+2. `scripts/release-version.mjs` derives the version from existing tags; the workflow runs
+   `node --test scripts/release-version.test.mjs` before trusting it. No version-bump commits.
+3. `release-build-artifacts.yml` is a reusable workflow called by both the alpha and stable
+   workflows, so an alpha exercises the real build.
+4. Channels are separated at the distribution layer — a distinct `alpha-latest.json` feed
+   means alpha users and stable users never collide.
+
+Kesha differs in two ways that shape the design. It has two artifacts with very different
+build costs (an npm publish is seconds; a four-platform Rust build with CoreML is not), and
+its distribution layer is npm, which already has dist-tags — so property 4 needs no new
+mechanism.
+
+Existing machinery that already does part of the job:
+
+- `.github/workflows/npm-publish.yml:105-119` routes any version containing `-` to the
+  `beta` dist-tag, so prereleases already cannot reach `latest` users.
+- `.github/scripts/check-versions.ts` parses prerelease identifiers and implements SemVer
+  precedence, including "a stable version outranks its prereleases".
+- `.github/workflows/build-engine.yml:409-411` already distinguishes prerelease tags from
+  stable ones and matches `v*` excluding `*-cli`.
+- `src/engine-install.ts:200` and `:439` build the asset URL as
+  `releases/download/v${engineVersion}/…`, so an alpha Engine tag resolves with no code
+  change, provided the tag matches `package.json#keshaEngine.version`
+  (`src/package-info.ts:5-6`).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- An opt-in alpha channel that never perturbs stable consumers.
+- CLI alphas continuously, with no human step between merge and installable artifact.
+- Engine alphas on demand, immediately consumable without an un-drafting step.
+- One publish path shared by both channels, so alphas rehearse the real mechanism.
+- Version derivation that is tested before it is trusted.
+
+**Non-Goals:**
+
+- Changing how stable releases are cut.
+- Auto-promoting an alpha to stable.
+- Reworking the `beta` dist-tag or introducing a beta workflow.
+- An in-CLI updater or update check.
+- Publishing from a workstation.
+
+## Decisions
+
+### Semantic versioning with a derived sequence, not calendar versioning
+
+Tolaria uses calendar versions (`2026.8.3-alpha.18`). That works for an app distributed by
+its own updater, but the CLI is an npm package whose consumers express ranges in SemVer, and
+whose stable line is already `1.x.y`. Switching to calendar versions would be a breaking
+change to how the package is consumed, for no benefit here.
+
+Alpha versions are therefore `<next-version>-alpha.<N>`, where `<N>` is one more than the
+highest existing alpha sequence for that base. SemVer compares numeric prerelease
+identifiers numerically, so `1.26.0-alpha.10` correctly sorts above `1.26.0-alpha.2`, and
+`1.26.0` above both.
+
+*Alternative considered:* using the workflow run number as the sequence. Rejected — it is
+monotonic but not contiguous, it resets if the workflow is recreated, and it carries no
+meaning when read in a release list.
+
+### `main` carries the next unreleased version
+
+Calendar versioning let Tolaria dodge the question "what version is this an alpha of".
+SemVer does not. Rather than infer the next version from commit messages, `package.json#version`
+becomes the next unreleased version immediately after each stable release: after 1.25.0
+ships, `main` reads `1.26.0`, and alphas are `1.26.0-alpha.N`.
+
+This makes the base explicit and reviewable in a diff, and makes the stable release a
+suffix-drop rather than a guess.
+
+*Alternative considered:* deriving the next version from conventional-commit types since the
+last tag. Rejected for now — it adds a second inference layer that can disagree with the
+maintainer's intent, and the base can always be corrected by editing one field.
+
+The alpha version is written into `package.json` **in the runner** at publish time and never
+committed, exactly as Tolaria injects its computed version into the build.
+
+### npm dist-tags are the channel mechanism
+
+No `alpha-latest.json` analogue is needed. `bun add -g @drakulavich/kesha-voice-kit@alpha`
+is the channel selector, and npm already refuses to move `latest` when publishing under
+another tag. The existing resolver at `npm-publish.yml:105-119` gains a third branch:
+`-alpha.` → `alpha`, other prereleases → `beta`, stable → `latest`.
+
+### CLI alphas continuous, Engine alphas on demand
+
+This is the deliberate divergence from Tolaria's uniform cadence. An npm publish is cheap
+enough to run per merge; a four-platform Rust build including the CoreML/Swift link is not,
+and the Engine changes far less often. Engine alphas are dispatched manually and publish as
+non-draft Prereleases, changing `build-engine.yml:484` from an unconditional `draft: true`
+to a draft only for stable tags.
+
+### Extracting the publish path is prerequisite work, not a follow-up
+
+If the alpha workflow publishes by its own copied steps, alphas stop being a rehearsal of
+the release and become a parallel implementation that can drift. The publish steps
+(`npm-publish.yml:60-119`: version guard, prior-publish check, dist-tag resolution, publish
+with provenance) move into a reusable workflow first, with no behaviour change, and both
+channels call it.
+
+This ordering also means the risky refactor lands in its own reviewable change, separate
+from the new capability.
+
+## Risks / Trade-offs
+
+- **An Engine alpha Prerelease fires `release: published`, which reaches the CLI publish
+  workflow.** Its version guard compares `package.json#version` against the tag and would
+  fail on every Engine alpha, turning a routine action red. → The publish workflow must
+  recognise an Engine-only tag and exit successfully without publishing, rather than failing
+  the version comparison.
+
+- **Alpha Engine tags could leak into lanes that download the published Engine**, breaking
+  unrelated pull requests. → Those lanes resolve the stable channel explicitly. The existing
+  `release/*` guard (`ci.yml:387`, `:448`, `:501`) is the precedent for scoping such lanes.
+
+- **Tag-name exhaustion is permanent.** At Tolaria's cadence the repository accumulates tags
+  fast, and GitHub never frees a name. → Sequence numbers make collisions impossible by
+  construction; pruning removes Releases and assets but never reissues an identifier.
+
+- **A continuously publishing pipeline is a continuously available supply-chain target.**
+  Every alpha publish holds `id-token: write` for provenance. → The existing hardening rule
+  applies unchanged: workflow expressions reach `run:` blocks only through `env:`, never by
+  direct interpolation.
+
+- **Alphas make it easy to ship the un-reviewed.** A merged-but-unreleased state stops being
+  a natural pause. → Alphas are opt-in and unversioned in documentation; nothing in the CLI
+  or docs points a first-time reader at the alpha channel.
+
+- **Publishing on every merge multiplies npm versions.** Unpublishing on npm is restricted,
+  so the alpha version list grows permanently. → Accepted: it is the cost of the property we
+  want, and the `alpha` dist-tag keeps the list out of the default resolution path.
+
+## Migration Plan
+
+1. Land the publish-path extraction with no behaviour change; verify by cutting the next
+   stable release through the reusable workflow.
+2. Set `package.json#version` to the next unreleased version once that release is out.
+3. Land the version-derivation script with its tests, exercised in CI but not yet wired to a
+   publish.
+4. Enable the alpha workflow on the default branch.
+5. Change Engine alpha publishing to non-draft Prerelease and dispatch one by hand.
+
+Rollback: disabling the alpha workflow stops alpha production immediately and affects no
+stable artifact. The `alpha` dist-tag can be left in place pointing at the last alpha, or
+removed; neither affects `latest`.
+
+## Open Questions
+
+- Retention window for alpha Releases. Days are the right unit at this cadence, but the
+  value depends on how far back anyone needs to reach.
+- Whether a CLI alpha may name an Engine alpha, or must always resolve a stable Engine.
+  Allowing it lets an Engine change be exercised through a CLI alpha; forbidding it keeps
+  the channels independent.
+- Whether `openspec/specs/GLOSSARY.md` should gain **channel**, **alpha**, and **Prerelease**
+  entries as part of this change or separately.
+- Whether the alpha workflow's path filter should include `rust/` — a merge touching only
+  Engine sources produces a CLI alpha that is byte-identical to its predecessor.

--- a/openspec/changes/alpha-release-channel/proposal.md
+++ b/openspec/changes/alpha-release-channel/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+Today the only way to exercise a change end to end is to cut a stable release: bump versions by hand, push a tag, wait for a draft, un-draft it, and accept that the tag name is burned forever and the npm publish is irreversible. That cost means changes reach a real install only in batches, and the release path itself — the part most likely to break — is exercised once per release rather than continuously.
+
+Maks wants to run a feature on his own laptop the way a user would, before it is blessed. Ira wants the release pipeline proven on every merge, not on release day.
+
+## What Changes
+
+- Introduce an **alpha channel** alongside the existing stable channel. Alpha builds are Prereleases: opt-in, never served to `bun add -g @drakulavich/kesha-voice-kit` without an explicit channel selector.
+- **CLI alphas publish continuously** — every push to `main` that touches CLI sources produces an npm publish under a dedicated `alpha` dist-tag. Installable as `bun add -g @drakulavich/kesha-voice-kit@alpha`.
+- **Engine alphas publish on demand** — a manually dispatched build produces a Prerelease GitHub Release whose tag matches the Engine version the CLI resolves. A four-platform Rust build is too expensive to run per merge, and the Engine changes far less often than the CLI.
+- **Alpha version strings are computed, never hand-edited.** No version-bump commit precedes an alpha; the pipeline derives the version from existing tags and injects it at publish time.
+- **Alpha and stable share one publish path.** The steps that publish to npm become a single reusable unit invoked by both channels, so an alpha exercises the real mechanism rather than a parallel imitation.
+- The npm dist-tag resolver gains a third outcome: `alpha` for `-alpha.` versions, `beta` for other Prereleases, `latest` for stable. Today every Prerelease collapses onto `beta`.
+- `main` carries the next unreleased version, so an alpha has an unambiguous base to attach a sequence to.
+- Alpha GitHub Releases are pruned on an age policy, so the release list stays readable at Tolaria-like cadence (18 alphas in a single day is normal there).
+
+## Capabilities
+
+### New Capabilities
+
+- `release-channels`: how a build reaches a user — which channels exist, what each promises about stability, how a channel is selected at install time, how alpha versions are derived and ordered, and which guarantees hold on alpha versus stable.
+
+### Modified Capabilities
+
+- `installation`: the pre-release verification requirement currently reads as if every published Engine asset carries the same end-to-end proof. Alpha Engine assets are published without waiting for the full published-asset smoke lane, so the requirement needs to state what verification an alpha carries and how an alpha is distinguished from a verified stable asset.
+
+## Non-goals
+
+- Not changing how stable releases are cut. The draft → validate → un-draft gate stays exactly as documented.
+- Not making alphas the default for any install command, hint, or documentation entry point.
+- Not promoting an alpha to stable automatically. A stable release remains a deliberate, human-initiated act.
+- Not introducing a beta channel workflow. The `beta` dist-tag keeps its current meaning and is out of scope here.
+- Not adding an in-CLI self-updater or update-check. Channel selection stays a package-manager concern.
+- Not publishing alphas from a laptop. Publishing stays in GitHub Actions with provenance, as today.
+
+## Impact
+
+- **Workflows**: `.github/workflows/npm-publish.yml` (publish steps extracted into a reusable workflow; dist-tag resolver extended), `.github/workflows/build-engine.yml` (alpha tags publish as non-draft Prereleases rather than drafts), plus a new alpha workflow triggered on pushes to `main`.
+- **Version machinery**: a new version-computation script with unit tests; `.github/scripts/check-versions.ts` already understands Prerelease semver and should keep passing unchanged.
+- **Engine resolution**: none expected. `src/engine-install.ts` builds the asset URL as `v${engineVersion}`, so an alpha Engine tag resolves with no code change — this needs confirming, not modifying.
+- **CI interaction**: lanes that download the published Engine must stay pinned to the stable channel, or alpha Engine tags will start failing unrelated pull requests.
+- **Release hygiene**: alpha tags accumulate quickly and GitHub reserves tag names permanently; the pruning policy applies to Releases, and its interaction with tag retention needs stating.
+- **Docs**: the release runbook and the `release-mechanics` skill gain an alpha section; user-facing install text continues to say bun, never npm.

--- a/openspec/changes/alpha-release-channel/specs/installation/spec.md
+++ b/openspec/changes/alpha-release-channel/specs/installation/spec.md
@@ -1,0 +1,64 @@
+## MODIFIED Requirements
+
+### Requirement: Every shipped platform is verified end to end before release
+
+The release pipeline SHALL verify, for each platform whose Engine is published **on the
+stable channel**, that the shipped binary performs real synthesis and real Transcription —
+not only that it builds and passes unit tests. A platform whose Engine ships without that
+verification SHALL be documented as unverified rather than presented as supported.
+
+Verification SHALL cover both the asset a user downloads today and the artifact a release is
+about to publish. These are different binaries reached by different means: a release branch
+cannot download its own Engine, because its tag does not exist until the release is un-drafted.
+
+Because the install-time ASR warm-up is non-fatal by design, a successful `kesha install`
+SHALL NOT by itself be treated as evidence that the Engine initialises on that platform.
+
+Engine assets published on the alpha channel SHALL NOT be presented as verified. An alpha
+Engine carries only the checks that ran before it was published, and the platform support
+matrix SHALL continue to reflect the stable channel — publishing an alpha SHALL NOT change
+what any platform is claimed to support.
+
+#### Scenario: Smoke on the published asset
+
+- GIVEN release v`<engineVersion>` publishes an Engine asset for a platform
+- WHEN the published-asset smoke lane runs on that platform
+- THEN it performs a cold `kesha install`, synthesises through `kesha say`, and
+  transcribes the result back
+- AND the lane does not run on `release/*` branches, whose tag is not yet published
+
+#### Scenario: Warm-up fails but install reports success
+
+- GIVEN the Engine installs and the CLI exits 0
+- AND the install log carries an ASR backend warm-up failure
+- WHEN the smoke lane inspects that log
+- THEN the lane fails rather than reporting the platform verified
+
+#### Scenario: Engine builds but cannot synthesise
+
+- GIVEN a platform's Engine compiles and its unit tests pass
+- AND its synthesis smoke fails
+- WHEN Ira consults the platform matrix
+- THEN that platform is not presented as supported
+
+#### Scenario: An alpha Engine does not change the support matrix
+
+- GIVEN an Engine alpha is published for a platform
+- WHEN Ira consults the platform matrix
+- THEN the matrix reflects the stable channel only
+- AND the alpha is not counted as evidence that the platform is supported
+
+#### Scenario: Alpha Engine assets do not gate stable lanes
+
+- GIVEN an Engine alpha has been published more recently than the newest stable Engine
+- WHEN a lane that downloads the published Engine runs on an unrelated pull request
+- THEN it resolves the stable Engine
+- AND the alpha does not affect that lane's outcome
+
+> *Technical Note — sources: `.github/workflows/ci.yml` (`published-engine-smoke` on
+> ubuntu-latest, `windows-engine-smoke` on windows-latest — both run a cold install and
+> `.github/scripts/smoke-synthesis.ts`), `.github/scripts/assert-install-warmup.ts`, and
+> `rust/src/cli/install.rs` (warm-up warns and continues, #298). The engine-downloading
+> lanes carry a `!startsWith(github.head_ref, 'release/')` guard at `ci.yml:387`, `:448`
+> and `:501`; the channel those lanes resolve is what keeps alpha Engine tags out of
+> unrelated pull requests.*

--- a/openspec/changes/alpha-release-channel/specs/release-channels/spec.md
+++ b/openspec/changes/alpha-release-channel/specs/release-channels/spec.md
@@ -1,0 +1,215 @@
+## ADDED Requirements
+
+### Requirement: Alpha builds reach only people who ask for them
+
+The project SHALL publish on two channels: **stable**, which is what an install command
+resolves when no channel is named, and **alpha**, which is reached only by naming it.
+Publishing an alpha SHALL NOT change what an unqualified install resolves, and SHALL NOT
+alter any existing stable artifact.
+
+Alpha builds carry no stability promise. They exist so Maks can run a change on his own
+machine before it is blessed, and so the release path is exercised continuously rather
+than once per release.
+
+#### Scenario: Maks opts into the alpha channel
+
+- GIVEN an alpha of the CLI has been published
+- WHEN Maks installs the CLI naming the alpha channel
+- THEN he receives the alpha build
+- AND the version he receives identifies itself as a prerelease
+
+#### Scenario: An alpha publish leaves the default channel untouched
+
+- GIVEN Ira's pipeline installs the CLI without naming a channel
+- WHEN an alpha is published
+- THEN Ira's pipeline continues to resolve the newest stable version
+- AND re-running the same pipeline before and after the alpha publish yields the same version
+
+#### Scenario: A stable release outranks its own alphas
+
+- GIVEN alphas exist for a version that has not shipped yet
+- WHEN that version is released on the stable channel
+- THEN the stable version SHALL be ordered above every alpha carrying the same base version
+
+> *Technical Note — sources: `.github/workflows/npm-publish.yml:105-119` resolves the npm
+> dist-tag today, collapsing every prerelease onto `beta`; this requirement needs a third
+> outcome for `-alpha.` versions. `.github/scripts/check-versions.ts` already implements
+> SemVer precedence including "a stable version outranks its prereleases".*
+
+### Requirement: CLI alphas publish on every merge that changes the CLI
+
+Every push to the default branch that changes CLI sources SHALL produce a published CLI
+alpha without further human action. A merge that changes nothing a user could run — docs,
+unrelated subprojects, workflow files not on the release path — SHALL NOT produce an alpha.
+
+Publishing SHALL remain a pipeline action performed with provenance. No alpha is published
+from a workstation.
+
+#### Scenario: A merge to the default branch produces an alpha
+
+- GIVEN a pull request changing CLI sources merges to the default branch
+- WHEN the alpha pipeline runs
+- THEN a CLI alpha is published on the alpha channel
+- AND its release notes list the commits since the previous alpha
+
+#### Scenario: A docs-only merge publishes nothing
+
+- GIVEN a pull request that changes only documentation merges to the default branch
+- WHEN the alpha pipeline evaluates the change
+- THEN no alpha is published
+- AND the pipeline reports that it deliberately skipped, rather than failing
+
+#### Scenario: Two merges land in quick succession
+
+- GIVEN an alpha publish is already in flight
+- WHEN a second qualifying merge lands before it finishes
+- THEN each merge SHALL end with a distinct published alpha version
+- AND no published alpha version is ever reused for different source
+
+> *Technical Note — the existing publish path fires on `release: published`
+> (`.github/workflows/npm-publish.yml:9-11`) and is therefore tied to the manual draft
+> gate; continuous alphas need a trigger on the default branch instead. Provenance comes
+> from `id-token: write` plus `npm publish --provenance` (`npm-publish.yml:22-24`).*
+
+### Requirement: Engine alphas are published deliberately, not per merge
+
+An Engine alpha SHALL be published only when a person asks for one. Engine alphas SHALL be
+Prereleases and SHALL be immediately consumable — an Engine alpha that requires a manual
+un-drafting step before it can be installed does not satisfy this requirement.
+
+An Engine alpha SHALL be resolvable by the CLI through the same mechanism that resolves a
+stable Engine, so that installing an alpha exercises the real download path.
+
+#### Scenario: Maks requests an Engine alpha
+
+- GIVEN a change to Engine sources has merged
+- WHEN Maks dispatches an Engine alpha build
+- THEN the Engine alpha is published as a Prerelease
+- AND `kesha install` against a CLI pinned to that Engine version downloads it without
+  any manual release step in between
+
+#### Scenario: A CLI alpha that does not change the Engine
+
+- GIVEN a CLI alpha whose merge changed no Engine sources
+- WHEN that alpha is published
+- THEN it SHALL resolve the current stable Engine
+- AND publishing it SHALL NOT require an Engine build
+
+#### Scenario: Publishing an Engine alpha does not publish a CLI
+
+- GIVEN an Engine alpha Prerelease is published
+- WHEN the publish pipelines react to it
+- THEN no CLI package is published as a side effect
+- AND the pipeline does not report a failure for having declined
+
+> *Technical Note — sources: `src/engine-install.ts:200` and `:439` build the asset URL as
+> `releases/download/v${engineVersion}/…`, so an Engine alpha resolves with no code change
+> provided its tag matches `package.json#keshaEngine.version` (`src/package-info.ts:5-6`).
+> `.github/workflows/build-engine.yml:409-411` already distinguishes prerelease tags, but
+> `:484` publishes every build as a draft. Publishing a Prerelease fires
+> `release: published`, which today reaches the CLI publish workflow.*
+
+### Requirement: Alpha versions are derived, never hand-written
+
+An alpha version SHALL be computed from the repository's existing tags at publish time. No
+commit SHALL be required to record an alpha version, and the default branch SHALL NOT
+accumulate version-bump commits for alphas.
+
+Alpha versions SHALL sort in publication order, SHALL sort below the stable version they
+lead up to, and SHALL be unique for the lifetime of the repository.
+
+The derivation SHALL be covered by its own tests, run before it is trusted to produce a
+version.
+
+#### Scenario: Sequence advances within a base version
+
+- GIVEN alphas already exist for the next unreleased version
+- WHEN another alpha is published for that same base version
+- THEN its sequence is one higher than the highest existing alpha for that base
+- AND it sorts above every earlier alpha for that base
+
+#### Scenario: Derivation is verified before use
+
+- GIVEN the alpha pipeline is about to compute a version
+- WHEN its tests fail
+- THEN no alpha is published
+
+#### Scenario: A malformed or unexpected existing tag
+
+- GIVEN the repository contains a tag that does not match the alpha naming scheme
+- WHEN the version is derived
+- THEN that tag is ignored rather than causing a wrong sequence
+- AND the derivation does not fail because of it
+
+> *Technical Note — the base version comes from `package.json#version`, which this change
+> makes "the next unreleased version" rather than "the last released one".
+> `.github/scripts/check-versions.ts` is the existing drift gate across
+> `package.json#version`, `package.json#keshaEngine.version`, and `rust/Cargo.toml`; it
+> already parses prerelease identifiers and must keep passing for alpha versions.*
+
+### Requirement: Alpha and stable publish through one path
+
+The steps that publish a build SHALL exist once and be invoked by both channels. A channel
+SHALL differ from another only in the inputs it supplies — which version, which channel
+label, which artifacts — not in the mechanism it uses.
+
+This is the property that makes an alpha meaningful as a rehearsal: a change to the publish
+path SHALL be exercised by alphas before a stable release depends on it.
+
+#### Scenario: A change to the publish path is rehearsed
+
+- GIVEN the shared publish steps are modified
+- WHEN the next alpha publishes
+- THEN that alpha exercised the modified steps
+- AND a subsequent stable release runs the same steps
+
+#### Scenario: A channel cannot silently diverge
+
+- GIVEN a fix is applied to the publish path for one channel
+- WHEN the other channel next publishes
+- THEN it SHALL use the fixed path rather than an unfixed copy
+
+> *Technical Note — today the publish steps live inline in
+> `.github/workflows/npm-publish.yml:60-119` (version guard, prior-publish check, dist-tag
+> resolution, publish with provenance) with no reusable entry point.*
+
+### Requirement: The release list stays readable at alpha cadence
+
+Alpha Releases SHALL be pruned on a stated age policy so that the release list remains
+usable for finding stable releases. Pruning SHALL NOT remove any stable release, and SHALL
+NOT free an alpha tag name for reuse — a published version identifier is never reissued for
+different source.
+
+#### Scenario: Old alphas are pruned
+
+- GIVEN alpha Releases older than the retention window exist
+- WHEN the pruning policy runs
+- THEN those alpha Releases are removed
+- AND every stable release remains
+
+#### Scenario: A pruned version is never reissued
+
+- GIVEN an alpha Release has been pruned
+- WHEN the next alpha version is derived
+- THEN it SHALL NOT reuse the pruned version identifier
+
+> *Technical Note — GitHub reserves tag names permanently, which the release runbook already
+> treats as an invariant ("Tag names are one-use"); pruning therefore applies to Releases and
+> assets, and the derivation must not depend on a pruned Release still existing.*
+
+## Open Issues
+
+- `openspec/specs/GLOSSARY.md` has no entry for **channel**, **alpha**, or **Prerelease**.
+  These terms are used throughout this spec and should be added to the glossary rather than
+  defined ad hoc here. Not resolved in this change's specs because the delta format covers
+  requirements, not the glossary.
+- The retention window for alpha Releases is stated as a policy but not given a number.
+  Tolaria's cadence (18 alphas in one day) suggests days rather than releases as the unit,
+  but the right value depends on how far back Maks ever needs to reach.
+- Whether a CLI alpha should be able to name an Engine alpha at all, or whether alpha CLIs
+  must always resolve a stable Engine, is unresolved. Allowing it makes the two channels
+  interact; forbidding it means an Engine change cannot be exercised through a CLI alpha.
+- Lanes that download the published Engine carry a `release/*` branch guard
+  (`.github/workflows/ci.yml:387`, `:448`, `:501`). Whether alpha Engine tags need an
+  analogous guard, or whether pinning those lanes to the stable channel is sufficient, is
+  not settled.

--- a/openspec/changes/alpha-release-channel/specs/release-channels/spec.md
+++ b/openspec/changes/alpha-release-channel/specs/release-channels/spec.md
@@ -115,6 +115,11 @@ An alpha version SHALL be computed from the repository's existing tags at publis
 commit SHALL be required to record an alpha version, and the default branch SHALL NOT
 accumulate version-bump commits for alphas.
 
+Every published alpha SHALL leave a tag behind at the commit it was built from. The tag is
+what the next derivation counts, what bounds the next set of release notes, and what makes
+a published version identifier permanently taken — an alpha that publishes an artifact
+without recording a tag would let the next derivation reuse its version.
+
 Alpha versions SHALL sort in publication order, SHALL sort below the stable version they
 lead up to, and SHALL be unique for the lifetime of the repository.
 
@@ -127,6 +132,21 @@ version.
 - WHEN another alpha is published for that same base version
 - THEN its sequence is one higher than the highest existing alpha for that base
 - AND it sorts above every earlier alpha for that base
+
+#### Scenario: Consecutive merges each advance the sequence
+
+- GIVEN an alpha has been published for the current base version
+- WHEN a further qualifying merge lands and its alpha is derived
+- THEN the derivation observes the previous alpha's tag
+- AND the new alpha carries the next sequence rather than repeating the published one
+
+#### Scenario: The artifact publishes but the tag does not land
+
+- GIVEN an alpha's artifact has been published
+- WHEN recording its tag fails
+- THEN the pipeline reports failure rather than success
+- AND the condition is surfaced, because the next derivation would otherwise reuse that
+  version identifier
 
 #### Scenario: Derivation is verified before use
 

--- a/openspec/changes/alpha-release-channel/specs/release-channels/spec.md
+++ b/openspec/changes/alpha-release-channel/specs/release-channels/spec.md
@@ -1,5 +1,44 @@
 ## ADDED Requirements
 
+### Requirement: A tag names exactly one artifact and one channel
+
+Every release tag SHALL identify which artifact it belongs to and whether it is stable or
+alpha, by its shape alone. A pipeline SHALL decide what to do with a tag without inspecting
+the commit it points at.
+
+A CLI tag SHALL NOT start an Engine build. The Engine build is the expensive half of the
+release and runs on a tag pattern today, so an ambiguous tag does not merely mislabel — it
+triggers work that was never asked for and then fails downstream validation.
+
+Tag validators SHALL accept the alpha shapes for the artifact they govern, and SHALL keep
+rejecting shapes that belong to another artifact.
+
+#### Scenario: A CLI alpha tag does not trigger an Engine build
+
+- GIVEN a CLI alpha is published and its tag is pushed
+- WHEN the Engine build workflow evaluates its tag filter
+- THEN it does not run
+
+#### Scenario: An Engine alpha tag passes Engine validators
+
+- GIVEN Maks dispatches an Engine alpha
+- WHEN the Engine workflow validates the tag shape and builds its release manifest
+- THEN the alpha shape is accepted
+- AND the resulting manifest describes that alpha
+
+#### Scenario: A tag belonging to another artifact is rejected
+
+- GIVEN a tag whose shape belongs to the CLI
+- WHEN an Engine-side validator evaluates it
+- THEN it is rejected rather than processed as an Engine release
+
+> *Technical Note — `.github/workflows/build-engine.yml:3-13` triggers on `v*` excluding
+> `!v*-cli`, so a bare `v<base>-alpha.N` CLI tag would start the Engine build. Its dispatch
+> validator (`:56`) accepts only `^v[0-9]+\.[0-9]+\.[0-9]+(-beta\.[0-9]+)?$`, and
+> `.github/scripts/release-manifest.mjs:8` applies the same pattern — both reject `-alpha.N`
+> today. `.github/workflows/npm-publish.yml:80-81` already strips a `-cli` suffix when
+> deriving the expected version from a tag.*
+
 ### Requirement: Alpha builds reach only people who ask for them
 
 The project SHALL publish on two channels: **stable**, which is what an install command
@@ -57,14 +96,22 @@ from a workstation.
 - GIVEN a pull request that changes only documentation merges to the default branch
 - WHEN the alpha pipeline evaluates the change
 - THEN no alpha is published
-- AND the pipeline reports that it deliberately skipped, rather than failing
+- AND the pipeline records that it deliberately skipped, in a form a person can read
+  afterwards without inferring it from an absent run
 
-#### Scenario: Two merges land in quick succession
+#### Scenario: Three merges land in quick succession
 
 - GIVEN an alpha publish is already in flight
-- WHEN a second qualifying merge lands before it finishes
-- THEN each merge SHALL end with a distinct published alpha version
+- WHEN two further qualifying merges land before it finishes
+- THEN each of the three merges SHALL end with its own published alpha version
+- AND no qualifying merge is silently dropped because a later one superseded it
 - AND no published alpha version is ever reused for different source
+
+> *Technical Note — a plain concurrency group is not sufficient: GitHub cancels an existing
+> pending run when a newer one joins the group, so the middle merge would disappear.
+> Queueing must be requested explicitly (`queue: max`, up to 100 pending), and it cannot be
+> combined with `cancel-in-progress`. A skip decision must also be made inside a job — a
+> workflow-level path filter prevents the run from existing, leaving nothing to report.*
 
 > *Technical Note — the existing publish path fires on `release: published`
 > (`.github/workflows/npm-publish.yml:9-11`) and is therefore tied to the manual draft
@@ -140,13 +187,19 @@ version.
 - THEN the derivation observes the previous alpha's tag
 - AND the new alpha carries the next sequence rather than repeating the published one
 
-#### Scenario: The artifact publishes but the tag does not land
+#### Scenario: The tag cannot be recorded
 
-- GIVEN an alpha's artifact has been published
+- GIVEN an alpha version has been derived
 - WHEN recording its tag fails
-- THEN the pipeline reports failure rather than success
-- AND the condition is surfaced, because the next derivation would otherwise reuse that
-  version identifier
+- THEN nothing is published under that version
+- AND the run reports failure rather than success
+
+#### Scenario: The tag lands but the publish fails
+
+- GIVEN an alpha's tag has been recorded
+- WHEN publishing the artifact then fails
+- THEN that version identifier SHALL NOT be reused by a later alpha
+- AND the next alpha takes the following sequence instead
 
 #### Scenario: Derivation is verified before use
 

--- a/openspec/changes/alpha-release-channel/tasks.md
+++ b/openspec/changes/alpha-release-channel/tasks.md
@@ -1,0 +1,62 @@
+## 1. Extract the publish path (no behaviour change)
+
+- [ ] 1.1 Move the publish steps from `.github/workflows/npm-publish.yml:60-119` (version guard, prior-publish check, dist-tag resolution, publish with provenance) into a reusable `workflow_call` workflow taking version, tag and channel as inputs
+- [ ] 1.2 Reduce `npm-publish.yml` to a thin caller of the reusable workflow, keeping its `release: published` and `workflow_dispatch` triggers and its `id-token: write` permission intact
+- [ ] 1.3 Confirm every `${{ }}` expression reaching a `run:` block still passes through `env:` rather than direct interpolation
+- [ ] 1.4 Verify the extraction by dispatching the workflow against an already-published tag and confirming it no-ops on the prior-publish check instead of republishing
+
+## 2. Teach the resolver about the alpha channel
+
+- [ ] 2.1 Extend the dist-tag resolver to three outcomes: `-alpha.` → `alpha`, other prereleases → `beta`, stable → `latest`
+- [ ] 2.2 Make the publish workflow exit successfully without publishing when the tag is an Engine-only release rather than failing the version guard
+- [ ] 2.3 Add a test or dry-run assertion covering all three resolver outcomes plus the Engine-only tag case
+
+## 3. Derive alpha versions
+
+- [ ] 3.1 Add a version-derivation script that reads existing tags and emits version, tag and channel, taking the base from `package.json#version`
+- [ ] 3.2 Make the sequence one higher than the highest existing alpha for that base, ignoring tags that do not match the alpha naming scheme
+- [ ] 3.3 Add unit tests for the derivation: first alpha for a base, sequence advance, malformed tag ignored, stable outranks its alphas
+- [ ] 3.4 Wire the tests to run in CI before any workflow consumes the derived version
+- [ ] 3.5 Confirm `bun run check:versions` passes for a derived alpha version
+
+## 4. Publish CLI alphas continuously
+
+- [ ] 4.1 Add an alpha workflow triggered on pushes to the default branch, with a path filter that skips changes which cannot alter what a user runs
+- [ ] 4.2 Write the derived version into `package.json` in the runner without committing it
+- [ ] 4.3 Call the reusable publish workflow with the alpha channel
+- [ ] 4.4 Generate release notes from the commits since the previous alpha tag
+- [ ] 4.5 Add a concurrency group so overlapping merges each end with a distinct published version
+- [ ] 4.6 Make a skipped run report the skip explicitly rather than failing
+
+## 5. Publish Engine alphas on demand
+
+- [ ] 5.1 Change `.github/workflows/build-engine.yml:484` to draft only stable tags, publishing alpha tags as non-draft Prereleases
+- [ ] 5.2 Confirm an Engine alpha tag flows through the existing prerelease detection at `:409-411` unchanged
+- [ ] 5.3 Verify `kesha install` resolves an Engine alpha through `src/engine-install.ts:200` with no code change when `keshaEngine.version` matches the alpha tag
+- [ ] 5.4 Confirm publishing an Engine alpha does not publish a CLI package and does not leave a red workflow run
+
+## 6. Keep alpha artifacts out of stable lanes
+
+- [ ] 6.1 Pin the lanes that download the published Engine (`ci.yml:387`, `:448`, `:501`) to the stable channel
+- [ ] 6.2 Verify an unrelated pull request is unaffected after an Engine alpha is published
+
+## 7. Retention
+
+- [ ] 7.1 Decide the retention window and record it in the spec, replacing the open issue
+- [ ] 7.2 Add a scheduled job pruning alpha Releases past the window, leaving every stable release intact
+- [ ] 7.3 Confirm the version derivation does not depend on a pruned Release still existing
+
+## 8. Versioning convention and documentation
+
+- [ ] 8.1 After the next stable release, set `package.json#version` to the next unreleased version
+- [ ] 8.2 Document the alpha channel in the release runbook and the `release-mechanics` skill, including that `main` carries the next unreleased version
+- [ ] 8.3 Add **channel**, **alpha** and **Prerelease** to `openspec/specs/GLOSSARY.md`
+- [ ] 8.4 Confirm no user-facing install hint or documentation entry point points a first-time reader at the alpha channel, and that alpha install text says bun, never npm
+
+## 9. End-to-end verification
+
+- [ ] 9.1 Merge a CLI-only change and confirm an alpha publishes without human action
+- [ ] 9.2 Install the alpha by naming the channel and confirm it runs
+- [ ] 9.3 Confirm an unqualified install still resolves the newest stable version before and after that alpha
+- [ ] 9.4 Merge a docs-only change and confirm nothing publishes
+- [ ] 9.5 Dispatch an Engine alpha and install it end to end

--- a/openspec/changes/alpha-release-channel/tasks.md
+++ b/openspec/changes/alpha-release-channel/tasks.md
@@ -1,65 +1,85 @@
-## 1. Extract the publish path (no behaviour change)
+## 1. Set the base version convention first
 
-- [ ] 1.1 Move the publish steps from `.github/workflows/npm-publish.yml:60-119` (version guard, prior-publish check, dist-tag resolution, publish with provenance) into a reusable `workflow_call` workflow taking version, tag and channel as inputs
-- [ ] 1.2 Reduce `npm-publish.yml` to a thin caller of the reusable workflow, keeping its `release: published` and `workflow_dispatch` triggers and its `id-token: write` permission intact
-- [ ] 1.3 Confirm every `${{ }}` expression reaching a `run:` block still passes through `env:` rather than direct interpolation
-- [ ] 1.4 Verify the extraction by dispatching the workflow against an already-published tag and confirming it no-ops on the prior-publish check instead of republishing
+- [ ] 1.1 After the next stable release, set `package.json#version` to the next unreleased version
+- [ ] 1.2 Confirm the base stays strictly ahead of `package.json#keshaEngine.version`, so `check-versions.ts:104` (`cli >= engine`) still holds once a `-alpha.N` suffix is added — a prerelease sorts below its own stable version
 
-## 2. Teach the resolver about the alpha channel
+## 2. Define the tag grammar and teach every validator
 
-- [ ] 2.1 Extend the dist-tag resolver to three outcomes: `-alpha.` → `alpha`, other prereleases → `beta`, stable → `latest`
-- [ ] 2.2 Make the publish workflow exit successfully without publishing when the tag is an Engine-only release rather than failing the version guard
-- [ ] 2.3 Add a test or dry-run assertion covering all three resolver outcomes plus the Engine-only tag case
+- [ ] 2.1 Record the grammar: CLI alphas as `v<base>-alpha.N-cli`, Engine alphas as `v<engineVersion>-alpha.N`
+- [ ] 2.2 Confirm `build-engine.yml:3-13` (`v*` excluding `!v*-cli`) does not trigger on a CLI alpha tag
+- [ ] 2.3 Widen the Engine dispatch tag validator at `build-engine.yml:56` to accept `-alpha.N` alongside `-beta.N`
+- [ ] 2.4 Widen `RELEASE_TAG_RE` in `.github/scripts/release-manifest.mjs:8` to accept `-alpha.N`
+- [ ] 2.5 Confirm `npm-publish.yml:80-81` derives the expected version correctly from a CLI alpha tag once `-cli` is stripped
+- [ ] 2.6 Add tests asserting each validator accepts its own artifact's alpha shape and rejects the other artifact's
 
-## 3. Derive alpha versions
+## 3. Extract the publish path (no behaviour change)
 
-- [ ] 3.1 Add a version-derivation script that reads existing tags and emits version, tag and channel, taking the base from `package.json#version`
-- [ ] 3.2 Make the sequence one higher than the highest existing alpha for that base, ignoring tags that do not match the alpha naming scheme
-- [ ] 3.3 Add unit tests for the derivation: first alpha for a base, sequence advance, malformed tag ignored, stable outranks its alphas
-- [ ] 3.4 Wire the tests to run in CI before any workflow consumes the derived version
-- [ ] 3.5 Confirm `bun run check:versions` passes for a derived alpha version
+- [ ] 3.1 Move the publish steps from `.github/workflows/npm-publish.yml:60-119` into a reusable `workflow_call` workflow taking version, tag and channel as inputs
+- [ ] 3.2 Make the reusable workflow apply the version input to `package.json` after its own checkout — a called workflow runs on its own runner and cannot see the caller's filesystem
+- [ ] 3.3 Make its version guard compare against the input rather than assuming the checkout already matches, and confirm `keshaEngine.version` is correct in the published tarball
+- [ ] 3.4 Reduce `npm-publish.yml` to a thin caller, keeping its triggers and `id-token: write` intact
+- [ ] 3.5 Confirm every `${{ }}` expression reaching a `run:` block still passes through `env:`
+- [ ] 3.6 Verify by dispatching against an already-published tag and confirming it no-ops on the prior-publish check
 
-## 4. Publish CLI alphas continuously
+## 4. Teach the resolver about the alpha channel
 
-- [ ] 4.1 Add an alpha workflow triggered on pushes to the default branch, with a path filter that skips changes which cannot alter what a user runs
-- [ ] 4.2 Write the derived version into `package.json` in the runner without committing it
-- [ ] 4.3 Call the reusable publish workflow with the alpha channel
-- [ ] 4.4 Create and push the derived alpha tag at the built commit, so the next derivation counts it and the next release notes have a boundary
-- [ ] 4.5 Fail the run if the artifact published but its tag did not land, rather than reporting success
-- [ ] 4.6 Generate release notes from the commits since the previous alpha tag
-- [ ] 4.7 Add a concurrency group so overlapping merges each end with a distinct published version
-- [ ] 4.8 Make a skipped run report the skip explicitly rather than failing
-- [ ] 4.9 Verify two consecutive qualifying merges produce two distinct published alpha versions
+- [ ] 4.1 Extend the dist-tag resolver to three outcomes: `-alpha.` → `alpha`, other prereleases → `beta`, stable → `latest`
+- [ ] 4.2 Make the publish workflow exit successfully without publishing when the tag belongs to another artifact, rather than failing the version guard
+- [ ] 4.3 Add assertions covering all three resolver outcomes plus the foreign-tag case
 
-## 5. Publish Engine alphas on demand
+## 5. Derive alpha versions
 
-- [ ] 5.1 Change `.github/workflows/build-engine.yml:484` to draft only stable tags, publishing alpha tags as non-draft Prereleases
-- [ ] 5.2 Confirm an Engine alpha tag flows through the existing prerelease detection at `:409-411` unchanged
-- [ ] 5.3 Verify `kesha install` resolves an Engine alpha through `src/engine-install.ts:200` with no code change when `keshaEngine.version` matches the alpha tag
-- [ ] 5.4 Confirm publishing an Engine alpha does not publish a CLI package and does not leave a red workflow run
+- [ ] 5.1 Add a version-derivation script that reads existing tags and emits version, tag and channel, taking the CLI base from `package.json#version`
+- [ ] 5.2 Make the sequence one higher than the highest existing alpha for that base and artifact, ignoring tags that do not match the grammar
+- [ ] 5.3 Give the derivation an Engine mode that bases on `keshaEngine.version` rather than the CLI version
+- [ ] 5.4 Make the derivation fail loudly if it would emit a version that cannot pass `check:versions`
+- [ ] 5.5 Fetch full history and tags before deriving, as `build-engine.yml:44-45` does
+- [ ] 5.6 Add unit tests: first alpha for a base, sequence advance, malformed tag ignored, foreign-artifact tag ignored, stable outranks its alphas
+- [ ] 5.7 Make the alpha workflow run those tests itself before consuming a derived version — passing in general CI does not gate a separate workflow
 
-## 6. Keep alpha artifacts out of stable lanes
+## 6. Publish CLI alphas continuously
 
-- [ ] 6.1 Pin the lanes that download the published Engine (`ci.yml:387`, `:448`, `:501`) to the stable channel
-- [ ] 6.2 Verify an unrelated pull request is unaffected after an Engine alpha is published
+- [ ] 6.1 Add an alpha workflow on pushes to the default branch, always triggered, deciding inside a job whether the change can alter what a user runs
+- [ ] 6.2 Enumerate the paths that count, including `package.json`, `bun.lock`, `bin/`, shell completions and packaged files — not only `src/`
+- [ ] 6.3 Record a skip in a form a person can read afterwards
+- [ ] 6.4 Create and push the derived tag at the built commit **before** publishing, as the reservation that makes the version permanently taken
+- [ ] 6.5 Call the reusable publish workflow with the alpha channel
+- [ ] 6.6 Generate release notes from the commits since the previous alpha tag for the same artifact
+- [ ] 6.7 Use `concurrency` with `queue: max` rather than a bare group — GitHub cancels an existing pending run when a newer one joins, dropping middle merges; queueing cannot be combined with `cancel-in-progress`
+- [ ] 6.8 Split privileges across jobs: unprivileged derivation and tests, a tag job with `contents: write` and no OIDC, a publish job with `id-token: write` and no tag write
+- [ ] 6.9 Pin every action in the new workflows by SHA
+- [ ] 6.10 Decide whether CLI alphas create a GitHub Release; if they do, make the publish workflow recognise its own tag on `release: published` and decline rather than republish
+- [ ] 6.11 Verify three consecutive qualifying merges produce three distinct published alpha versions
 
-## 7. Retention
+## 7. Publish Engine alphas on demand
 
-- [ ] 7.1 Decide the retention window and record it in the spec, replacing the open issue
-- [ ] 7.2 Add a scheduled job pruning alpha Releases past the window, leaving every stable release intact
-- [ ] 7.3 Confirm the version derivation does not depend on a pruned Release still existing
+- [ ] 7.1 Change `.github/workflows/build-engine.yml:484` to draft only stable tags, publishing alpha tags as non-draft Prereleases
+- [ ] 7.2 Confirm an Engine alpha tag passes the widened validators from group 2 end to end, including manifest generation
+- [ ] 7.3 Verify `kesha install` resolves an Engine alpha through `src/engine-install.ts:200` when `keshaEngine.version` matches the alpha tag
+- [ ] 7.4 Confirm publishing an Engine alpha does not publish a CLI package and does not leave a red workflow run
 
-## 8. Versioning convention and documentation
+## 8. Keep alpha artifacts out of stable lanes
 
-- [ ] 8.1 After the next stable release, set `package.json#version` to the next unreleased version
-- [ ] 8.2 Document the alpha channel in the release runbook and the `release-mechanics` skill, including that `main` carries the next unreleased version
-- [ ] 8.3 Add **channel**, **alpha** and **Prerelease** to `openspec/specs/GLOSSARY.md`
-- [ ] 8.4 Confirm no user-facing install hint or documentation entry point points a first-time reader at the alpha channel, and that alpha install text says bun, never npm
+- [ ] 8.1 Make the lanes that download the published Engine (`ci.yml:387`, `:448`, `:501`) resolve an explicit stable version rather than inheriting possibly-prerelease metadata
+- [ ] 8.2 Verify an unrelated pull request is unaffected after an Engine alpha is published
 
-## 9. End-to-end verification
+## 9. Retention
 
-- [ ] 9.1 Merge a CLI-only change and confirm an alpha publishes without human action
-- [ ] 9.2 Install the alpha by naming the channel and confirm it runs
-- [ ] 9.3 Confirm an unqualified install still resolves the newest stable version before and after that alpha
-- [ ] 9.4 Merge a docs-only change and confirm nothing publishes
-- [ ] 9.5 Dispatch an Engine alpha and install it end to end
+- [ ] 9.1 Decide the retention window and which artifact it prunes, and record it in the spec, replacing the open issue
+- [ ] 9.2 Add a scheduled job pruning alpha Releases past the window, leaving every stable release and every tag intact
+- [ ] 9.3 Confirm the derivation does not depend on a pruned Release still existing
+
+## 10. Documentation
+
+- [ ] 10.1 Document the alpha channel in the release runbook and the `release-mechanics` skill, including the tag grammar and that `main` carries the next unreleased version
+- [ ] 10.2 Add **channel**, **alpha** and **Prerelease** to `openspec/specs/GLOSSARY.md`
+- [ ] 10.3 Confirm no user-facing install hint points a first-time reader at the alpha channel, and that alpha install text says bun, never npm
+
+## 11. End-to-end verification
+
+- [ ] 11.1 Merge a CLI-only change and confirm an alpha publishes without human action
+- [ ] 11.2 Install the alpha by naming the channel and confirm it runs
+- [ ] 11.3 Confirm an unqualified install still resolves the newest stable version before and after that alpha
+- [ ] 11.4 Merge a docs-only change and confirm nothing publishes and the skip is visible
+- [ ] 11.5 Dispatch an Engine alpha and install it end to end
+- [ ] 11.6 Confirm a CLI alpha tag left the Engine build workflow untriggered

--- a/openspec/changes/alpha-release-channel/tasks.md
+++ b/openspec/changes/alpha-release-channel/tasks.md
@@ -24,9 +24,12 @@
 - [ ] 4.1 Add an alpha workflow triggered on pushes to the default branch, with a path filter that skips changes which cannot alter what a user runs
 - [ ] 4.2 Write the derived version into `package.json` in the runner without committing it
 - [ ] 4.3 Call the reusable publish workflow with the alpha channel
-- [ ] 4.4 Generate release notes from the commits since the previous alpha tag
-- [ ] 4.5 Add a concurrency group so overlapping merges each end with a distinct published version
-- [ ] 4.6 Make a skipped run report the skip explicitly rather than failing
+- [ ] 4.4 Create and push the derived alpha tag at the built commit, so the next derivation counts it and the next release notes have a boundary
+- [ ] 4.5 Fail the run if the artifact published but its tag did not land, rather than reporting success
+- [ ] 4.6 Generate release notes from the commits since the previous alpha tag
+- [ ] 4.7 Add a concurrency group so overlapping merges each end with a distinct published version
+- [ ] 4.8 Make a skipped run report the skip explicitly rather than failing
+- [ ] 4.9 Verify two consecutive qualifying merges produce two distinct published alpha versions
 
 ## 5. Publish Engine alphas on demand
 

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -16,6 +16,7 @@ rules:
   proposal:
     - Always include a "Non-goals" section
   specs:
+    - Put SHALL or MUST in the requirement's FIRST line — the validator reads only that line, so a SHALL on line two still fails
     - Use glossary terms from openspec/specs/GLOSSARY.md verbatim
     - Every requirement needs at least one happy-path and one error/edge scenario
     - State outcomes, not implementation mechanisms, in requirement text


### PR DESCRIPTION
Refs #685

OpenSpec proposal for an opt-in alpha channel. Documents only — no workflow or source changes in this PR.

## Why

The release path runs once per release, and exercising a change end to end costs a one-use tag plus an irreversible npm publish. Alphas make the release mechanism continuous and let a change be run on a real install before it is blessed.

## Shape

- **CLI alphas continuously** — every push to `main` touching CLI sources publishes to the npm `alpha` dist-tag
- **Engine alphas on demand** — dispatched, published as non-draft Prereleases
- **One publish path shared by both channels**, so an alpha rehearses the real mechanism
- **Versions derived from tags**, not hand-edited; no version-bump commits

Modelled on [`refactoringhq/tolaria`](https://github.com/refactoringhq/tolaria) (alpha on every push to `main`; 18 in a day is normal there). Its four load-bearing properties are push-triggered alphas, a tested version-derivation script, a build workflow shared with stable, and channel separation at the distribution layer.

Kesha needs no new mechanism for the last one — npm dist-tags already are it, and `npm-publish.yml:105-119` already keeps prereleases off `latest`.

Two deliberate divergences: SemVer with a derived sequence instead of calendar versions, and split cadence per artifact.

## Artifacts

| File | Contents |
| --- | --- |
| `proposal.md` | why, what changes, capabilities, non-goals, impact |
| `design.md` | decisions with alternatives, risks → mitigations, migration, open questions |
| `specs/release-channels/spec.md` | new capability — 6 requirements |
| `specs/installation/spec.md` | delta — pre-release verification now scoped to the stable channel |
| `tasks.md` | 9 groups, ordered so the publish-path extraction lands first |

`openspec validate --changes` — 3 passed, 0 failed.

## Notable in the design

Extracting the publish path is prerequisite work, not a follow-up: if the alpha workflow publishes by its own copied steps, alphas stop rehearsing the release and become a parallel implementation that drifts.

Three traps are captured rather than deferred — an engine alpha Prerelease fires `release: published` and would fail the CLI publish version guard; alpha engine tags must not leak into the lanes that download the published engine; and GitHub reserves tag names permanently, so pruning can apply to Releases but never frees an identifier.

Four questions are left open rather than invented: the retention window, whether a CLI alpha may name an engine alpha, glossary entries for channel/alpha/Prerelease, and whether the path filter should include `rust/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FkpxF1agJV6kpBdWpYo4YH