### PR TITLE
fix(install): stop downloading ONNX ASR weights a CoreML build cannot read

### DIFF
--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -158,7 +158,8 @@ jobs:
       # coreml code because no PR CI job ever tried to build it.
       - name: Check coreml feature
         if: matrix.os == 'macos-14'
-        run: cd rust && cargo check --features coreml --no-default-features
+        # --all-targets so the `#[cfg(feature = "coreml")]` tests compile here too (#708).
+        run: cd rust && cargo check --features coreml --no-default-features --all-targets
 
       # The default-feature nextest run (`run-cargo-test.sh`) builds only
       # `onnx,tts`, so the darwin-arm64 FluidAudio paths — `system_kokoro`

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ curl -fsSL https://bun.sh/install | bash        # or: brew install oven-sh/bun/b
 bun add -g @drakulavich/kesha-voice-kit
 kesha --version                                 # confirms `kesha` resolved on PATH
 kesha install --plan                            # preview exact download/disk sizes first — downloads nothing
-kesha install        # ~2.5 GB (engine + speech-to-text models), explicit — never automatic.
+kesha install        # ~2.5 GB on Linux/Windows; ~0.6 GB on Apple Silicon, whose CoreML
+                      # engine uses a different, smaller model set. Explicit — never automatic.
                       # No progress bar during the model step; can take several minutes.
                       # Prefer a guided wizard? `kesha init` walks through the same choices interactively.
 

--- a/openspec/changes/darwin-skips-onnx-asr/.openspec.yaml
+++ b/openspec/changes/darwin-skips-onnx-asr/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-04

--- a/openspec/changes/darwin-skips-onnx-asr/design.md
+++ b/openspec/changes/darwin-skips-onnx-asr/design.md
@@ -60,7 +60,7 @@ no-auto-download guarantee is unchanged; the check simply stops asking about the
 
 *Alternative considered:* return `true` unconditionally on coreml. Rejected — it deletes the
 guard rather than correcting it, and the first `kesha audio.ogg` on a fresh machine would then
-pull ~934 MB with no warning at all.
+pull ~473 MB with no warning at all.
 
 ### D3 — `--plan` names the external bundle instead of hiding it
 
@@ -69,7 +69,7 @@ is replaced by one describing FluidAudio's bundle: named, approximate size, and 
 by the Backend rather than by Kesha.
 
 Dropping the row entirely was rejected: `--plan` exists so the cost is known before it is paid,
-and ~934 MB is still a cost. Quoting 2.43 GB of ONNX is wrong; quoting nothing is also wrong.
+and ~473 MB is still a cost. Quoting 2.43 GB of ONNX is wrong; quoting nothing is also wrong.
 
 ### D4 — Diagnostics follow the Kokoro precedent
 
@@ -94,7 +94,7 @@ rather than inventing a second vocabulary for "lives outside the Model cache".
   sibling is the wrong target. Keying on it would report a healthy install as broken, which is
   the exact regression this change exists to avoid.
 - **Install feels slower to complete on macOS despite downloading less**, because the
-  ~934 MB moves from a visible download into the warm-up step. Worth watching against #680's
+  ~473 MB moves from a visible download into the warm-up step. Worth watching against #680's
   complaint; not a reason to keep downloading 2.43 GB.
 
 ## Open Questions

--- a/openspec/changes/darwin-skips-onnx-asr/design.md
+++ b/openspec/changes/darwin-skips-onnx-asr/design.md
@@ -1,0 +1,104 @@
+## Context
+
+`models::install` builds one manifest for every build:
+
+```rust
+let manifest: Vec<&ModelFile> = ASR_FILES.iter().chain(LANG_ID_FILES.iter()).collect();
+```
+
+`ASR_FILES` has no `cfg`, so it compiles into the CoreML binary too, and
+`create_backend`'s coreml arm discards the directory it names (`let _ = model_dir;`).
+`lang_id.rs` only ever asks for `ModelKind::LangId`. Nothing on that build reads
+`models/parakeet-tdt-v3`.
+
+The directory is nevertheless load-bearing in one place: `transcribe::ensure_asr_installed`
+gates Transcription on `is_cached(ModelKind::Asr)`. On darwin that check is not protecting
+against a missing model — FluidAudio fetches its own bundle at warm-up (or at first use under
+`--no-warmup`) — it is acting as a proxy for "the user ran `kesha install`".
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A macOS install downloads only what its Backend can read.
+- What `--plan` promises equals what the platform downloads.
+- A healthy macOS install reports healthy in `status` and `doctor`.
+- No change to Linux/Windows behaviour whatsoever.
+
+**Non-Goals:**
+
+- Changing how or when FluidAudio fetches its ASR bundle.
+- Hash-pinning that bundle (it is fetched by the Swift library, not by `download_verified`).
+- The CharsiuG2P set darwin also over-downloads — same class, separate change.
+
+## Decisions
+
+### D1 — Gate the manifest, not the `ModelKind`
+
+`ASR_FILES` and its two uses (`install`'s manifest, `is_cached_in`'s `Asr` arm) become
+`#[cfg(not(feature = "coreml"))]`. `ModelKind::Asr`, `model_dir(Asr)` and the enum stay — they
+remain meaningful on ONNX builds and are referenced by the warm-up call path on both.
+
+Gating the const is required, not cosmetic: under `-D warnings`, an `ASR_FILES` left unreferenced
+on the coreml build is a `dead_code` error (CLAUDE.md NO SPECULATIVE FIELDS).
+
+*Alternative considered:* a runtime `if cfg!(feature = "coreml")` inside `install`. Rejected —
+it leaves the 5-entry const compiled into a binary that can never use it, and `cfg!` would not
+silence `dead_code` anyway.
+
+### D2 — On CoreML, Transcription's pre-flight asks FluidAudio's question
+
+`ensure_asr_installed` keeps its contract — *refuse with an actionable hint rather than
+download* — but on a coreml build it checks FluidAudio's external cache instead of the ONNX
+directory.
+
+This is deliberately **not** a behaviour change for the user, and that is worth stating
+precisely: today, a darwin user who runs `kesha install --no-warmup` gets the ONNX files
+(so the gate passes) and then FluidAudio downloads its bundle silently at first transcribe.
+After this change the gate reports the state of the bundle that actually matters. The
+no-auto-download guarantee is unchanged; the check simply stops asking about the wrong files.
+
+*Alternative considered:* return `true` unconditionally on coreml. Rejected — it deletes the
+guard rather than correcting it, and the first `kesha audio.ogg` on a fresh machine would then
+pull ~934 MB with no warning at all.
+
+### D3 — `--plan` names the external bundle instead of hiding it
+
+`install-plan.ts` builds its ASR row from the same `ASR_FILES` list. On a CoreML target that row
+is replaced by one describing FluidAudio's bundle: named, approximate size, and marked as fetched
+by the Backend rather than by Kesha.
+
+Dropping the row entirely was rejected: `--plan` exists so the cost is known before it is paid,
+and ~934 MB is still a cost. Quoting 2.43 GB of ONNX is wrong; quoting nothing is also wrong.
+
+### D4 — Diagnostics follow the Kokoro precedent
+
+`status --disk` and `doctor` already report the FluidAudio *Kokoro* cache as an external
+component. The ASR bundle gets the same treatment on coreml builds, reusing that presentation
+rather than inventing a second vocabulary for "lives outside the Model cache".
+
+## Risks / Trade-offs
+
+- **A stale diagnostic makes a healthy install look broken** → this is the main risk and the
+  reason the TS half is in scope rather than deferred. Acceptance is a real macOS install where
+  `status --disk` and `doctor` both report ASR healthy with no ONNX path in sight.
+- **The Rust change is invisible to PR CI.** `rust-test.yml` builds `onnx,tts` for the nextest
+  run; the coreml feature set is only type-checked by the darwin clippy lane. So the gated
+  branch compiles under review but is never *run* there — verification needs a local coreml
+  build, the same way `kokoro_rate_e2e.rs` documents itself as a local/release-smoke gate.
+- **`ensure_asr_installed` on coreml now depends on a path FluidAudio owns.** If upstream moves
+  its cache, the check goes stale. Mitigated by deriving the path from one helper next to the
+  existing `fluidaudio_ane_kokoro_dir`, so there is a single place to fix. The path is
+  `<ApplicationSupport>/FluidAudio/Models/parakeet-tdt-0.6b-v3` — note that `Repo.folderName`
+  **strips** the `-coreml` suffix, so the plausible-looking `parakeet-tdt-0.6b-v3-coreml`
+  sibling is the wrong target. Keying on it would report a healthy install as broken, which is
+  the exact regression this change exists to avoid.
+- **Install feels slower to complete on macOS despite downloading less**, because the
+  ~934 MB moves from a visible download into the warm-up step. Worth watching against #680's
+  complaint; not a reason to keep downloading 2.43 GB.
+
+## Open Questions
+
+- Should `--no-warmup` on darwin now warn that ASR weights are not yet present? It is the one
+  path that ends with an install that cannot transcribe until the next command downloads
+  something. Out of scope here, but it is the honest follow-up.

--- a/openspec/changes/darwin-skips-onnx-asr/proposal.md
+++ b/openspec/changes/darwin-skips-onnx-asr/proposal.md
@@ -1,0 +1,72 @@
+## Why
+
+`kesha install` on darwin-arm64 downloads the 2.43 GB Parakeet TDT v3 **ONNX** weight set, and
+the CoreML Engine it just installed cannot open a single byte of it. That is ~72% of the install
+payload spent on files nothing will read — and since #681 made the model phase visible, it is
+also ~72% of what a new macOS user now watches tick by.
+
+Measured on an M2 after a normal install:
+
+```
+2431.8 MB  ~/.cache/kesha/models/parakeet-tdt-v3     <- unusable on a coreml build
+  82.1 MB  ~/.cache/kesha/models/lang-id-ecapa
+```
+
+while the weights that Transcription actually runs on live in FluidAudio's own cache,
+`~/Library/Application Support/FluidAudio/Models/parakeet-tdt-0.6b-v3{,-coreml}`, ~934 MB.
+
+The cause is that `models::install` has no backend branch and `ASR_FILES` carries no `cfg` gate,
+so the ONNX manifest compiles into — and downloads on — every build, including the one whose
+`create_backend` does `let _ = model_dir;`.
+
+## What Changes
+
+- A CoreML build no longer downloads the ONNX ASR manifest. Language ID, VAD, TTS and the
+  Engine binary are unaffected.
+- `kesha install --plan` stops quoting an ASR bundle the platform will not fetch, and names the
+  CoreML bundle the warm-up pulls instead, so the number shown before download matches what is
+  downloaded.
+- `kesha status --disk` and `kesha doctor` report ASR from FluidAudio's external cache on a
+  CoreML build rather than pointing at an ONNX directory that will now be absent — otherwise a
+  perfectly healthy macOS install would render as "ASR missing" and send users to reinstall.
+- The Transcription pre-flight that today gates on the ONNX directory keeps working on CoreML
+  without pretending that directory means anything there.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `installation`: the stated install cost becomes backend-dependent instead of one blanket
+  figure, because the two backends no longer download the same set.
+- `diagnostics`: `status --disk` and `doctor` report the ASR component from the backend's real
+  location — extending the treatment the spec already gives the FluidAudio *Kokoro* cache to the
+  ASR bundle, which is the same situation and was simply missed.
+
+## Non-goals
+
+- **Changing which weights CoreML Transcription uses.** FluidAudio keeps managing its own
+  bundle, at its own path, on its own schedule.
+- **Making the FluidAudio fetch explicit.** Today the bundle is pulled by the install-time
+  warm-up, and by first use when `--no-warmup` was passed. That is pre-existing behaviour and is
+  not touched here; if it should become an explicit, hash-pinned download, that is its own change.
+- **The `es/fr/it/pt` CharsiuG2P set**, which darwin also downloads and also does not use
+  (FluidAudio has its own G2P). Same class of waste, deliberately separate — it needs its own
+  measurement and its own scenarios.
+- **Anything about the Actions cache budget.** This change shrinks `macOS-kesha-engine-v1` as a
+  side effect, which #675 depends on, but no CI file changes here.
+
+## Impact
+
+- `rust/src/models.rs` (`ASR_FILES` gating, `is_cached_in`, `install`), `rust/src/transcribe/mod.rs`
+  (`ensure_asr_installed`), `rust/src/cli/install.rs` (warm-up path).
+- `src/install-plan.ts`, `src/status.ts`, `src/doctor.ts` — the user-facing half.
+- macOS users: ~2.43 GB less downloaded and stored per install.
+- CI: `macOS-kesha-engine-v1` drops from 2350 MB to ~140 MB, which is the headroom #675 needs.
+- **Every touched surface is user-visible on macOS.** The risk is not a crash; it is a healthy
+  install that *looks* broken because a diagnostic still points at the old path.
+
+Closes #684. Unblocks #675.

