### PR TITLE
fix(ci): seed the Parakeet CoreML cache from main so PRs can read it

### DIFF
--- a/.github/scripts/verify-fluid-asr-bundle.ts
+++ b/.github/scripts/verify-fluid-asr-bundle.ts
@@ -1,0 +1,24 @@
+#!/usr/bin/env bun
+/**
+ * Gate between populating FluidAudio's ASR bundle and saving it to the shared cache.
+ *
+ * `kesha-engine install` treats a warm-up failure as non-fatal, so a cold seed run whose
+ * download died partway still exits 0. Saving that writes a partial bundle under an
+ * immutable exact key: later seed probes hit it and skip repair, while every PR restores
+ * the broken entry (#675).
+ */
+import { existsSync } from "fs";
+import { join } from "path";
+import { FLUID_ASR_REQUIRED, fluidAsrCachePath } from "../../src/fluid-asr-cache";
+
+const dir = fluidAsrCachePath();
+const missing = FLUID_ASR_REQUIRED.filter((entry) => !existsSync(join(dir, entry)));
+
+if (missing.length > 0) {
+  console.error(`Refusing to seed an incomplete FluidAudio ASR bundle at ${dir}`);
+  console.error(`missing: ${missing.join(", ")}`);
+  console.error("The populate step reported success, so this is a partial or failed fetch.");
+  process.exit(1);
+}
+
+console.log(`FluidAudio ASR bundle complete at ${dir} (${FLUID_ASR_REQUIRED.length} entries).`);

--- a/.github/workflows/cache-seed.yml
+++ b/.github/workflows/cache-seed.yml
@@ -137,6 +137,15 @@ jobs:
           cd rust
           cargo run --no-default-features --features coreml -- install
 
+      - name: 🍞 Setup Bun workspace
+        if: steps.probe.outputs.cache-hit != 'true'
+        uses: ./.github/actions/setup-bun
+
+      # install exits 0 on a failed warm-up; the exact key is immutable, so a partial save poisons every PR (#675).
+      - name: Verify the bundle before saving
+        if: steps.probe.outputs.cache-hit != 'true'
+        run: bun .github/scripts/verify-fluid-asr-bundle.ts
+
       - name: Save Parakeet CoreML models
         if: steps.probe.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/cache-seed.yml
+++ b/.github/workflows/cache-seed.yml
@@ -19,10 +19,14 @@ name: "🌱 Seed shared caches"
 on:
   push:
     branches: [main]
-    # The key hashes rust/ci/download-kokoro.sh, so only a change to that file can
-    # make a re-seed necessary. Without this filter every push to main — up to 26
-    # a day here — spun three runners to probe a guaranteed hit.
-    paths: ["rust/ci/download-kokoro.sh", "rust/src/models.rs", ".github/workflows/cache-seed.yml"]
+    # Only a change to a file some cache key hashes can make a re-seed necessary.
+    # Without this filter every push to main — up to 26 a day here — spun runners
+    # to probe a guaranteed hit. Cargo.lock is here for the Parakeet key (#675).
+    paths:
+      - "rust/ci/download-kokoro.sh"
+      - "rust/src/models.rs"
+      - "rust/Cargo.lock"
+      - ".github/workflows/cache-seed.yml"
   # Eviction does not wait for pushes. Without this, a bundle evicted under budget
   # pressure stays gone until someone happens to touch the download script, and
   # every PR job in between pays a full cold download.
@@ -87,6 +91,58 @@ jobs:
         with:
           path: ${{ env.KOKORO_CACHE }}
           key: kokoro-models-v1-${{ runner.os }}-${{ hashFiles('rust/ci/download-kokoro.sh') }}
