### PR TITLE
chore(release): v1.26.0 (CLI-only)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.25.0",
+  "version": "1.26.0",
   "description": "Give your tools a voice — speech to text and back, 25 languages, up to ~19× faster than Whisper. On your machine.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
CLI-only release. Bumps `package.json#version` 1.25.0 → 1.26.0 and nothing else — `keshaEngine.version` and `rust/Cargo.toml` stay at **1.24.7**, so no engine rebuild and the `-cli` tag suffix keeps `build-engine.yml` out of it.

Minor rather than patch because #667 added Windows x64 support.

## What ships

| PR | |
| --- | --- |
| #679 | `kesha init` no longer hangs at the first yes/no question |
| #681 | model-install output streams live instead of arriving in one burst at the end (TypeScript half) |
| #673 | download backpressure instead of buffering |
| #667 | Windows x64 unblocked |

The published 1.25.0 has the `init` hang, and `kesha init` is the documented onboarding entry point — that is what makes this worth cutting now rather than batching further.

## What does not ship

The Rust half of #681 — the byte-progress bar for large model downloads — stays unreleased. It needs an engine release, and the engine has no other user-visible change to justify a four-platform rebuild yet.

## Pre-flight

- Feature matrix vs cargo defaults: `default = ["onnx", "tts"]`; `tts` in all three rows, `onnx` correctly absent from the CoreML row
- `🧪 CI` and `🧪 Rust Tests` green on main
- `bun run check:versions` clean
- `bun test` — 599 pass, 5 skip, 0 fail
- `bunx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FkpxF1agJV6kpBdWpYo4YH