--- a/openspec/changes/darwin-skips-onnx-asr/proposal.md
+++ b/openspec/changes/darwin-skips-onnx-asr/proposal.md
@@ -13,7 +13,7 @@ Measured on an M2 after a normal install:
 ```
 
 while the weights that Transcription actually runs on live in FluidAudio's own cache,
-`~/Library/Application Support/FluidAudio/Models/parakeet-tdt-0.6b-v3{,-coreml}`, ~934 MB.
+`~/Library/Application Support/FluidAudio/Models/parakeet-tdt-0.6b-v3`, ~473 MB. (A `…-v3-coreml` sibling also exists on disk; nothing in the current FluidAudio resolves to it, so it is not counted.)
 
 The cause is that `models::install` has no backend branch and `ASR_FILES` carries no `cfg` gate,
 so the ONNX manifest compiles into — and downloads on — every build, including the one whose

--- a/openspec/changes/darwin-skips-onnx-asr/specs/diagnostics/spec.md
+++ b/openspec/changes/darwin-skips-onnx-asr/specs/diagnostics/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: Diagnostics report ASR from the Backend's real location
+
+`kesha status --disk` and `kesha doctor` SHALL report the ASR component from wherever the
+compiled Backend keeps its weights. On a CoreML Engine that is FluidAudio's external cache,
+reported separately from Kesha's Model cache — the same treatment the FluidAudio Kokoro cache
+already receives, and for the same reason.
+
+A healthy install SHALL NOT be rendered as missing ASR because a diagnostic points at a
+directory the platform no longer populates.
+
+#### Scenario: Maks checks disk usage on Apple Silicon
+
+- GIVEN a healthy CoreML install on darwin-arm64
+- WHEN Maks runs `kesha status --disk`
+- THEN the ASR row reports FluidAudio's external cache, marked as external like the Kokoro row
+- AND no row claims ASR is missing
+
+#### Scenario: Maks runs doctor after installing
+
+- GIVEN the same install
+- WHEN Maks runs `kesha doctor`
+- THEN the ASR check passes
+- AND its reported path is the one his Backend actually reads
+
+#### Scenario: the external ASR cache is genuinely absent
+
+- GIVEN a CoreML install where FluidAudio's cache has not been populated yet
+- WHEN Maks runs `kesha doctor`
+- THEN ASR is reported as not yet fetched, with the action that populates it
+- AND the report does not name the ONNX path, which is not what this platform uses
+
+> *Technical Note — sources: `src/status.ts:150` and `src/doctor.ts:209`, which both hardcode
+> `models/parakeet-tdt-v3`. The FluidAudio ASR bundle path is not a guess: `AsrModels`
+> resolves `defaultCacheDirectory(for: .v3)` → `MLModelConfigurationUtils.defaultModelsDirectory`
+> = `<ApplicationSupport>/FluidAudio/Models/<repo.folderName>`, and `folderName` strips the
+> `-coreml` suffix from `Repo.parakeetV3` (`parakeet-tdt-0.6b-v3-coreml`), giving
+> **`~/Library/Application Support/FluidAudio/Models/parakeet-tdt-0.6b-v3`** (473 MB measured).
+> A sibling `…-v3-coreml` directory also exists on this machine; nothing in the current version
+> resolves to it, so the check must not key on it. The existing Kokoro precedent is
+> `models::fluidaudio_ane_kokoro_dir`, which points at the separate TTS root `~/.cache/fluidaudio`
+> — upstream keeps ASR/VAD/diarization and TTS in two different roots by design
+> (`ModelHub.clearAllCaches`).*

--- a/openspec/changes/darwin-skips-onnx-asr/specs/installation/spec.md
+++ b/openspec/changes/darwin-skips-onnx-asr/specs/installation/spec.md
@@ -1,0 +1,60 @@
+## ADDED Requirements
+
+### Requirement: Install downloads only what the compiled Backend can use
+
+`kesha install` SHALL download the ASR weights of the Backend compiled into the Engine, and
+SHALL NOT download the weights of the other Backend. The two Backends are compile-time
+exclusive with no runtime fallback, so weights for the absent Backend can never be read.
+
+On a CoreML Engine the ASR weights are managed by FluidAudio in its own external cache; Kesha
+SHALL NOT mirror them into the Model cache.
+
+#### Scenario: Maks installs on Apple Silicon
+
+- GIVEN Maks is on darwin-arm64, whose released Engine is CoreML
+- WHEN he runs `kesha install`
+- THEN the Parakeet ONNX weight set is not downloaded
+- AND Language ID, VAD and any requested TTS models are downloaded as before
+
+#### Scenario: Ira installs on Linux
+
+- GIVEN Ira is on a platform whose released Engine is ONNX
+- WHEN she runs `kesha install`
+- THEN the Parakeet ONNX weight set is downloaded, unchanged from before
+
+#### Scenario: Transcription still refuses when its models are absent
+
+- GIVEN an installed Engine whose ASR weights are not present
+- WHEN Maks transcribes a file
+- THEN the CLI fails with an actionable install hint rather than downloading anything silently
+
+## MODIFIED Requirements
+
+### Requirement: Install cost is stated before download
+
+User-facing install documentation SHALL state the approximate download/disk cost of
+`kesha install` and the quiet-progress behavior of the model step next to the command itself,
+and SHALL present `kesha install --plan` (exact sizes, downloads nothing) and
+`kesha status --disk` as the user-facing cost-inspection commands.
+
+The stated cost SHALL match what the running platform will actually download. Because the two
+Backends download different ASR weights, a single blanket figure SHALL NOT be presented as if it
+applied everywhere; `--plan` SHALL quote the compiled Backend's own set, and SHALL name any
+weights fetched by the Backend outside the Model cache rather than omitting them.
+
+#### Scenario: reading Quick Start
+
+- **WHEN** a new user reads the README Quick Start install step
+- **THEN** the expected download size, disk footprint, and the `--plan` preview command are visible without leaving the section
+
+#### Scenario: previewing the plan on Apple Silicon
+
+- GIVEN Maks is on darwin-arm64
+- WHEN he runs `kesha install --plan`
+- THEN the plan does not list the Parakeet ONNX bundle as a download
+- AND the ASR weights his Backend will fetch are named, with their approximate size
+- AND nothing is downloaded
+
+> *Technical Note — sources: `src/install-plan.ts` (`asr: ASR_FILES`, `modelBundle("ASR Parakeet
+> TDT v3", …)`), `rust/src/models.rs::install` (no backend branch today),
+> `rust/src/backend/mod.rs::create_backend` (`let _ = model_dir` on the coreml arm).*

--- a/openspec/changes/darwin-skips-onnx-asr/tasks.md
+++ b/openspec/changes/darwin-skips-onnx-asr/tasks.md
@@ -1,0 +1,37 @@
+## 1. Engine: stop downloading what CoreML cannot read
+
+- [x] 1.1 Add a `fluidaudio_asr_dir()` helper next to `fluidaudio_ane_kokoro_dir`, resolving `<ApplicationSupport>/FluidAudio/Models/parakeet-tdt-0.6b-v3` — the `-coreml` suffix is stripped by `Repo.folderName`, so do not key on the `…-v3-coreml` sibling (D2)
+- [x] 1.2 Gate `ASR_FILES` and its `is_cached_in` arm on `#[cfg(not(feature = "coreml"))]` (D1)
+- [x] 1.3 Drop `ASR_FILES` from `models::install`'s manifest on coreml builds; leave Language ID, VAD and TTS untouched
+- [x] 1.4 `transcribe::ensure_asr_installed` checks FluidAudio's cache on coreml and keeps the existing hint text shape (D2)
+- [x] 1.5 `cargo check --features coreml --no-default-features` and the default build both clean
+
+## 2. CLI: make the promise match the download
+
+- [x] 2.1 `install-plan.ts` emits the FluidAudio ASR row on darwin-arm64 instead of the ONNX bundle, with size and "fetched by the backend" framing (D3)
+- [x] 2.2 `status.ts --disk` reports ASR from FluidAudio's cache on a CoreML engine, marked external like the Kokoro row (D4)
+- [x] 2.3 `doctor.ts` does the same, and its ASR check passes on a healthy CoreML install
+- [x] 2.4 Neither surface names `models/parakeet-tdt-v3` on a CoreML engine
+
+## 3. Tests
+
+- [x] 3.1 Rust: `models::install` manifest excludes ASR under coreml and includes it otherwise
+- [x] 3.2 Rust: `is_cached(Asr)` / `ensure_asr_installed` behaviour on both feature sets
+- [x] 3.3 TS: `install-plan` snapshot for darwin-arm64 has no ONNX ASR bundle and does list the external one
+- [x] 3.4 TS: `status --disk` and `doctor` render the external ASR row on a CoreML capabilities fixture
+- [x] 3.5 Check `manifest_tests` and `install_plan_model_paths_match_runtime_manifests` still hold under both feature sets
+
+## 4. Verification
+
+- [x] 4.1 `bun test && bunx tsc --noEmit`
+- [x] 4.2 `make rust-test`, `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, plus `cargo check --features coreml --no-default-features`
+- [x] 4.3 Local coreml build: `kesha install --plan` on darwin quotes no ONNX ASR and names the external bundle
+- [x] 4.4 Local coreml build against a scratch `KESHA_CACHE_DIR`: install, then confirm `models/parakeet-tdt-v3` is absent and transcription still works
+- [x] 4.5 `kesha status --disk` and `kesha doctor` on that install both report ASR healthy, neither names the ONNX path — the regression this change most risks (Risks)
+- [x] 4.6 Measure the new macOS install payload and record it against the 2.43 GB claimed saving
+
+## 5. Land
+
+- [ ] 5.1 PR body with `Closes #684`, the before/after payload numbers, and the note that PR CI never runs the coreml branch
+- [ ] 5.2 Wait for CI and Greptile on the head SHA; resolve P1/P2 findings
+- [ ] 5.3 Comment on #675 that the budget headroom is now available, and re-plan the cache work against the new `macOS-kesha-engine-v1` size

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -24,6 +24,11 @@ pub struct ModelFile {
 /// Parakeet TDT v3 ONNX weights. Hashes pinned from a clean install against
 /// `huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx` — an upstream
 /// republish becomes a deliberate PR to bump.
+///
+/// Absent on `coreml` builds: that backend transcribes through FluidAudio's own
+/// bundle and `create_backend` discards the ONNX dir outright, so downloading
+/// these 2.43 GB would be pure waste (#684).
+#[cfg(not(feature = "coreml"))]
 const ASR_FILES: &[ModelFile] = &[
     ModelFile {
         rel_path: "models/parakeet-tdt-v3/encoder-model.onnx",
@@ -554,6 +559,23 @@ pub fn fluidaudio_ane_kokoro_dir() -> PathBuf {
         .join("ANE")
 }
 
+/// FluidAudio's ASR bundle directory. Not under `KESHA_CACHE_DIR` — FluidAudio
+/// downloads and reads it here, and `AsrModels` resolves it as
+/// `<ApplicationSupport>/FluidAudio/Models/<repo.folderName>`, where `folderName`
+/// **strips** the `-coreml` suffix from `parakeet-tdt-0.6b-v3-coreml`. Keying on
+/// the `…-v3-coreml` sibling that also exists on disk would report a healthy
+/// install as broken (#684).
+#[cfg(feature = "coreml")]
+pub fn fluidaudio_asr_dir() -> PathBuf {
+    dirs::home_dir()
+        .expect("cannot determine home directory")
+        .join("Library")
+        .join("Application Support")
+        .join("FluidAudio")
+        .join("Models")
+        .join("parakeet-tdt-0.6b-v3")
+}
+
 /// Download + SHA-verify every advertised Kokoro voice pack directly into
 /// FluidAudio's ANE cache so `KokoroAneManager.ensureVoicePack` resolves them
 /// local-first (#475). Idempotent: an existing pack that already matches its
@@ -736,7 +758,12 @@ pub fn is_cached(kind: ModelKind) -> bool {
 /// stays single-source.
 pub fn is_cached_in(kind: ModelKind, dir: &Path) -> bool {
     match kind {
+        #[cfg(not(feature = "coreml"))]
         ModelKind::Asr => has_all_files(dir, ASR_FILES),
+        // `dir` is the ONNX layout, which this backend never reads; FluidAudio owns
+        // where its weights live, so that is the only thing worth checking here.
+        #[cfg(feature = "coreml")]
+        ModelKind::Asr => fluidaudio_asr_dir().is_dir(),
         ModelKind::LangId => has_all_files(dir, LANG_ID_FILES),
         ModelKind::Vad => has_all_files(dir, VAD_FILES),
         #[cfg(feature = "tts")]
@@ -792,7 +819,10 @@ pub fn install(no_cache: bool) -> Result<()> {
 
     // Always hash-verify even on cache hits — catches silent corruption (#174).
     // 4-worker pool (#178) overlaps ASR + lang-id round-trips within HF's per-IP tolerance.
+    #[cfg(not(feature = "coreml"))]
     let manifest: Vec<&ModelFile> = ASR_FILES.iter().chain(LANG_ID_FILES.iter()).collect();
+    #[cfg(feature = "coreml")]
+    let manifest: Vec<&ModelFile> = LANG_ID_FILES.iter().collect();
     parallel_download(&cache, &manifest, no_cache)?;
 
     cleanup_legacy();
@@ -867,6 +897,7 @@ mod manifest_tests {
         let plan: serde_json::Value = serde_json::from_str(include_str!("../../model-plan.json"))
             .expect("model plan JSON must parse");
 
+        #[cfg(not(feature = "coreml"))]
         assert_plan_paths(&plan, "asr", ASR_FILES);
         assert_plan_paths(&plan, "langId", LANG_ID_FILES);
         assert_plan_paths(&plan, "vad", VAD_FILES);
@@ -899,6 +930,7 @@ mod manifest_tests {
     }
 
     #[test]
+    #[cfg(not(feature = "coreml"))]
     fn asr_manifest_has_expected_files_and_hashes() {
         assert_eq!(ASR_FILES.len(), 5);
         assert!(ASR_FILES.iter().any(|f| f.rel_path.ends_with("/vocab.txt")));
@@ -1838,6 +1870,20 @@ mod characterization_tests {
         Ok(())
     }
 
+    /// `Repo.folderName` strips the `-coreml` suffix, and a `…-v3-coreml` sibling
+    /// exists on disk. Keying on it would report a healthy install as missing ASR.
+    #[test]
+    #[cfg(feature = "coreml")]
+    fn fluidaudio_asr_dir_is_the_directory_fluidaudio_loads_from() {
+        let dir = fluidaudio_asr_dir();
+        assert!(dir.ends_with("parakeet-tdt-0.6b-v3"), "{dir:?}");
+        assert!(
+            dir.to_string_lossy()
+                .contains("Library/Application Support/FluidAudio/Models"),
+            "{dir:?} is not FluidAudio's ASR root"
+        );
+    }
+
     #[test]
     fn model_kind_subdir_table() {
         assert_eq!(ModelKind::Asr.subdir(), "models/parakeet-tdt-v3");
@@ -1872,6 +1918,7 @@ mod characterization_tests {
     }
 
     #[test]
+    #[cfg(not(feature = "coreml"))]
     fn is_cached_in_asr_true_when_all_files_present() {
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path().join("models/parakeet-tdt-v3");
@@ -1884,6 +1931,7 @@ mod characterization_tests {
     }
 
     #[test]
+    #[cfg(not(feature = "coreml"))]
     fn is_cached_in_asr_false_when_one_file_missing() {
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path().join("models/parakeet-tdt-v3");

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -576,6 +576,36 @@ pub fn fluidaudio_asr_dir() -> PathBuf {
         .join("parakeet-tdt-0.6b-v3")
 }
 
+/// Entries FluidAudio's `requiredModelsV3` opens, minus the encoder — that one
+/// is precision-dependent (`Encoder.mlmodelc` at int8, `EncoderInt4.mlmodelc` at
+/// int4), so it is checked separately rather than pinned to one precision.
+#[cfg(feature = "coreml")]
+const FLUID_ASR_REQUIRED: &[&str] = &[
+    "Preprocessor.mlmodelc",
+    "Decoder.mlmodelc",
+    "JointDecisionv3.mlmodelc",
+    "parakeet_vocab.json",
+];
+
+#[cfg(feature = "coreml")]
+const FLUID_ASR_ENCODERS: &[&str] = &["Encoder.mlmodelc", "EncoderInt4.mlmodelc"];
+
+/// True iff FluidAudio's bundle is complete enough to transcribe. A bare
+/// `is_dir()` is not enough: an interrupted fetch leaves the directory present
+/// but partial, preflight would pass, and FluidAudio would then download the
+/// remainder mid-transcribe — exactly the silent multi-GB download the
+/// no-auto-download rule exists to prevent (#684).
+#[cfg(feature = "coreml")]
+pub fn fluidaudio_asr_ready() -> bool {
+    fluidaudio_asr_ready_in(&fluidaudio_asr_dir())
+}
+
+#[cfg(feature = "coreml")]
+fn fluidaudio_asr_ready_in(dir: &Path) -> bool {
+    FLUID_ASR_REQUIRED.iter().all(|f| dir.join(f).exists())
+        && FLUID_ASR_ENCODERS.iter().any(|f| dir.join(f).exists())
+}
+
 /// Download + SHA-verify every advertised Kokoro voice pack directly into
 /// FluidAudio's ANE cache so `KokoroAneManager.ensureVoicePack` resolves them
 /// local-first (#475). Idempotent: an existing pack that already matches its
@@ -763,7 +793,7 @@ pub fn is_cached_in(kind: ModelKind, dir: &Path) -> bool {
         // `dir` is the ONNX layout, which this backend never reads; FluidAudio owns
         // where its weights live, so that is the only thing worth checking here.
         #[cfg(feature = "coreml")]
-        ModelKind::Asr => fluidaudio_asr_dir().is_dir(),
+        ModelKind::Asr => fluidaudio_asr_ready(),
         ModelKind::LangId => has_all_files(dir, LANG_ID_FILES),
         ModelKind::Vad => has_all_files(dir, VAD_FILES),
         #[cfg(feature = "tts")]
@@ -1882,6 +1912,48 @@ mod characterization_tests {
                 .contains("Library/Application Support/FluidAudio/Models"),
             "{dir:?} is not FluidAudio's ASR root"
         );
+    }
+
+    /// An interrupted FluidAudio fetch leaves the directory present but partial.
+    /// Treating that as cached lets preflight pass and the backend finish the
+    /// download mid-transcribe, violating the no-auto-download rule (#684).
+    #[test]
+    #[cfg(feature = "coreml")]
+    fn fluidaudio_asr_readiness_requires_the_whole_bundle() {
+        let dir = std::env::temp_dir().join(format!("kesha-fluid-asr-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+
+        assert!(
+            !fluidaudio_asr_ready_in(&dir),
+            "empty dir must not be ready"
+        );
+
+        fs::write(dir.join("Encoder.mlmodelc"), b"x").unwrap();
+        assert!(
+            !fluidaudio_asr_ready_in(&dir),
+            "encoder alone must not be ready"
+        );
+
+        for f in FLUID_ASR_REQUIRED {
+            fs::write(dir.join(f), b"x").unwrap();
+        }
+        assert!(
+            fluidaudio_asr_ready_in(&dir),
+            "complete bundle must be ready"
+        );
+
+        // int4 encoder substitutes for int8 — pinning one precision would report a
+        // healthy install as broken.
+        fs::remove_file(dir.join("Encoder.mlmodelc")).unwrap();
+        assert!(!fluidaudio_asr_ready_in(&dir));
+        fs::write(dir.join("EncoderInt4.mlmodelc"), b"x").unwrap();
+        assert!(
+            fluidaudio_asr_ready_in(&dir),
+            "int4 encoder must satisfy the check"
+        );
+
+        let _ = fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -781,10 +781,8 @@ pub fn is_cached(kind: ModelKind) -> bool {
     is_cached_in(kind, &model_dir(kind))
 }
 
-/// True iff `kind`'s required files are present in `dir` — callers that
-/// resolved the directory themselves (e.g. from a function-supplied cache
-/// root) use this instead of [`is_cached`] so the cache root parameter
-/// stays single-source.
+/// True iff `kind` is usable. `dir` is the Kesha cache location; the coreml `Asr`
+/// arm ignores it, since FluidAudio owns that bundle outside the cache entirely.
 pub fn is_cached_in(kind: ModelKind, dir: &Path) -> bool {
     match kind {
         #[cfg(not(feature = "coreml"))]

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -576,19 +576,19 @@ pub fn fluidaudio_asr_dir() -> PathBuf {
         .join("parakeet-tdt-0.6b-v3")
 }
 
-/// Entries FluidAudio's `requiredModelsV3` opens, minus the encoder — that one
-/// is precision-dependent (`Encoder.mlmodelc` at int8, `EncoderInt4.mlmodelc` at
-/// int4), so it is checked separately rather than pinned to one precision.
+/// What FluidAudio's own `modelsExist` requires. The encoder is pinned to int8
+/// because the bridge calls `downloadAndLoad(to:)` with its default
+/// `useInt8Encoder: true` — accepting `EncoderInt4.mlmodelc` here would pass
+/// preflight and then let FluidAudio fetch the int8 encoder on first transcribe.
+/// If the bridge ever selects precision, this must follow it.
 #[cfg(feature = "coreml")]
 const FLUID_ASR_REQUIRED: &[&str] = &[
     "Preprocessor.mlmodelc",
+    "Encoder.mlmodelc",
     "Decoder.mlmodelc",
     "JointDecisionv3.mlmodelc",
     "parakeet_vocab.json",
 ];
-
-#[cfg(feature = "coreml")]
-const FLUID_ASR_ENCODERS: &[&str] = &["Encoder.mlmodelc", "EncoderInt4.mlmodelc"];
 
 /// True iff FluidAudio's bundle is complete enough to transcribe. A bare
 /// `is_dir()` is not enough: an interrupted fetch leaves the directory present
@@ -603,7 +603,6 @@ pub fn fluidaudio_asr_ready() -> bool {
 #[cfg(feature = "coreml")]
 fn fluidaudio_asr_ready_in(dir: &Path) -> bool {
     FLUID_ASR_REQUIRED.iter().all(|f| dir.join(f).exists())
-        && FLUID_ASR_ENCODERS.iter().any(|f| dir.join(f).exists())
 }
 
 /// Download + SHA-verify every advertised Kokoro voice pack directly into
@@ -1943,14 +1942,13 @@ mod characterization_tests {
             "complete bundle must be ready"
         );
 
-        // int4 encoder substitutes for int8 — pinning one precision would report a
-        // healthy install as broken.
+        // The bridge loads int8, so an int4-only bundle is unusable: calling it ready
+        // would pass preflight and let FluidAudio fetch the int8 encoder mid-transcribe.
         fs::remove_file(dir.join("Encoder.mlmodelc")).unwrap();
-        assert!(!fluidaudio_asr_ready_in(&dir));
         fs::write(dir.join("EncoderInt4.mlmodelc"), b"x").unwrap();
         assert!(
-            fluidaudio_asr_ready_in(&dir),
-            "int4 encoder must satisfy the check"
+            !fluidaudio_asr_ready_in(&dir),
+            "int4-only bundle must not satisfy an int8 loader"
         );
 
         let _ = fs::remove_dir_all(&dir);

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -3,7 +3,13 @@ import { confirm, multiselect, isCancel, cancel } from "@clack/prompts";
 import { renderInstallPlan } from "../install-plan";
 import { log } from "../log";
 import { getEngineCapabilities } from "../engine";
-import { performInstall, resolveBackendFlag, resolveNoCacheFlag, TTS_LANG_FALLBACK } from "./install";
+import {
+  performInstall,
+  resolveBackendFlag,
+  resolveNoCacheFlag,
+  TTS_LANG_FALLBACK,
+  unavailableBackendError,
+} from "./install";
 import type { SharedInstallArgs } from "./types";
 
 const TTS_LANG_LABELS: Record<string, string> = {
@@ -171,7 +177,13 @@ export async function promptInitSelection(
   };
 }
 
-async function printPlan(selection: InitSelection): Promise<void> {
+/** Mirrors the guard in `performInstall`: a preview must not describe an install this platform rejects (#684). */
+async function printPlan(selection: InitSelection): Promise<boolean> {
+  const backendError = unavailableBackendError(selection.backend);
+  if (backendError) {
+    log.error(backendError);
+    return false;
+  }
   log.info(
     await renderInstallPlan({
       noCache: selection.noCache,
@@ -181,6 +193,7 @@ async function printPlan(selection: InitSelection): Promise<void> {
       diarize: selection.diarize,
     }),
   );
+  return true;
 }
 
 async function runNonInteractive(selection: InitSelection): Promise<void> {
@@ -190,7 +203,10 @@ async function runNonInteractive(selection: InitSelection): Promise<void> {
     log.warn("--diarize is currently darwin-arm64 only; omitting it from non-interactive examples.");
   }
   log.info(renderInitOverview(canDiarize));
-  await printPlan(printableSelection);
+  if (!(await printPlan(printableSelection))) {
+    process.exitCode = 2;
+    return;
+  }
   log.info("Run one of these commands from an interactive terminal:");
   for (const command of initSuggestionCommands(printableSelection, canDiarize)) {
     log.info(`  ${command.join(" ")}`);
@@ -251,7 +267,7 @@ export const initCommand = defineCommand({
 
     if (args.plan) {
       log.info(renderInitOverview());
-      await printPlan(selection);
+      if (!(await printPlan(selection))) process.exitCode = 2;
       return;
     }
 
@@ -286,7 +302,10 @@ export const initCommand = defineCommand({
       noCache,
     );
     log.info("");
-    await printPlan(prompted);
+    if (!(await printPlan(prompted))) {
+      process.exitCode = 2;
+      return;
+    }
     const confirmed = await promptConfirm(
       `Run \`${initInstallArgs(prompted).join(" ")}\` now?`,
       true,

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -182,6 +182,7 @@ async function printPlan(selection: InitSelection): Promise<boolean> {
   const backendError = unavailableBackendError(selection.backend);
   if (backendError) {
     log.error(backendError);
+    process.exitCode = 2;
     return false;
   }
   log.info(
@@ -203,10 +204,7 @@ async function runNonInteractive(selection: InitSelection): Promise<void> {
     log.warn("--diarize is currently darwin-arm64 only; omitting it from non-interactive examples.");
   }
   log.info(renderInitOverview(canDiarize));
-  if (!(await printPlan(printableSelection))) {
-    process.exitCode = 2;
-    return;
-  }
+  if (!(await printPlan(printableSelection))) return;
   log.info("Run one of these commands from an interactive terminal:");
   for (const command of initSuggestionCommands(printableSelection, canDiarize)) {
     log.info(`  ${command.join(" ")}`);
@@ -267,7 +265,7 @@ export const initCommand = defineCommand({
 
     if (args.plan) {
       log.info(renderInitOverview());
-      if (!(await printPlan(selection))) process.exitCode = 2;
+      await printPlan(selection);
       return;
     }
 
@@ -302,10 +300,7 @@ export const initCommand = defineCommand({
       noCache,
     );
     log.info("");
-    if (!(await printPlan(prompted))) {
-      process.exitCode = 2;
-      return;
-    }
+    if (!(await printPlan(prompted))) return;
     const confirmed = await promptConfirm(
       `Run \`${initInstallArgs(prompted).join(" ")}\` now?`,
       true,

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -121,7 +121,7 @@ function finishInstallDiagnostic(
 }
 
 /** Null when the requested backend is installable here. `KESHA_ENGINE_BIN` opts out — the user supplied their own engine. */
-function unavailableBackendError(backend: string | undefined): string | null {
+export function unavailableBackendError(backend: string | undefined): string | null {
   const platformBackend = defaultBackendForPlatform();
   if (!backend || process.env.KESHA_ENGINE_BIN || !platformBackend) return null;
   if (backend === platformBackend) return null;

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -120,6 +120,17 @@ function finishInstallDiagnostic(
   }
 }
 
+/** Null when the requested backend is installable here. `KESHA_ENGINE_BIN` opts out — the user supplied their own engine. */
+function unavailableBackendError(backend: string | undefined): string | null {
+  const platformBackend = defaultBackendForPlatform();
+  if (!backend || process.env.KESHA_ENGINE_BIN || !platformBackend) return null;
+  if (backend === platformBackend) return null;
+  return (
+    `Requested backend "${backend}" is not available on this platform; ` +
+    `the release engine uses "${platformBackend}".`
+  );
+}
+
 export async function performInstall(
   noCache: boolean,
   backend: string | undefined,
@@ -128,7 +139,14 @@ export async function performInstall(
   diarize = false,
   plan = false,
 ) {
+  // A plan for an unavailable backend previews what its own printed command rejects (#684).
+  const backendError = unavailableBackendError(backend);
   if (plan) {
+    if (backendError) {
+      log.error(backendError);
+      process.exitCode = 2;
+      return;
+    }
     log.info(await renderInstallPlan({ noCache, backend, ttsLangs, vad, diarize }));
     return;
   }
@@ -154,13 +172,9 @@ export async function performInstall(
         "(see https://github.com/drakulavich/kesha-voice-kit/issues/199).",
       );
     }
-    const platformBackend = defaultBackendForPlatform();
-    if (backend && !process.env.KESHA_ENGINE_BIN && platformBackend && backend !== platformBackend) {
+    if (backendError) {
       errorKind = "validation_failed";
-      throw new Error(
-        `Requested backend "${backend}" is not available on this platform; ` +
-          `the release engine uses "${platformBackend}".`,
-      );
+      throw new Error(backendError);
     }
     await downloadEngine(noCache, backend, { ttsLangs, vad, diarize });
     await maybeAskForStar(getEngineBinPath(), packageVersion, log);

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -16,6 +16,7 @@ import {
   fluidKokoroCacheInfo,
   type FluidKokoroCacheInfo,
 } from "./fluid-kokoro-cache";
+import { fluidAsrCacheInfo, fluidAsrCachePath } from "./fluid-asr-cache";
 import { diagnosticHomeDir, dirSizeBytes } from "./diagnostic-paths";
 import {
   getDiagnosticLogStatus,
@@ -206,7 +207,11 @@ function collectCache(
   const engineDir = dirname(dirname(binPath));
   const components: CacheComponent[] = [
     { label: "Engine", ...pathSummary(engineDir) },
-    { label: "ASR (Parakeet)", ...pathSummary(join(cache, "models/parakeet-tdt-v3")) },
+    // A CoreML engine never populates the ONNX dir; pointing at it would render a
+    // healthy darwin install as "ASR missing" (#684).
+    fluidAsrCacheInfo().supported
+      ? { label: "ASR (Parakeet, FluidAudio)", ...pathSummary(fluidAsrCachePath()) }
+      : { label: "ASR (Parakeet)", ...pathSummary(join(cache, "models/parakeet-tdt-v3")) },
     { label: "Language ID", ...pathSummary(join(cache, "models/lang-id-ecapa")) },
     { label: "VAD (Silero)", ...pathSummary(join(cache, "models/silero-vad")) },
     { label: "TTS (Kokoro)", ...pathSummary(join(cache, "models/kokoro-82m")) },

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -16,7 +16,7 @@ import {
   fluidKokoroCacheInfo,
   type FluidKokoroCacheInfo,
 } from "./fluid-kokoro-cache";
-import { fluidAsrCacheInfo, fluidAsrCachePath } from "./fluid-asr-cache";
+import { fluidAsrCacheInfo, isCoremlBackend } from "./fluid-asr-cache";
 import { diagnosticHomeDir, dirSizeBytes } from "./diagnostic-paths";
 import {
   getDiagnosticLogStatus,
@@ -206,9 +206,7 @@ function collectCache(
   const cache = keshaCacheDir();
   const binPath = getEngineBinPath();
   const engineDir = dirname(dirname(binPath));
-  // The engine's compiled backend, not the host platform: a darwin-arm64 ONNX build
-  // reads the Kesha cache like any other ONNX build.
-  const coreml = backend === "coreml";
+  const coreml = isCoremlBackend(backend);
   const components: CacheComponent[] = [
     { label: "Engine", ...pathSummary(engineDir) },
     // A CoreML engine never populates the ONNX dir; pointing at it would render a

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -201,22 +201,35 @@ async function collectEngine(redact: boolean): Promise<DoctorReport["engine"]> {
 function collectCache(
   redact: boolean,
   fluidKokoro: FluidKokoroCacheInfo,
+  backend?: string,
 ): DoctorReport["cache"] {
   const cache = keshaCacheDir();
   const binPath = getEngineBinPath();
   const engineDir = dirname(dirname(binPath));
+  // The engine's compiled backend, not the host platform: a darwin-arm64 ONNX build
+  // reads the Kesha cache like any other ONNX build.
+  const coreml = backend === "coreml";
   const components: CacheComponent[] = [
     { label: "Engine", ...pathSummary(engineDir) },
     // A CoreML engine never populates the ONNX dir; pointing at it would render a
     // healthy darwin install as "ASR missing" (#684).
-    fluidAsrCacheInfo().supported
-      ? { label: "ASR (Parakeet, FluidAudio)", ...pathSummary(fluidAsrCachePath()) }
-      : { label: "ASR (Parakeet)", ...pathSummary(join(cache, "models/parakeet-tdt-v3")) },
+    ...(coreml
+      ? []
+      : [{ label: "ASR (Parakeet)", ...pathSummary(join(cache, "models/parakeet-tdt-v3")) }]),
     { label: "Language ID", ...pathSummary(join(cache, "models/lang-id-ecapa")) },
     { label: "VAD (Silero)", ...pathSummary(join(cache, "models/silero-vad")) },
     { label: "TTS (Kokoro)", ...pathSummary(join(cache, "models/kokoro-82m")) },
     { label: "TTS (Vosk)", ...pathSummary(join(cache, "models/vosk-ru")) },
   ];
+  if (coreml) {
+    const fluidAsr = fluidAsrCacheInfo();
+    components.push({
+      label: "ASR (Parakeet, FluidAudio) (external)",
+      path: fluidAsr.path,
+      exists: fluidAsr.exists,
+      sizeBytes: fluidAsr.sizeBytes,
+    });
+  }
   if (fluidKokoro.supported) {
     components.push({
       label: "FluidAudio Kokoro cache (external)",
@@ -351,6 +364,7 @@ export async function collectDoctorReport(
 ): Promise<DoctorReport> {
   const redact = options.redact === true;
   const fluidKokoro = fluidKokoroCacheInfo();
+  const engine = await collectEngine(redact);
   return {
     generatedAt: new Date().toISOString(),
     redacted: redact,
@@ -360,8 +374,8 @@ export async function collectDoctorReport(
       platform: process.platform,
       arch: process.arch,
     },
-    engine: await collectEngine(redact),
-    cache: collectCache(redact, fluidKokoro),
+    engine,
+    cache: collectCache(redact, fluidKokoro, engine.capabilities?.backend),
     optionalComponents: collectOptionalComponents(redact, fluidKokoro),
     stats: collectStats(redact),
     diagnosticLogs: collectDiagnosticLogs(redact),

--- a/src/fluid-asr-cache.ts
+++ b/src/fluid-asr-cache.ts
@@ -29,6 +29,31 @@ export function fluidAsrCachePath(homeDir = diagnosticHomeDir()): string {
   );
 }
 
+/**
+ * Entries FluidAudio's `requiredModelsV3` opens. The encoder is precision-dependent
+ * (`Encoder.mlmodelc` at int8, `EncoderInt4.mlmodelc` at int4) so it is checked as
+ * an alternation — pinning one precision would report a healthy install as broken.
+ */
+const FLUID_ASR_REQUIRED = [
+  "Preprocessor.mlmodelc",
+  "Decoder.mlmodelc",
+  "JointDecisionv3.mlmodelc",
+  "parakeet_vocab.json",
+];
+const FLUID_ASR_ENCODERS = ["Encoder.mlmodelc", "EncoderInt4.mlmodelc"];
+
+/**
+ * Complete enough to transcribe. Mirrors `models.rs::fluidaudio_asr_ready` — a bare
+ * directory check would call an interrupted fetch healthy, and the engine would then
+ * download the remainder on first transcribe (#684).
+ */
+export function fluidAsrCacheReady(path: string): boolean {
+  return (
+    FLUID_ASR_REQUIRED.every((f) => existsSync(join(path, f))) &&
+    FLUID_ASR_ENCODERS.some((f) => existsSync(join(path, f)))
+  );
+}
+
 export function fluidAsrCacheInfo(
   options: {
     platform?: typeof process.platform;
@@ -42,7 +67,7 @@ export function fluidAsrCacheInfo(
   return {
     supported,
     path,
-    exists: supported && existsSync(path),
+    exists: supported && fluidAsrCacheReady(path),
     sizeBytes: supported ? dirSizeBytes(path) : 0,
   };
 }

--- a/src/fluid-asr-cache.ts
+++ b/src/fluid-asr-cache.ts
@@ -1,0 +1,48 @@
+import { existsSync } from "fs";
+import { join } from "path";
+import { diagnosticHomeDir, dirSizeBytes } from "./diagnostic-paths";
+import { isDarwinArm64 } from "./fluid-kokoro-cache";
+
+export const FLUID_ASR_CACHE_NOTE =
+  "FluidAudio CoreML in-engine; the ASR weights are fetched by the backend during install warm-up, outside Kesha's pinned model cache";
+
+export interface FluidAsrCacheInfo {
+  supported: boolean;
+  path: string;
+  exists: boolean;
+  sizeBytes: number;
+}
+
+/**
+ * FluidAudio loads ASR from `<ApplicationSupport>/FluidAudio/Models/<repo folder>`,
+ * and that folder name has the `-coreml` suffix stripped — the `…-v3-coreml` sibling
+ * that also appears on disk is not what it reads (#684).
+ */
+export function fluidAsrCachePath(homeDir = diagnosticHomeDir()): string {
+  return join(
+    homeDir,
+    "Library",
+    "Application Support",
+    "FluidAudio",
+    "Models",
+    "parakeet-tdt-0.6b-v3",
+  );
+}
+
+export function fluidAsrCacheInfo(
+  options: {
+    platform?: typeof process.platform;
+    arch?: typeof process.arch;
+    homeDir?: string;
+  } = {},
+): FluidAsrCacheInfo {
+  const supported = isDarwinArm64(options.platform, options.arch);
+  const path = fluidAsrCachePath(options.homeDir);
+
+  return {
+    supported,
+    path,
+    exists: supported && existsSync(path),
+    sizeBytes: supported ? dirSizeBytes(path) : 0,
+  };
+}

--- a/src/fluid-asr-cache.ts
+++ b/src/fluid-asr-cache.ts
@@ -6,6 +6,17 @@ import { isDarwinArm64 } from "./fluid-kokoro-cache";
 export const FLUID_ASR_CACHE_NOTE =
   "FluidAudio CoreML in-engine; the ASR weights are fetched by the backend during install warm-up, outside Kesha's pinned model cache";
 
+/**
+ * Which ASR layout applies. The engine's reported backend is authoritative, but the
+ * capabilities probe can fail on a perfectly healthy install — falling through to
+ * "not CoreML" there would point darwin diagnostics at an ONNX directory this platform
+ * never populates and render a working install as broken (#684).
+ */
+export function isCoremlBackend(backend?: string): boolean {
+  if (backend) return backend === "coreml";
+  return isDarwinArm64();
+}
+
 export interface FluidAsrCacheInfo {
   supported: boolean;
   path: string;

--- a/src/fluid-asr-cache.ts
+++ b/src/fluid-asr-cache.ts
@@ -2,23 +2,22 @@ import { existsSync } from "fs";
 import { join } from "path";
 import { diagnosticHomeDir, dirSizeBytes } from "./diagnostic-paths";
 import { isDarwinArm64 } from "./fluid-kokoro-cache";
+import { engineTarget } from "./engine-targets";
 
 export const FLUID_ASR_CACHE_NOTE =
-  "FluidAudio CoreML in-engine; the ASR weights are fetched by the backend during install warm-up, outside Kesha's pinned model cache";
+  "required for speech-to-text; fetched by the backend during warm-up, outside Kesha's model cache";
 
 /**
- * Which ASR layout applies. The engine's reported backend is authoritative, but the
- * capabilities probe can fail on a perfectly healthy install — falling through to
- * "not CoreML" there would point darwin diagnostics at an ONNX directory this platform
- * never populates and render a working install as broken (#684).
+ * Which ASR layout applies. The reported backend is authoritative; when the capabilities
+ * probe yields nothing, fall back to the platform's shipped backend rather than to "not
+ * CoreML", which would point darwin at an ONNX directory it never populates (#684).
  */
 export function isCoremlBackend(
   backend?: string,
-  platform?: typeof process.platform,
-  arch?: typeof process.arch,
+  platform?: string,
+  arch?: string,
 ): boolean {
-  if (backend) return backend === "coreml";
-  return isDarwinArm64(platform, arch);
+  return (backend ?? engineTarget(platform, arch)?.backend) === "coreml";
 }
 
 export interface FluidAsrCacheInfo {
@@ -50,7 +49,7 @@ export function fluidAsrCachePath(homeDir = diagnosticHomeDir()): string {
  * accepting `EncoderInt4.mlmodelc` would pass preflight and then let FluidAudio fetch
  * the int8 encoder on first transcribe. Keep in step with `models.rs::FLUID_ASR_REQUIRED`.
  */
-const FLUID_ASR_REQUIRED = [
+export const FLUID_ASR_REQUIRED = [
   "Preprocessor.mlmodelc",
   "Encoder.mlmodelc",
   "Decoder.mlmodelc",

--- a/src/fluid-asr-cache.ts
+++ b/src/fluid-asr-cache.ts
@@ -41,17 +41,18 @@ export function fluidAsrCachePath(homeDir = diagnosticHomeDir()): string {
 }
 
 /**
- * Entries FluidAudio's `requiredModelsV3` opens. The encoder is precision-dependent
- * (`Encoder.mlmodelc` at int8, `EncoderInt4.mlmodelc` at int4) so it is checked as
- * an alternation — pinning one precision would report a healthy install as broken.
+ * What FluidAudio's own `modelsExist` requires. The encoder is pinned to int8 because
+ * the bridge calls `downloadAndLoad(to:)` with its default `useInt8Encoder: true` —
+ * accepting `EncoderInt4.mlmodelc` would pass preflight and then let FluidAudio fetch
+ * the int8 encoder on first transcribe. Keep in step with `models.rs::FLUID_ASR_REQUIRED`.
  */
 const FLUID_ASR_REQUIRED = [
   "Preprocessor.mlmodelc",
+  "Encoder.mlmodelc",
   "Decoder.mlmodelc",
   "JointDecisionv3.mlmodelc",
   "parakeet_vocab.json",
 ];
-const FLUID_ASR_ENCODERS = ["Encoder.mlmodelc", "EncoderInt4.mlmodelc"];
 
 /**
  * Complete enough to transcribe. Mirrors `models.rs::fluidaudio_asr_ready` — a bare
@@ -59,10 +60,7 @@ const FLUID_ASR_ENCODERS = ["Encoder.mlmodelc", "EncoderInt4.mlmodelc"];
  * download the remainder on first transcribe (#684).
  */
 export function fluidAsrCacheReady(path: string): boolean {
-  return (
-    FLUID_ASR_REQUIRED.every((f) => existsSync(join(path, f))) &&
-    FLUID_ASR_ENCODERS.some((f) => existsSync(join(path, f)))
-  );
+  return FLUID_ASR_REQUIRED.every((f) => existsSync(join(path, f)));
 }
 
 export function fluidAsrCacheInfo(

--- a/src/fluid-asr-cache.ts
+++ b/src/fluid-asr-cache.ts
@@ -12,9 +12,13 @@ export const FLUID_ASR_CACHE_NOTE =
  * "not CoreML" there would point darwin diagnostics at an ONNX directory this platform
  * never populates and render a working install as broken (#684).
  */
-export function isCoremlBackend(backend?: string): boolean {
+export function isCoremlBackend(
+  backend?: string,
+  platform?: typeof process.platform,
+  arch?: typeof process.arch,
+): boolean {
   if (backend) return backend === "coreml";
-  return isDarwinArm64();
+  return isDarwinArm64(platform, arch);
 }
 
 export interface FluidAsrCacheInfo {
@@ -58,6 +62,12 @@ const FLUID_ASR_REQUIRED = [
  * Complete enough to transcribe. Mirrors `models.rs::fluidaudio_asr_ready` — a bare
  * directory check would call an interrupted fetch healthy, and the engine would then
  * download the remainder on first transcribe (#684).
+ *
+ * Existence-only on purpose: FluidAudio's own `modelsExist` is `fileExists` over the same
+ * names, and its download skips whatever that predicate accepts. Requiring more here (that
+ * each `.mlmodelc` is a directory, that `coremldata.bin` is inside) would report not-ready
+ * for a bundle FluidAudio considers present, so `kesha install` would fetch nothing and the
+ * user could never clear the error. Match the loader; do not out-strict it.
  */
 export function fluidAsrCacheReady(path: string): boolean {
   return FLUID_ASR_REQUIRED.every((f) => existsSync(join(path, f)));

--- a/src/install-plan.ts
+++ b/src/install-plan.ts
@@ -13,7 +13,12 @@ import {
   isDarwinArm64,
 } from "./fluid-kokoro-cache";
 import modelPlan from "../model-plan.json" with { type: "json" };
-import { fluidAsrCacheInfo, isCoremlBackend } from "./fluid-asr-cache";
+import {
+  FLUID_ASR_CACHE_NOTE,
+  fluidAsrCachePath,
+  fluidAsrCacheReady,
+  isCoremlBackend,
+} from "./fluid-asr-cache";
 
 export interface InstallPlanOptions {
   noCache?: boolean;
@@ -49,8 +54,6 @@ interface PlanComponent {
   note?: string;
   /** Fetched by a backend into its own cache — excluded from the Kesha-managed totals. */
   external?: boolean;
-  /** Size is an estimate, not summed from a pinned manifest; rendered without a byte count. */
-  approx?: boolean;
 }
 
 interface PlanWarmup {
@@ -165,27 +168,16 @@ async function planBackendIsCoreml(options: InstallPlanOptions): Promise<boolean
   return isCoremlBackend(probed?.backend);
 }
 
-function asrComponent(cacheRoot: string, noCache: boolean, coreml: boolean): PlanComponent {
-  if (!coreml) {
-    return bundleComponent({
-      cacheRoot,
-      name: "ASR Parakeet TDT v3",
-      source: "model cache",
-      files: ASR_FILES,
-      refresh: noCache,
-      note: "required for speech-to-text",
-    });
-  }
+function fluidAsrComponent(): PlanComponent {
   return {
     name: "ASR Parakeet TDT v3 (CoreML)",
     source: "FluidAudio cache",
     sizeBytes: FLUID_ASR_BUNDLE_BYTES,
-    cached: fluidAsrCacheInfo().exists,
+    cached: fluidAsrCacheReady(fluidAsrCachePath()),
     // `--no-cache` is a Kesha-cache flag; FluidAudio's bundle is not re-fetched by it.
     refresh: false,
     external: true,
-    approx: true,
-    note: "required for speech-to-text; fetched by the backend during warm-up, outside Kesha's model cache",
+    note: FLUID_ASR_CACHE_NOTE,
   };
 }
 
@@ -309,7 +301,9 @@ function assembleComponents(input: {
   const components: PlanComponent[] = [
     buildEngineComponent(input.binPath, noCache),
     ...buildSidecarComponents(input.engineDir, noCache),
-    asrComponent(cacheRoot, noCache, input.coreml),
+    input.coreml
+      ? fluidAsrComponent()
+      : modelBundle("ASR Parakeet TDT v3", ASR_FILES, "required for speech-to-text"),
     modelBundle(
       "Audio language ID ECAPA",
       LANG_ID_FILES,
@@ -353,8 +347,8 @@ function renderComponentLines(components: PlanComponent[]): string[] {
   const status = (c: PlanComponent) => (c.refresh ? "refresh" : c.cached ? "cached" : "needed");
   const lines: string[] = [];
   for (const c of components) {
-    const size = c.approx ? `~${humanBytes(c.sizeBytes)}` : humanBytes(c.sizeBytes);
-    const detail = c.approx ? "approximate" : `${c.sizeBytes} bytes`;
+    const size = c.external ? `~${humanBytes(c.sizeBytes)}` : humanBytes(c.sizeBytes);
+    const detail = c.external ? "approximate" : `${c.sizeBytes} bytes`;
     lines.push(`  - ${c.name}: ${size} (${detail}, ${status(c)}, ${c.source})`);
     if (c.note) lines.push(`    ${c.note}`);
   }

--- a/src/install-plan.ts
+++ b/src/install-plan.ts
@@ -47,6 +47,10 @@ interface PlanComponent {
   cached: boolean;
   refresh: boolean;
   note?: string;
+  /** Fetched by a backend into its own cache — excluded from the Kesha-managed totals. */
+  external?: boolean;
+  /** Size is an estimate, not summed from a pinned manifest; rendered without a byte count. */
+  approx?: boolean;
 }
 
 interface PlanWarmup {
@@ -136,18 +140,31 @@ function bundleComponent(input: {
   };
 }
 
-/// A CoreML engine cannot read the ONNX weights, so quoting their 2.43 GB would
-/// promise a download that never happens. FluidAudio fetches its own bundle during
-/// the install warm-up instead — still a cost, so it is named rather than dropped (#684).
-///
-/// Measured from `parakeet-tdt-0.6b-v3`, the directory the current FluidAudio actually
-/// loads. A `…-v3-coreml` sibling may also exist from earlier versions; counting it here
-/// would overstate the plan against what `status --disk` then reports.
+/**
+ * A CoreML engine cannot read the ONNX weights, so quoting their 2.43 GB would
+ * promise a download that never happens. FluidAudio fetches its own bundle during
+ * the install warm-up instead — still a cost, so it is named rather than dropped (#684).
+ *
+ * Measured from `parakeet-tdt-0.6b-v3`, the directory the current FluidAudio actually
+ * loads. A `…-v3-coreml` sibling may also exist from earlier versions; counting it here
+ * would overstate the plan against what `status --disk` then reports. An estimate, not a
+ * manifest sum — rendered as approximate.
+ */
 const FLUID_ASR_BUNDLE_BYTES = 473 * 1024 * 1024;
 
-function asrComponent(cacheRoot: string, noCache: boolean): PlanComponent {
-  const fluid = fluidAsrCacheInfo();
-  if (!fluid.supported) {
+/**
+ * An explicit `--coreml` / `--onnx` wins; otherwise the platform decides which released
+ * binary `install` will fetch. Deliberately not probing the installed engine: `--plan`
+ * stays synchronous and must work before any engine exists.
+ */
+function planBackendIsCoreml(options: InstallPlanOptions): boolean {
+  if (options.backend === "coreml") return true;
+  if (options.backend === "onnx") return false;
+  return isDarwinArm64();
+}
+
+function asrComponent(cacheRoot: string, noCache: boolean, coreml: boolean): PlanComponent {
+  if (!coreml) {
     return bundleComponent({
       cacheRoot,
       name: "ASR Parakeet TDT v3",
@@ -161,8 +178,11 @@ function asrComponent(cacheRoot: string, noCache: boolean): PlanComponent {
     name: "ASR Parakeet TDT v3 (CoreML)",
     source: "FluidAudio cache",
     sizeBytes: FLUID_ASR_BUNDLE_BYTES,
-    cached: fluid.exists,
-    refresh: noCache,
+    cached: fluidAsrCacheInfo().exists,
+    // `--no-cache` is a Kesha-cache flag; FluidAudio's bundle is not re-fetched by it.
+    refresh: false,
+    external: true,
+    approx: true,
     note: "required for speech-to-text; fetched by the backend during warm-up, outside Kesha's model cache",
   };
 }
@@ -286,7 +306,7 @@ function assembleComponents(input: {
   const components: PlanComponent[] = [
     buildEngineComponent(input.binPath, noCache),
     ...buildSidecarComponents(input.engineDir, noCache),
-    asrComponent(cacheRoot, noCache),
+    asrComponent(cacheRoot, noCache, planBackendIsCoreml(options)),
     modelBundle(
       "Audio language ID ECAPA",
       LANG_ID_FILES,
@@ -330,7 +350,9 @@ function renderComponentLines(components: PlanComponent[]): string[] {
   const status = (c: PlanComponent) => (c.refresh ? "refresh" : c.cached ? "cached" : "needed");
   const lines: string[] = [];
   for (const c of components) {
-    lines.push(`  - ${c.name}: ${humanBytes(c.sizeBytes)} (${c.sizeBytes} bytes, ${status(c)}, ${c.source})`);
+    const size = c.approx ? `~${humanBytes(c.sizeBytes)}` : humanBytes(c.sizeBytes);
+    const detail = c.approx ? "approximate" : `${c.sizeBytes} bytes`;
+    lines.push(`  - ${c.name}: ${size} (${detail}, ${status(c)}, ${c.source})`);
     if (c.note) lines.push(`    ${c.note}`);
   }
   return lines;
@@ -342,14 +364,25 @@ function renderWarmupLines(warmups: PlanWarmup[]): string[] {
 }
 
 function renderTotalLines(components: PlanComponent[]): string[] {
-  const coldBytes = components.reduce((sum, c) => sum + c.sizeBytes, 0);
-  const expectedNetworkBytes = components.reduce((sum, c) => (c.cached && !c.refresh ? sum : sum + c.sizeBytes), 0);
-  return [
+  // External components are fetched by a backend into its own cache, so they cannot
+  // sit under a total labelled "Kesha-managed" — they get their own line (#684).
+  const managed = components.filter((c) => !c.external);
+  const external = components.filter((c) => c.external);
+  const coldBytes = managed.reduce((sum, c) => sum + c.sizeBytes, 0);
+  const expectedNetworkBytes = managed.reduce((sum, c) => (c.cached && !c.refresh ? sum : sum + c.sizeBytes), 0);
+  const lines = [
     "",
     "Totals:",
     `  Cold-cache Kesha-managed download: ${humanBytes(coldBytes)}`,
     `  Expected Kesha-managed network for this run: ${humanBytes(expectedNetworkBytes)}`,
   ];
+  const externalPending = external.reduce((sum, c) => (c.cached ? sum : sum + c.sizeBytes), 0);
+  if (externalPending > 0) {
+    lines.push(
+      `  Additionally fetched by the backend into its own cache: ~${humanBytes(externalPending)}`,
+    );
+  }
+  return lines;
 }
 
 function renderBehaviorLines(ttsLangs: string[], wantsAnyKokoro: boolean): string[] {

--- a/src/install-plan.ts
+++ b/src/install-plan.ts
@@ -1,7 +1,7 @@
 import { existsSync, statSync } from "fs";
 import { humanBytes } from "./format";
 import { dirname, join } from "path";
-import { getEngineBinPath } from "./engine";
+import { getEngineBinPath, getEngineCapabilities } from "./engine";
 import { SIDECARS } from "./engine-install";
 import { engineTarget } from "./engine-targets";
 import { readInstalledEngineVersion } from "./engine-version-marker";
@@ -13,7 +13,7 @@ import {
   isDarwinArm64,
 } from "./fluid-kokoro-cache";
 import modelPlan from "../model-plan.json" with { type: "json" };
-import { fluidAsrCacheInfo } from "./fluid-asr-cache";
+import { fluidAsrCacheInfo, isCoremlBackend } from "./fluid-asr-cache";
 
 export interface InstallPlanOptions {
   noCache?: boolean;
@@ -153,14 +153,16 @@ function bundleComponent(input: {
 const FLUID_ASR_BUNDLE_BYTES = 473 * 1024 * 1024;
 
 /**
- * An explicit `--coreml` / `--onnx` wins; otherwise the platform decides which released
- * binary `install` will fetch. Deliberately not probing the installed engine: `--plan`
- * stays synchronous and must work before any engine exists.
+ * An explicit `--coreml` / `--onnx` wins. Otherwise ask the installed engine, so a custom
+ * `KESHA_ENGINE_BIN` is planned for what it actually is rather than what the host usually
+ * ships (#684). The probe is optional: `--plan` must still work before any engine exists,
+ * and `isCoremlBackend` falls back to the platform when it yields nothing.
  */
-function planBackendIsCoreml(options: InstallPlanOptions): boolean {
+async function planBackendIsCoreml(options: InstallPlanOptions): Promise<boolean> {
   if (options.backend === "coreml") return true;
   if (options.backend === "onnx") return false;
-  return isDarwinArm64();
+  const probed = await getEngineCapabilities().catch(() => null);
+  return isCoremlBackend(probed?.backend);
 }
 
 function asrComponent(cacheRoot: string, noCache: boolean, coreml: boolean): PlanComponent {
@@ -297,6 +299,7 @@ function assembleComponents(input: {
   engineDir: string;
   noCache: boolean;
   options: InstallPlanOptions;
+  coreml: boolean;
   tts: ReturnType<typeof buildTtsComponents>;
 }): PlanComponent[] {
   const { cacheRoot, noCache, options } = input;
@@ -306,7 +309,7 @@ function assembleComponents(input: {
   const components: PlanComponent[] = [
     buildEngineComponent(input.binPath, noCache),
     ...buildSidecarComponents(input.engineDir, noCache),
-    asrComponent(cacheRoot, noCache, planBackendIsCoreml(options)),
+    asrComponent(cacheRoot, noCache, input.coreml),
     modelBundle(
       "Audio language ID ECAPA",
       LANG_ID_FILES,
@@ -445,7 +448,8 @@ export async function renderInstallPlan(options: InstallPlanOptions = {}): Promi
   const ttsLangs = options.ttsLangs ?? [];
 
   const tts = buildTtsComponents(cacheRoot, ttsLangs, noCache);
-  const components = assembleComponents({ cacheRoot, binPath, engineDir, noCache, options, tts });
+  const coreml = await planBackendIsCoreml(options);
+  const components = assembleComponents({ cacheRoot, binPath, engineDir, noCache, options, coreml, tts });
 
   const lines = [
     ...renderHeader(cacheRoot, binPath, options.backend),

--- a/src/install-plan.ts
+++ b/src/install-plan.ts
@@ -13,6 +13,7 @@ import {
   isDarwinArm64,
 } from "./fluid-kokoro-cache";
 import modelPlan from "../model-plan.json" with { type: "json" };
+import { fluidAsrCacheInfo } from "./fluid-asr-cache";
 
 export interface InstallPlanOptions {
   noCache?: boolean;
@@ -135,6 +136,37 @@ function bundleComponent(input: {
   };
 }
 
+/// A CoreML engine cannot read the ONNX weights, so quoting their 2.43 GB would
+/// promise a download that never happens. FluidAudio fetches its own bundle during
+/// the install warm-up instead — still a cost, so it is named rather than dropped (#684).
+///
+/// Measured from `parakeet-tdt-0.6b-v3`, the directory the current FluidAudio actually
+/// loads. A `…-v3-coreml` sibling may also exist from earlier versions; counting it here
+/// would overstate the plan against what `status --disk` then reports.
+const FLUID_ASR_BUNDLE_BYTES = 473 * 1024 * 1024;
+
+function asrComponent(cacheRoot: string, noCache: boolean): PlanComponent {
+  const fluid = fluidAsrCacheInfo();
+  if (!fluid.supported) {
+    return bundleComponent({
+      cacheRoot,
+      name: "ASR Parakeet TDT v3",
+      source: "model cache",
+      files: ASR_FILES,
+      refresh: noCache,
+      note: "required for speech-to-text",
+    });
+  }
+  return {
+    name: "ASR Parakeet TDT v3 (CoreML)",
+    source: "FluidAudio cache",
+    sizeBytes: FLUID_ASR_BUNDLE_BYTES,
+    cached: fluid.exists,
+    refresh: noCache,
+    note: "required for speech-to-text; fetched by the backend during warm-up, outside Kesha's model cache",
+  };
+}
+
 function buildEngineComponent(binPath: string, noCache: boolean): PlanComponent {
   const engineAsset = engineAssetForPlatform();
   if (engineAsset) {
@@ -254,7 +286,7 @@ function assembleComponents(input: {
   const components: PlanComponent[] = [
     buildEngineComponent(input.binPath, noCache),
     ...buildSidecarComponents(input.engineDir, noCache),
-    modelBundle("ASR Parakeet TDT v3", ASR_FILES, "required for speech-to-text"),
+    asrComponent(cacheRoot, noCache),
     modelBundle(
       "Audio language ID ECAPA",
       LANG_ID_FILES,

--- a/src/status.ts
+++ b/src/status.ts
@@ -11,6 +11,7 @@ import { log } from "./log";
 import { packageVersion } from "./package-info";
 import { keshaCacheDir } from "./paths";
 import { fluidKokoroCacheInfo } from "./fluid-kokoro-cache";
+import { fluidAsrCacheInfo, fluidAsrCachePath } from "./fluid-asr-cache";
 import { dirSizeBytes } from "./diagnostic-paths";
 import pc from "picocolors";
 
@@ -147,7 +148,11 @@ export function renderStatus(report: StatusReport): void {
 function buildDiskComponents(cache: string, engineDir: string): Array<{ label: string; path: string }> {
   return [
     { label: "Engine", path: engineDir },
-    { label: "ASR (Parakeet)", path: join(cache, "models/parakeet-tdt-v3") },
+    // A CoreML engine never populates the ONNX dir; pointing at it would render a
+    // healthy darwin install as "ASR missing" (#684).
+    fluidAsrCacheInfo().supported
+      ? { label: "ASR (Parakeet, FluidAudio)", path: fluidAsrCachePath() }
+      : { label: "ASR (Parakeet)", path: join(cache, "models/parakeet-tdt-v3") },
     { label: "Language ID", path: join(cache, "models/lang-id-ecapa") },
     { label: "VAD (Silero)", path: join(cache, "models/silero-vad") },
     { label: "TTS (Kokoro)", path: join(cache, "models/kokoro-82m") },

--- a/src/status.ts
+++ b/src/status.ts
@@ -221,8 +221,10 @@ function collectDiskUsage(binPath: string, backend?: string): StatusDiskUsage {
       fluidKokoro.exists && fluidKokoro.sizeBytes > 0
         ? { path: fluidKokoro.path, sizeBytes: fluidKokoro.sizeBytes }
         : null,
+    // Gate on readiness, not size, so a partial bundle is not shown as a present
+    // cache while doctor reports it missing.
     fluidAsr:
-      coreml && fluidAsr.sizeBytes > 0
+      coreml && fluidAsr.exists && fluidAsr.sizeBytes > 0
         ? { path: fluidAsr.path, sizeBytes: fluidAsr.sizeBytes }
         : null,
   };

--- a/src/status.ts
+++ b/src/status.ts
@@ -11,7 +11,7 @@ import { log } from "./log";
 import { packageVersion } from "./package-info";
 import { keshaCacheDir } from "./paths";
 import { fluidKokoroCacheInfo } from "./fluid-kokoro-cache";
-import { fluidAsrCacheInfo, fluidAsrCachePath } from "./fluid-asr-cache";
+import { fluidAsrCacheInfo, isCoremlBackend } from "./fluid-asr-cache";
 import { dirSizeBytes } from "./diagnostic-paths";
 import pc from "picocolors";
 
@@ -198,9 +198,7 @@ function collectDiskUsage(binPath: string, backend?: string): StatusDiskUsage {
   const cache = keshaCacheDir();
   // Two levels up from the binary (`<cache>/engine/bin/`) so future engine-root siblings are counted.
   const engineDir = join(binPath, "..", "..");
-  // The engine's compiled backend, not the host platform: a darwin-arm64 ONNX build
-  // reads the Kesha cache like any other ONNX build.
-  const coreml = backend === "coreml";
+  const coreml = isCoremlBackend(backend);
 
   const components: StatusDiskComponent[] = [];
   for (const c of buildDiskComponents(cache, engineDir, coreml)) {

--- a/src/status.ts
+++ b/src/status.ts
@@ -53,6 +53,7 @@ export interface StatusDiskUsage {
   componentTotalBytes: number;
   totalBytes: number;
   fluidKokoro: { path: string; sizeBytes: number } | null;
+  fluidAsr: { path: string; sizeBytes: number } | null;
 }
 
 /**
@@ -91,7 +92,7 @@ export async function collectStatus(options: ShowStatusOptions = {}): Promise<St
       ? null
       : `Run \`${installHint()}\` to download the engine and models.`,
     // Absent engine means no disk walk, matching the human path (#647).
-    disk: installed && options.disk ? collectDiskUsage(path) : null,
+    disk: installed && options.disk ? collectDiskUsage(path, capabilities?.backend) : null,
   };
 }
 
@@ -145,14 +146,19 @@ export function renderStatus(report: StatusReport): void {
 }
 
 
-function buildDiskComponents(cache: string, engineDir: string): Array<{ label: string; path: string }> {
+function buildDiskComponents(
+  cache: string,
+  engineDir: string,
+  coreml: boolean,
+): Array<{ label: string; path: string }> {
   return [
     { label: "Engine", path: engineDir },
-    // A CoreML engine never populates the ONNX dir; pointing at it would render a
-    // healthy darwin install as "ASR missing" (#684).
-    fluidAsrCacheInfo().supported
-      ? { label: "ASR (Parakeet, FluidAudio)", path: fluidAsrCachePath() }
-      : { label: "ASR (Parakeet)", path: join(cache, "models/parakeet-tdt-v3") },
+    // A CoreML engine never populates the ONNX dir, and its own bundle lives outside
+    // the Kesha cache — so it is reported under external caches, not here, or the rows
+    // would sum past a Total that cannot include it (#684).
+    ...(coreml
+      ? []
+      : [{ label: "ASR (Parakeet)", path: join(cache, "models/parakeet-tdt-v3") }]),
     { label: "Language ID", path: join(cache, "models/lang-id-ecapa") },
     { label: "VAD (Silero)", path: join(cache, "models/silero-vad") },
     { label: "TTS (Kokoro)", path: join(cache, "models/kokoro-82m") },
@@ -174,20 +180,30 @@ function logDiskRows(rows: StatusDiskComponent[], total: number, componentTotal:
   }
 }
 
-function logFluidKokoroCache(fluidKokoro: StatusDiskUsage["fluidKokoro"]): void {
-  if (!fluidKokoro) return;
+function logExternalCaches(disk: StatusDiskUsage): void {
+  if (!disk.fluidKokoro && !disk.fluidAsr) return;
   log.info("");
   log.info(`External caches (not included in Kesha total):`);
-  log.info(`  FluidAudio Kokoro: ${humanBytes(fluidKokoro.sizeBytes)} (${fluidKokoro.path})`);
+  if (disk.fluidAsr) {
+    log.info(`  FluidAudio ASR:    ${humanBytes(disk.fluidAsr.sizeBytes)} (${disk.fluidAsr.path})`);
+  }
+  if (disk.fluidKokoro) {
+    log.info(
+      `  FluidAudio Kokoro: ${humanBytes(disk.fluidKokoro.sizeBytes)} (${disk.fluidKokoro.path})`,
+    );
+  }
 }
 
-function collectDiskUsage(binPath: string): StatusDiskUsage {
+function collectDiskUsage(binPath: string, backend?: string): StatusDiskUsage {
   const cache = keshaCacheDir();
   // Two levels up from the binary (`<cache>/engine/bin/`) so future engine-root siblings are counted.
   const engineDir = join(binPath, "..", "..");
+  // The engine's compiled backend, not the host platform: a darwin-arm64 ONNX build
+  // reads the Kesha cache like any other ONNX build.
+  const coreml = backend === "coreml";
 
   const components: StatusDiskComponent[] = [];
-  for (const c of buildDiskComponents(cache, engineDir)) {
+  for (const c of buildDiskComponents(cache, engineDir, coreml)) {
     const sizeBytes = dirSizeBytes(c.path);
     if (sizeBytes > 0) components.push({ label: c.label, sizeBytes });
   }
@@ -196,6 +212,7 @@ function collectDiskUsage(binPath: string): StatusDiskUsage {
   const cacheTotal = dirSizeBytes(cache);
   const engineOutsideCache = engineDir.startsWith(cache) ? 0 : dirSizeBytes(engineDir);
   const fluidKokoro = fluidKokoroCacheInfo();
+  const fluidAsr = fluidAsrCacheInfo();
 
   return {
     cachePath: cache,
@@ -206,6 +223,10 @@ function collectDiskUsage(binPath: string): StatusDiskUsage {
       fluidKokoro.exists && fluidKokoro.sizeBytes > 0
         ? { path: fluidKokoro.path, sizeBytes: fluidKokoro.sizeBytes }
         : null,
+    fluidAsr:
+      coreml && fluidAsr.sizeBytes > 0
+        ? { path: fluidAsr.path, sizeBytes: fluidAsr.sizeBytes }
+        : null,
   };
 }
 
@@ -214,7 +235,7 @@ function showDiskUsage(disk: StatusDiskUsage): void {
 
   log.info(`Disk usage (${disk.cachePath}):`);
   logDiskRows(disk.components, disk.totalBytes, disk.componentTotalBytes);
-  logFluidKokoroCache(disk.fluidKokoro);
+  logExternalCaches(disk);
   log.info("");
   log.info(
     pc.dim(`  To reset cache: rm -rf ${disk.cachePath} — next \`kesha install\` re-downloads.`),

--- a/src/status.ts
+++ b/src/status.ts
@@ -210,7 +210,8 @@ function collectDiskUsage(binPath: string, backend?: string): StatusDiskUsage {
   const cacheTotal = dirSizeBytes(cache);
   const engineOutsideCache = engineDir.startsWith(cache) ? 0 : dirSizeBytes(engineDir);
   const fluidKokoro = fluidKokoroCacheInfo();
-  const fluidAsr = fluidAsrCacheInfo();
+  // Only walked when it is the backend in play; otherwise the size is computed and dropped.
+  const fluidAsr = coreml ? fluidAsrCacheInfo() : null;
 
   return {
     cachePath: cache,
@@ -224,7 +225,7 @@ function collectDiskUsage(binPath: string, backend?: string): StatusDiskUsage {
     // Gate on readiness, not size, so a partial bundle is not shown as a present
     // cache while doctor reports it missing.
     fluidAsr:
-      coreml && fluidAsr.exists && fluidAsr.sizeBytes > 0
+      fluidAsr?.exists && fluidAsr.sizeBytes > 0
         ? { path: fluidAsr.path, sizeBytes: fluidAsr.sizeBytes }
         : null,
   };

--- a/tests/unit/fluid-asr-cache.test.ts
+++ b/tests/unit/fluid-asr-cache.test.ts
@@ -15,12 +15,25 @@ describe("fluidAsrCacheInfo", () => {
     expect(path.endsWith("-coreml")).toBe(false);
   });
 
-  test("reports the bundle on darwin-arm64 when it exists", () => {
+  const COMPLETE = [
+    "Preprocessor.mlmodelc",
+    "Decoder.mlmodelc",
+    "JointDecisionv3.mlmodelc",
+    "parakeet_vocab.json",
+    "Encoder.mlmodelc",
+  ];
+
+  function seed(homeDir: string, entries: string[]): string {
+    const cache = fluidAsrCachePath(homeDir);
+    mkdirSync(cache, { recursive: true });
+    for (const e of entries) writeFileSync(join(cache, e), "coreml");
+    return cache;
+  }
+
+  test("reports the bundle on darwin-arm64 when it is complete", () => {
     const dir = mkdtempSync(join(tmpdir(), "kesha-fluid-asr-cache-test-"));
     try {
-      const cache = fluidAsrCachePath(dir);
-      mkdirSync(cache, { recursive: true });
-      writeFileSync(join(cache, "Encoder.mlmodelc"), "coreml");
+      const cache = seed(dir, COMPLETE);
 
       const info = fluidAsrCacheInfo({ platform: "darwin", arch: "arm64", homeDir: dir });
 
@@ -28,6 +41,47 @@ describe("fluidAsrCacheInfo", () => {
       expect(info.path).toBe(cache);
       expect(info.exists).toBe(true);
       expect(info.sizeBytes).toBeGreaterThan(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("accepts the int4 encoder in place of int8", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-fluid-asr-cache-int4-"));
+    try {
+      seed(dir, [
+        ...COMPLETE.filter((f) => f !== "Encoder.mlmodelc"),
+        "EncoderInt4.mlmodelc",
+      ]);
+      expect(fluidAsrCacheInfo({ platform: "darwin", arch: "arm64", homeDir: dir }).exists).toBe(
+        true,
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // An interrupted fetch leaves the directory present but partial. Calling that
+  // healthy lets preflight pass and FluidAudio finish the download mid-transcribe.
+  test("reports a partial bundle as absent, not healthy", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-fluid-asr-cache-partial-"));
+    try {
+      seed(dir, ["Encoder.mlmodelc"]);
+      expect(fluidAsrCacheInfo({ platform: "darwin", arch: "arm64", homeDir: dir }).exists).toBe(
+        false,
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("reports an empty bundle directory as absent", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-fluid-asr-cache-bare-"));
+    try {
+      mkdirSync(fluidAsrCachePath(dir), { recursive: true });
+      expect(fluidAsrCacheInfo({ platform: "darwin", arch: "arm64", homeDir: dir }).exists).toBe(
+        false,
+      );
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/tests/unit/fluid-asr-cache.test.ts
+++ b/tests/unit/fluid-asr-cache.test.ts
@@ -17,10 +17,10 @@ describe("fluidAsrCacheInfo", () => {
 
   const COMPLETE = [
     "Preprocessor.mlmodelc",
+    "Encoder.mlmodelc",
     "Decoder.mlmodelc",
     "JointDecisionv3.mlmodelc",
     "parakeet_vocab.json",
-    "Encoder.mlmodelc",
   ];
 
   function seed(homeDir: string, entries: string[]): string {
@@ -46,7 +46,9 @@ describe("fluidAsrCacheInfo", () => {
     }
   });
 
-  test("accepts the int4 encoder in place of int8", () => {
+  // The bridge calls downloadAndLoad with useInt8Encoder: true, so an int4-only bundle
+  // is unusable — accepting it would pass preflight and let FluidAudio fetch int8.
+  test("rejects an int4-only bundle, which an int8 loader cannot use", () => {
     const dir = mkdtempSync(join(tmpdir(), "kesha-fluid-asr-cache-int4-"));
     try {
       seed(dir, [
@@ -54,7 +56,7 @@ describe("fluidAsrCacheInfo", () => {
         "EncoderInt4.mlmodelc",
       ]);
       expect(fluidAsrCacheInfo({ platform: "darwin", arch: "arm64", homeDir: dir }).exists).toBe(
-        true,
+        false,
       );
     } finally {
       rmSync(dir, { recursive: true, force: true });

--- a/tests/unit/fluid-asr-cache.test.ts
+++ b/tests/unit/fluid-asr-cache.test.ts
@@ -1,8 +1,13 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import { fluidAsrCacheInfo, fluidAsrCachePath, isCoremlBackend } from "../../src/fluid-asr-cache";
+import {
+  FLUID_ASR_REQUIRED,
+  fluidAsrCacheInfo,
+  fluidAsrCachePath,
+  isCoremlBackend,
+} from "../../src/fluid-asr-cache";
 import { defaultBackendForPlatform, unavailableBackendError } from "../../src/cli/install";
 
 describe("isCoremlBackend", () => {
@@ -155,5 +160,29 @@ describe("unavailableBackendError", () => {
     process.env.KESHA_ENGINE_BIN = "/tmp/custom-engine";
     const other = defaultBackendForPlatform() === "coreml" ? "onnx" : "coreml";
     expect(unavailableBackendError(other)).toBeNull();
+  });
+});
+
+// The bundle contract is hardcoded in both languages; nothing else fails when only one
+// side is edited, and the int4 hole (#684) was exactly that kind of silent divergence.
+describe("Rust/TS FluidAudio contract agreement", () => {
+  const rust = readFileSync(
+    join(import.meta.dir, "..", "..", "rust", "src", "models.rs"),
+    "utf8",
+  );
+
+  function rustList(constName: string): string[] {
+    const block = rust.match(new RegExp(`const ${constName}: &\\[&str\\] = &\\[([^\\]]*)\\]`));
+    if (!block) throw new Error(`${constName} not found in rust/src/models.rs`);
+    return [...block[1]!.matchAll(/"([^"]+)"/g)].map((m) => m[1]!);
+  }
+
+  test("required entry lists match", () => {
+    expect(rustList("FLUID_ASR_REQUIRED").sort()).toEqual([...FLUID_ASR_REQUIRED].sort());
+  });
+
+  test("cache directory name matches", () => {
+    const leaf = fluidAsrCachePath("/tmp/home").split("/").pop();
+    expect(rust).toContain(`.join("${leaf}")`);
   });
 });

--- a/tests/unit/fluid-asr-cache.test.ts
+++ b/tests/unit/fluid-asr-cache.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { fluidAsrCacheInfo, fluidAsrCachePath } from "../../src/fluid-asr-cache";
+
+describe("fluidAsrCacheInfo", () => {
+  // `Repo.folderName` strips the `-coreml` suffix, and a `…-v3-coreml` sibling exists
+  // on disk. Reporting that one would call a healthy install broken.
+  test("points at the directory FluidAudio loads from, not the -coreml sibling", () => {
+    const path = fluidAsrCachePath("/tmp/home");
+    expect(path).toBe(
+      join("/tmp/home", "Library", "Application Support", "FluidAudio", "Models", "parakeet-tdt-0.6b-v3"),
+    );
+    expect(path.endsWith("-coreml")).toBe(false);
+  });
+
+  test("reports the bundle on darwin-arm64 when it exists", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-fluid-asr-cache-test-"));
+    try {
+      const cache = fluidAsrCachePath(dir);
+      mkdirSync(cache, { recursive: true });
+      writeFileSync(join(cache, "Encoder.mlmodelc"), "coreml");
+
+      const info = fluidAsrCacheInfo({ platform: "darwin", arch: "arm64", homeDir: dir });
+
+      expect(info.supported).toBe(true);
+      expect(info.path).toBe(cache);
+      expect(info.exists).toBe(true);
+      expect(info.sizeBytes).toBeGreaterThan(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("reports absent rather than throwing when the bundle was never fetched", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-fluid-asr-cache-empty-"));
+    try {
+      const info = fluidAsrCacheInfo({ platform: "darwin", arch: "arm64", homeDir: dir });
+      expect(info.supported).toBe(true);
+      expect(info.exists).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("stays inert off darwin-arm64, where the ONNX path is the real one", () => {
+    const info = fluidAsrCacheInfo({ platform: "linux", arch: "x64", homeDir: "/tmp/home" });
+    expect(info.supported).toBe(false);
+    expect(info.exists).toBe(false);
+    expect(info.sizeBytes).toBe(0);
+  });
+});

--- a/tests/unit/fluid-asr-cache.test.ts
+++ b/tests/unit/fluid-asr-cache.test.ts
@@ -1,8 +1,23 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import { fluidAsrCacheInfo, fluidAsrCachePath } from "../../src/fluid-asr-cache";
+import { fluidAsrCacheInfo, fluidAsrCachePath, isCoremlBackend } from "../../src/fluid-asr-cache";
+import { defaultBackendForPlatform, unavailableBackendError } from "../../src/cli/install";
+
+describe("isCoremlBackend", () => {
+  test("trusts the engine's reported backend over the host platform", () => {
+    expect(isCoremlBackend("coreml", "linux", "x64")).toBe(true);
+    expect(isCoremlBackend("onnx", "darwin", "arm64")).toBe(false);
+  });
+
+  // A failed probe must not point darwin at an ONNX dir it never populates (#684).
+  test("falls back to the platform when the capabilities probe yields nothing", () => {
+    expect(isCoremlBackend(undefined, "darwin", "arm64")).toBe(true);
+    expect(isCoremlBackend(undefined, "darwin", "x64")).toBe(false);
+    expect(isCoremlBackend(undefined, "linux", "x64")).toBe(false);
+  });
+});
 
 describe("fluidAsrCacheInfo", () => {
   // `Repo.folderName` strips the `-coreml` suffix, and a `…-v3-coreml` sibling exists
@@ -23,10 +38,18 @@ describe("fluidAsrCacheInfo", () => {
     "parakeet_vocab.json",
   ];
 
+  // `.mlmodelc` are compiled-model directories holding `coremldata.bin`, not flat files.
   function seed(homeDir: string, entries: string[]): string {
     const cache = fluidAsrCachePath(homeDir);
     mkdirSync(cache, { recursive: true });
-    for (const e of entries) writeFileSync(join(cache, e), "coreml");
+    for (const e of entries) {
+      if (e.endsWith(".mlmodelc")) {
+        mkdirSync(join(cache, e), { recursive: true });
+        writeFileSync(join(cache, e, "coremldata.bin"), "compiled");
+      } else {
+        writeFileSync(join(cache, e), "{}");
+      }
+    }
     return cache;
   }
 
@@ -105,5 +128,32 @@ describe("fluidAsrCacheInfo", () => {
     expect(info.supported).toBe(false);
     expect(info.exists).toBe(false);
     expect(info.sizeBytes).toBe(0);
+  });
+});
+
+describe("unavailableBackendError", () => {
+  const saved = process.env.KESHA_ENGINE_BIN;
+  afterEach(() => {
+    if (saved === undefined) delete process.env.KESHA_ENGINE_BIN;
+    else process.env.KESHA_ENGINE_BIN = saved;
+  });
+
+  test("accepts an omitted backend and the platform's own", () => {
+    delete process.env.KESHA_ENGINE_BIN;
+    expect(unavailableBackendError(undefined)).toBeNull();
+    expect(unavailableBackendError(defaultBackendForPlatform())).toBeNull();
+  });
+
+  // Gates both `install --plan` and `init --plan` against previewing a rejected install (#684).
+  test("rejects a backend this platform does not ship", () => {
+    delete process.env.KESHA_ENGINE_BIN;
+    const other = defaultBackendForPlatform() === "coreml" ? "onnx" : "coreml";
+    expect(unavailableBackendError(other)).toContain(other);
+  });
+
+  test("defers to a user-supplied engine", () => {
+    process.env.KESHA_ENGINE_BIN = "/tmp/custom-engine";
+    const other = defaultBackendForPlatform() === "coreml" ? "onnx" : "coreml";
+    expect(unavailableBackendError(other)).toBeNull();
   });
 });

--- a/tests/unit/fluid-asr-cache.test.ts
+++ b/tests/unit/fluid-asr-cache.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
-import { join } from "path";
+import { basename, join } from "path";
 import { tmpdir } from "os";
 import {
   FLUID_ASR_REQUIRED,
@@ -182,7 +182,6 @@ describe("Rust/TS FluidAudio contract agreement", () => {
   });
 
   test("cache directory name matches", () => {
-    const leaf = fluidAsrCachePath("/tmp/home").split("/").pop();
-    expect(rust).toContain(`.join("${leaf}")`);
+    expect(rust).toContain(`.join("${basename(fluidAsrCachePath("/tmp/home"))}")`);
   });
 });


### PR DESCRIPTION
## What a macOS user gets

`kesha install` on darwin-arm64 downloaded the **2.43 GB Parakeet ONNX** weight set — roughly **72% of the install payload** — for a backend that cannot open a single byte of it. Since #681 made the model phase visible, that was also most of what a new user sat watching.

Measured on an M2 against a scratch `KESHA_CACHE_DIR`:

| | before | after |
|---|---|---|
| `kesha install` download | ~2.5 GB | **97.5 MB** (language ID only) |
| `models/parakeet-tdt-v3` | created | never created |
| transcription | works | works |

## Why it happened

`models::install` had no backend branch, `ASR_FILES` carried no `cfg` gate, and `create_backend`'s coreml arm does `let _ = model_dir;`. `lang_id.rs` only ever asks for `ModelKind::LangId`. Nothing on that build reads the directory.

## The user-facing half was not optional

Three surfaces named the ONNX path. Shipping the download fix alone would have rendered a **healthy** macOS install as "ASR missing" and sent people to reinstall — worse than the wasted gigabytes:

- `status --disk` and `doctor` now report ASR from FluidAudio's cache (`ASR (Parakeet, FluidAudio): 473 MB`), reusing the external-component treatment the Kokoro cache already receives rather than inventing a second vocabulary.
- `install --plan` quotes the bundle the backend really fetches instead of a 2.43 GB download that never happens.

## One detail worth reading

The path is derived, not guessed. FluidAudio resolves `<ApplicationSupport>/FluidAudio/Models/<repo.folderName>`, and `folderName` **strips** the `-coreml` suffix — so the plausible-looking `…-v3-coreml` sibling that also exists on disk is the wrong target. Keying on it would have reintroduced the exact "healthy install looks broken" failure this PR exists to prevent. Tests pin it on both the Rust and TS sides.

`--plan` initially quoted 934 MB while `status` measured 473 MB; the constant had been counting both directories. Corrected to the measured figure, with the reason in a comment.

## Verified where CI structurally cannot

`--features coreml` compiles in exactly two places: `coreml-regression` (PR, gated on a paths-filter) and `build-engine.yml` (release). That filter lists `backend/fluidaudio.rs`, `build.rs`, `Cargo.{toml,lock}` — **not** `rust/src/models.rs`, which this PR is what first puts `#[cfg(feature = "coreml")]` code into. So `coreml-regression` reported `skipping` here and **nothing in PR CI compiled the branch this PR exists to change** (`rust-push-gate` is Ubuntu-only, so post-merge does not cover it either). A green PR here proves less than usual.

Filed as #708 rather than fixed inline: the one-line filter fix would import a no-retry ANE flake (#661/#678) onto every model pin bump, so the right shape is a separate `cargo check --features coreml` job — which is a CI design call that should not ride along in this PR.

Verification was therefore done by hand on a local darwin release build (`coreml,tts,system_tts,system_kokoro,system_diarize,system_text_lang`): install into a scratch cache, transcription, `status --disk`, `doctor`, `install --plan`.

Automated: `cargo clippy --all-targets -D warnings` clean on **both** feature sets, `make rust-test` 401 passed, `bun test` 646 passed, `tsc`, `cargo fmt`, `openspec validate --strict`.

## Known behaviour change

`kesha install --no-warmup` on darwin now leaves an install that refuses to transcribe until the weights are fetched, where previously the ONNX files satisfied the pre-flight and FluidAudio downloaded silently on first use. That is the no-auto-download rule working as written, but it is a real change to that flag's contract and worth a follow-up decision.

Side effect for #675: `macOS-kesha-engine-v1` should drop from 2350 MB to ~140 MB, which is the cache-budget headroom that issue needs.

Planning artifacts: `openspec/changes/darwin-skips-onnx-asr/`.

Closes #684
Refs #675

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzppPnnE76JDqGao3Zj4jq
