### PR TITLE
feat(release): resolve the npm dist-tag from the prerelease identifier

### DIFF
--- a/.github/scripts/npm-dist-tag.d.mts
+++ b/.github/scripts/npm-dist-tag.d.mts
@@ -1,0 +1,2 @@
+// The module stays .mjs because npm-publish.yml runs it under node, not bun.
+export function npmDistTag(version: string): string;

--- a/.github/scripts/npm-dist-tag.mjs
+++ b/.github/scripts/npm-dist-tag.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+/**
+ * Resolve the npm dist-tag a version publishes to.
+ *
+ * Derived from the SemVer prerelease identifier rather than from a hardcoded list, so a new
+ * channel needs no edit here: `1.27.0-alpha.1` → `alpha`, `-rc.1` → `rc`, stable → `latest`.
+ * Publishing a prerelease to `latest` would hand it to everyone who never named a channel,
+ * so a version that decodes to `latest` is rejected instead (#685).
+ *
+ * Run via `node .github/scripts/npm-dist-tag.mjs [version]`; prints the tag on stdout.
+ */
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const CHANNEL_RE = /^[a-z][a-z0-9-]*$/;
+
+export function npmDistTag(version) {
+  if (typeof version !== "string" || version === "") {
+    throw new Error("npm dist-tag needs a version string");
+  }
+  if (!version.includes("-")) return "latest";
+
+  const channel = version.slice(version.indexOf("-") + 1).split(".")[0];
+  if (!CHANNEL_RE.test(channel)) {
+    throw new Error(
+      `cannot resolve an npm dist-tag from prerelease version ${version}: ` +
+        `'${channel}' is not a usable channel name (expected something like alpha, beta, rc)`,
+    );
+  }
+  if (channel === "latest") {
+    throw new Error(
+      `refusing to publish prerelease ${version} to the 'latest' dist-tag — ` +
+        "it would reach everyone who did not ask for a prerelease",
+    );
+  }
+  return channel;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  const version = process.argv[2] ?? JSON.parse(readFileSync("package.json", "utf8")).version;
+  process.stdout.write(`${npmDistTag(version)}\n`);
+}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,10 +2,11 @@ name: "📦 npm Publish"
 
 # Fires once a GitHub release leaves draft (the manual gate per CLAUDE.md
 # release flow). Stable releases publish to npm's default `latest` dist-tag;
-# SemVer prereleases (`vX.Y.Z-beta.N`) publish to the `beta` dist-tag so
-# normal `bun add -g @drakulavich/kesha-voice-kit@latest` users do not get
-# unstable builds. CLI-only marker releases (`vX.Y.Z-cli`) follow the same
-# dist-tag rule after stripping `-cli`.
+# a SemVer prerelease publishes to the dist-tag named by its prerelease
+# identifier (`-beta.N` -> `beta`, `-alpha.N` -> `alpha`), so normal
+# `bun add -g @drakulavich/kesha-voice-kit@latest` users do not get unstable
+# builds and channels do not collide with each other. CLI-only marker
+# releases (`vX.Y.Z-cli`) follow the same rule after stripping `-cli`.
 on:
   release:
     types: [published]
@@ -105,14 +106,9 @@ jobs:
       - name: Resolve npm dist-tag
         id: dist_tag
         run: |
-          version=$(jq -r .version package.json)
-          if [[ "$version" == *-* ]]; then
-            echo "tag=beta" >> "$GITHUB_OUTPUT"
-            echo "$version is a prerelease — publishing to npm dist-tag beta."
-          else
-            echo "tag=latest" >> "$GITHUB_OUTPUT"
-            echo "$version is stable — publishing to npm dist-tag latest."
-          fi
+          tag=$(node .github/scripts/npm-dist-tag.mjs)
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "$(jq -r .version package.json) publishes to npm dist-tag $tag."
 
       - name: Publish to npm with provenance
         if: steps.registry.outputs.already_published == 'false'

