### PR TITLE
fix(package): stop shipping tests that .npmignore already excluded

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "SKILL.md",
     "LICENSE",
     "NOTICES.md",
-    "README.md"
+    "README.md",
+    "!src/__tests__"
   ],
   "openclaw": {
     "extensions": [


### PR DESCRIPTION
You asked for a `.npmignore`. There already is one — and it has been powerless.

## What was actually wrong

`.npmignore` has listed `src/__tests__/` and `*.test.ts` for a long time:

```
tests/
docs/
src/__tests__/
.gitattributes
*.test.ts
```

npm packed them anyway. When `package.json#files` is present it is *the* allowlist, and a root `.npmignore` does not subtract from it. The stated intent has been inert.

## Verified with the packer, not by reading the config

Writing those same patterns into `.npmignore` changed nothing. A negation inside `files` took effect:

| | files | unpacked | `src/__tests__` |
| --- | --- | --- | --- |
| before | 75 | 350 kB | packed |
| after | 72 | 347 kB | none |

## Scope

Three files and 3 kB, so this is about correctness rather than weight: someone installing the CLI should not receive its test suite, and the repo already said as much.

`.npmignore` stays — it still governs anything not reached through `files`.

## Correction

I told Greptile on #703 that this repo has no `.npmignore`. That was wrong — I inferred it from a shell alias that returned nothing. The conclusion I drew from it still held (those files do ship, so treating changes to them as publishable was correct), but the stated reason was not. Corrected on that thread.

## Consequence for #703

Once tests stop shipping, the alpha filter's `files`-prefix approach becomes slightly wrong: it would mark `src/__tests__/x.test.ts` publishable when the tarball no longer contains it. That is the safe direction — a spare alpha version rather than a missed one — but I am switching that filter to the real packed list, which handles negations, `.npmignore` and everything else by construction.

## Verification

- `npm pack --dry-run` before and after, shown above
- `bun test` — 642 pass, 5 skip, 0 fail
- `bunx tsc --noEmit`, `check:versions`, `check:workflows`, `check:release-manifest` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FkpxF1agJV6kpBdWpYo4YH