### PR TITLE
fix(ci): drop rust-cache from the Parakeet seed job

### DIFF
--- a/.github/workflows/cache-seed.yml
+++ b/.github/workflows/cache-seed.yml
@@ -121,11 +121,9 @@ jobs:
         if: steps.probe.outputs.cache-hit != 'true'
         with:
           toolchain: stable
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        if: steps.probe.outputs.cache-hit != 'true'
-        with:
-          workspaces: rust
 
+      # Deliberately no rust-cache: this job builds only on a miss, and its artifacts
+      # cost 716 MB of a budget whose pressure already evicts the bundle it seeds.
       - name: Install system audio deps (Opus)
         if: steps.probe.outputs.cache-hit != 'true'
         run: brew install opus pkg-config


### PR DESCRIPTION
## What

Removes `Swatinem/rust-cache` from the `parakeet` seed job added in #734.

## Why

The job inherited that step from `coreml-regression`, where it pays off — that job runs on every CoreML-touching PR. Here the trade is inverted: the seed builds **only on a cache miss**, so the entry buys a few minutes a handful of times a month. It cost **716 MB**, larger than the **446 MB** bundle the job exists to seed:

```
716MB  refs/heads/main  v0-rust-parakeet-Darwin-arm64-af5aa912-…   ← this
446MB  refs/heads/main  parakeet-coreml-models-v1-macOS-7b7ea177…  ← the point of the job
```

My mistake in #734: I copied the step list from `coreml-regression` without re-deriving whether caching a rare build is worth its footprint.

## Context that makes this urgent

#734 did close #675 — the seed ran on the merge commit and `parakeet-coreml-models-v1-*` appeared on `refs/heads/main` for the first time ever, at 446 MB (confirming the path narrowing; the whole `Models/` tree would have been ~930 MB).

**It was then evicted within the hour**, along with all three `kokoro-models-v1-*`. The repo went 18 entries / 13297 MB → 11 entries / 10771 MB against a 10 GB cap.

So `#675`'s fix is correct but currently cannot deliver: anything seeded is evicted before a PR can read it. This PR removes 716 MB of self-inflicted pressure, but it does not solve the budget on its own — three entries hold 89% of the cap:

| MB | ref | key |
|---|---|---|
| 3386 | main | `Linux-kesha-models-tts-v1` |
| 3386 | main | `Windows-kesha-models-tts-v1` |
| 2350 | PR#737/merge | `macOS-kesha-engine-v1` |

`macOS-kesha-engine-v1` is the interesting one: it predates #684, which cut a macOS install from ~2.4 GB to ~142 MB of Kesha-managed models. Deleting it should let it re-seed an order of magnitude smaller. That is an operational action on the caches API rather than a code change, so it is not in this PR.

Refs #675.