### PR TITLE
fix(release): publish alphas through the workflow npm trusts

### DIFF
--- a/.github/scripts/dispatch-npm-publish.sh
+++ b/.github/scripts/dispatch-npm-publish.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# npm Trusted Publishing validates the name of the workflow that *entered* the run, and a
+# package may configure only one, so an alpha has to publish through npm-publish.yml (#731).
+set -euo pipefail
+
+WORKFLOW=npm-publish.yml
+
+latest_dispatch_run() {
+  gh run list --workflow "$WORKFLOW" --event workflow_dispatch --limit 1 \
+    --json databaseId --jq '.[0].databaseId // 0'
+}
+
+before=$(latest_dispatch_run)
+gh workflow run "$WORKFLOW" -f tag="$TAG"
+echo "Dispatched $WORKFLOW for $TAG." >&2
+
+run="$before"
+for _ in $(seq 1 30); do
+  sleep 2
+  run=$(latest_dispatch_run)
+  [ "$run" != "$before" ] && break
+done
+
+# A dispatch that never became a run would leave the tag reserved and nothing published,
+# which is the failure this whole gate exists to make impossible to miss.
+if [ "$run" = "$before" ]; then
+  echo "::error::$WORKFLOW never started for $TAG — the version is tagged but unpublished." >&2
+  exit 1
+fi
+
+echo "Watching run $run." >&2
+gh run watch "$run" --exit-status

--- a/.github/scripts/dispatch-npm-publish.sh
+++ b/.github/scripts/dispatch-npm-publish.sh
@@ -5,25 +5,26 @@ set -euo pipefail
 
 WORKFLOW=npm-publish.yml
 
-latest_dispatch_run() {
-  gh run list --workflow "$WORKFLOW" --event workflow_dispatch --limit 1 \
-    --json databaseId --jq '.[0].databaseId // 0'
+# Dispatching on the tag pins provenance to the published commit and names the run uniquely.
+run_for_tag() {
+  gh run list --workflow "$WORKFLOW" --branch "$TAG" --limit 1 \
+    --json databaseId --jq '.[0].databaseId // ""'
 }
 
-before=$(latest_dispatch_run)
-gh workflow run "$WORKFLOW" -f tag="$TAG"
+before=$(run_for_tag)
+gh workflow run "$WORKFLOW" --ref "$TAG" -f tag="$TAG"
 echo "Dispatched $WORKFLOW for $TAG." >&2
 
 run="$before"
 for _ in $(seq 1 30); do
   sleep 2
-  run=$(latest_dispatch_run)
-  [ "$run" != "$before" ] && break
+  run=$(run_for_tag)
+  [ -n "$run" ] && [ "$run" != "$before" ] && break
 done
 
 # A dispatch that never became a run would leave the tag reserved and nothing published,
-# which is the failure this whole gate exists to make impossible to miss.
-if [ "$run" = "$before" ]; then
+# which is the failure this gate exists to make impossible to miss.
+if [ -z "$run" ] || [ "$run" = "$before" ]; then
   echo "::error::$WORKFLOW never started for $TAG — the version is tagged but unpublished." >&2
   exit 1
 fi

--- a/.github/scripts/release-tags.d.mts
+++ b/.github/scripts/release-tags.d.mts
@@ -3,4 +3,8 @@ export const ENGINE_TAG_ERE: string;
 export const ENGINE_TAG_RE: RegExp;
 export const STABLE_TAG_RE: RegExp;
 export function isStableTag(tag: string): boolean;
-export function cliPublishTarget(tag: string): { version: string; engineOnly: boolean };
+export function cliPublishTarget(tag: string): {
+  version: string;
+  engineOnly: boolean;
+  derived: boolean;
+};

--- a/.github/scripts/release-tags.mjs
+++ b/.github/scripts/release-tags.mjs
@@ -29,9 +29,12 @@ const CLI_MARKER = "-cli";
 export function cliPublishTarget(tag) {
   const cliMarked = tag.endsWith(CLI_MARKER);
   const base = cliMarked ? tag.slice(0, -CLI_MARKER.length) : tag;
+  const version = base.replace(/^v/, "");
   return {
-    version: base.replace(/^v/, ""),
+    version,
     engineOnly: !cliMarked && base.includes("-"),
+    // An alpha version is minted at publish time, so no commit carries it to verify against.
+    derived: version.includes("-alpha."),
   };
 }
 
@@ -42,5 +45,7 @@ if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
     process.exit(2);
   }
   const target = cliPublishTarget(tag);
