### PR TITLE
feat(ci): synthesise darwin on macos-15, where the Kokoro vocoder actually runs

### DIFF
--- a/.claude/skills/tts-internals/SKILL.md
+++ b/.claude/skills/tts-internals/SKILL.md
@@ -34,6 +34,7 @@ Install Kokoro + Vosk-TTS explicitly with `kesha install --tts` (~990 MB). `maco
 - `KESHA_ENGINE_BIN` — override the engine-binary path (useful when iterating on `rust/target/release/kesha-engine`).
 - `KESHA_CACHE_DIR` — isolated test cache.
 - `KESHA_MODEL_MIRROR` — redirect HF downloads to an internal mirror (#121), preserving `/<owner>/<repo>/resolve/<ref>/<file>` for `wget --mirror`; empty/unset = no-op. Rust `models.rs::apply_mirror` and TS `status.ts::activeModelMirror` both trim trailing slashes.
+- `KESHA_KOKORO_COMPUTE_UNITS` — `default` (FluidAudio's tuned per-stage mapping; Albert/PostAlbert/Alignment/Vocoder on the ANE) · `cpu-and-gpu` · `all-ane` · `cpu-only`. Diagnostic only, and darwin-arm64 `system_kokoro` only: FluidAudio's `KokoroAne.md` recommends the CPU baseline when deciding whether an artefact is the model or the accelerator. Unset is `default`; blank is treated as unset (a conditional GHA `env:` exports an empty string); an unknown value fails before model init rather than falling back to the ANE the caller was avoiding. Nothing in CI sets it — a non-ANE preset does **not** rescue the `macos-14` image, which fails on the vocoder's shape contract regardless (#678).
 - macOS dev runtime: `DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib`. Release binaries fix up via `install_name_tool`.
 - macOS build env: `LIBCLANG_PATH=/Library/Developer/CommandLineTools/usr/lib`, `RUSTFLAGS="-L /opt/homebrew/lib"`.
 

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -346,11 +346,13 @@ jobs:
           path: kesha-textlang-darwin-arm64
 
   # Exercises the macos-14 artifact elsewhere: that image is required to build, and cannot run the vocoder (#678).
+  # Advisory until the second-invocation SIGBUS is fixed (#740) — a permanently red gate only teaches people to ignore red.
   darwin-synthesis-smoke:
-    name: Darwin synthesis smoke
+    name: Darwin synthesis smoke (advisory)
     needs: build
     runs-on: macos-15
     timeout-minutes: 30
+    continue-on-error: true
     env:
       KESHA_ENGINE_BIN: ${{ github.workspace }}/kesha-engine-darwin-arm64
       # FluidAudio reports CoreML failures on stdout, which the bridge guard discards; this routes them to stderr (#678).
@@ -405,7 +407,7 @@ jobs:
         run: bun .github/scripts/smoke-synthesis.ts --no-roundtrip synthesis-smoke
 
   release:
-    needs: [build, darwin-synthesis-smoke]
+    needs: build
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -121,6 +121,10 @@ jobs:
       MACOSX_DEPLOYMENT_TARGET: "14.0"
       # Points the CLI at the staged artifact for the pre-upload smoke, as release-branch-engine-smoke does (#671).
       KESHA_ENGINE_BIN: ${{ github.workspace }}/${{ matrix.binary }}
+      # Job-wide since `kesha install` warms Kokoro too; cpu-only because the runner virtualises Metal as well as the ANE (#678).
+      KESHA_KOKORO_COMPUTE_UNITS: ${{ matrix.os == 'macos-14' && 'cpu-only' || '' }}
+      # Routes FluidAudio's stdout-only CoreML diagnostics to stderr, so a darwin failure is readable in the log (#678).
+      KESHA_DEBUG: ${{ matrix.os == 'macos-14' && '1' || '' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Select Xcode 16 (Swift 6)
@@ -315,8 +319,6 @@ jobs:
 
       - name: 🗣️ Pre-upload synthesis smoke
         shell: bash
-        env:
-          KESHA_KOKORO_COMPUTE_UNITS: ${{ matrix.os == 'macos-14' && 'cpu-and-gpu' || '' }}
         run: bun .github/scripts/smoke-synthesis.ts --no-roundtrip synthesis-smoke
 
       - name: Inspect macOS dynamic deps

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -121,10 +121,6 @@ jobs:
       MACOSX_DEPLOYMENT_TARGET: "14.0"
       # Points the CLI at the staged artifact for the pre-upload smoke, as release-branch-engine-smoke does (#671).
       KESHA_ENGINE_BIN: ${{ github.workspace }}/${{ matrix.binary }}
-      # Job-wide since `kesha install` warms Kokoro too; cpu-only because the runner virtualises Metal as well as the ANE (#678).
-      KESHA_KOKORO_COMPUTE_UNITS: ${{ matrix.os == 'macos-14' && 'cpu-only' || '' }}
-      # Routes FluidAudio's stdout-only CoreML diagnostics to stderr, so a darwin failure is readable in the log (#678).
-      KESHA_DEBUG: ${{ matrix.os == 'macos-14' && '1' || '' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Select Xcode 16 (Swift 6)
@@ -287,16 +283,19 @@ jobs:
           fi
 
       # The smoke above proves the artifact starts and advertises `tts`, not that it synthesises (#671, #636).
-      # macOS covers Kokoro only, and only off the ANE the runner lacks (#678); AVSpeech still times out there.
+      # darwin synthesises in `darwin-synthesis-smoke` instead — macos-14's CoreML cannot run the vocoder (#678).
       - name: 🍞 Setup Bun workspace
+        if: matrix.os != 'macos-14'
         uses: ./.github/actions/setup-bun
 
       - name: 🔗 Link the CLI
+        if: matrix.os != 'macos-14'
         shell: bash
         run: bun link
 
       # Load-bearing: on a version mismatch `downloadEngine` fetches the published engine, whose tag does not exist yet.
       - name: 🧾 Mark staged engine version
+        if: matrix.os != 'macos-14'
         shell: bash
         run: |
           bun -e '
@@ -304,13 +303,12 @@ jobs:
             await Bun.write(`${process.env.KESHA_ENGINE_BIN}.version`, `${pkg.keshaEngine.version}\n`);
           '
 
-      # FluidAudio owns `~/.cache/fluidaudio` — the staged ANE voice packs and the bundle it self-fetches.
       - name: 🔊 Install English TTS models
+        if: matrix.os != 'macos-14'
         uses: ./.github/actions/install-kesha-backend
         with:
           cache-path: |
             ~/.cache/kesha
-            ~/.cache/fluidaudio
           cache-key: ${{ runner.os }}-kesha-models-tts-v1
           cache-restore-keys: ${{ runner.os }}-kesha-models-tts-
           ffmpeg-provider: skip
@@ -318,6 +316,7 @@ jobs:
           cache-write: "false"
 
       - name: 🗣️ Pre-upload synthesis smoke
+        if: matrix.os != 'macos-14'
         shell: bash
         run: bun .github/scripts/smoke-synthesis.ts --no-roundtrip synthesis-smoke
 
@@ -346,8 +345,69 @@ jobs:
           name: kesha-textlang-darwin-arm64
           path: kesha-textlang-darwin-arm64
 
-  release:
+  # darwin cannot synthesise inside the build job: macos-14 is required for the build
+  # (COREML BUILD TRIPLE) and its CoreML cannot run the Kokoro vocoder at all (#678).
+  # So the artifact built there is exercised here instead, on a newer image.
+  darwin-synthesis-smoke:
+    name: Darwin synthesis smoke
     needs: build
+    runs-on: macos-15
+    timeout-minutes: 30
+    env:
+      KESHA_ENGINE_BIN: ${{ github.workspace }}/kesha-engine-darwin-arm64
+      # FluidAudio reports CoreML failures on stdout, which the bridge guard discards; this routes them to stderr (#678).
+      KESHA_DEBUG: "1"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: kesha-engine-darwin-arm64
+
+      # Sibling-next-to-engine, the lookup order `tts::avspeech::helper_path` uses.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: say-avspeech-darwin-arm64
+
+      - name: Restore the executable bits upload-artifact drops
+        shell: bash
+        run: chmod +x kesha-engine-darwin-arm64 say-avspeech-darwin-arm64
+
+      - name: 🍞 Setup Bun workspace
+        uses: ./.github/actions/setup-bun
+
+      - name: 🔗 Link the CLI
+        shell: bash
+        run: bun link
+
+      # Load-bearing: on a version mismatch `downloadEngine` fetches the published engine, whose tag does not exist yet.
+      - name: 🧾 Mark staged engine version
+        shell: bash
+        run: |
+          bun -e '
+            const pkg = await Bun.file("package.json").json();
+            await Bun.write(`${process.env.KESHA_ENGINE_BIN}.version`, `${pkg.keshaEngine.version}\n`);
+          '
+
+      # FluidAudio owns `~/.cache/fluidaudio` — the ANE voice packs install stages, plus the bundle it self-fetches.
+      - name: 🔊 Install English TTS models
+        uses: ./.github/actions/install-kesha-backend
+        with:
+          cache-path: |
+            ~/.cache/kesha
+            ~/.cache/fluidaudio
+          cache-key: ${{ runner.os }}-kesha-models-tts-v1
+          cache-restore-keys: ${{ runner.os }}-kesha-models-tts-
+          ffmpeg-provider: skip
+          install-args: --tts en
+          cache-write: "false"
+
+      - name: 🗣️ Synthesis smoke
+        shell: bash
+        run: bun .github/scripts/smoke-synthesis.ts --no-roundtrip synthesis-smoke
+
+  release:
+    needs: [build, darwin-synthesis-smoke]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -345,9 +345,7 @@ jobs:
           name: kesha-textlang-darwin-arm64
           path: kesha-textlang-darwin-arm64
 
-  # darwin cannot synthesise inside the build job: macos-14 is required for the build
-  # (COREML BUILD TRIPLE) and its CoreML cannot run the Kokoro vocoder at all (#678).
-  # So the artifact built there is exercised here instead, on a newer image.
+  # Exercises the macos-14 artifact elsewhere: that image is required to build, and cannot run the vocoder (#678).
   darwin-synthesis-smoke:
     name: Darwin synthesis smoke
     needs: build

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -346,7 +346,7 @@ jobs:
           path: kesha-textlang-darwin-arm64
 
   # Exercises the macos-14 artifact elsewhere: that image is required to build, and cannot run the vocoder (#678).
-  # Advisory until the second-invocation SIGBUS is fixed (#740) — a permanently red gate only teaches people to ignore red.
+  # Advisory until the longer-sentence SIGBUS is fixed (#742) — a permanently red gate only teaches people to ignore red.
   darwin-synthesis-smoke:
     name: Darwin synthesis smoke (advisory)
     needs: build

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -283,19 +283,16 @@ jobs:
           fi
 
       # The smoke above proves the artifact starts and advertises `tts`, not that it synthesises (#671, #636).
-      # macOS is exempt throughout: neither TTS engine runs on an ANE-less, audio-less runner (#678).
+      # macOS covers Kokoro only, and only off the ANE the runner lacks (#678); AVSpeech still times out there.
       - name: 🍞 Setup Bun workspace
-        if: matrix.os != 'macos-14'
         uses: ./.github/actions/setup-bun
 
       - name: 🔗 Link the CLI
-        if: matrix.os != 'macos-14'
         shell: bash
         run: bun link
 
       # Load-bearing: on a version mismatch `downloadEngine` fetches the published engine, whose tag does not exist yet.
       - name: 🧾 Mark staged engine version
-        if: matrix.os != 'macos-14'
         shell: bash
         run: |
           bun -e '
@@ -303,12 +300,13 @@ jobs:
             await Bun.write(`${process.env.KESHA_ENGINE_BIN}.version`, `${pkg.keshaEngine.version}\n`);
           '
 
+      # FluidAudio owns `~/.cache/fluidaudio` — the staged ANE voice packs and the bundle it self-fetches.
       - name: 🔊 Install English TTS models
-        if: matrix.os != 'macos-14'
         uses: ./.github/actions/install-kesha-backend
         with:
           cache-path: |
             ~/.cache/kesha
+            ~/.cache/fluidaudio
           cache-key: ${{ runner.os }}-kesha-models-tts-v1
           cache-restore-keys: ${{ runner.os }}-kesha-models-tts-
           ffmpeg-provider: skip
@@ -316,8 +314,9 @@ jobs:
           cache-write: "false"
 
       - name: 🗣️ Pre-upload synthesis smoke
-        if: matrix.os != 'macos-14'
         shell: bash
+        env:
+          KESHA_KOKORO_COMPUTE_UNITS: ${{ matrix.os == 'macos-14' && 'cpu-and-gpu' || '' }}
         run: bun .github/scripts/smoke-synthesis.ts --no-roundtrip synthesis-smoke
 
       - name: Inspect macOS dynamic deps

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -32,7 +32,7 @@ code never needs sanitizing.
 | `E_TRANSCRIBE_FAILED` | transcribe | no | The ASR pipeline failed. | Re-run; file a bug with a support bundle. |
 | `E_DIARIZE_TIMEOUT` | transcribe | yes | Speaker diarization timed out (cold compile or long audio). | Re-run once warm; shorten the audio. |
 | `E_ENGINE_SPAWN` | internal | no | The CLI couldn't spawn the engine subprocess. | `kesha install`; check the engine binary path (`KESHA_ENGINE_BIN`). |
-| `E_INVALID_ARG` | input | no | A CLI flag or argument was invalid. | See `kesha --help`. |
+| `E_INVALID_ARG` | input | no | A CLI flag, argument, or `KESHA_*` value was invalid. | See `kesha --help`; the message names the setting and its accepted values. |
 | `E_INTERNAL` | internal | no | An unexpected or uncoded failure. | File a bug with `kesha support-bundle`. |
 
 ## Where codes come from

--- a/rust/src/fluid_stdout.rs
+++ b/rust/src/fluid_stdout.rs
@@ -118,19 +118,40 @@ pub(crate) fn with_silenced_stdout<R>(devnull: Option<&OwnedFd>, f: impl FnOnce(
     f()
 }
 
-/// One-shot variant for non-hot-path FluidAudio calls (Kokoro synth,
-/// diarization): opens `/dev/null` itself for the duration of `f`. A failed
-/// open runs `f` with stdout untouched (best-effort). Wrap the FluidAudio
-/// instance's *whole* lifetime (create → call → drop) so teardown-time CoreML
-/// noise is silenced too.
+/// Where FluidAudio's stdout chatter goes for the duration of a one-shot call:
+/// `/dev/null` normally, stderr under `KESHA_DEBUG`.
+///
+/// CoreML reports real failures — the ANE-less prepare error and the E5RT
+/// exceptions behind it (#678) — on stdout, so discarding it unconditionally
+/// makes those failures unreadable exactly where they matter: a CI runner you
+/// cannot attach to. Redirecting to stderr is safe because callers write their
+/// payload *after* the guard returns, so nothing of ours is misrouted.
 #[cfg(any(feature = "system_kokoro", feature = "system_diarize"))]
-pub(crate) fn with_silenced_stdout_oneshot<R>(f: impl FnOnce() -> R) -> R {
-    let devnull: Option<OwnedFd> = std::fs::OpenOptions::new()
+fn oneshot_sink() -> Option<OwnedFd> {
+    use std::os::fd::FromRawFd;
+
+    if crate::debug::enabled() {
+        // SAFETY: dup(STDERR) hands back a fresh fd that OwnedFd will close.
+        let raw = unsafe { libc::dup(libc::STDERR_FILENO) };
+        if raw >= 0 {
+            return Some(unsafe { OwnedFd::from_raw_fd(raw) });
+        }
+    }
+    std::fs::OpenOptions::new()
         .write(true)
         .open("/dev/null")
         .ok()
-        .map(OwnedFd::from);
-    with_silenced_stdout(devnull.as_ref(), f)
+        .map(OwnedFd::from)
+}
+
+/// One-shot variant for non-hot-path FluidAudio calls (Kokoro synth,
+/// diarization). A failed open runs `f` with stdout untouched (best-effort).
+/// Wrap the FluidAudio instance's *whole* lifetime (create → call → drop) so
+/// teardown-time CoreML noise is captured too.
+#[cfg(any(feature = "system_kokoro", feature = "system_diarize"))]
+pub(crate) fn with_silenced_stdout_oneshot<R>(f: impl FnOnce() -> R) -> R {
+    let sink = oneshot_sink();
+    with_silenced_stdout(sink.as_ref(), f)
 }
 
 /// Permanently redirect the process's stdout to `/dev/null` and hand back a

--- a/rust/src/fluid_stdout.rs
+++ b/rust/src/fluid_stdout.rs
@@ -124,8 +124,15 @@ pub(crate) fn with_silenced_stdout<R>(devnull: Option<&OwnedFd>, f: impl FnOnce(
 /// CoreML reports real failures — the ANE-less prepare error and the E5RT
 /// exceptions behind it (#678) — on stdout, so discarding it unconditionally
 /// makes those failures unreadable exactly where they matter: a CI runner you
-/// cannot attach to. Redirecting to stderr is safe because callers write their
-/// payload *after* the guard returns, so nothing of ours is misrouted.
+/// cannot attach to.
+///
+/// Scope of what this changes, precisely: only where fd 1 points *while the
+/// guard is held*. Callers write their payload after it returns, so the
+/// redirect never misroutes kesha's own output. It does **not** address the
+/// hazard this module documents for the permanent-redirect variant — a
+/// background CoreML print landing on real stdout after the guard restores
+/// fd 1, which can still corrupt a streamed WAV. That is unchanged either way,
+/// since `/dev/null` does not catch a post-restore print either.
 #[cfg(any(feature = "system_kokoro", feature = "system_diarize"))]
 fn oneshot_sink() -> Option<OwnedFd> {
     use std::os::fd::FromRawFd;

--- a/rust/src/tts/fluid_kokoro.rs
+++ b/rust/src/tts/fluid_kokoro.rs
@@ -144,9 +144,7 @@ fn ensure_script_supported(fluid_id: &str, text: &str) -> Result<()> {
 /// Env var overriding which CoreML compute units the Kokoro pipeline loads on.
 const COMPUTE_UNITS_ENV: &str = "KESHA_KOKORO_COMPUTE_UNITS";
 
-/// Accepted [`COMPUTE_UNITS_ENV`] values. Spelled to match FluidAudio's own
-/// `TtsComputeUnitPreset` CLI names so a value carries over unchanged when
-/// debugging against upstream tooling.
+/// Accepted [`COMPUTE_UNITS_ENV`] values, spelled as FluidAudio's own `TtsComputeUnitPreset` CLI names.
 const COMPUTE_UNIT_PRESETS: &[(&str, KokoroComputeUnits)] = &[
     ("default", KokoroComputeUnits::Default),
     ("cpu-and-gpu", KokoroComputeUnits::CpuAndGpu),
@@ -431,28 +429,22 @@ mod tests {
         }
     }
 
-    /// `compute_units_from_env` reads a process-global, so these cases share one
-    /// test rather than racing each other across nextest's threads.
     #[test]
     fn compute_units_env_defaults_and_validates() {
-        struct EnvGuard;
-        impl Drop for EnvGuard {
-            fn drop(&mut self) {
-                unsafe { std::env::remove_var(COMPUTE_UNITS_ENV) };
-            }
+        use crate::util::test_env::{lock, EnvGuard};
+        let _lock = lock();
+
+        {
+            let _g = EnvGuard::unset(COMPUTE_UNITS_ENV);
+            assert_eq!(
+                compute_units_from_env().expect("unset is valid"),
+                KokoroComputeUnits::Default
+            );
         }
-        let _guard = EnvGuard;
 
-        unsafe { std::env::remove_var(COMPUTE_UNITS_ENV) };
-        assert_eq!(
-            compute_units_from_env().expect("unset is valid"),
-            KokoroComputeUnits::Default
-        );
-
-        // Whitespace-only is treated as unset, not as a typo — a CI step that
-        // exports the var conditionally would otherwise fail every darwin run.
+        // GHA exports a conditional `env:` as the empty string rather than omitting it.
         for blank in ["", "   "] {
-            unsafe { std::env::set_var(COMPUTE_UNITS_ENV, blank) };
+            let _g = EnvGuard::set(COMPUTE_UNITS_ENV, blank);
             assert_eq!(
                 compute_units_from_env().expect("blank is valid"),
                 KokoroComputeUnits::Default
@@ -465,7 +457,7 @@ mod tests {
             ("ALL-ANE", KokoroComputeUnits::AllAne),
             ("default", KokoroComputeUnits::Default),
         ] {
-            unsafe { std::env::set_var(COMPUTE_UNITS_ENV, value) };
+            let _g = EnvGuard::set(COMPUTE_UNITS_ENV, value);
             let parsed = compute_units_from_env().unwrap_or_else(|e| panic!("{value:?}: {e}"));
             assert_eq!(parsed, expected);
             assert_eq!(preset_name(parsed), value.trim().to_ascii_lowercase());
@@ -473,11 +465,22 @@ mod tests {
 
         // An unknown preset must fail loudly rather than silently synthesizing
         // on the ANE the caller was trying to avoid.
-        unsafe { std::env::set_var(COMPUTE_UNITS_ENV, "ane-please") };
+        let _g = EnvGuard::set(COMPUTE_UNITS_ENV, "ane-please");
         let err = compute_units_from_env().expect_err("unknown preset must error");
         let msg = err.to_string();
         assert!(msg.contains("ane-please"), "{msg}");
         assert!(msg.contains("cpu-and-gpu"), "{msg}");
+    }
+
+    /// `preset_name` falls back to "default" for an unlisted variant, so a
+    /// `KokoroComputeUnits` growing a variant must extend the table or the
+    /// error text would name a preset the engine is not using.
+    #[test]
+    fn every_preset_round_trips_through_its_name() {
+        for (name, units) in COMPUTE_UNIT_PRESETS {
+            assert_eq!(preset_name(*units), *name);
+        }
+        assert_eq!(COMPUTE_UNIT_PRESETS.len(), 4, "extend the table");
     }
 
     #[test]

--- a/rust/src/tts/fluid_kokoro.rs
+++ b/rust/src/tts/fluid_kokoro.rs
@@ -12,7 +12,7 @@
 
 use anyhow::{Context, Result};
 
-use fluidaudio_rs::FluidAudio;
+use fluidaudio_rs::{FluidAudio, KokoroComputeUnits};
 
 use crate::coded_bail;
 use crate::errors::ErrorCode;
@@ -141,20 +141,85 @@ fn ensure_script_supported(fluid_id: &str, text: &str) -> Result<()> {
     Ok(())
 }
 
+/// Env var overriding which CoreML compute units the Kokoro pipeline loads on.
+const COMPUTE_UNITS_ENV: &str = "KESHA_KOKORO_COMPUTE_UNITS";
+
+/// Accepted [`COMPUTE_UNITS_ENV`] values. Spelled to match FluidAudio's own
+/// `TtsComputeUnitPreset` CLI names so a value carries over unchanged when
+/// debugging against upstream tooling.
+const COMPUTE_UNIT_PRESETS: &[(&str, KokoroComputeUnits)] = &[
+    ("default", KokoroComputeUnits::Default),
+    ("cpu-and-gpu", KokoroComputeUnits::CpuAndGpu),
+    ("all-ane", KokoroComputeUnits::AllAne),
+    ("cpu-only", KokoroComputeUnits::CpuOnly),
+];
+
+fn preset_name(units: KokoroComputeUnits) -> &'static str {
+    COMPUTE_UNIT_PRESETS
+        .iter()
+        .find(|(_, u)| *u == units)
+        .map(|(name, _)| *name)
+        .unwrap_or("default")
+}
+
+/// Read [`COMPUTE_UNITS_ENV`], defaulting to FluidAudio's empirical per-stage
+/// mapping (Albert / PostAlbert / Alignment / Vocoder on the Neural Engine).
+///
+/// The override exists for hosts with no usable ANE — notably a virtualised
+/// macOS guest such as a GitHub-hosted `macos-14` runner, where CoreML fails to
+/// prepare exactly those stages ("Failed to prepare the model for predictions",
+/// #678). Real Apple Silicon should never set it.
+fn compute_units_from_env() -> Result<KokoroComputeUnits> {
+    let Some(raw) = std::env::var_os(COMPUTE_UNITS_ENV) else {
+        return Ok(KokoroComputeUnits::Default);
+    };
+    let raw = raw.to_string_lossy();
+    let value = raw.trim();
+    if value.is_empty() {
+        return Ok(KokoroComputeUnits::Default);
+    }
+    let lowered = value.to_ascii_lowercase();
+    COMPUTE_UNIT_PRESETS
+        .iter()
+        .find(|(name, _)| *name == lowered)
+        .map(|(_, units)| *units)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "{COMPUTE_UNITS_ENV}='{value}' is not a known CoreML compute-units preset. \
+                 Use one of: {}. `default` is the tuned mapping and the right choice on real \
+                 Apple Silicon; override it only where no Neural Engine is exposed, such as a \
+                 virtualised macOS guest.",
+                COMPUTE_UNIT_PRESETS
+                    .iter()
+                    .map(|(name, _)| *name)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )
+        })
+}
+
 /// Initialize a FluidAudio Kokoro bridge for `voice_id` and run `f` against it
 /// with the process's stdout silenced for the whole bridge lifetime (create →
 /// call → drop). FluidAudio's CoreML pipeline writes diagnostics to stdout that
 /// would corrupt `kesha say`'s WAV byte stream; the oneshot guard restores fd 1
-/// on return (#259, mirrors the diarize/ASR guard).
+/// on return (#259, mirrors the diarize/ASR guard). The non-ANE presets widen
+/// that leak — CPU+GPU adds E5RT "Data-dependent shapes were disabled" lines —
+/// so the guard matters more, not less, when the override is set.
 fn with_kokoro<R>(voice_id: &str, f: impl FnOnce(&FluidAudio) -> Result<R>) -> Result<R> {
     // The voice's language selects the KokoroAne variant in the bridge
     // (`zh` → Mandarin, else English). Unknown voices default to English.
     let lang = lang_for_fluid_id(voice_id).unwrap_or("en-us");
+    let compute_units = compute_units_from_env()?;
     crate::fluid_stdout::with_silenced_stdout_oneshot(|| {
         let audio = FluidAudio::new().context("init FluidAudio bridge")?;
         audio
-            .init_kokoro(voice_id, lang)
-            .context("init FluidAudio Kokoro (downloads the model on first run)")?;
+            .init_kokoro_with_compute_units(voice_id, lang, compute_units)
+            .with_context(|| {
+                format!(
+                    "init FluidAudio Kokoro on {} compute units (downloads the model on first run)",
+                    preset_name(compute_units)
+                )
+            })?;
         f(&audio)
     })
 }
@@ -364,6 +429,55 @@ mod tests {
                 pcm.len()
             );
         }
+    }
+
+    /// `compute_units_from_env` reads a process-global, so these cases share one
+    /// test rather than racing each other across nextest's threads.
+    #[test]
+    fn compute_units_env_defaults_and_validates() {
+        struct EnvGuard;
+        impl Drop for EnvGuard {
+            fn drop(&mut self) {
+                unsafe { std::env::remove_var(COMPUTE_UNITS_ENV) };
+            }
+        }
+        let _guard = EnvGuard;
+
+        unsafe { std::env::remove_var(COMPUTE_UNITS_ENV) };
+        assert_eq!(
+            compute_units_from_env().expect("unset is valid"),
+            KokoroComputeUnits::Default
+        );
+
+        // Whitespace-only is treated as unset, not as a typo — a CI step that
+        // exports the var conditionally would otherwise fail every darwin run.
+        for blank in ["", "   "] {
+            unsafe { std::env::set_var(COMPUTE_UNITS_ENV, blank) };
+            assert_eq!(
+                compute_units_from_env().expect("blank is valid"),
+                KokoroComputeUnits::Default
+            );
+        }
+
+        for (value, expected) in [
+            ("cpu-and-gpu", KokoroComputeUnits::CpuAndGpu),
+            (" cpu-only ", KokoroComputeUnits::CpuOnly),
+            ("ALL-ANE", KokoroComputeUnits::AllAne),
+            ("default", KokoroComputeUnits::Default),
+        ] {
+            unsafe { std::env::set_var(COMPUTE_UNITS_ENV, value) };
+            let parsed = compute_units_from_env().unwrap_or_else(|e| panic!("{value:?}: {e}"));
+            assert_eq!(parsed, expected);
+            assert_eq!(preset_name(parsed), value.trim().to_ascii_lowercase());
+        }
+
+        // An unknown preset must fail loudly rather than silently synthesizing
+        // on the ANE the caller was trying to avoid.
+        unsafe { std::env::set_var(COMPUTE_UNITS_ENV, "ane-please") };
+        let err = compute_units_from_env().expect_err("unknown preset must error");
+        let msg = err.to_string();
+        assert!(msg.contains("ane-please"), "{msg}");
+        assert!(msg.contains("cpu-and-gpu"), "{msg}");
     }
 
     #[test]

--- a/rust/src/tts/fluid_kokoro.rs
+++ b/rust/src/tts/fluid_kokoro.rs
@@ -177,23 +177,25 @@ fn compute_units_from_env() -> Result<KokoroComputeUnits> {
         return Ok(KokoroComputeUnits::Default);
     }
     let lowered = value.to_ascii_lowercase();
-    COMPUTE_UNIT_PRESETS
+    if let Some((_, units)) = COMPUTE_UNIT_PRESETS
         .iter()
         .find(|(name, _)| *name == lowered)
-        .map(|(_, units)| *units)
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "{COMPUTE_UNITS_ENV}='{value}' is not a known CoreML compute-units preset. \
-                 Use one of: {}. `default` is the tuned mapping and the right choice on real \
-                 Apple Silicon; override it only where no Neural Engine is exposed, such as a \
-                 virtualised macOS guest.",
-                COMPUTE_UNIT_PRESETS
-                    .iter()
-                    .map(|(name, _)| *name)
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            )
-        })
+    {
+        return Ok(*units);
+    }
+    // Coded: an uncoded error surfaces as E_INTERNAL, blaming the engine for the user's typo.
+    coded_bail!(
+        ErrorCode::InvalidArg,
+        "{COMPUTE_UNITS_ENV}='{value}' is not a known CoreML compute-units preset. \
+         Use one of: {}. `default` is the tuned mapping and the right choice on real \
+         Apple Silicon; override it only where no Neural Engine is exposed, such as a \
+         virtualised macOS guest.",
+        COMPUTE_UNIT_PRESETS
+            .iter()
+            .map(|(name, _)| *name)
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
 }
 
 /// Initialize a FluidAudio Kokoro bridge for `voice_id` and run `f` against it
@@ -463,10 +465,10 @@ mod tests {
             assert_eq!(preset_name(parsed), value.trim().to_ascii_lowercase());
         }
 
-        // An unknown preset must fail loudly rather than silently synthesizing
-        // on the ANE the caller was trying to avoid.
+        // Must fail loudly instead of silently using the ANE the caller was avoiding.
         let _g = EnvGuard::set(COMPUTE_UNITS_ENV, "ane-please");
         let err = compute_units_from_env().expect_err("unknown preset must error");
+        assert_eq!(crate::errors::code_of(&err), ErrorCode::InvalidArg);
         let msg = err.to_string();
         assert!(msg.contains("ane-please"), "{msg}");
         assert!(msg.contains("cpu-and-gpu"), "{msg}");

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -31,6 +31,7 @@ const KNOWN_ENV_KEYS = [
   "KESHA_STATS_DB",
   "KESHA_DEBUG",
   "KESHA_DEBUG_FD",
+  "KESHA_KOKORO_COMPUTE_UNITS",
 ] as const;
 
 interface DoctorOptions {


### PR DESCRIPTION
Refs #678

## The fix is a runner image, not a compute-units workaround

This started as #678's option 1 — plumb FluidAudio's `computeUnits` lever so Kokoro could skip a Neural Engine the runner does not expose. Measuring it refuted the premise, so the shape changed.

| host | preset | first synthesis | later synthesis |
|---|---|---|---|
| macos-14 | `default` (ANE) | fails — the original #678 error | — |
| macos-14 | `cpu-and-gpu` | fails | fails (`..._mps_graph` shapes) |
| macos-14 | `cpu-only` | fails (`anchor` rank 1 vs 2) | fails (same) |
| **macos-15** | `default` | **ok, 37.4 s** | ok |
| **macos-15** | `cpu-and-gpu` | **ok, 33.4 s** | ok |
| **macos-15** | `cpu-only` | **ok, 45.3 s** | ok |
| M2 / macOS 26.5.2 | all four | ok | ok |

`cpu-only` engages neither the ANE nor Metal and still fails on 14. `default` pins the vocoder to a Neural Engine that `macos-15` does not have either, and succeeds there. Both point one way: the blocker is **that image's CoreML**, not the missing accelerator. The `macos-15` rows use a binary built on `macos-14`, so exactly one axis moved.

## Change

- **`darwin-synthesis-smoke`**, a new job on `macos-15`, downloads the artifact the `macos-14` build produced and runs the existing `smoke-synthesis.ts` against it.
- **Build stays on `macos-14`** — COREML BUILD TRIPLE requires it. An earlier probe that moved the whole matrix row crashed differently, conflating build host with run host; that measurement was discarded rather than reported.
- **Advisory, not a gate.** `continue-on-error`, and `release` still needs `build` alone, because #742 keeps the lane red. It reports darwin synthesis on every engine build instead of the zero coverage it replaces, and becomes a gate in the commit that closes #742. A permanently red required check only teaches people to ignore red.
- **`KESHA_DEBUG` on the lane.** FluidAudio reports CoreML failures on stdout, which `with_silenced_stdout_oneshot` discards (#259). Under `KESHA_DEBUG` that guard now redirects to **stderr instead of discarding**. Without it every row above reads `E_INTERNAL: fluid-kokoro: FluidAudio Kokoro synthesis` and nothing more — the blindness #678 records costing a week on the ASR half. This is the part of the PR most worth keeping.
- **`KESHA_KOKORO_COMPUTE_UNITS`** (`default` / `cpu-and-gpu` / `all-ane` / `cpu-only`) stays as a documented diagnostic — it is what proved the ANE axis innocent, and FluidAudio's `KokoroAne.md` recommends the CPU baseline for artefact investigations. CI no longer sets it, so it is listed in `doctor.ts`'s `KNOWN_ENV_KEYS` and in the `tts-internals` skill rather than being reachable only from the source. Unknown values fail before model init; blank is treated as unset, since a conditional GHA `env:` exports an empty string.

## Known-open: #742

The lane is red because a longer sentence SIGBUSes on `macos-15`. Filed separately with a one-line repro. I had this wrong at first and said so there: I read it as "the second engine invocation dies", which probing refuted — the crash follows the **text**, not the call order. A 44-character sentence crashes as the *first* call in its step; 8- and 13-character ones succeed as the second, third and fourth, including through the CLI wrapper. Also ruled out by measurement: the e5rt cache, `KESHA_DEBUG` itself, and the compute-unit preset.

## Verification

`bun test` 686 pass · `tsc --noEmit` clean · `cargo fmt --check` clean · `cargo clippy --all-targets -D warnings` clean on the full darwin feature set · `cargo nextest` 402 pass · `bun run check:workflows` clean. On an M2 through the real bridge, all four presets synthesise a valid 24 kHz `am_michael` WAV and `bogus-preset` fails with the actionable message before init.

## Review

Two adversarial passes. Findings acted on, each verified against the code first: `kesha install` calls `warmDarwinKokoro`, so a smoke-step-only variable would have left every macOS build hitting the failure first; the env test reimplemented a private guard instead of `util::test_env::lock`, the crate-wide protocol, and had the race model backwards; `preset_name`'s fallback could silently misname a preset if the enum grew a variant, now pinned by a round-trip test; and the env var needed documenting once CI stopped setting it.

One finding was declined with a reason: that the `KESHA_DEBUG` redirect can corrupt streamed WAV output. The hazard is real — a background CoreML print landing on stdout after the guard restores fd 1 — but it predates this change and is identical with `/dev/null`, which does not catch a post-restore print either. The doc comment now states that scope precisely instead of claiming "safe".

Two things found along the way, neither fixed here: `--no-warmup` does not suppress the darwin Kokoro warm-up (it reaches the engine's installer, but `warmDarwinKokoro` is TypeScript-side and unconditional), and `cache-seed.yml` seeds only ubuntu and windows, so this lane cold-fetches its models every run.

## Upstream

[FluidInference/fluidaudio-rs#21](https://github.com/FluidInference/fluidaudio-rs/pull/21) offers upstream the same lever the fork already carries. Not a blocker — `with_models_dir` (#688) keeps the fork pinned regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UU2vgxhrf56CN8YDqbg3q1