### PR TITLE
chore(rust): point fluidaudio-rs at the fork for the models-dir and compute-unit APIs

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -677,7 +677,7 @@ dependencies = [
 [[package]]
 name = "fluidaudio-rs"
 version = "0.14.8"
-source = "git+https://github.com/FluidInference/fluidaudio-rs?rev=2d8e6b6891ccaf0807f8b6562893b24e5e1ec0f4#2d8e6b6891ccaf0807f8b6562893b24e5e1ec0f4"
+source = "git+https://github.com/drakulavich/fluidaudio-rs?rev=9b7ceda98c4b0485590c04805c62ebde76e66159#9b7ceda98c4b0485590c04805c62ebde76e66159"
 dependencies = [
  "thiserror 1.0.69",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -68,13 +68,19 @@ ort = { version = "2.0.0-rc.12" }
 ndarray = { version = "0.17" }
 
 # FluidAudio (macOS): ASR (CoreML/ANE), native Kokoro TTS, and model-path
-# diarization. Now on upstream `FluidInference/fluidaudio-rs` — the Kokoro
-# binding (upstream PR #19) and `diarize_file_with_models` both landed there, so
-# the fork is retired. Pinned to a rev for reproducible builds. API is unchanged
-# from the fork: `init_kokoro` takes a `lang` arg → `zh` selects the `.mandarin`
-# variant (tone-aware Mandarin G2P), else `.english` (#492); retains the `--rate`
-# model-native speed (#475).
-fluidaudio-rs = { git = "https://github.com/FluidInference/fluidaudio-rs", rev = "2d8e6b6891ccaf0807f8b6562893b24e5e1ec0f4", optional = true }
+# diarization. Back on the fork — NOT a leftover, do not "restore" upstream: it
+# carries two things upstream lacks, both prerequisites for open work.
+# `FluidAudio::with_models_dir` roots ASR/Kokoro/compile-cache under one
+# directory (#688), and `init_kokoro_with_compute_units` selects CoreML compute
+# units, which is the only way Kokoro runs where no ANE is exposed (#678 — the
+# default pins the vocoder stage to it, so a hosted macOS runner cannot even
+# prepare the program). Retire the fork once both land upstream.
+# Trade-off to know: this rev trails `FluidInference/main`, so upstream commits
+# after the previous pin are not present. Everything kesha calls is verified to
+# build against it.
+# `init_kokoro` still takes `lang` → `zh` selects `.mandarin` (tone-aware
+# Mandarin G2P), else `.english` (#492); `--rate` stays model-native (#475).
+fluidaudio-rs = { git = "https://github.com/drakulavich/fluidaudio-rs", rev = "9b7ceda98c4b0485590c04805c62ebde76e66159", optional = true }
 audioadapter-buffers = "3.0.0"
 
 # TTS (Kokoro + SSML parser; G2P via ONNX ByT5 at runtime, see #123)

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -65,7 +65,12 @@ allow-wildcard-paths = true
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-# Upstream FluidAudio Rust bindings, consumed by the `coreml`/`system_*`
-# features (#199, #259). Was the personal fork until the Kokoro binding landed
-# upstream (FluidInference/fluidaudio-rs#19); fork now retired.
-allow-git = ["https://github.com/FluidInference/fluidaudio-rs"]
+# FluidAudio Rust bindings, consumed by the `coreml`/`system_*` features
+# (#199, #259). Both URLs stay allowed: the pin is on the fork for
+# `with_models_dir` (#688) and `init_kokoro_with_compute_units` (#678), which
+# upstream does not expose, and moves back to `FluidInference` once they land
+# there. See rust/Cargo.toml for why the fork is deliberate.
+allow-git = [
+  "https://github.com/FluidInference/fluidaudio-rs",
+  "https://github.com/drakulavich/fluidaudio-rs",
+]


### PR DESCRIPTION
## Why

Two open items need APIs that upstream `fluidaudio-rs` does not expose. Both landed in the fork ([drakulavich/fluidaudio-rs#4](https://github.com/drakulavich/fluidaudio-rs/pull/4)):

| API | Unblocks |
|---|---|
| `FluidAudio::with_models_dir` | #688 — kesha's models live in four roots, only one of them ours |
| `init_kokoro_with_compute_units` | #678 — the only way Kokoro runs where no ANE is exposed |

On #678 specifically: FluidAudio pins the Kokoro vocoder stage to `.cpuAndNeuralEngine`, and a GitHub-hosted macOS runner is an ANE-less VM, so CoreML cannot prepare that program at all. Verified on an M2 that `CpuAndGpu` synthesises in 4.4 s, so the escape hatch works — it just was not reachable from Rust.

## The trade-off, stated plainly

This rev **trails** `FluidInference/main`: upstream commits made after the previous pin are not in this tree. That is a real cost and the reason the `Cargo.toml` comment now explains why the fork is deliberate — the old comment said "the fork is retired", and without a replacement the next reader would restore upstream as a cleanup and silently break both items above.

Retire the fork once both APIs land upstream.

## Verification

Nothing here was assumed from matching method names:

- `cargo check --features coreml --no-default-features` — clean
- `cargo clippy --all-targets` over the full darwin release set (`coreml,tts,system_tts,system_kokoro,system_diarize,system_text_lang`) with `-D warnings` — clean
- `make rust-test` — 401 passed
- `bun test` 604 passed, `bunx tsc --noEmit`, `cargo fmt --check` — clean

The default `onnx,tts` build never compiles `fluidaudio-rs` (it is optional and darwin-gated), so the non-Darwin platforms are untouched by this change.

Refs #678, #688

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzppPnnE76JDqGao3Zj4jq