--- a/tests/unit/npm-dist-tag.test.ts
+++ b/tests/unit/npm-dist-tag.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { npmDistTag } from "../../.github/scripts/npm-dist-tag.mjs";
+
+describe("npmDistTag", () => {
+  test("a stable version publishes to latest", () => {
+    expect(npmDistTag("1.27.0")).toBe("latest");
+  });
+
+  test("a prerelease publishes to the channel it names", () => {
+    expect(npmDistTag("1.27.0-alpha.1")).toBe("alpha");
+    expect(npmDistTag("1.27.0-beta.2")).toBe("beta");
+  });
+
+  test("a channel it has never heard of still resolves", () => {
+    expect(npmDistTag("1.27.0-rc.1")).toBe("rc");
+    expect(npmDistTag("1.27.0-next.1")).toBe("next");
+  });
+
+  test("alpha and beta do not share a dist-tag", () => {
+    expect(npmDistTag("1.27.0-alpha.1")).not.toBe(npmDistTag("1.27.0-beta.1"));
+  });
+
+  test("a prerelease can never reach the latest dist-tag", () => {
+    expect(() => npmDistTag("1.27.0-latest.1")).toThrow(/refusing/);
+  });
+
+  test("rejects a prerelease identifier that is not a usable channel name", () => {
+    for (const version of ["1.27.0-1", "1.27.0-.1", "1.27.0-Alpha.1", "1.27.0-"]) {
+      expect(() => npmDistTag(version)).toThrow(/not a usable channel name/);
+    }
+  });
+
+  test("rejects a missing version rather than guessing", () => {
+    expect(() => npmDistTag("")).toThrow();
+  });
+});


### PR DESCRIPTION
Refs #685 — task 4.1. Blocking: this must land before any alpha is un-drafted.

## Why this is not cosmetic

Without it the alpha channel does not exist at the consumer end. `Resolve npm dist-tag` was:

```bash
if [[ "$version" == *-* ]]; then echo "tag=beta"
```

A CLI alpha (`1.27.0-alpha.1`) satisfies that branch and publishes to `@beta`. Everyone on `bun add -g @drakulavich/kesha-voice-kit@beta` — the install line documented in the `release-mechanics` skill — would silently start receiving alphas, and `npm view …@beta version` would stop meaning "the latest beta".

Un-drafting is the irreversible step, so this bites on the **first published alpha**, not in review.

## Change

Derive the tag from the SemVer prerelease identifier rather than from "has a hyphen":

| version | dist-tag |
| --- | --- |
| `1.27.0` | `latest` |
| `1.27.0-alpha.1` | `alpha` |
| `1.27.0-beta.2` | `beta` |
| `1.27.0-rc.1` | `rc` |

Generalises to any future channel with no further edit — strictly less code than adding an `alpha` special case beside the `beta` one.

## Two refusals instead of a silent surprise

- A version whose identifier decodes to `latest` (`1.27.0-latest.1`) is **rejected**. Publishing a prerelease there hands it to everyone who never asked for one.
- An identifier that is not a usable channel name (`1.27.0-1`, `1.27.0-Alpha.1`, `1.27.0-`) is **rejected** rather than silently becoming a dist-tag nobody meant to create.

## Why a script and not inline bash

The logic no longer fits CLAUDE.md's three-line limit for inline CI scripts. Extracting it also makes it unit-testable, which the inline bash was not.

Verified the refusal actually fails the workflow step, rather than being swallowed by command substitution — under `bash -e` as Actions runs it, a failing substitution in an assignment aborts the step:

```
$ bash -e -c 'tag=$(node .github/scripts/npm-dist-tag.mjs 1.27.0-latest.1); echo REACHED'
step exit=1          # REACHED never printed
```

## Verification

- `bun test` — 618 pass (7 new), 5 skip, 0 fail
- `bunx tsc --noEmit`, `bun run check:workflows`, `bun run check:release-manifest` — clean
- Exercised end to end the way the workflow calls it (no args → reads `package.json`)

## Still open on the alpha channel

Two things named in the #692 review, neither blocking this PR:

- The stable-engine-tag comparison against `package.json#version` already trips on `main` (CLI 1.27.0 vs engine 1.24.7) and must be settled **before the next stable engine release**.
- The alpha channel has no documented policy yet — the validators accept three shapes with no stated rule for choosing between them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FkpxF1agJV6kpBdWpYo4YH