### PR TITLE
perf(test): stop loading a 935MB model to assert a pure branch

### DIFF
--- a/rust/src/tts/vosk.rs
+++ b/rust/src/tts/vosk.rs
@@ -20,6 +20,17 @@ pub struct Vosk {
     sample_rate: u32,
 }
 
+/// Split out so the range contract is testable without loading the ~935 MB bundle (#707).
+fn validate_speaker_id(speaker_id: u32) -> Result<()> {
+    if speaker_id >= SPEAKER_COUNT {
+        anyhow::bail!(
+            "vosk speaker_id must be 0..{} (got {speaker_id})",
+            SPEAKER_COUNT
+        );
+    }
+    Ok(())
+}
+
 impl Vosk {
     /// Load the model bundle from `model_dir`. Expects the directory layout
     /// produced by `models::VOSK_RU_FILES` (model.onnx, dictionary, config.json,
@@ -44,12 +55,7 @@ impl Vosk {
 
     /// `rate` maps to vosk's `speech_rate` (1.0 = model default).
     pub fn infer(&mut self, text: &str, speaker_id: u32, rate: f32) -> Result<Vec<f32>> {
-        if speaker_id >= SPEAKER_COUNT {
-            anyhow::bail!(
-                "vosk speaker_id must be 0..{} (got {speaker_id})",
-                SPEAKER_COUNT
-            );
-        }
+        validate_speaker_id(speaker_id)?;
         let pcm = self
             .synth
             .synth_audio(
@@ -82,20 +88,13 @@ mod tests {
 
     #[test]
     fn rejects_out_of_range_speaker() {
-        if !ci_true_or_skip("rejects_out_of_range_speaker") {
-            return;
-        }
-        let dir = crate::models::model_dir(crate::models::ModelKind::VoskRu);
-        if !crate::models::is_cached(crate::models::ModelKind::VoskRu) {
-            eprintln!(
-                "vosk model not cached at {} — skipping speaker_id range test",
-                dir.display()
-            );
-            return;
-        }
-        let mut v = Vosk::load(&dir).expect("load vosk");
-        let err = v.infer("привет", SPEAKER_COUNT, 1.0).unwrap_err();
+        let err = validate_speaker_id(SPEAKER_COUNT).unwrap_err();
         assert!(err.to_string().contains("speaker_id"), "msg: {err}");
+    }
+
+    #[test]
+    fn accepts_the_highest_valid_speaker() {
+        assert!(validate_speaker_id(SPEAKER_COUNT - 1).is_ok());
     }
 
     #[test]
@@ -113,6 +112,10 @@ mod tests {
         }
         let mut v = Vosk::load(&dir).expect("load vosk");
         assert_eq!(v.sample_rate(), 22050, "vosk-ru-0.9-multi is 22.05 kHz");
+        // Proves infer() still routes through validate_speaker_id; the standalone
+        // unit test above cannot catch that call being dropped.
+        let err = v.infer("привет", SPEAKER_COUNT, 1.0).unwrap_err();
+        assert!(err.to_string().contains("speaker_id"), "msg: {err}");
         let pcm = v.infer("Привет, мир.", 4, 1.0).expect("synth");
         // ~0.5s at 22.05kHz = 11025 samples lower bound; allow loose floor.
         assert!(pcm.len() > 5000, "got only {} samples", pcm.len());

--- a/rust/src/tts/vosk.rs
+++ b/rust/src/tts/vosk.rs
@@ -116,7 +116,9 @@ mod tests {
         // unit test above cannot catch that call being dropped.
         let err = v.infer("привет", SPEAKER_COUNT, 1.0).unwrap_err();
         assert!(err.to_string().contains("speaker_id"), "msg: {err}");
-        let pcm = v.infer("Привет, мир.", 4, 1.0).expect("synth");
+        let pcm = v
+            .infer("Привет, мир.", SPEAKER_COUNT - 1, 1.0)
+            .expect("synth");
         // ~0.5s at 22.05kHz = 11025 samples lower bound; allow loose floor.
         assert!(pcm.len() > 5000, "got only {} samples", pcm.len());
         for &s in pcm.iter().take(10000) {


### PR DESCRIPTION
Closes #707.

## The problem

`tts::vosk::tests::rejects_out_of_range_speaker` did a full cold `Vosk::load` — ~935 MB across two ONNX sessions and a ~100 MB dictionary parse — purely to reach a check that `infer` evaluates *before* touching the synth:

```rust
pub fn infer(&mut self, text: &str, speaker_id: u32, rate: f32) -> Result<Vec<f32>> {
    if speaker_id >= SPEAKER_COUNT { anyhow::bail!(...); }
```

Measured from run 30907659674:

| platform | this test | next-slowest Rust test |
|---|---|---|
| ubuntu | 88.814s | 24.8s |
| macos-14 | 77.901s | — |
| windows | **143.393s** | — |

On Windows it was part of the suite's critical path.

## The change

`validate_speaker_id` is split out so the contract can be asserted without the bundle. The test now runs in **~0.02s**, and since it no longer needs `CI=true` or a cached model, it runs **locally** too — it previously self-skipped for every developer, so the check was CI-only by accident.

## Why the wiring assertion moved rather than disappeared

Extracting the validator alone would have left a hole: a unit test proves the validator rejects, **not** that `infer` calls it. Deleting `validate_speaker_id(speaker_id)?;` would then go unnoticed.

So the end-to-end assertion moves into `synth_short_phrase_produces_audio`, which already pays the model load — making it free:

```rust
let err = v.infer("привет", SPEAKER_COUNT, 1.0).unwrap_err();
assert!(err.to_string().contains("speaker_id"), "msg: {err}");
```

Net effect on coverage is positive: the range contract is now asserted in two places instead of one, and the boundary case (`SPEAKER_COUNT - 1` is valid) is asserted for the first time.

## Verification

- `make rust-test` → **402 passed, 0 skipped** (was 401 tests; one added).
- `cargo fmt` clean, `cargo clippy --all-targets --features tts -- -D warnings` → exit 0, zero warnings.
- Targeted run: `rejects_out_of_range_speaker` and `accepts_the_highest_valid_speaker` pass in 0.023s each.
- `bunx tsc --noEmit` clean, `bun test` → 654 passed, 0 fail.

**Not verified locally:** the Vosk model is not cached on my machine, so `synth_short_phrase_produces_audio` self-skipped and the relocated wiring assertion was not exercised here. CI has the model and will run it — that is the check to watch on this PR.

`cargo check --features coreml --no-default-features` was not run: that build excludes `tts`, so `vosk.rs` is not compiled into it and this change cannot affect it.

## Not addressed here

The remaining cold-load cost of `synth_short_phrase_produces_audio` (still 78–144s). #707 notes the next question — whether the ONNX session commits or the dictionary parse is the long pole — which is worth measuring before optimising further. This PR removes one of the two loads; it does not make the other one faster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UU2vgxhrf56CN8YDqbg3q1