+
+  parakeet:
+    name: Parakeet CoreML models
+    # Without a main-scoped copy, coreml-regression's PR-scoped entry is unreadable (#675).
+    runs-on: macos-14
+    timeout-minutes: 40
+    env:
+      MACOSX_DEPLOYMENT_TARGET: "14.0"
+    steps:
+      # Before the probe: the key hashes rust/Cargo.lock, which hashFiles resolves in the workspace.
+      - name: 📥 Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Probe cache
+        id: probe
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/Library/Application Support/FluidAudio/Models
+          key: parakeet-coreml-models-v1-${{ runner.os }}-${{ hashFiles('rust/Cargo.lock') }}
+          lookup-only: true
+
+      - name: Select Xcode 16 (Swift 6)
+        if: steps.probe.outputs.cache-hit != 'true'
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
+        with:
+          xcode-version: "16.2"
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        if: steps.probe.outputs.cache-hit != 'true'
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        if: steps.probe.outputs.cache-hit != 'true'
+        with:
+          workspaces: rust
+
+      - name: Install system audio deps (Opus)
+        if: steps.probe.outputs.cache-hit != 'true'
+        run: brew install opus pkg-config
+
+      # FluidAudio owns the bundle: install's warm-up builds the backend, which fetches on a miss.
+      - name: Populate the FluidAudio ASR bundle
+        if: steps.probe.outputs.cache-hit != 'true'
+        run: |
+          cd rust
+          cargo run --no-default-features --features coreml -- install
+
+      - name: Save Parakeet CoreML models
+        if: steps.probe.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/Library/Application Support/FluidAudio/Models
+          key: parakeet-coreml-models-v1-${{ runner.os }}-${{ hashFiles('rust/Cargo.lock') }}
 
   kesha-models:
     name: Kesha models (${{ matrix.os }})

--- a/.github/workflows/cache-seed.yml
+++ b/.github/workflows/cache-seed.yml
@@ -108,7 +108,7 @@ jobs:
         id: probe
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: ~/Library/Application Support/FluidAudio/Models
+          path: ~/Library/Application Support/FluidAudio/Models/parakeet-tdt-0.6b-v3
           key: parakeet-coreml-models-v1-${{ runner.os }}-${{ hashFiles('rust/Cargo.lock') }}
           lookup-only: true
 
@@ -150,7 +150,7 @@ jobs:
         if: steps.probe.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: ~/Library/Application Support/FluidAudio/Models
+          path: ~/Library/Application Support/FluidAudio/Models/parakeet-tdt-0.6b-v3
           key: parakeet-coreml-models-v1-${{ runner.os }}-${{ hashFiles('rust/Cargo.lock') }}
 
   kesha-models:

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -414,7 +414,7 @@ jobs:
       - name: 🎧 Restore Parakeet CoreML models
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: ~/Library/Application Support/FluidAudio/Models
+          path: ~/Library/Application Support/FluidAudio/Models/parakeet-tdt-0.6b-v3
           # Keyed on the fluidaudio-rs pin (Cargo.lock): a bump changes the model
           # set. The prefix restore-key warm-starts from the prior bundle so a
           # bump tops up the delta instead of re-fetching everything.

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -405,19 +405,19 @@ jobs:
       - name: Install system audio deps (Opus)
         run: brew install opus pkg-config
 
-      # Restore the compiled Parakeet CoreML bundle. On a cache miss the models
-      # are fetched from HuggingFace once, during the test's `init_asr()`, and
-      # saved back under this key — the fetch is bounded to the seed run and
-      # named plainly here, honoring the no-silent-download contract.
-      - name: 🎧 Cache Parakeet CoreML models
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      # Restore-only: this job runs on pull_request, and GitHub scopes a cache to
+      # the ref that wrote it, so anything saved here is readable by re-runs of
+      # this PR alone — never by main, never by another PR (#675, the defect #663
+      # fixed for Kokoro). cache-seed.yml writes this key from main instead.
+      # On a miss the bundle is still fetched during the test's `init_asr()`;
+      # the run is slower, not wrong.
+      - name: 🎧 Restore Parakeet CoreML models
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/Library/Application Support/FluidAudio/Models
-          # Key on the fluidaudio-rs pin (Cargo.lock). actions/cache never
-          # saves on an exact-key hit, so a static key would let a model-set
-          # change after a bump silently re-download every run without ever
-          # persisting. The prefix restore-key warm-starts from the prior
-          # bundle on a bump, and the job re-saves under the new exact key.
+          # Keyed on the fluidaudio-rs pin (Cargo.lock): a bump changes the model
+          # set. The prefix restore-key warm-starts from the prior bundle so a
+          # bump tops up the delta instead of re-fetching everything.
           key: parakeet-coreml-models-v1-${{ runner.os }}-${{ hashFiles('rust/Cargo.lock') }}
           restore-keys: |
             parakeet-coreml-models-v1-${{ runner.os }}-


