### PR TITLE
fix(release): an engine tag answers to the engine version

### DIFF
--- a/.github/scripts/release-manifest.mjs
+++ b/.github/scripts/release-manifest.mjs
@@ -5,7 +5,6 @@ import { linuxPackageNames } from "./linux-package-names.mjs";
 import {
   ENGINE_TAG_ERE,
   ENGINE_TAG_RE,
-  expectedTagVersion,
   isStableTag,
 } from "./release-tags.mjs";
 
@@ -119,9 +118,11 @@ function buildManifest(tag) {
   }
 
   const sbomName = `kesha-voice-kit-${tag}.spdx.json`;
-  const expected = expectedTagVersion(tag, { cliVersion: pkg.version, engineVersion });
-  if (tag.slice(1) !== expected.version) {
-    throw new Error(`release tag ${tag} must match ${expected.field} (${expected.version})`);
+  // Every tag here is an engine tag, stable included; the CLI version names packages (#696).
+  if (tag.slice(1) !== engineVersion) {
+    throw new Error(
+      `release tag ${tag} must match package.json#keshaEngine.version (${engineVersion})`,
+    );
   }
 
   const assets = [
@@ -217,7 +218,7 @@ function validateSourceConsistency(manifest) {
 }
 
 const pkg = readPackage();
-const defaultTag = `v${pkg.version}`;
+const defaultTag = `v${pkg.keshaEngine?.version ?? pkg.version}`;
 const tag = getArg("--tag") ?? defaultTag;
 if (!ENGINE_TAG_RE.test(tag)) {
   throw new Error(

--- a/.github/scripts/release-tags.d.mts
+++ b/.github/scripts/release-tags.d.mts
@@ -3,8 +3,4 @@ export const ENGINE_TAG_ERE: string;
 export const ENGINE_TAG_RE: RegExp;
 export const STABLE_TAG_RE: RegExp;
 export function isStableTag(tag: string): boolean;
-export function expectedTagVersion(
-  tag: string,
-  versions: { cliVersion: string; engineVersion: string },
-): { field: string; version: string };
 export function cliPublishTarget(tag: string): { version: string; engineOnly: boolean };

--- a/.github/scripts/release-tags.mjs
+++ b/.github/scripts/release-tags.mjs
@@ -18,18 +18,6 @@ export function isStableTag(tag) {
   return STABLE_TAG_RE.test(tag);
 }
 
-/**
- * Which version field an engine tag must equal, and what to call it in an error.
- *
- * Stable tags also name the Linux packages, whose filenames come from the CLI version;
- * a prerelease builds none, so it answers to the engine version the manifest describes.
- */
-export function expectedTagVersion(tag, { cliVersion, engineVersion }) {
-  return isStableTag(tag)
-    ? { field: "package.json#version", version: cliVersion }
-    : { field: "package.json#keshaEngine.version", version: engineVersion };
-}
-
 const CLI_MARKER = "-cli";
 
 /**

--- a/tests/unit/release-tag-grammar.test.ts
+++ b/tests/unit/release-tag-grammar.test.ts
@@ -74,8 +74,17 @@ describe("release manifest tag check", () => {
     expect(await manifestAccepts([`--tag`, `v${pkg.version}`])).toBe(false);
   });
 
+  // Reverting the default *and* the assertion makes `v<cliVersion>` exit 0 again (grok).
   test("with no tag it defaults to the engine version rather than the CLI's", async () => {
-    expect(await manifestAccepts([])).toBe(true);
+    const proc = Bun.spawn(["node", ".github/scripts/release-manifest.mjs"], {
+      cwd: `${import.meta.dir}/../..`,
+      stdout: "pipe",
+      stderr: "ignore",
+    });
+    const manifest = JSON.parse(await new Response(proc.stdout).text());
+
+    expect(await proc.exited).toBe(0);
+    expect(manifest.tag).toBe(`v${pkg.keshaEngine.version}`);
   });
 });
 

--- a/tests/unit/release-tag-grammar.test.ts
+++ b/tests/unit/release-tag-grammar.test.ts
@@ -5,7 +5,6 @@ import {
   cliPublishTarget,
   ENGINE_TAG_ERE,
   ENGINE_TAG_RE,
-  expectedTagVersion,
 } from "../../.github/scripts/release-tags.mjs";
 
 const WORKFLOW = ".github/workflows/build-engine.yml";
@@ -50,29 +49,33 @@ describe("engine build trigger", () => {
   });
 });
 
-describe("expectedTagVersion", () => {
-  const pkg = { cliVersion: "1.27.0", engineVersion: "1.24.7" };
+// Driven through the script because that assertion is the gate build-engine.yml runs (#696).
+describe("release manifest tag check", () => {
+  const pkg = JSON.parse(readFileSync(`${import.meta.dir}/../../package.json`, "utf8"));
 
-  test("a stable tag answers to the CLI version, which names the Linux packages", () => {
-    expect(expectedTagVersion("v1.27.0", pkg)).toEqual({
-      field: "package.json#version",
-      version: "1.27.0",
+  async function manifestAccepts(args: string[]): Promise<boolean> {
+    const proc = Bun.spawn(["node", ".github/scripts/release-manifest.mjs", ...args, "--check"], {
+      cwd: `${import.meta.dir}/../..`,
+      stdout: "ignore",
+      stderr: "ignore",
     });
+    return (await proc.exited) === 0;
+  }
+
+  test("the two version lines have diverged, so the check can tell them apart", () => {
+    expect(pkg.version).not.toBe(pkg.keshaEngine.version);
   });
 
-  test("a prerelease answers to the engine version the manifest describes", () => {
-    for (const tag of ["v1.24.7-alpha.1", "v1.24.7-beta.1"]) {
-      expect(expectedTagVersion(tag, pkg)).toEqual({
-        field: "package.json#keshaEngine.version",
-        version: "1.24.7",
-      });
-    }
+  test("a stable tag naming the engine version is accepted", async () => {
+    expect(await manifestAccepts([`--tag`, `v${pkg.keshaEngine.version}`])).toBe(true);
   });
 
-  test("an engine alpha whose version line carries the suffix matches", () => {
-    const alpha = { cliVersion: "1.27.0", engineVersion: "1.24.8-alpha.1" };
+  test("a tag naming the CLI version is rejected — the engine never releases under it", async () => {
+    expect(await manifestAccepts([`--tag`, `v${pkg.version}`])).toBe(false);
+  });
 
-    expect(expectedTagVersion("v1.24.8-alpha.1", alpha).version).toBe("1.24.8-alpha.1");
+  test("with no tag it defaults to the engine version rather than the CLI's", async () => {
+    expect(await manifestAccepts([])).toBe(true);
   });
 });
 


### PR DESCRIPTION
`expectedTagVersion` required a **stable** tag to equal `package.json#version` — the CLI version — justified by the Linux package filenames. Since #691 `main` carries the next unreleased CLI version, so the two lines have diverged and every stable engine tag fails manifest generation against a field that has nothing to do with the engine:

```
$ node .github/scripts/release-manifest.mjs --tag v1.24.8 --check
Error: release tag v1.24.8 must match package.json#version (1.27.0)
```

Worse in the other direction: `v1.27.0` — a tag the engine will never release under — was **accepted**.

`ENGINE_TAG_RE` already guarantees the tag is an engine tag, so `tagVersion === engineVersion` is the invariant that holds for every tag this script can see, stable included. Asserting it directly deletes the branch rather than reversing it.

The no-tag default followed the same wrong field. That path is not dead — `ci.yml` runs it on every PR via `check:release-manifest` — so it defaults to the engine version now too.

| invocation | before | after |
| --- | --- | --- |
| `--tag v1.24.7` (the engine version) | ❌ wants 1.27.0 | ✅ |
| `--tag v1.24.8` (next engine release) | ❌ wants 1.27.0 | ✅ once `keshaEngine.version` is bumped, as the release procedure does first |
| `--tag v1.27.0` (the CLI version) | ✅ | ❌ `must match package.json#keshaEngine.version (1.24.7)` |
| no tag (`check:release-manifest`) | ✅ by coincidence | ✅ by construction |

## What survives of the packaging rule, precisely

The deleted branch enforced *tag ↔ CLI-version equality*, which made a `.deb` filename carry the tag's number. That coupling is **gone, deliberately** — it is the subject of #728, not something relocated. What still holds after this PR:

| guarantee | held | where |
| --- | --- | --- |
| the tag names an engine version | ✅ new | the assertion in `buildManifest` |
| Linux packages only on stable tags | ✅ unchanged | `isStableTag(tag)` |
| the CLI version is a stable `X.Y.Z` | ✅ unchanged | `validateLinuxPackageVersion` — **shape only** |
| built filenames == manifest filenames | ✅ unchanged | both read `pkg.version` |
| tag number == package filename number | ❌ gone | #728 |

An earlier revision of this description claimed `validateLinuxPackageVersion` re-enforces what the branch did. It does not — it checks the shape, never the tag.

## Tests

The old assertion is deleted rather than reworded, so `expectedTagVersion` goes with it and the tests drive the script instead — that exit code is the gate `build-engine.yml` actually runs, and the values come from the repo's real `package.json`, with a guard test asserting the two lines still differ so the others cannot pass vacuously.

The no-tag test asserts the `tag` the manifest chose rather than its exit code. Exit code was not enough: reverting the default *and* the assertion together puts `v<cliVersion>` back on both sides and the script exits 0 again. Verified by simulating that reversion — the weaker test passed it, the current one fails, alongside the other two.

## Surfaced while verifying, filed separately

- **#728** — the `.deb`/`.rpm` compile `bin/kesha.js`, so they ship the **CLI**, yet they are published only on stable **engine** tags. `v1.25.0-cli` and `v1.26.0-cli` carry none, which is why apt sits at CLI 1.24.7 while npm is at 1.26.0.
- **#729** — the npm half of the same divergence, and the sharper edge: `engineOnly` is decided by `base.includes("-")`, so a **stable** engine tag still routes to `npm publish`. Following the documented lockstep bump, un-drafting `v1.24.8` would publish CLI 1.24.8 and move npm `latest` **backwards** from 1.26.0. This PR makes the manifest accept that tag; #729 decides whether un-drafting it is safe. Both should land before the next stable engine release.

Closes #696