### PR TITLE
fix(release): refuse an alpha engine pin, and name the gate that refused

### DIFF
--- a/.github/scripts/alpha-requested.sh
+++ b/.github/scripts/alpha-requested.sh
@@ -20,5 +20,10 @@ if [ "$PACKED" = "true" ] && printf '%s' ",$labels," | grep -q ',alpha,'; then
   echo "PR carries the alpha label and changed packed files — publishing." >&2
 else
   echo "publish=false"
-  echo "Not publishing: packed=${PACKED}, labels=[${labels}] (needs the 'alpha' label)." >&2
+  # Naming the gate that actually refused: the old line blamed the label even when it was on.
+  if [ "$PACKED" = "true" ]; then
+    echo "Not publishing: nothing asked for an alpha. Labels: [${labels}]." >&2
+  else
+    echo "Not publishing: nothing that ships changed. Labels: [${labels}]." >&2
+  fi
 fi

--- a/.github/scripts/check-versions.ts
+++ b/.github/scripts/check-versions.ts
@@ -66,6 +66,18 @@ if (cmp(cli, engine) < 0) {
   failed = true;
 }
 
+if (engine.prerelease[0] === "alpha") {
+  console.error(
+    `rule 3 violated: package.json#keshaEngine.version (${fmt(engine)}) must not be an ` +
+      `alpha. This pin is the only thing that decides which engine every lane downloads ` +
+      `(src/engine-install.ts, check-engine-targets.ts) — nothing resolves "latest" — so ` +
+      `committing an alpha points unrelated pull requests at a throwaway build, and ships ` +
+      `it in the next release. Exercise an engine alpha through KESHA_ENGINE_BIN or an ` +
+      `explicit install instead. A '-beta.N' pin is a release candidate and stays allowed.`,
+  );
+  failed = true;
+}
+
 if (failed) {
   console.error(
     `\nResolved sources:\n  package.json#version:              ${fmt(cli)}\n  package.json#keshaEngine.version: ${fmt(engine)}\n  rust/Cargo.toml#version:          ${fmt(cargo)}`,

--- a/.github/scripts/check-versions.ts
+++ b/.github/scripts/check-versions.ts
@@ -66,14 +66,16 @@ if (cmp(cli, engine) < 0) {
   failed = true;
 }
 
-if (engine.prerelease[0] === "alpha") {
+if (engine.prerelease.some((id) => id.toLowerCase().startsWith("alpha"))) {
   console.error(
     `rule 3 violated: package.json#keshaEngine.version (${fmt(engine)}) must not be an ` +
       `alpha. This pin is the only thing that decides which engine every lane downloads ` +
       `(src/engine-install.ts, check-engine-targets.ts) — nothing resolves "latest" — so ` +
       `committing an alpha points unrelated pull requests at a throwaway build, and ships ` +
-      `it in the next release. Exercise an engine alpha through KESHA_ENGINE_BIN or an ` +
-      `explicit install instead. A '-beta.N' pin is a release candidate and stays allowed.`,
+      `it in the next release. To try one, put the binary somewhere and point ` +
+      `KESHA_ENGINE_BIN at it; do not run \`kesha install\` against that path unless you ` +
+      `also write a matching \`\${bin}.version\`, because a mismatch re-downloads the ` +
+      `pinned engine over it. A '-beta.N' pin is a release candidate and stays allowed.`,
   );
   failed = true;
 }

--- a/tests/unit/check-versions.test.ts
+++ b/tests/unit/check-versions.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const REPO = `${import.meta.dir}/../..`;
+const SCRIPT = `${REPO}/.github/scripts/check-versions.ts`;
+
+// Nothing here is symlinked to the repo, so the fixture is safe to remove recursively.
+async function check(cli: string, engine: string, cargo = engine) {
+  const dir = mkdtempSync(join(tmpdir(), "kesha-versions-"));
+  try {
+    mkdirSync(join(dir, "rust"));
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify({ version: cli, keshaEngine: { version: engine } }),
+    );
+    writeFileSync(join(dir, "rust/Cargo.toml"), `version = "${cargo}"\n`);
+    const proc = Bun.spawn(["bun", SCRIPT], { cwd: dir, stdout: "ignore", stderr: "pipe" });
+    const stderr = await new Response(proc.stderr).text();
+    return { accepted: (await proc.exited) === 0, stderr };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe("engine pin channel", () => {
+  test("an alpha engine pin is rejected", async () => {
+    const { accepted, stderr } = await check("1.27.0", "1.24.8-alpha.1");
+
+    expect(accepted).toBe(false);
+    expect(stderr).toContain("rule 3 violated");
+  });
+
+  // Betas have legitimately sat on main (1.22.0-beta.2) — a release candidate is what CI
+  // should be exercising, unlike a throwaway alpha.
+  test("a beta engine pin is allowed", async () => {
+    expect((await check("1.27.0", "1.24.8-beta.1")).accepted).toBe(true);
+  });
+
+  test("a stable engine pin is allowed", async () => {
+    expect((await check("1.27.0", "1.24.8")).accepted).toBe(true);
+  });
+
+  test("the repository's own pin passes every rule", async () => {
+    const pkg = await Bun.file(`${REPO}/package.json`).json();
+
+    expect((await check(pkg.version, pkg.keshaEngine.version)).accepted).toBe(true);
+  });
+});

--- a/tests/unit/check-versions.test.ts
+++ b/tests/unit/check-versions.test.ts
@@ -42,9 +42,26 @@ describe("engine pin channel", () => {
     expect((await check("1.27.0", "1.24.8")).accepted).toBe(true);
   });
 
-  test("the repository's own pin passes every rule", async () => {
-    const pkg = await Bun.file(`${REPO}/package.json`).json();
+  // Alpha-shaped, not `prerelease[0] === "alpha"`: the rule is about what the pin means.
+  test("an alpha in any casing or position is rejected", async () => {
+    for (const pin of ["1.24.8-Alpha.1", "1.24.8-alpha1", "1.24.8-0.alpha.1"]) {
+      expect((await check("1.27.0", pin)).accepted).toBe(false);
+    }
+  });
 
-    expect((await check(pkg.version, pkg.keshaEngine.version)).accepted).toBe(true);
+  test("other prerelease channels are left alone", async () => {
+    for (const pin of ["1.24.8-rc.1", "1.24.8-pre.1"]) {
+      expect((await check("1.27.0", pin)).accepted).toBe(true);
+    }
+  });
+
+  // In the real cwd, so rule 1 reads the actual rust/Cargo.toml rather than a fixture
+  // written to agree with the pin by construction.
+  test("the repository itself passes every rule, Cargo.toml included", async () => {
+    const proc = Bun.spawn(["bun", SCRIPT], { cwd: REPO, stdout: "ignore", stderr: "pipe" });
+    const stderr = await new Response(proc.stderr).text();
+
+    expect(stderr).toBe("");
+    expect(await proc.exited).toBe(0);
   });
 });


### PR DESCRIPTION
Group 8 of #685 — "keep alpha artifacts out of stable lanes".

## The plan's premise did not survive tracing it

8.1 asked the three engine-downloading lanes (`ci.yml` `integration-tests-full`, `windows-engine-smoke`, `release-branch-engine-smoke`) to "resolve an explicit stable version rather than inheriting possibly-prerelease metadata".

Nothing in this repo resolves a "latest" release. Every path that reaches a released engine builds a URL from exactly one field:

| site | resolves from |
| --- | --- |
| `src/engine-install.ts:200` (sidecars) | `v${keshaEngine.version}` |
| `src/engine-install.ts:439` (engine binary) | `v${keshaEngine.version}` |
| `.github/scripts/check-engine-targets.ts:19` | `releases/tags/v${keshaEngine.version}` |

There is no `/releases/latest` anywhere, so there is no metadata for a prerelease to sneak in through. The pin **is** the channel — the only way an engine alpha reaches an unrelated pull request is if someone commits it.

That inverts the fix. Making the lanes resolve some other stable version would have them test a configuration that does not exist, and would hide a genuinely broken pin rather than catch it. The constraint belongs on the pin.

## Rule 3

`check-versions.ts` now refuses an engine pin carrying an `-alpha.` identifier, alongside the two existing rules.

Deliberately **not** "never a prerelease": `main` has legitimately carried `1.22.0-beta.2` (commits `66816436`, `5d9b9feb`), and a release candidate is precisely what CI should be exercising. The distinction is what the two channels mean — a beta is a candidate you intend to ship, an alpha is a throwaway build for feeling out a change. Committing an alpha points every lane at it *and* ships it in the next release, since the published CLI's pin is what `kesha install` reads.

An engine alpha is exercised through `KESHA_ENGINE_BIN` or an explicit install instead — never the committed pin.

That also answers 8.2 by construction: publishing an engine alpha cannot affect an unrelated PR, because after this nothing can point at it.

## The skip message named the wrong gate

#735 merged carrying the `alpha` label and logged:

```
Not publishing: packed=false, labels=[alpha] (needs the 'alpha' label).
```

The label was on. What refused was the packed-paths gate. The line now names whichever one actually refused, verified against a stubbed `gh` in all three states:

| packed | label | line |
| --- | --- | --- |
| false | on | `nothing that ships changed. Labels: [alpha].` |
| true | off | `nothing asked for an alpha. Labels: [WIP].` |
| true | on | publishes |

## Verification

695 pass / 5 skip / 0 fail, `tsc` clean, `check:versions` passes on the repo's own pin. New tests drive the real script against fixture repos: an alpha pin is rejected with `rule 3 violated`, a beta pin and a stable pin are accepted, and the repository's own versions pass every rule.

Refs #685