### PR TITLE
fix(release): an engine tag publishes no CLI

### DIFF
--- a/.claude/skills/release-engine/SKILL.md
+++ b/.claude/skills/release-engine/SKILL.md
@@ -69,6 +69,11 @@ engine's number would publish that as npm `latest` and downgrade every user (#72
 engine tag publishes no npm package at all now — users get the new engine when a
 `-cli` release ships the bumped pin (Mode A, after this one).
 
+**Raise, never lower.** If the new engine version would overtake `package.json#version`,
+raise the CLI line to match in the same commit — `check:versions` rule 2 requires
+`cli >= engine` and will reject the release commit otherwise. Raising is safe because the
+result still leads the published `latest`; only lowering downgrades users.
+
 ```bash
 cd rust && cargo check
 cd ..

--- a/.claude/skills/release-engine/SKILL.md
+++ b/.claude/skills/release-engine/SKILL.md
@@ -56,13 +56,18 @@ If anything fails, STOP. Do not bump versions.
 
 ## Engine release procedure
 
-### Step 1: Version bump in lockstep
+### Step 1: Version bump — engine fields ONLY
 
 Bump these THREE in the same commit:
 
 - `rust/Cargo.toml` — `version = "X.Y.Z"`
 - `rust/Cargo.lock` — refresh via `cd rust && cargo check`
-- `package.json` — both `version` AND `keshaEngine.version`
+- `package.json#keshaEngine.version` — **not** `package.json#version`
+
+Since #691 `main` carries the next unreleased CLI version; dragging it down to the
+engine's number would publish that as npm `latest` and downgrade every user (#729). An
+engine tag publishes no npm package at all now — users get the new engine when a
+`-cli` release ships the bumped pin (Mode A, after this one).
 
 ```bash
 cd rust && cargo check

--- a/.claude/skills/release-mechanics/SKILL.md
+++ b/.claude/skills/release-mechanics/SKILL.md
@@ -28,7 +28,7 @@ npm view @drakulavich/kesha-voice-kit version   # within ~60s, expect X.Y.Z
 
 **Engine release** (anything under `rust/` or an engine bump):
 
-1. Bump `rust/Cargo.toml`, `rust/Cargo.lock` (`cargo check`), `package.json#keshaEngine.version`, usually `package.json#version`.
+1. Bump `rust/Cargo.toml`, `rust/Cargo.lock` (`cargo check`), `package.json#keshaEngine.version` — leave `package.json#version` alone, it carries the next unreleased CLI (#691). An engine tag publishes nothing to npm; the bumped pin reaches users with the next `-cli` release (#729).
 2. Merge to main.
 3. Tag/push: `git tag vX.Y.Z && git push origin vX.Y.Z` → `build-engine.yml`.
 4. Write release notes before publishing. Draft releases start with an empty body:

--- a/.claude/skills/release-mechanics/SKILL.md
+++ b/.claude/skills/release-mechanics/SKILL.md
@@ -28,7 +28,7 @@ npm view @drakulavich/kesha-voice-kit version   # within ~60s, expect X.Y.Z
 
 **Engine release** (anything under `rust/` or an engine bump):
 
-1. Bump `rust/Cargo.toml`, `rust/Cargo.lock` (`cargo check`), `package.json#keshaEngine.version` — leave `package.json#version` alone, it carries the next unreleased CLI (#691). An engine tag publishes nothing to npm; the bumped pin reaches users with the next `-cli` release (#729).
+1. Bump `rust/Cargo.toml`, `rust/Cargo.lock` (`cargo check`), `package.json#keshaEngine.version` — leave `package.json#version` alone, it carries the next unreleased CLI (#691). An engine tag publishes nothing to npm; the bumped pin reaches users with the next `-cli` release (#729). If the engine would overtake the CLI line, raise it to match — rule 2 (`cli >= engine`) rejects the commit otherwise — but never lower it.
 2. Merge to main.
 3. Tag/push: `git tag vX.Y.Z && git push origin vX.Y.Z` → `build-engine.yml`.
 4. Write release notes before publishing. Draft releases start with an empty body:

--- a/.github/scripts/release-tags.mjs
+++ b/.github/scripts/release-tags.mjs
@@ -23,8 +23,9 @@ const CLI_MARKER = "-cli";
 /**
  * What the CLI publish path should do with a release tag.
  *
- * An engine prerelease publishes no CLI: reacting to it would compare an engine version
- * against `package.json#version` and fail a workflow nobody asked to run (#685).
+ * No engine tag publishes a CLI. Since #691 a bare tag names the engine version only, so
+ * reacting to one would publish `main`'s CLI under the engine's number and drag npm's
+ * `latest` backwards; the CLI ships from its own `-cli` marker tag instead (#729).
  */
 export function cliPublishTarget(tag) {
   const cliMarked = tag.endsWith(CLI_MARKER);
@@ -32,7 +33,7 @@ export function cliPublishTarget(tag) {
   const version = base.replace(/^v/, "");
   return {
     version,
-    engineOnly: !cliMarked && base.includes("-"),
+    engineOnly: !cliMarked,
     // An alpha version is minted at publish time, so no commit carries it to verify against.
     derived: version.includes("-alpha."),
   };

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,6 +7,7 @@ name: "📦 npm Publish"
 # `bun add -g @drakulavich/kesha-voice-kit@latest` users do not get unstable
 # builds and channels do not collide with each other. CLI-only marker
 # releases (`vX.Y.Z-cli`) follow the same rule after stripping `-cli`.
+# Only `-cli` tags publish: a bare tag names the engine, not the CLI (#729).
 # The publish itself lives in release-npm-publish.yml, shared with alpha (#685).
 on:
   release:

--- a/tests/unit/release-tag-grammar.test.ts
+++ b/tests/unit/release-tag-grammar.test.ts
@@ -157,18 +157,18 @@ describe("cliPublishTarget", () => {
     });
   });
 
-  test("an engine prerelease publishes no CLI", () => {
-    for (const tag of ["v1.24.8-alpha.1", "v1.24.8-beta.1"]) {
+  // A bare tag names the engine version, so publishing it would put main's unreleased CLI
+  // on npm under the engine's number and move `latest` backwards (#729).
+  test("no engine tag publishes a CLI, stable included", () => {
+    for (const tag of ["v1.24.8", "v1.24.8-alpha.1", "v1.24.8-beta.1"]) {
       expect(cliPublishTarget(tag).engineOnly).toBe(true);
     }
   });
 
-  test("a stable tag still publishes the CLI, as it does today", () => {
-    expect(cliPublishTarget("v1.24.8")).toEqual({
-      version: "1.24.8",
-      engineOnly: false,
-      derived: false,
-    });
+  test("the CLI ships only from its own marker tag", () => {
+    for (const tag of ["v1.26.0-cli", "v1.27.0-alpha.1-cli"]) {
+      expect(cliPublishTarget(tag).engineOnly).toBe(false);
+    }
   });
 });
 


### PR DESCRIPTION
`engineOnly` was decided by `!cliMarked && base.includes("-")` — true only for unmarked *prereleases*. A bare stable engine tag such as `v1.24.8` therefore still routed into the CLI publish path, and both outcomes were wrong:

| how the release commit is prepared | what happens today |
| --- | --- |
| following `release-engine` Mode B, which bumps `package.json#version` **and** `keshaEngine.version` in lockstep | guard passes → `npm publish` 1.24.8 → **npm `latest` moves from 1.26.0 down to 1.24.8** |
| bumping only the engine line, per #691 | guard fails → red run on the release, no CLI published |

The first is the default path, because the skills documented the lockstep bump. `npm publish` points `latest` at whatever it publishes regardless of ordering, so it is a real downgrade for every `bun add -g @drakulavich/kesha-voice-kit@latest` user — and unpublishing is not a remedy.

## The rule

Before #691 the two version lines were realigned at engine-release time, so a bare tag legitimately named both artifacts at once. Since `main` carries the next unreleased CLI version, a bare tag says nothing about the CLI at all.

`v1.25.0-cli` and `v1.26.0-cli` already show the convention that holds in practice — every CLI publish comes from a marker tag — and #703 added alphas as a third marked path. So the decision is the **marker**, not the presence of a hyphen:

```js
engineOnly: !cliMarked
```

| tag | publishes a CLI |
| --- | --- |
| `v1.24.8` | no — engine |
| `v1.24.8-beta.1` | no — engine |
| `v1.24.8-alpha.1` | no — engine |
| `v1.26.0-cli` | yes, 1.26.0 |
| `v1.27.0-alpha.1-cli` | yes, 1.27.0-alpha.1 |

Nothing is lost by not publishing on the engine tag: what reaches users is the `keshaEngine.version` pin inside the *published CLI*, so a new engine has always required a subsequent CLI publish to be visible. The lockstep bump made both happen under one tag; it no longer can.

## The instruction that would have caused it

`release-engine` Mode B said to bump `package.json` — "both `version` AND `keshaEngine.version`". `release-mechanics` said "usually `package.json#version`". Those are the sentences that would have produced the downgrade, so both now say the engine release leaves the CLI line alone and explain why.

## Tests

The old test was named "a stable tag still publishes the CLI, as it does today" — it pinned the behaviour rather than the intent, which is exactly how this survived #703 and #727. Replaced by two: no engine tag publishes a CLI, stable included; and the CLI ships only from its own marker tag.

Verification: 686 pass / 5 skip / 0 fail, `tsc` and `check:workflows` clean. Two earlier runs on this branch flaked in `tests/cli-contracts` with different counts each time — the known macOS Gatekeeper timing flake on freshly written fake engines, not this change; `tests/unit` and `tests/integration` are clean in isolation.

Closes #729