-  process.stdout.write(`version=${target.version}\nengine_only=${target.engineOnly}\n`);
+  process.stdout.write(
+    `version=${target.version}\nengine_only=${target.engineOnly}\nderived=${target.derived}\n`,
+  );
 }

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -20,6 +20,11 @@ on:
 permissions:
   contents: read
 
+# An older publish finishing last would drag its dist-tag backwards (#731).
+concurrency:
+  group: npm-publish
+  queue: max
+
 jobs:
   resolve:
     runs-on: ubuntu-latest

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -27,6 +27,7 @@ jobs:
       tag: ${{ steps.tag.outputs.tag }}
       version: ${{ steps.tag.outputs.version }}
       engine_only: ${{ steps.tag.outputs.engine_only }}
+      derived: ${{ steps.tag.outputs.derived }}
       dist_tag: ${{ steps.dist.outputs.dist_tag }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -62,3 +63,4 @@ jobs:
       ref: ${{ needs.resolve.outputs.tag }}
       version: ${{ needs.resolve.outputs.version }}
       dist-tag: ${{ needs.resolve.outputs.dist_tag }}
+      inject-version: ${{ needs.resolve.outputs.derived == 'true' }}

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -101,15 +101,19 @@ jobs:
           git tag "$TAG" "$SHA"
           git push origin "$TAG"
 
+  # No OIDC here: npm-publish.yml owns the only entry name npm's publisher trusts (#731).
   publish:
-    name: Publish to npm
+    name: Publish through npm-publish.yml
     needs: [decide, reserve-tag]
+    runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
-    uses: ./.github/workflows/release-npm-publish.yml
-    with:
-      ref: ${{ github.sha }}
-      version: ${{ needs.decide.outputs.version }}
-      dist-tag: ${{ needs.decide.outputs.dist_tag }}
-      inject-version: true
+      actions: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Dispatch the publish and wait for it
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.decide.outputs.tag }}
+        run: .github/scripts/dispatch-npm-publish.sh

--- a/tests/unit/release-tag-grammar.test.ts
+++ b/tests/unit/release-tag-grammar.test.ts
@@ -141,3 +141,27 @@ describe("alpha publish entry", () => {
     expect(publish.with["inject-version"]).toContain("derived");
   });
 });
+
+describe("publish serialisation and provenance", () => {
+  const script = readFileSync(
+    `${import.meta.dir}/../../.github/scripts/dispatch-npm-publish.sh`,
+    "utf8",
+  );
+
+  // Without --ref the run's head_sha is main's tip, so provenance attests a commit whose
+  // tree is not what shipped; it is also what makes the run findable by tag.
+  test("the dispatch pins the run to the tag being published", () => {
+    expect(script).toContain('--ref "$TAG"');
+    expect(script).toContain('--branch "$TAG"');
+  });
+
+  test("an unidentifiable run fails rather than watching whatever is newest", () => {
+    expect(script).toContain('[ -z "$run" ]');
+  });
+
+  test("publishes are serialised so a late one cannot move a dist-tag backwards", () => {
+    const publish = parse(readFileSync(`${import.meta.dir}/../../.github/workflows/npm-publish.yml`, "utf8"));
+
+    expect(publish.concurrency).toEqual({ group: "npm-publish", queue: "max" });
+  });
+});

