### PR TITLE
chore(ci): control run for the coreml-regression failures on #699

### DIFF
--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -42,6 +42,7 @@ jobs:
             # fluidaudio-rs commit, so a bump (the regression vector) always
             # lands here even though it's a git-branch dep.
             coreml:
+              # Listing this workflow means any edit to it wakes the ANE lane on a cold cache (#675).
               - 'rust/src/backend/fluidaudio.rs'
               - 'rust/build.rs'
               - 'rust/Cargo.toml'


### PR DESCRIPTION
**Draft / control experiment. Not for merge as-is — close once it has answered the question.**

## Question

`coreml-regression` has failed 3/3 on #699 while passing 2/2 on other branches today, across *both* fluidaudio-rs pins. #699's diff contains no Rust code and does not touch that job — it only wakes it because `.github/workflows/rust-test.yml` is listed in the `coreml` paths filter. But the asymmetry is real and I could not rule out #699 as the cause by inspection.

The one variable I could not isolate: every pass was before 10:10 UTC, every failure after 10:33. `coreml-regression` never runs on main (`if: github.event_name == 'pull_request'`), so there is no post-10:53 data point from any other branch to compare against.

## Method

The entire diff is **one line of comment**. That is enough to match the `coreml` filter and wake the ANE lane, on current main's content, with a cold cache (guaranteed cold by #675 — caches are PR-scoped and main never populates one).

- `coreml-regression` **fails here** → the failures on #699 are environmental, not caused by that PR.
- `coreml-regression` **passes here** → something about #699 really is implicated, and it must not be merged until that is understood.

## Today's data

| time (UTC) | branch | pin (cache key) | cold? | result |
|---|---|---|---|---|
| 08:09 | dependabot | upstream `b62bf67d` | yes | pass (212s) |
| 10:10 | fluidaudio-fork | fork `7b7ea177` | yes | pass |
| 10:30 | fluidaudio-fork | fork `7b7ea177` | no (warm) | pass |
| 10:33 | #699 | upstream `b62bf67d` | yes | fail (85s) |
| 10:42 | #699 | upstream `b62bf67d` | yes | fail (149s) |
| 11:05 | #699 | fork `7b7ea177` | yes | fail |

#694 merged at 10:53, which is why #699's merge commit switched cache keys.

Failures are consistently *faster* than the pass (85s / 149s vs 212s), so they are not timeouts — the Swift bridge returns `Transcription failed` early, which is consistent with an incomplete model download.

Refs #675

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UU2vgxhrf56CN8YDqbg3q1