### PR TITLE
fix(deps): clear two high advisories blocking the release gate

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -23,8 +23,9 @@
     },
   },
   "overrides": {
-    "fast-uri": "^3.1.3",
+    "fast-uri": "^3.1.5",
     "hono": "^4.12.25",
+    "ip-address": "^10.3.1",
   },
   "packages": {
     "@clack/core": ["@clack/core@1.4.0", "", { "dependencies": { "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-7Wctjq6f7c1CPz8sPpkwUnz8yRgVANkpNupb81q432FjcJg4l+Sw7XANdNSdWfAKq0IHI0JTcUeK5dxs/HrGPw=="],
@@ -147,7 +148,7 @@
 
     "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
 
-    "fast-uri": ["fast-uri@3.1.4", "", {}, "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw=="],
+    "fast-uri": ["fast-uri@3.1.5", "", {}, "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="],
 
     "fast-wrap-ansi": ["fast-wrap-ansi@0.2.2", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q=="],
 
@@ -183,7 +184,7 @@
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
-    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
+    "ip-address": ["ip-address@10.4.0", "", {}, "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ=="],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
   },
   "overrides": {
     "hono": "^4.12.25",
-    "fast-uri": "^3.1.3"
+    "fast-uri": "^3.1.5",
+    "ip-address": "^10.3.1"
   }
 }


### PR DESCRIPTION
Prerequisite for the v1.26.0 release PR (#689).

## What

`bun audit --audit-level=high` reports two high transitive advisories, both under `@modelcontextprotocol/sdk`:

| Package | Vulnerable | Path | Advisory |
| --- | --- | --- | --- |
| `fast-uri` | `>=3.0.0 <3.1.5` | `@modelcontextprotocol/sdk › ajv › fast-uri` | [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) |
| `ip-address` | `<=10.3.0` | `@modelcontextprotocol/sdk › express-rate-limit › ip-address` | [GHSA-mwp4-54f8-5fhr](https://github.com/advisories/GHSA-mwp4-54f8-5fhr) |

The `fast-uri` override already existed but was **stale** at `^3.1.3`, which predates the fix. `ip-address` had no override.

`bun update` does not resolve either — the SDK's transitive ranges keep pulling vulnerable versions even after it moves 1.29.0 → 1.30.0.

Raises `fast-uri` to `^3.1.5` and adds `ip-address` at `^10.3.1`. Resolves to **fast-uri 3.1.5** and **ip-address 10.4.0**; `bun audit --audit-level=high` exits 0.

## Why now

`bun-audit` runs on a PR only when dependency files change (`needs.changes.outputs.deps == true`), and a release bump necessarily touches `package.json` — so the release PR is the first thing to trip it. That is deliberate: the job labels itself *"non-blocking until promotion PR"*, and `security-audit` is the required aggregator check. A release is exactly where this debt is meant to be paid.

Kept out of #689 so the release PR stays a one-field change.

## Verification

- `bun audit --audit-level=high` — exit 0, no findings
- `bun test` — 599 pass, 5 skip, 0 fail
- `bunx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FkpxF1agJV6kpBdWpYo4YH