### PR DESCRIPTION
## Why

`coreml-regression` both wrote and read `parakeet-coreml-models-v1-*`, but the job is `pull_request`-only and GitHub scopes a cache to the ref that wrote it. Every entry it minted was readable by re-runs of that one PR and nothing else — never `main`, never another PR.

Not a theory. The repo has no `parakeet-*` entry on any ref, so **the key has never been hit once**:

```
$ gh api "repos/.../actions/caches?per_page=100" --jq '...' | grep -i parakeet
(no output)
```

Same scoping defect #663 fixed for Kokoro, left in place for Parakeet.

## What

- `cache-seed.yml` gains a `parakeet` job mirroring `kokoro`: `lookup-only` probe, populate on a miss, save from `main`.
- The step in `coreml-regression` becomes **restore-only**, so PR runs stop minting private copies. On a miss the bundle is still fetched during `init_asr()` — slower, not wrong.
- `rust/Cargo.lock` joins the seed workflow's push paths. The Parakeet key hashes it, so without that a fluidaudio-rs bump changes the key while the seed keeps refreshing the old one.

## Verified, not assumed

The load-bearing assumption is that `install` populates FluidAudio's bundle on a cold cache. I moved the real directory aside and ran it:

```
Warming up ASR backend (one-time, ~20-30 s for the ANE compile on first install)...
ASR backend warmed up (dt=173714ms).
Install complete.                                    # exit 0
470M  ~/Library/Application Support/FluidAudio/Models/parakeet-tdt-0.6b-v3
```

That cold download also **independently confirms the file list #684 pins**: the fresh set is exactly `Preprocessor` / `Encoder` / `Decoder` / `JointDecisionv3` + vocab. My stale local copy additionally carried a v2 `JointDecision.mlmodelc` that upstream no longer ships — so #684's list was validated against a real distribution, not against my machine's history.

Populating by building from source rather than reusing the released engine: a pre-#684 binary would also pull 2.43 GB of ONNX weights a CoreML build cannot read — wasteful, and needless exposure to the HuggingFace rate limiting in #724.

## Two corrections to the issue's premises

- **Budget is tight, and my first reading of it was wrong.** I initially measured 5 GB and called the addition comfortable. Re-measured: **10796 MB across 17 entries** — essentially at the 10 GB cap. The earlier number predated this PR's own CI adding 2331 MB. The entry is now scoped to the load directory alone (~470 MB rather than the ~930 MB the whole `Models/` tree would have cost), but it will still likely evict something. Worth pruning dead main-scoped keys separately.
- **The size discrepancy is resolved.** The issue flags 935 MB vs ~450 MB as disagreeing and worth re-measuring. 935 MB counted both `parakeet-tdt-0.6b-v3` **and** its `…-v3-coreml` sibling; the directory FluidAudio actually loads is 470 MB, matching the workflow's original estimate.

## Note on what CI can show here

This changes cache plumbing, and the seed job only runs on `main` / schedule / dispatch — a PR run cannot demonstrate it working. What a green PR proves is that nothing else broke. The proof it works is the first `coreml-regression` run after this lands reporting a cache hit, and a `parakeet-coreml-models-v1-*` entry appearing on `refs/heads/main`.

Closes #675.
