### PR TITLE
test: give the pid-poll helpers 10s of headroom

### DIFF
--- a/tests/helpers/process.ts
+++ b/tests/helpers/process.ts
@@ -1,8 +1,9 @@
 import { existsSync, readFileSync } from "fs";
 
 const PID_FILE_POLL_INTERVAL_MS = 25;
-const PID_FILE_POLL_ATTEMPTS = 80;
-const PID_EXIT_POLL_ATTEMPTS = 120;
+// 10s budgets, ~10x the slowest observed teardown (1.0s), so a loaded runner still asserts.
+const PID_FILE_POLL_ATTEMPTS = 400;
+const PID_EXIT_POLL_ATTEMPTS = 400;
 
 export async function waitForPidFile(path: string): Promise<number> {
   for (let i = 0; i < PID_FILE_POLL_ATTEMPTS; i++) {

--- a/tests/helpers/process.ts
+++ b/tests/helpers/process.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from "fs";
 
 const PID_FILE_POLL_INTERVAL_MS = 25;
-// 10s budgets, ~10x the slowest observed teardown (1.0s), so a loaded runner still asserts.
+// 10s: the fake engine traps SIGTERM, so every abort waits out FORCE_KILL_GRACE_MS before SIGKILL.
 const PID_FILE_POLL_ATTEMPTS = 400;
 const PID_EXIT_POLL_ATTEMPTS = 400;
 


### PR DESCRIPTION
PR 2 of the design merged in #693 — but **only half of it**. The other half was dropped after its prerequisite check refuted the premise. Details below, since the design doc says otherwise and shouldn't be trusted on this point.

## What landed

`abort terminates the spawned engine process tree` (`tests/unit/engine.test.ts:204`) runs 31ms–1.0s on macOS and a stable 1.0s on ubuntu. The stability on ubuntu is the informative part: 1.0s is real process-teardown latency, not poll granularity, so polling *faster* would achieve nothing.

What was thin is headroom. `waitForPidFile` allowed 80 × 25ms = 2s against an observed ~1.0s worst case — only 2× margin. A loaded runner could breach it, and the failure would surface as `timed out waiting for pid file` rather than the assertion the test exists to make. Both ceilings now allow 10s.

Costs nothing when the process exits promptly: both loops return on the first successful poll. Worst case is 20s if one test exhausts both, still inside the suite's `--timeout 30000` (CI runs `bun run test:unit` / `test:integration`, both of which set it).

## What was dropped, and why

The design claimed merging `tts::vosk::tests::synth_short_phrase_produces_audio` and `rejects_out_of_range_speaker` into one test would "save roughly one to two minutes per platform per run", since each independently calls `Vosk::load`. It also required verifying that claim against a raw JUnit artifact first, because the two reported *identical* durations on the dashboard — too exact to be coincidence.

Checked against artifacts from run 30907659674. Both parts of the premise were wrong:

| platform | `rejects` | `synth` | start delta | whole suite |
|---|---|---|---|---|
| ubuntu | 88.814s | 90.165s | 16ms | 96.495s |
| macos-14 | 77.901s | 81.753s | 4ms | 111.779s |
| windows | 143.393s | 144.167s | 19ms | 159.827s |

1. The durations are **not** identical — 88.8 vs 90.2 on ubuntu. The dashboard rounded both to "1 min 36 sec".
2. The two tests start within 4–19ms of each other on every platform, so nextest runs them **concurrently**, not serially. A merged test would take as long as the slower of the two. The predicted saving does not exist.

So merging them would buy roughly nothing in wall clock, while coupling an error-path assertion to a happy-path one and making a failure less diagnostic. Dropped under the design's own prerequisite clause.

## Worth a separate look

The real finding is that these two tests cost 78–144s **each**, against a next-slowest Rust test of 22.8s. On Windows they are the critical path for the entire suite. That is a genuine cost, but the fix is not "merge two tests" — it is understanding why exercising a cached Vosk model takes over a minute. Happy to open an issue with the numbers above if useful.

## Verification

`bunx tsc --noEmit` clean. `bun run test:unit` → 503 tests, 0 fail. `bun run test:integration` → 51 tests, 0 fail. Both files that consume these helpers (`engine.test.ts`, `cli-contracts.test.ts`) pass individually — 20/20 each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UU2vgxhrf56CN8YDqbg3q1