### PR TITLE
feat(release): derive alpha versions from the tags that exist

### DIFF
--- a/.github/scripts/check-versions.ts
+++ b/.github/scripts/check-versions.ts
@@ -13,63 +13,17 @@
  * build matrix.
  */
 import { readFileSync } from "node:fs";
+import { cmp, fmt, parseSemver, type SemVer } from "./semver";
 
-type SemVer = {
-  major: number;
-  minor: number;
-  patch: number;
-  prerelease: string[];
-};
-
-function parseSemver(raw: string, label: string): SemVer {
-  const m = raw.match(
-    /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/,
-  );
-  if (!m) {
-    console.error(`${label}: not a valid x.y.z semver (got '${raw}')`);
+function parseOrExit(raw: string, label: string): SemVer {
+  try {
+    return parseSemver(raw, label);
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
     process.exit(1);
   }
-  return {
-    major: Number(m[1]),
-    minor: Number(m[2]),
-    patch: Number(m[3]),
-    prerelease: m[4]?.split(".") ?? [],
-  };
 }
 
-function cmp(a: SemVer, b: SemVer): number {
-  if (a.major !== b.major) return a.major - b.major;
-  if (a.minor !== b.minor) return a.minor - b.minor;
-  if (a.patch !== b.patch) return a.patch - b.patch;
-
-  // SemVer precedence: a stable version outranks its prereleases.
-  if (a.prerelease.length === 0 && b.prerelease.length === 0) return 0;
-  if (a.prerelease.length === 0) return 1;
-  if (b.prerelease.length === 0) return -1;
-
-  const len = Math.max(a.prerelease.length, b.prerelease.length);
-  for (let i = 0; i < len; i++) {
-    const ai = a.prerelease[i];
-    const bi = b.prerelease[i];
-    if (ai === undefined) return -1;
-    if (bi === undefined) return 1;
-    if (ai === bi) continue;
-
-    const an = ai.match(/^(0|[1-9]\d*)$/);
-    const bn = bi.match(/^(0|[1-9]\d*)$/);
-    if (an && bn) return Number(ai) - Number(bi);
-    if (an) return -1;
-    if (bn) return 1;
-    return ai < bi ? -1 : 1;
-  }
-
-  return 0;
-}
-
-function fmt(v: SemVer): string {
-  const base = `${v.major}.${v.minor}.${v.patch}`;
-  return v.prerelease.length ? `${base}-${v.prerelease.join(".")}` : base;
-}
 
 const pkgRaw = JSON.parse(readFileSync("package.json", "utf8"));
 const cargoToml = readFileSync("rust/Cargo.toml", "utf8");
@@ -81,12 +35,12 @@ if (!cargoVersionMatch) {
   process.exit(1);
 }
 
-const cli = parseSemver(pkgRaw.version, "package.json#version");
-const engine = parseSemver(
+const cli = parseOrExit(pkgRaw.version, "package.json#version");
+const engine = parseOrExit(
   pkgRaw.keshaEngine?.version ?? "",
   "package.json#keshaEngine.version",
 );
-const cargo = parseSemver(cargoVersionMatch[1], "rust/Cargo.toml#version");
+const cargo = parseOrExit(cargoVersionMatch[1], "rust/Cargo.toml#version");
 
 let failed = false;
 

--- a/.github/scripts/derive-alpha-version.ts
+++ b/.github/scripts/derive-alpha-version.ts
@@ -1,0 +1,106 @@
+#!/usr/bin/env bun
+/**
+ * Derive the next alpha version and tag from the tags that already exist.
+ *
+ * No commit records an alpha version — the sequence lives in the tags, which is why every
+ * published alpha must leave one behind (#685). Run with `cli` or `engine`; prints
+ * `version=`/`tag=` lines suitable for `$GITHUB_OUTPUT`.
+ */
+import { readFileSync } from "node:fs";
+import { cmp, parseSemver } from "./semver";
+
+export type Channel = "cli" | "engine";
+
+/** CLI alphas carry the `-cli` marker so the engine build's `!v*-cli` filter skips them (#685). */
+const MARKER: Record<Channel, string> = { cli: "-cli", engine: "" };
+
+export function alphaTag(channel: Channel, base: string, sequence: number): string {
+  return `v${base}-alpha.${sequence}${MARKER[channel]}`;
+}
+
+export function nextSequence(channel: Channel, base: string, tags: string[]): number {
+  if (tags.length === 0) {
+    throw new Error(
+      "no tags visible — refusing to derive a sequence that would restart at 1. " +
+        "Fetch full history and tags before deriving (a shallow checkout looks identical to a fresh repo).",
+    );
+  }
+  const pattern = new RegExp(
+    `^v${base.replace(/[.\\+*?^$()[\]{}|]/g, "\\$&")}-alpha\\.(\\d+)${MARKER[channel]}$`,
+  );
+  let highest = 0;
+  for (const tag of tags) {
+    const match = pattern.exec(tag.trim());
+    if (match) highest = Math.max(highest, Number(match[1]));
+  }
+  return highest + 1;
+}
+
+/**
+ * `check-versions.ts` requires the CLI version to be >= the engine version, and a prerelease
+ * sorts below its own stable version — so a CLI base equal to the engine version would make
+ * every alpha of it fail that gate. Refuse here rather than at publish time.
+ */
+export function assertPassesVersionGate(version: string, engineVersion: string): void {
+  if (cmp(parseSemver(version, "derived version"), parseSemver(engineVersion, "engine version")) < 0) {
+    throw new Error(
+      `derived version ${version} is below package.json#keshaEngine.version (${engineVersion}) ` +
+        "and would fail `bun run check:versions`. Bump the base on main so it leads the engine version.",
+    );
+  }
+}
+
+/**
+ * The CLI base comes from `package.json#version`, which main carries as the *next* unreleased
+ * version. `keshaEngine.version` is the opposite — the *released* engine the CLI downloads — so
+ * an engine alpha must name its target explicitly, or it would derive an alpha of an already
+ * released version, which sorts below it and reads as a downgrade.
+ */
+export function deriveAlpha(
+  channel: Channel,
+  pkg: { version: string; keshaEngine?: { version?: string } },
+  tags: string[],
+  engineBase?: string,
+): { version: string; tag: string; sequence: number } {
+  const engineVersion = pkg.keshaEngine?.version ?? pkg.version;
+  let base: string;
+
+  if (channel === "cli") {
+    base = pkg.version;
+  } else {
+    if (!engineBase) {
+      throw new Error(
+        "an engine alpha needs its target version — package.json#keshaEngine.version " +
+          `(${engineVersion}) names the released engine, and an alpha of it would sort below it`,
+      );
+    }
+    base = engineBase;
+    if (cmp(parseSemver(base, "engine base"), parseSemver(engineVersion, "engine version")) <= 0) {
+      throw new Error(
+        `engine alpha base ${base} must be above the released engine version ${engineVersion}`,
+      );
+    }
+  }
+
+  if (base.includes("-")) {
+    throw new Error(`alpha base must be a stable version, got ${base} — alphas derive from it`);
+  }
+
+  const sequence = nextSequence(channel, base, tags);
+  const version = `${base}-alpha.${sequence}`;
+  if (channel === "cli") assertPassesVersionGate(version, engineVersion);
+
+  return { version, tag: alphaTag(channel, base, sequence), sequence };
+}
+
+if (import.meta.main) {
+  const channel = process.argv[2] as Channel;
+  if (channel !== "cli" && channel !== "engine") {
+    console.error("usage: bun .github/scripts/derive-alpha-version.ts <cli|engine> [engine-base-version]");
+    process.exit(2);
+  }
+  const pkg = JSON.parse(readFileSync("package.json", "utf8"));
+  const tags = Bun.spawnSync(["git", "tag", "--list"]).stdout.toString().split("\n").filter(Boolean);
+  const derived = deriveAlpha(channel, pkg, tags, process.argv[3]);
+  process.stdout.write(`version=${derived.version}\ntag=${derived.tag}\n`);
+}

--- a/.github/scripts/semver.ts
+++ b/.github/scripts/semver.ts
@@ -1,0 +1,61 @@
+/**
+ * SemVer parsing and precedence, shared by the version drift gate and the alpha
+ * version derivation — both must agree on "a stable version outranks its prereleases",
+ * or a derived alpha could pass one and fail the other (#685).
+ */
+
+export type SemVer = {
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease: string[];
+};
+
+export function parseSemver(raw: string, label: string): SemVer {
+  const m = raw.match(
+    /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/,
+  );
+  if (!m) {
+    throw new Error(`${label}: not a valid x.y.z semver (got '${raw}')`);
+  }
+  return {
+    major: Number(m[1]),
+    minor: Number(m[2]),
+    patch: Number(m[3]),
+    prerelease: m[4]?.split(".") ?? [],
+  };
+}
+
+export function cmp(a: SemVer, b: SemVer): number {
+  if (a.major !== b.major) return a.major - b.major;
+  if (a.minor !== b.minor) return a.minor - b.minor;
+  if (a.patch !== b.patch) return a.patch - b.patch;
+
+  // SemVer precedence: a stable version outranks its prereleases.
+  if (a.prerelease.length === 0 && b.prerelease.length === 0) return 0;
+  if (a.prerelease.length === 0) return 1;
+  if (b.prerelease.length === 0) return -1;
+
+  const len = Math.max(a.prerelease.length, b.prerelease.length);
+  for (let i = 0; i < len; i++) {
+    const ai = a.prerelease[i];
+    const bi = b.prerelease[i];
+    if (ai === undefined) return -1;
+    if (bi === undefined) return 1;
+    if (ai === bi) continue;
+
+    const an = ai.match(/^(0|[1-9]\d*)$/);
+    const bn = bi.match(/^(0|[1-9]\d*)$/);
+    if (an && bn) return Number(ai) - Number(bi);
+    if (an) return -1;
+    if (bn) return 1;
+    return ai < bi ? -1 : 1;
+  }
+
+  return 0;
+}
+
+export function fmt(v: SemVer): string {
+  const base = `${v.major}.${v.minor}.${v.patch}`;
+  return v.prerelease.length ? `${base}-${v.prerelease.join(".")}` : base;
+}

--- a/tests/unit/derive-alpha-version.test.ts
+++ b/tests/unit/derive-alpha-version.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+import {
+  alphaTag,
+  assertPassesVersionGate,
+  deriveAlpha,
+  nextSequence,
+} from "../../.github/scripts/derive-alpha-version";
+
+const PKG = { version: "1.27.0", keshaEngine: { version: "1.24.7" } };
+const SOME_TAGS = ["v1.24.7", "v1.26.0-cli", "v1.22.0-beta.1"];
+
+describe("nextSequence", () => {
+  test("starts at 1 when the base has no alphas yet", () => {
+    expect(nextSequence("cli", "1.27.0", SOME_TAGS)).toBe(1);
+  });
+
+  test("takes one above the highest existing alpha, not the count", () => {
+    const tags = [...SOME_TAGS, "v1.27.0-alpha.1-cli", "v1.27.0-alpha.7-cli"];
+
+    expect(nextSequence("cli", "1.27.0", tags)).toBe(8);
+  });
+
+  test("compares sequences numerically, not as strings", () => {
+    const tags = [...SOME_TAGS, "v1.27.0-alpha.9-cli", "v1.27.0-alpha.10-cli"];
+
+    expect(nextSequence("cli", "1.27.0", tags)).toBe(11);
+  });
+
+  test("ignores alphas of a different base", () => {
+    expect(nextSequence("cli", "1.27.0", [...SOME_TAGS, "v1.26.0-alpha.5-cli"])).toBe(1);
+  });
+
+  test("ignores the other artifact's alphas", () => {
+    expect(nextSequence("cli", "1.27.0", [...SOME_TAGS, "v1.27.0-alpha.5"])).toBe(1);
+    expect(nextSequence("engine", "1.27.0", [...SOME_TAGS, "v1.27.0-alpha.5-cli"])).toBe(1);
+  });
+
+  test("ignores malformed tags rather than mis-counting", () => {
+    const tags = [...SOME_TAGS, "v1.27.0-alpha-cli", "v1.27.0-alpha.x-cli", "1.27.0-alpha.3-cli"];
+
+    expect(nextSequence("cli", "1.27.0", tags)).toBe(1);
+  });
+
+  // A shallow checkout has no tags and is indistinguishable from a fresh repo (#685).
+  test("refuses to derive when no tags are visible at all", () => {
+    expect(() => nextSequence("cli", "1.27.0", [])).toThrow(/no tags visible/);
+  });
+});
+
+describe("alphaTag", () => {
+  test("a CLI alpha carries the marker the engine build filters out", () => {
+    expect(alphaTag("cli", "1.27.0", 3)).toBe("v1.27.0-alpha.3-cli");
+  });
+
+  test("an engine alpha does not", () => {
+    expect(alphaTag("engine", "1.24.8", 3)).toBe("v1.24.8-alpha.3");
+  });
+});
+
+describe("assertPassesVersionGate", () => {
+  test("accepts a version that leads the engine", () => {
+    expect(() => assertPassesVersionGate("1.27.0-alpha.1", "1.24.7")).not.toThrow();
+  });
+
+  // A prerelease sorts below its own stable version, so an equal base fails check:versions.
+  test("rejects a base equal to the engine version", () => {
+    expect(() => assertPassesVersionGate("1.24.7-alpha.1", "1.24.7")).toThrow(/check:versions/);
+  });
+});
+
+describe("deriveAlpha", () => {
+  test("the CLI base comes from the next unreleased version on main", () => {
+    expect(deriveAlpha("cli", PKG, SOME_TAGS)).toEqual({
+      version: "1.27.0-alpha.1",
+      tag: "v1.27.0-alpha.1-cli",
+      sequence: 1,
+    });
+  });
+
+  test("an engine alpha must name its target rather than inherit the released one", () => {
+    expect(() => deriveAlpha("engine", PKG, SOME_TAGS)).toThrow(/needs its target version/);
+  });
+
+  test("an engine alpha derives from the named target", () => {
+    expect(deriveAlpha("engine", PKG, SOME_TAGS, "1.24.8")).toEqual({
+      version: "1.24.8-alpha.1",
+      tag: "v1.24.8-alpha.1",
+      sequence: 1,
+    });
+  });
+
+  test("refuses an engine target at or below what is already released", () => {
+    for (const base of ["1.24.7", "1.24.6"]) {
+      expect(() => deriveAlpha("engine", PKG, SOME_TAGS, base)).toThrow(/must be above/);
+    }
+  });
+
+  test("refuses a base that is already a prerelease", () => {
+    const pkg = { version: "1.27.0-alpha.1", keshaEngine: { version: "1.24.7" } };
+
+    expect(() => deriveAlpha("cli", pkg, SOME_TAGS)).toThrow(/must be a stable version/);
+  });
+});


### PR DESCRIPTION
Refs #685 — task 5. Nothing publishes an alpha yet; this is the derivation the workflow will consume.

## How the sequence is decided

`nextSequence` takes **one above the highest existing alpha** for that base and artifact — not the count. A count silently repeats a version if a tag is ever missing, and the whole point of the tag is that the identifier is permanently taken.

It compares numerically (so `alpha.10` follows `alpha.9` rather than sorting between `alpha.1` and `alpha.2`) and ignores tags belonging to another base, the other artifact, or no grammar at all.

An **empty tag list is refused**, not derived from. A shallow checkout is indistinguishable from a fresh repository, and the failure it produces — restarting at `alpha.1` — is exactly the silent version reuse the tag exists to prevent.

## A bug I found by running it, not by reading it

The CLI base is `package.json#version`, which main carries as the *next unreleased* version. I initially took the engine base from `keshaEngine.version` by symmetry. Running it against this repo:

```
$ bun .github/scripts/derive-alpha-version.ts engine
version=1.24.7-alpha.1
```

`1.24.7` is **already released**. That alpha sorts *below* the release it claims to precede — a downgrade wearing a newer tag. `keshaEngine.version` is the opposite of the CLI field: it names the engine the CLI currently downloads, so it can never be an alpha base.

An engine alpha now names its target explicitly and is refused if that target is not above what has shipped:

| invocation | result |
| --- | --- |
| `engine` | refused — *needs its target version* |
| `engine 1.24.8` | `1.24.8-alpha.1` / `v1.24.8-alpha.1` |
| `engine 1.24.7` | refused — *must be above the released engine version* |
| `cli` | `1.27.0-alpha.1` / `v1.27.0-alpha.1-cli` |

## Guarding the version gate up front

`assertPassesVersionGate` refuses a CLI version that would fail `bun run check:versions`. A prerelease sorts below its own stable version, so a base equal to the engine version makes *every* alpha of it fail rule 2. Catching that at derivation beats catching it at publish time.

## Shared SemVer

Parsing and precedence move to `.github/scripts/semver.ts`, shared with the drift gate — both must agree on "a stable version outranks its prereleases", or a derived alpha could pass one and fail the other.

`parseSemver` now **throws** instead of calling `process.exit`, so it is testable. `check-versions.ts` wraps it and prints the identical message; `bun run check:versions` still passes unchanged.

## Verification

- `bun test` — 642 pass (16 new), 5 skip, 0 fail
- `bunx tsc --noEmit`, `check:versions`, `check:workflows`, `check:release-manifest` — clean
- Exercised every branch of the CLI entry point against the real tag list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FkpxF1agJV6kpBdWpYo4YH