### PR TITLE
test(release): drive the manifest tag check from version fixtures

### DIFF
--- a/tests/unit/release-tag-grammar.test.ts
+++ b/tests/unit/release-tag-grammar.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { afterAll, describe, expect, test } from "bun:test";
+import {
+  mkdtempSync,
+  readFileSync,
+  rmdirSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { parse } from "yaml";
 import {
   cliPublishTarget,
@@ -51,36 +60,79 @@ describe("engine build trigger", () => {
 
 // Driven through the script because that assertion is the gate build-engine.yml runs (#696).
 describe("release manifest tag check", () => {
-  const pkg = JSON.parse(readFileSync(`${import.meta.dir}/../../package.json`, "utf8"));
+  const REPO = `${import.meta.dir}/../..`;
+  const SCRIPT = `${REPO}/.github/scripts/release-manifest.mjs`;
+  const pkg = JSON.parse(readFileSync(`${REPO}/package.json`, "utf8"));
 
-  async function manifestAccepts(args: string[]): Promise<boolean> {
-    const proc = Bun.spawn(["node", ".github/scripts/release-manifest.mjs", ...args, "--check"], {
-      cwd: `${import.meta.dir}/../..`,
+  // Assert the message, not just a non-zero exit: an unrelated crash must not read as rejection.
+  async function manifestCheck(args: string[], cwd = REPO) {
+    const proc = Bun.spawn(["node", SCRIPT, ...args, "--check"], {
+      cwd,
       stdout: "ignore",
-      stderr: "ignore",
+      stderr: "pipe",
     });
-    return (await proc.exited) === 0;
+    const stderr = await new Response(proc.stderr).text();
+    return { accepted: (await proc.exited) === 0, stderr };
   }
 
-  test("the two version lines have diverged, so the check can tell them apart", () => {
-    expect(pkg.version).not.toBe(pkg.keshaEngine.version);
+  // validateSourceConsistency reads src/, .github/ and packaging/ from cwd, so link the real ones in.
+  const fixtures: string[] = [];
+  const LINKED = ["src", ".github", "packaging"];
+
+  function fixtureRepo(version: string, engineVersion: string): string {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-manifest-"));
+    for (const entry of LINKED) symlinkSync(`${REPO}/${entry}`, join(dir, entry));
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify({ version, keshaEngine: { version: engineVersion } }),
+    );
+    fixtures.push(dir);
+    return dir;
+  }
+
+  afterAll(() => {
+    // Unlink by name rather than rm -r: never let cleanup walk into the linked repo dirs.
+    for (const dir of fixtures) {
+      for (const entry of [...LINKED, "package.json"]) unlinkSync(join(dir, entry));
+      rmdirSync(dir);
+    }
   });
 
   test("a stable tag naming the engine version is accepted", async () => {
-    expect(await manifestAccepts([`--tag`, `v${pkg.keshaEngine.version}`])).toBe(true);
+    expect((await manifestCheck(["--tag", `v${pkg.keshaEngine.version}`])).accepted).toBe(true);
   });
 
   test("a tag naming the CLI version is rejected — the engine never releases under it", async () => {
-    expect(await manifestAccepts([`--tag`, `v${pkg.version}`])).toBe(false);
+    const cwd = fixtureRepo("9.9.9", "1.24.8");
+    const { accepted, stderr } = await manifestCheck(["--tag", "v9.9.9"], cwd);
+
+    expect(accepted).toBe(false);
+    expect(stderr).toContain("must match package.json#keshaEngine.version (1.24.8)");
+  });
+
+  // Lockstep is legal (check-versions.ts rule 2 is `cli >= engine`), so divergence is not an invariant.
+  test("a release where both lines carry the same version still validates", async () => {
+    const cwd = fixtureRepo("1.24.8", "1.24.8");
+    expect((await manifestCheck(["--tag", "v1.24.8"], cwd)).accepted).toBe(true);
+  });
+
+  test("an engine alpha is accepted when the version line carries the suffix too", async () => {
+    const cwd = fixtureRepo("1.27.0", "1.24.8-alpha.1");
+    expect((await manifestCheck(["--tag", "v1.24.8-alpha.1"], cwd)).accepted).toBe(true);
+  });
+
+  test("the base version of an alpha is not an alias for it, in either direction", async () => {
+    const alpha = fixtureRepo("1.27.0", "1.24.8-alpha.1");
+    expect((await manifestCheck(["--tag", "v1.24.8"], alpha)).accepted).toBe(false);
+
+    // Stripping -alpha.N before compare would publish an alpha tag as the stable release.
+    const stable = `v${pkg.keshaEngine.version}-alpha.1`;
+    expect((await manifestCheck(["--tag", stable])).accepted).toBe(false);
   });
 
   // Reverting the default *and* the assertion makes `v<cliVersion>` exit 0 again (grok).
   test("with no tag it defaults to the engine version rather than the CLI's", async () => {
-    const proc = Bun.spawn(["node", ".github/scripts/release-manifest.mjs"], {
-      cwd: `${import.meta.dir}/../..`,
-      stdout: "pipe",
-      stderr: "ignore",
-    });
+    const proc = Bun.spawn(["node", SCRIPT], { cwd: REPO, stdout: "pipe", stderr: "ignore" });
     const manifest = JSON.parse(await new Response(proc.stdout).text());
 
     expect(await proc.exited).toBe(0);

--- a/tests/unit/release-tag-grammar.test.ts
+++ b/tests/unit/release-tag-grammar.test.ts
@@ -126,8 +126,8 @@ describe("release manifest tag check", () => {
     expect((await manifestCheck(["--tag", "v1.24.8"], alpha)).accepted).toBe(false);
 
     // Stripping -alpha.N before compare would publish an alpha tag as the stable release.
-    const stable = `v${pkg.keshaEngine.version}-alpha.1`;
-    expect((await manifestCheck(["--tag", stable])).accepted).toBe(false);
+    const stable = fixtureRepo("1.27.0", "1.24.8");
+    expect((await manifestCheck(["--tag", "v1.24.8-alpha.1"], stable)).accepted).toBe(false);
   });
 
   // Reverting the default *and* the assertion makes `v<cliVersion>` exit 0 again (grok).


### PR DESCRIPTION
Three test-coverage gaps from a second adversarial review of #727 (grok), all in `release-tag-grammar.test.ts`. No production code changes — the validator #727 shipped is correct; only what the suite can see about it was too narrow.

## The suite could only see today's version numbers

`expect(pkg.version).not.toBe(pkg.keshaEngine.version)` asserted the two lines stay diverged *forever*. But `check-versions.ts` rule 2 is `cli >= engine` — equality is legal, and before #691 the lines were realigned at engine-release time, so lockstep is the historical norm rather than an edge case. A combined release commit would have gone red against a perfectly correct validator.

The rejection case now builds a fixture that varies both lines itself, so no test depends on what `main` happens to carry:

| fixture (`version` / `keshaEngine.version`) | tag | expected |
| --- | --- | --- |
| `9.9.9` / `1.24.8` | `v9.9.9` | rejected, naming the engine field |
| `1.24.8` / `1.24.8` | `v1.24.8` | accepted — lockstep is not a failure |
| `1.27.0` / `1.24.8-alpha.1` | `v1.24.8-alpha.1` | accepted |
| `1.27.0` / `1.24.8-alpha.1` | `v1.24.8` | rejected |

## Alpha coverage left with the branch it tested

#727 correctly collapsed the stable/prerelease split into one full-string compare — and the deleted tests were the only ones exercising `-alpha.N` / `-beta.N`. The new suite pins the property that actually matters now: a base version is not an alias for its alpha, in either direction. A future regression that strips the suffix before comparing would publish an alpha tag as the stable release, and nothing would have caught it.

## Rejection was any non-zero exit

`stderr: "ignore"` plus `exited !== 0` meant a crash counted as "correctly rejected". Rejections now assert the error message.

This matters more than it sounds: fixtures link the real `src/`, `.github/` and `packaging/` into the temp dir because `validateSourceConsistency` reads them relative to cwd. A bare fixture dir exits non-zero on ENOENT — exactly the false-green the message assertion closes.

## Verification

Mutation-tested rather than assumed green:

| mutation | result |
| --- | --- |
| strip prerelease suffix from both sides before compare | alias test fails |
| revert #727 — stable tags answer to the CLI version again | 3 tests fail |

`bun test` 680 pass / 0 fail, `bunx tsc --noEmit` clean. Cleanup unlinks fixture entries by name rather than `rm -r`, so it can never walk into the linked repo directories; `git status` after a run confirms the tree is untouched.

Refs #727. The P2 from the same review is packaging, filed and flagged as #728.