### PR TITLE
chore: carry the next unreleased version on main

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "description": "Give your tools a voice — speech to text and back, 25 languages, up to ~19× faster than Whisper. On your machine.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Refs #685

v1.26.0 is published, so `package.json#version` moves to **1.27.0**. `main` now names the version being worked toward rather than the one already out.

## Why this and not later

This is task 1.1 of the alpha-release-channel change, and it is deliberately first in that plan rather than last.

Alpha versions derive as `<base>-alpha.N`, and a prerelease sorts *below* its own stable version. `check-versions.ts:104` requires `package.json#version >= package.json#keshaEngine.version`, so an alpha only passes the gate while the base leads the engine version. The base at 1.26.0 with the engine at 1.24.7 happens to satisfy it today — the margin is what keeps it satisfied once a `-alpha.N` suffix is appended.

It also makes a stable release a suffix drop instead of a guess about what version comes next.

## Scope

One field. `keshaEngine.version` and `rust/Cargo.toml` stay at 1.24.7.

## Verification

- `bun run check:versions` — exit 0
- `bun test` — 599 pass, 5 skip, 0 fail
- `bunx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FkpxF1agJV6kpBdWpYo4YH