--- a/tests/unit/release-tag-grammar.test.ts
+++ b/tests/unit/release-tag-grammar.test.ts
@@ -90,13 +90,18 @@ describe("release manifest tag check", () => {
 
 describe("cliPublishTarget", () => {
   test("a CLI marker tag publishes the version the tag names", () => {
-    expect(cliPublishTarget("v1.26.0-cli")).toEqual({ version: "1.26.0", engineOnly: false });
+    expect(cliPublishTarget("v1.26.0-cli")).toEqual({
+      version: "1.26.0",
+      engineOnly: false,
+      derived: false,
+    });
   });
 
   test("a CLI alpha keeps its prerelease identifier", () => {
     expect(cliPublishTarget("v1.27.0-alpha.1-cli")).toEqual({
       version: "1.27.0-alpha.1",
       engineOnly: false,
+      derived: true,
     });
   });
 
@@ -107,6 +112,32 @@ describe("cliPublishTarget", () => {
   });
 
   test("a stable tag still publishes the CLI, as it does today", () => {
-    expect(cliPublishTarget("v1.24.8")).toEqual({ version: "1.24.8", engineOnly: false });
+    expect(cliPublishTarget("v1.24.8")).toEqual({
+      version: "1.24.8",
+      engineOnly: false,
+      derived: false,
+    });
+  });
+});
+
+// npm's trusted publisher is keyed to one entry workflow name, so an alpha that publishes
+// from its own workflow gets an opaque 404 from the registry (#731).
+describe("alpha publish entry", () => {
+  const read = (p: string) => readFileSync(`${import.meta.dir}/../../${p}`, "utf8");
+  const alpha = read(".github/workflows/release-alpha.yml");
+
+  test("the alpha workflow holds no OIDC credential", () => {
+    expect(alpha).not.toContain("id-token");
+  });
+
+  test("it publishes by dispatching npm-publish.yml", () => {
+    expect(read(".github/scripts/dispatch-npm-publish.sh")).toContain("WORKFLOW=npm-publish.yml");
+    expect(parse(alpha).jobs.publish.steps.at(-1).run).toContain("dispatch-npm-publish.sh");
+  });
+
+  test("npm-publish injects the version for tags no commit carries", () => {
+    const publish = parse(read(".github/workflows/npm-publish.yml")).jobs.publish;
+
+    expect(publish.with["inject-version"]).toContain("derived");
   });
 });


### PR DESCRIPTION
The first real alpha ran on the merge of #706, reserved `v1.27.0-alpha.1-cli`, and then failed at the registry — leaving the tag with nothing behind it.

```
npm notice publish Signed provenance statement with source and build information from GitHub Actions
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/@drakulavich%2fkesha-voice-kit
```

Provenance was signed and written to the transparency log, so OIDC minted fine. npm refused the exchange, and `E404` on `PUT` is how the registry answers an authorization failure.

## Why

Two lines from the npm Trusted Publishers docs, which together rule out the shape #703 shipped:

> When GitHub Actions workflows use `workflow_call` or `workflow_dispatch` for publishing, validation checks **the calling workflow's name**, not the workflow containing the publish command.

> **Each package can only have one trusted publisher configured at a time.**

Every publish that has ever succeeded entered through `npm-publish.yml`. An alpha entered through `release-alpha.yml`, so the name could not match — and there is no second slot to register it in. Permissions were never the problem: `id-token: write` was granted on both the caller job and the reusable workflow, exactly as the docs require.

## The fix, and the trap inside it

Alphas now publish by **dispatching `npm-publish.yml`**, so the entry name is the one npm trusts and nothing changes on npmjs.com.

The obvious alternative — have `release-alpha` create a GitHub prerelease and let `release: published` fire the publisher — silently does not work:

> To prevent recursive workflow runs, actions performed using the `GITHUB_TOKEN` generally do not trigger new workflow runs. **Exceptions include `workflow_dispatch` and `repository_dispatch`, which always trigger runs.**

A Release created from a workflow would have fired nothing at all, and the alpha would have gone green having published nothing. `workflow_dispatch` is explicitly exempt, so no PAT or App token is needed.

## Consequences worth stating

- **`release-alpha.yml` no longer holds `id-token: write` anywhere.** The workflow that runs on every push to `main` now carries no publishing credential; it asks the workflow that owns one to act. It trades OIDC for `actions: write`, which is the narrower capability.
- **The dispatch waits on the run it started.** Fire-and-forget would make `release-alpha` go green while the publish failed elsewhere — the exact silent-skip failure this channel has produced twice now. If the dispatched run never starts, that is an error, not a shrug.
- **`npm-publish.yml` learns `inject-version`** for tags no commit carries. The alpha commit's `package.json` says `1.27.0` while the tag says `1.27.0-alpha.1`, so the verify-instead-of-inject path would have rejected it. `cliPublishTarget` decides which it is, keeping tag semantics in the one file that owns them.

| tag | version | engine_only | derived |
| --- | --- | --- | --- |
| `v1.27.0-alpha.1-cli` | 1.27.0-alpha.1 | false | **true** — injected |
| `v1.26.0-cli` | 1.26.0 | false | false — verified |
| `v1.24.8` | 1.24.8 | false | false — verified |
| `v1.24.8-beta.1` | — | **true** — no CLI publish | false |

## Tests

Three assertions encode the constraint so it cannot regress quietly, since the symptom is an opaque 404 rather than anything readable: the alpha workflow contains no `id-token`, it publishes via `dispatch-npm-publish.sh` targeting `npm-publish.yml`, and `npm-publish.yml` wires `inject-version` to the resolver rather than hardcoding it.

## Still open

`v1.27.0-alpha.1-cli` points at a commit whose alpha was never published, and re-running cannot fix it retroactively. Deleting the orphan tag frees `.1`; leaving it resumes at `.2` with a permanent hole. Either is fine — it should be a decision rather than a leftover.

Related: **stable is not broken** (its entry name is unchanged) but it is *unverified* — #700 moved the publish steps into the reusable workflow after v1.26.0 shipped, so no release has yet gone through it. The first stable release will be the test.

Closes #731