### PR TITLE
feat(release): publish engine alphas live, ahead of the pin

### DIFF
--- a/.claude/skills/release-mechanics/SKILL.md
+++ b/.claude/skills/release-mechanics/SKILL.md
@@ -76,7 +76,7 @@ npm view @drakulavich/kesha-voice-kit version   # within ~60s, expect X.Y.Z
 **Alpha channel** (#685) — versions are derived from tags at publish time and never committed, so `main` carries the *next* unreleased CLI version as the alpha base:
 
 - **CLI alphas** publish themselves. Label a PR `alpha`; on merge `release-alpha.yml` derives `vX.Y.Z-alpha.N-cli`, pushes the tag, then dispatches `npm-publish.yml` (npm Trusted Publishing validates the *entry* workflow name, so an alpha must publish through that one). Install with `bun add -g @drakulavich/kesha-voice-kit@alpha`. `workflow_dispatch` skips the label gate for a PR merged without one.
-- **Engine alphas** are dispatched by hand, tagged `vX.Y.Z-alpha.N` (no `-cli`), and publish **live, not as a draft** — an alpha behind the un-draft gate is not installable. Beta keeps its draft.
+- **Engine alphas** are dispatched by hand, tagged `vX.Y.Z-alpha.N` (no `-cli`), and end up **live, not draft** — an alpha behind the un-draft gate is not installable. The build still creates a draft and un-drafts it after upload: releases here are immutable, so an asset uploaded to a published release 422s. Beta keeps its draft.
 - An engine alpha leads the pin instead of matching it: `package.json#keshaEngine.version` may never name an alpha (#738), so pick a base above it, and leave all three version fields alone. The build writes the tag's version into `rust/Cargo.toml` in the runner, so `kesha-engine --version` reports the alpha.
 
 ```bash

--- a/.claude/skills/release-mechanics/SKILL.md
+++ b/.claude/skills/release-mechanics/SKILL.md
@@ -73,6 +73,19 @@ npm view @drakulavich/kesha-voice-kit version   # within ~60s, expect X.Y.Z
 - Verify beta with `npm view @drakulavich/kesha-voice-kit@beta version`; user-facing beta install is `bun add -g @drakulavich/kesha-voice-kit@beta && kesha install`.
 - Promote by cutting a later stable `vX.Y.Z` release; do not reuse the beta tag or try to retag it as stable.
 
+**Alpha channel** (#685) — versions are derived from tags at publish time and never committed, so `main` carries the *next* unreleased CLI version as the alpha base:
+
+- **CLI alphas** publish themselves. Label a PR `alpha`; on merge `release-alpha.yml` derives `vX.Y.Z-alpha.N-cli`, pushes the tag, then dispatches `npm-publish.yml` (npm Trusted Publishing validates the *entry* workflow name, so an alpha must publish through that one). Install with `bun add -g @drakulavich/kesha-voice-kit@alpha`. `workflow_dispatch` skips the label gate for a PR merged without one.
+- **Engine alphas** are dispatched by hand, tagged `vX.Y.Z-alpha.N` (no `-cli`), and publish **live, not as a draft** — an alpha behind the un-draft gate is not installable. Beta keeps its draft.
+- An engine alpha leads the pin instead of matching it: `package.json#keshaEngine.version` may never name an alpha (#738), so pick a base above it, and leave all three version fields alone. The build writes the tag's version into `rust/Cargo.toml` in the runner, so `kesha-engine --version` reports the alpha.
+
+```bash
+gh workflow run "🔨 Build Engine" -R drakulavich/kesha-voice-kit \
+  -f tag="$(bun .github/scripts/derive-alpha-version.ts engine 1.24.8 | sed -n 's/^tag=//p')" \
+  -f ref=main -f notes="Engine alpha."
+kesha install --engine-version 1.24.8-alpha.1   # a later plain `kesha install` restores the pin
+```
+
 **Alternate tag path:** `workflow_dispatch` validates tag shape and authors notes inline, useful when a sandbox cannot push tags:
 
 ```bash

--- a/.github/scripts/classify-release-tag.d.mts
+++ b/.github/scripts/classify-release-tag.d.mts
@@ -1,0 +1,1 @@
+export function classifyReleaseTag(tag: string): { draft: boolean; prerelease: boolean };

--- a/.github/scripts/classify-release-tag.d.mts
+++ b/.github/scripts/classify-release-tag.d.mts
@@ -1,1 +1,1 @@
-export function classifyReleaseTag(tag: string): { draft: boolean; prerelease: boolean };
+export function classifyReleaseTag(tag: string): { publish: boolean; prerelease: boolean };

--- a/.github/scripts/classify-release-tag.mjs
+++ b/.github/scripts/classify-release-tag.mjs
@@ -1,17 +1,20 @@
 #!/usr/bin/env node
 /**
- * Decide how a release tag is published: draft or live, release or Prerelease.
+ * Decide how a release tag is published: Prerelease or not, and whether the build publishes
+ * the draft itself.
  *
- * Stable and beta tags stay drafts because un-drafting is the human gate that validates the
- * binaries before anyone can download them. An alpha has no such gate — it is dispatched on
- * purpose and must be installable the moment the build finishes (#685), so it publishes live.
- * Prints `draft=`/`prerelease=` lines suitable for `$GITHUB_OUTPUT`.
+ * Every release is *created* as a draft regardless — this repository has GitHub immutable
+ * releases enabled, and an asset uploaded after publication fails with 422 "Cannot upload
+ * asset to an immutable release". Stable and beta then wait for the human un-draft gate that
+ * validates the binaries; an alpha is dispatched on purpose and must be installable the
+ * moment the build finishes (#685), so the workflow un-drafts it in a later step.
+ * Prints `publish=`/`prerelease=` lines suitable for `$GITHUB_OUTPUT`.
  */
 import { pathToFileURL } from "node:url";
 import { isEngineAlphaTag, isStableTag } from "./release-tags.mjs";
 
 export function classifyReleaseTag(tag) {
-  return { draft: !isEngineAlphaTag(tag), prerelease: !isStableTag(tag) };
+  return { publish: isEngineAlphaTag(tag), prerelease: !isStableTag(tag) };
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
@@ -21,5 +24,5 @@ if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
     process.exit(2);
   }
   const kind = classifyReleaseTag(tag);
-  process.stdout.write(`draft=${kind.draft}\nprerelease=${kind.prerelease}\n`);
+  process.stdout.write(`publish=${kind.publish}\nprerelease=${kind.prerelease}\n`);
 }

--- a/.github/scripts/classify-release-tag.mjs
+++ b/.github/scripts/classify-release-tag.mjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+/**
+ * Decide how a release tag is published: draft or live, release or Prerelease.
+ *
+ * Stable and beta tags stay drafts because un-drafting is the human gate that validates the
+ * binaries before anyone can download them. An alpha has no such gate — it is dispatched on
+ * purpose and must be installable the moment the build finishes (#685), so it publishes live.
+ * Prints `draft=`/`prerelease=` lines suitable for `$GITHUB_OUTPUT`.
+ */
+import { pathToFileURL } from "node:url";
+import { isEngineAlphaTag, isStableTag } from "./release-tags.mjs";
+
+export function classifyReleaseTag(tag) {
+  return { draft: !isEngineAlphaTag(tag), prerelease: !isStableTag(tag) };
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  const tag = process.argv[2];
+  if (!tag) {
+    console.error("usage: node .github/scripts/classify-release-tag.mjs <tag>");
+    process.exit(2);
+  }
+  const kind = classifyReleaseTag(tag);
+  process.stdout.write(`draft=${kind.draft}\nprerelease=${kind.prerelease}\n`);
+}

--- a/.github/scripts/release-manifest.mjs
+++ b/.github/scripts/release-manifest.mjs
@@ -5,8 +5,10 @@ import { linuxPackageNames } from "./linux-package-names.mjs";
 import {
   ENGINE_TAG_ERE,
   ENGINE_TAG_RE,
+  isEngineAlphaTag,
   isStableTag,
 } from "./release-tags.mjs";
+import { cmp, parseSemver } from "../../src/semver.mjs";
 
 const REPOSITORY = "drakulavich/kesha-voice-kit";
 const MANIFEST_NAME = "kesha-release-manifest.json";
@@ -110,20 +112,42 @@ function asset(name, kind, platforms, install, checksummed = true) {
   };
 }
 
+/**
+ * An alpha is published ahead of the pin, never as it.
+ *
+ * The pin names the *released* engine and may never name an alpha (#738), so an alpha tag
+ * cannot be required to equal it. Requiring it to outrank the pin keeps what the exact-match
+ * rule was protecting: `v1.24.8-alpha.1` against a pin already at `1.24.8` sorts below it and
+ * is still refused, so an alpha can never stand in for the stable release of its own base.
+ */
+function assertTagNamesThisRelease(tag, pinnedVersion) {
+  const version = tag.slice(1);
+  if (version === pinnedVersion) return;
+
+  const ahead =
+    isEngineAlphaTag(tag) &&
+    cmp(parseSemver(version, "release tag"), parseSemver(pinnedVersion, "pinned engine version")) > 0;
+  if (ahead) return;
+
+  throw new Error(
+    `release tag ${tag} must match package.json#keshaEngine.version (${pinnedVersion})` +
+      (isEngineAlphaTag(tag) ? ` or name an alpha above it` : ""),
+  );
+}
+
 function buildManifest(tag) {
   const pkg = readPackage();
-  const engineVersion = pkg.keshaEngine?.version ?? pkg.version;
-  if (typeof pkg.version !== "string" || typeof engineVersion !== "string") {
+  const pinnedVersion = pkg.keshaEngine?.version ?? pkg.version;
+  if (typeof pkg.version !== "string" || typeof pinnedVersion !== "string") {
     throw new Error("package.json must contain version and keshaEngine.version strings");
   }
 
   const sbomName = `kesha-voice-kit-${tag}.spdx.json`;
   // Every tag here is an engine tag, stable included; the CLI version names packages (#696).
-  if (tag.slice(1) !== engineVersion) {
-    throw new Error(
-      `release tag ${tag} must match package.json#keshaEngine.version (${engineVersion})`,
-    );
-  }
+  assertTagNamesThisRelease(tag, pinnedVersion);
+
+  // The tag, not the pin: an alpha ships a version no commit carries (#685).
+  const engineVersion = tag.slice(1);
 
   const assets = [
     ...ENGINE_ASSETS.map((p) => asset(p.engineAsset, "engine", [p.id], p.install)),

--- a/.github/scripts/release-tags.d.mts
+++ b/.github/scripts/release-tags.d.mts
@@ -2,7 +2,9 @@
 export const ENGINE_TAG_ERE: string;
 export const ENGINE_TAG_RE: RegExp;
 export const STABLE_TAG_RE: RegExp;
+export const ALPHA_TAG_RE: RegExp;
 export function isStableTag(tag: string): boolean;
+export function isEngineAlphaTag(tag: string): boolean;
 export function cliPublishTarget(tag: string): {
   version: string;
   engineOnly: boolean;

--- a/.github/scripts/release-tags.mjs
+++ b/.github/scripts/release-tags.mjs
@@ -13,9 +13,15 @@ export const ENGINE_TAG_ERE = "^v[0-9]+\\.[0-9]+\\.[0-9]+(-(beta|alpha)\\.[0-9]+
 
 export const ENGINE_TAG_RE = new RegExp(ENGINE_TAG_ERE);
 export const STABLE_TAG_RE = /^v[0-9]+\.[0-9]+\.[0-9]+$/;
+export const ALPHA_TAG_RE = /^v[0-9]+\.[0-9]+\.[0-9]+-alpha\.[0-9]+$/;
 
 export function isStableTag(tag) {
   return STABLE_TAG_RE.test(tag);
+}
+
+/** Engine alphas only. A CLI alpha ends in `-cli` and never reaches an engine-side validator. */
+export function isEngineAlphaTag(tag) {
+  return ALPHA_TAG_RE.test(tag);
 }
 
 const CLI_MARKER = "-cli";

--- a/.github/scripts/set-cargo-version.d.mts
+++ b/.github/scripts/set-cargo-version.d.mts
@@ -1,0 +1,1 @@
+export function withCargoVersion(manifest: string, version: string): string;

--- a/.github/scripts/set-cargo-version.mjs
+++ b/.github/scripts/set-cargo-version.mjs
@@ -16,23 +16,30 @@ import { isSemver } from "../../src/semver.mjs";
 
 const MANIFEST = "rust/Cargo.toml";
 
+const PACKAGE_TABLE = /^\[package\][^\S\r\n]*(#.*)?$/m;
+/** Only the value is replaced, so a trailing comment and the line's ending survive untouched. */
+const VERSION_LINE = /^(version[^\S\r\n]*=[^\S\r\n]*)("[^"]*"|'[^']*')/m;
+
 export function withCargoVersion(manifest, version) {
   if (!isSemver(version)) {
     throw new Error(`refusing to write a non-SemVer version into Cargo.toml: ${version}`);
   }
-  if (!manifest.startsWith("[package]")) {
-    throw new Error("Cargo.toml must open with [package] for the version rewrite to be unambiguous");
+
+  const header = PACKAGE_TABLE.exec(manifest);
+  if (!header) {
+    throw new Error("Cargo.toml has no [package] table to take a version from");
   }
 
-  const end = manifest.indexOf("\n[", 1);
-  const head = end === -1 ? manifest : manifest.slice(0, end);
-  const tail = end === -1 ? "" : manifest.slice(end);
-  const rewritten = head.replace(/^version = "[^"]*"$/m, `version = "${version}"`);
-  if (rewritten === head) {
+  const start = header.index + header[0].length;
+  const offset = manifest.slice(start).search(/^\[/m);
+  const end = offset === -1 ? manifest.length : start + offset;
+  const table = manifest.slice(start, end);
+  const rewritten = table.replace(VERSION_LINE, `$1"${version}"`);
+  if (rewritten === table) {
     throw new Error("[package] has no version line to replace");
   }
 
-  return rewritten + tail;
+  return manifest.slice(0, start) + rewritten + manifest.slice(end);
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {

--- a/.github/scripts/set-cargo-version.mjs
+++ b/.github/scripts/set-cargo-version.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+/**
+ * Write a version into `rust/Cargo.toml` without committing it.
+ *
+ * An engine alpha is published ahead of the pin, so no commit carries its version — but
+ * `kesha-engine --version` reports `CARGO_PKG_VERSION`, and a binary that names the pinned
+ * release is indistinguishable from the stable build it is meant to be tested against (#685).
+ * The build applies the tag's version in the runner, mirroring what
+ * `set-package-version.mjs` does for the CLI tarball.
+ *
+ * Rewrites only the `version` of the `[package]` table; dependency versions are left alone.
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+import { isSemver } from "../../src/semver.mjs";
+
+const MANIFEST = "rust/Cargo.toml";
+
+export function withCargoVersion(manifest, version) {
+  if (!isSemver(version)) {
+    throw new Error(`refusing to write a non-SemVer version into Cargo.toml: ${version}`);
+  }
+  if (!manifest.startsWith("[package]")) {
+    throw new Error("Cargo.toml must open with [package] for the version rewrite to be unambiguous");
+  }
+
+  const end = manifest.indexOf("\n[", 1);
+  const head = end === -1 ? manifest : manifest.slice(0, end);
+  const tail = end === -1 ? "" : manifest.slice(end);
+  const rewritten = head.replace(/^version = "[^"]*"$/m, `version = "${version}"`);
+  if (rewritten === head) {
+    throw new Error("[package] has no version line to replace");
+  }
+
+  return rewritten + tail;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  const version = process.argv[2];
+  if (!version) {
+    console.error("usage: node .github/scripts/set-cargo-version.mjs <version>");
+    process.exit(2);
+  }
+  writeFileSync(MANIFEST, withCargoVersion(readFileSync(MANIFEST, "utf8"), version));
+}

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -536,11 +536,19 @@ jobs:
             cosign sign-blob --yes --bundle "${name}.sigstore.json" "$name"
           done < <(find . -maxdepth 1 -type f ! -name '*.sigstore.json' -print0 | sort -z)
 
-      # Draft for stable and beta, live for an alpha — an alpha nobody can install is not one (#685).
-      - name: Create release with binaries
+      # Always a draft: releases here are immutable, and an asset uploaded after publication 422s.
+      - name: Create draft release with binaries
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           body_path: release-notes.md
           files: release-assets/*
-          draft: ${{ steps.release_kind.outputs.draft }}
+          draft: true
           prerelease: ${{ steps.release_kind.outputs.prerelease }}
+
+      # Stable and beta wait for the human un-draft gate; an alpha nobody can install is not one (#685).
+      - name: Publish the alpha
+        if: steps.release_kind.outputs.publish == 'true'
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit "$TAG_NAME" --draft=false

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -179,6 +179,14 @@ jobs:
         # configure-time. Cheaper than installing libopus via vcpkg.
         run: Add-Content -Path $env:GITHUB_ENV -Value "CMAKE_POLICY_VERSION_MINIMUM=3.5"
 
+      # Without this the binary reports the pinned release it is meant to be tested against (#685).
+      - name: Apply the alpha engine version
+        if: startsWith(github.ref, 'refs/tags/') && contains(github.ref_name, '-alpha.')
+        shell: bash
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: node .github/scripts/set-cargo-version.mjs "${TAG_NAME#v}"
+
       - name: Build release binary
         run: cd rust && cargo build --release --target ${{ matrix.target }} --features ${{ matrix.features }} --no-default-features
       - name: Prepare artifact
@@ -461,12 +469,7 @@ jobs:
         id: release_kind
         env:
           TAG_NAME: ${{ github.ref_name }}
-        run: |
-          if [[ "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "prerelease=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "prerelease=true" >> "$GITHUB_OUTPUT"
-          fi
+        run: node .github/scripts/classify-release-tag.mjs "$TAG_NAME" >> "$GITHUB_OUTPUT"
 
       - name: Generate source SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
@@ -533,10 +536,11 @@ jobs:
             cosign sign-blob --yes --bundle "${name}.sigstore.json" "$name"
           done < <(find . -maxdepth 1 -type f ! -name '*.sigstore.json' -print0 | sort -z)
 
-      - name: Create draft release with binaries
+      # Draft for stable and beta, live for an alpha — an alpha nobody can install is not one (#685).
+      - name: Create release with binaries
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           body_path: release-notes.md
           files: release-assets/*
-          draft: true
+          draft: ${{ steps.release_kind.outputs.draft }}
           prerelease: ${{ steps.release_kind.outputs.prerelease }}

--- a/openspec/changes/alpha-release-channel/design.md
+++ b/openspec/changes/alpha-release-channel/design.md
@@ -119,6 +119,26 @@ and the Engine changes far less often. Engine alphas are dispatched manually and
 non-draft Prereleases, changing `build-engine.yml:484` from an unconditional `draft: true`
 to a draft only for stable tags.
 
+### An Engine alpha leads the pin, and the runner carries its version
+
+`release-manifest.mjs` required the release tag to equal `package.json#keshaEngine.version`,
+which no Engine alpha can satisfy: the pin names the *released* Engine and may never name an
+alpha (#738). Exact match is therefore relaxed to "equal to the pin, or an alpha above it".
+That keeps what the original rule protected — `v1.24.8-alpha.1` against a pin already at
+`1.24.8` sorts below it and is still refused, so an alpha can never stand in for the stable
+release of its own base — while a stable or beta tag ahead of the pin stays an error, because
+there it means the bump was forgotten.
+
+The same gap appears inside the binary: `kesha-engine --version` reports `CARGO_PKG_VERSION`,
+so an alpha built from `main` would identify itself as the pinned release it is meant to be
+tested against. The build applies the tag's version to `rust/Cargo.toml` in the runner, exactly
+as the publish workflow applies the derived version to `package.json` — the version is carried
+by the tag, never by a commit. Cargo re-locks by itself, as the build does not pass `--locked`.
+
+Beta tags keep their draft, unlike alphas. A beta is a release candidate whose binaries are
+validated by hand before anyone can download them; that gate is the point of the beta channel,
+and removing it here would change how a channel this change does not touch behaves.
+
 ### Tag grammar: `-cli` suffix for CLI, bare prerelease for the Engine
 
 `build-engine.yml:3-13` triggers on `v*` excluding `!v*-cli`, so a bare `v<base>-alpha.N`

--- a/openspec/changes/alpha-release-channel/design.md
+++ b/openspec/changes/alpha-release-channel/design.md
@@ -139,6 +139,21 @@ Beta tags keep their draft, unlike alphas. A beta is a release candidate whose b
 validated by hand before anyone can download them; that gate is the point of the beta channel,
 and removing it here would change how a channel this change does not touch behaves.
 
+### An alpha is published by un-drafting, not by being created live
+
+This repository has GitHub immutable releases enabled (`"immutable": true` on every published
+release, which is also why tag names are permanently reserved). GitHub refuses an asset upload
+to a published release, and `softprops/action-gh-release` creates a prerelease live whenever
+`draft: false` is passed explicitly — `const draft = prerelease === true ? config.input_draft
+=== true : true` — uploading its assets afterwards. Publishing an alpha that way therefore
+fails with 422 "Cannot upload asset to an immutable release", after the tag has already been
+created: a burned tag and an empty published release.
+
+Every release is created as a draft, and an alpha is un-drafted by a following step once the
+assets are attached. This is the pattern the action's own error guidance prescribes, and it
+keeps the property the requirement asks for — no human step between dispatch and an
+installable artifact — without the alpha and the stable path diverging on how assets land.
+
 ### Tag grammar: `-cli` suffix for CLI, bare prerelease for the Engine
 
 `build-engine.yml:3-13` triggers on `v*` excluding `!v*-cli`, so a bare `v<base>-alpha.N`

--- a/openspec/changes/alpha-release-channel/tasks.md
+++ b/openspec/changes/alpha-release-channel/tasks.md
@@ -53,10 +53,12 @@
 
 ## 7. Publish Engine alphas on demand
 
-- [ ] 7.1 Change `.github/workflows/build-engine.yml:484` to draft only stable tags, publishing alpha tags as non-draft Prereleases
+- [x] 7.1 Change `.github/workflows/build-engine.yml:484` to draft only stable tags, publishing alpha tags as non-draft Prereleases — beta keeps its draft, whose hand-validation gate is the point of that channel
 - [ ] 7.2 Confirm an Engine alpha tag passes the widened validators from group 2 end to end, including manifest generation
 - [ ] 7.3 Verify `kesha install --engine-version <alpha>` installs the Engine alpha, and that `kesha install` afterwards restores the pin — the pin itself may never name an alpha (#736 rule 3), so the old plan of matching `keshaEngine.version` to the alpha tag is not available (#738)
 - [ ] 7.4 Confirm publishing an Engine alpha does not publish a CLI package and does not leave a red workflow run
+- [x] 7.5 Let the release manifest accept an alpha tag above the pin, since the pin may never name one (#738), while still rejecting an alpha at or below it
+- [x] 7.6 Apply the alpha tag's version to `rust/Cargo.toml` in the runner, so the binary does not report the pinned release it is meant to be tested against
 
 ## 8. Keep alpha artifacts out of stable lanes
 

--- a/openspec/changes/alpha-release-channel/tasks.md
+++ b/openspec/changes/alpha-release-channel/tasks.md
@@ -53,7 +53,7 @@
 
 ## 7. Publish Engine alphas on demand
 
-- [x] 7.1 Change `.github/workflows/build-engine.yml:484` to draft only stable tags, publishing alpha tags as non-draft Prereleases — beta keeps its draft, whose hand-validation gate is the point of that channel
+- [x] 7.1 Publish alpha tags as live Prereleases — created as a draft like every release, since immutable releases refuse an asset upload after publication, then un-drafted by a following step; beta keeps its draft, whose hand-validation gate is the point of that channel
 - [ ] 7.2 Confirm an Engine alpha tag passes the widened validators from group 2 end to end, including manifest generation
 - [ ] 7.3 Verify `kesha install --engine-version <alpha>` installs the Engine alpha, and that `kesha install` afterwards restores the pin — the pin itself may never name an alpha (#736 rule 3), so the old plan of matching `keshaEngine.version` to the alpha tag is not available (#738)
 - [ ] 7.4 Confirm publishing an Engine alpha does not publish a CLI package and does not leave a red workflow run

--- a/tests/unit/release-tag-grammar.test.ts
+++ b/tests/unit/release-tag-grammar.test.ts
@@ -73,15 +73,26 @@ describe("engine alpha publication", () => {
   });
 
   // An alpha behind the un-draft gate is not installable, which is the whole point of one (#685).
-  test("an alpha publishes live while stable and beta stay drafts", () => {
-    expect(classifyReleaseTag("v1.24.8-alpha.1")).toEqual({ draft: false, prerelease: true });
-    expect(classifyReleaseTag("v1.24.8")).toEqual({ draft: true, prerelease: false });
-    expect(classifyReleaseTag("v1.24.8-beta.1")).toEqual({ draft: true, prerelease: true });
+  test("only an alpha publishes itself, and only stable is not a prerelease", () => {
+    expect(classifyReleaseTag("v1.24.8-alpha.1")).toEqual({ publish: true, prerelease: true });
+    expect(classifyReleaseTag("v1.24.8")).toEqual({ publish: false, prerelease: false });
+    expect(classifyReleaseTag("v1.24.8-beta.1")).toEqual({ publish: false, prerelease: true });
   });
 
-  test("the release step takes both flags from the classifier", () => {
-    expect(releaseStep.with.draft).toBe("${{ steps.release_kind.outputs.draft }}");
+  // Releases here are immutable: an asset uploaded after publication fails with a 422.
+  test("assets are always uploaded to a draft", () => {
+    expect(releaseStep.with.draft).toBe(true);
     expect(releaseStep.with.prerelease).toBe("${{ steps.release_kind.outputs.prerelease }}");
+  });
+
+  test("the alpha is un-drafted afterwards, by the classifier's verdict", () => {
+    const publishStep = steps.find((s: { name?: string }) => s.name === "Publish the alpha");
+
+    expect(steps.indexOf(publishStep)).toBeGreaterThan(steps.indexOf(releaseStep));
+    expect(publishStep.if).toBe("steps.release_kind.outputs.publish == 'true'");
+    expect(publishStep.run).toContain("--draft=false");
+    expect(publishStep.run).not.toContain("${{");
+    expect(publishStep.env.TAG_NAME).toBe("${{ github.ref_name }}");
   });
 
   test("the build applies the alpha version, and only for a tag that names one", () => {

--- a/tests/unit/release-tag-grammar.test.ts
+++ b/tests/unit/release-tag-grammar.test.ts
@@ -10,10 +10,12 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { parse } from "yaml";
+import { classifyReleaseTag } from "../../.github/scripts/classify-release-tag.mjs";
 import {
   cliPublishTarget,
   ENGINE_TAG_ERE,
   ENGINE_TAG_RE,
+  isEngineAlphaTag,
 } from "../../.github/scripts/release-tags.mjs";
 
 const WORKFLOW = ".github/workflows/build-engine.yml";
@@ -55,6 +57,42 @@ describe("engine tag grammar", () => {
 describe("engine build trigger", () => {
   test("CLI marker tags are excluded from the push filter", () => {
     expect(parse(WORKFLOW_YAML).on.push.tags).toEqual(["v*", "!v*-cli"]);
+  });
+});
+
+describe("engine alpha publication", () => {
+  const steps = parse(WORKFLOW_YAML).jobs.release.steps;
+  const releaseStep = steps.find((s: { uses?: string }) => s.uses?.startsWith("softprops/"));
+  const buildSteps = parse(WORKFLOW_YAML).jobs.build.steps;
+
+  test("only an engine alpha shape counts as one", () => {
+    expect(isEngineAlphaTag("v1.24.8-alpha.1")).toBe(true);
+    for (const tag of ["v1.24.8", "v1.24.8-beta.1", "v1.27.0-alpha.1-cli", "v1.24.8-alpha"]) {
+      expect(isEngineAlphaTag(tag)).toBe(false);
+    }
+  });
+
+  // An alpha behind the un-draft gate is not installable, which is the whole point of one (#685).
+  test("an alpha publishes live while stable and beta stay drafts", () => {
+    expect(classifyReleaseTag("v1.24.8-alpha.1")).toEqual({ draft: false, prerelease: true });
+    expect(classifyReleaseTag("v1.24.8")).toEqual({ draft: true, prerelease: false });
+    expect(classifyReleaseTag("v1.24.8-beta.1")).toEqual({ draft: true, prerelease: true });
+  });
+
+  test("the release step takes both flags from the classifier", () => {
+    expect(releaseStep.with.draft).toBe("${{ steps.release_kind.outputs.draft }}");
+    expect(releaseStep.with.prerelease).toBe("${{ steps.release_kind.outputs.prerelease }}");
+  });
+
+  test("the build applies the alpha version, and only for a tag that names one", () => {
+    const inject = buildSteps.find((s: { name?: string }) => s.name === "Apply the alpha engine version");
+
+    expect(inject.run).toContain("set-cargo-version.mjs");
+    expect(inject.if).toContain("startsWith(github.ref, 'refs/tags/')");
+    expect(inject.if).toContain("contains(github.ref_name, '-alpha.')");
+    // The tag reaches the shell as a variable; `$(…)` in a ref must not execute (#291).
+    expect(inject.run).not.toContain("${{");
+    expect(inject.env.TAG_NAME).toBe("${{ github.ref_name }}");
   });
 });
 
@@ -119,6 +157,41 @@ describe("release manifest tag check", () => {
   test("an engine alpha is accepted when the version line carries the suffix too", async () => {
     const cwd = fixtureRepo("1.27.0", "1.24.8-alpha.1");
     expect((await manifestCheck(["--tag", "v1.24.8-alpha.1"], cwd)).accepted).toBe(true);
+  });
+
+  // The pin names the released engine and may never name an alpha (#738), so an alpha leads it.
+  test("an engine alpha above the pin is accepted", async () => {
+    const cwd = fixtureRepo("1.27.0", "1.24.7");
+    expect((await manifestCheck(["--tag", "v1.24.8-alpha.1"], cwd)).accepted).toBe(true);
+  });
+
+  test("an engine alpha below the pin is rejected", async () => {
+    const cwd = fixtureRepo("1.27.0", "1.24.9");
+    const { accepted, stderr } = await manifestCheck(["--tag", "v1.24.8-alpha.1"], cwd);
+
+    expect(accepted).toBe(false);
+    expect(stderr).toContain("or name an alpha above it");
+  });
+
+  // Only alphas may lead the pin; a stable or beta tag ahead of it means the bump was forgotten.
+  test("a stable or beta tag above the pin is still rejected", async () => {
+    const cwd = fixtureRepo("1.27.0", "1.24.7");
+
+    expect((await manifestCheck(["--tag", "v1.24.8"], cwd)).accepted).toBe(false);
+    expect((await manifestCheck(["--tag", "v1.24.8-beta.1"], cwd)).accepted).toBe(false);
+  });
+
+  test("the manifest describes the alpha, not the pin it leads", async () => {
+    const cwd = fixtureRepo("1.27.0", "1.24.7");
+    const proc = Bun.spawn(["node", SCRIPT, "--tag", "v1.24.8-alpha.1"], {
+      cwd,
+      stdout: "pipe",
+      stderr: "ignore",
+    });
+    const manifest = JSON.parse(await new Response(proc.stdout).text());
+
+    expect(manifest.tag).toBe("v1.24.8-alpha.1");
+    expect(manifest.engineVersion).toBe("1.24.8-alpha.1");
   });
 
   test("the base version of an alpha is not an alias for it, in either direction", async () => {

--- a/tests/unit/set-cargo-version.test.ts
+++ b/tests/unit/set-cargo-version.test.ts
@@ -17,13 +17,24 @@ describe("withCargoVersion", () => {
     expect(after.slice(after.indexOf("\n[dependencies]"))).toBe(before);
   });
 
+  // Split on both endings: a Windows checkout carries CRLF, which the rewrite preserves.
+  const lines = (source: string) => source.split(/\r?\n/);
+
   test("rewrites exactly one line", () => {
-    const original = MANIFEST.split("\n");
-    const changed = withCargoVersion(MANIFEST, "1.24.8-alpha.1")
-      .split("\n")
-      .filter((line: string, i: number) => line !== original[i]);
+    const original = lines(MANIFEST);
+    const changed = lines(withCargoVersion(MANIFEST, "1.24.8-alpha.1")).filter(
+      (line: string, i: number) => line !== original[i],
+    );
 
     expect(changed).toEqual(['version = "1.24.8-alpha.1"']);
+  });
+
+  test("a CRLF manifest keeps its line endings", () => {
+    const crlf = MANIFEST.replace(/\n/g, "\r\n");
+    const out = withCargoVersion(crlf, "1.24.8-alpha.1");
+
+    expect(out).toContain('version = "1.24.8-alpha.1"\r\n');
+    expect(out.match(/(?<!\r)\n/)).toBeNull();
   });
 
   test("refuses a version that is not SemVer", () => {

--- a/tests/unit/set-cargo-version.test.ts
+++ b/tests/unit/set-cargo-version.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { withCargoVersion } from "../../.github/scripts/set-cargo-version.mjs";
+
+const MANIFEST = readFileSync(`${import.meta.dir}/../../rust/Cargo.toml`, "utf8");
+
+describe("withCargoVersion", () => {
+  test("replaces the [package] version", () => {
+    expect(withCargoVersion(MANIFEST, "1.24.8-alpha.1")).toContain('version = "1.24.8-alpha.1"');
+  });
+
+  // The rewrite is a regex over a TOML file; a dependency pin is one `version = "…"` away.
+  test("leaves dependency versions alone", () => {
+    const before = MANIFEST.slice(MANIFEST.indexOf("\n[dependencies]"));
+    const after = withCargoVersion(MANIFEST, "1.24.8-alpha.1");
+
+    expect(after.slice(after.indexOf("\n[dependencies]"))).toBe(before);
+  });
+
+  test("rewrites exactly one line", () => {
+    const original = MANIFEST.split("\n");
+    const changed = withCargoVersion(MANIFEST, "1.24.8-alpha.1")
+      .split("\n")
+      .filter((line: string, i: number) => line !== original[i]);
+
+    expect(changed).toEqual(['version = "1.24.8-alpha.1"']);
+  });
+
+  test("refuses a version that is not SemVer", () => {
+    for (const bad of ["latest", "1.24", "v1.24.8", '1.24.8"\nname = "evil']) {
+      expect(() => withCargoVersion(MANIFEST, bad)).toThrow(/non-SemVer/);
+    }
+  });
+
+  test("refuses a manifest whose first table is not [package]", () => {
+    expect(() => withCargoVersion('[workspace]\nversion = "1.0.0"\n', "1.24.8-alpha.1")).toThrow(
+      /\[package\]/,
+    );
+  });
+
+  test("refuses a [package] table with no version line", () => {
+    expect(() => withCargoVersion('[package]\nname = "kesha-engine"\n', "1.24.8-alpha.1")).toThrow(
+      /no version line/,
+    );
+  });
+});

--- a/tests/unit/set-cargo-version.test.ts
+++ b/tests/unit/set-cargo-version.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { withCargoVersion } from "../../.github/scripts/set-cargo-version.mjs";
 
-const MANIFEST = readFileSync(`${import.meta.dir}/../../rust/Cargo.toml`, "utf8");
+// Normalised, not inherited: a Windows checkout carries CRLF and would double it below.
+const MANIFEST = readFileSync(`${import.meta.dir}/../../rust/Cargo.toml`, "utf8").replace(
+  /\r\n/g,
+  "\n",
+);
+const CRLF_MANIFEST = MANIFEST.replace(/\n/g, "\r\n");
 
 describe("withCargoVersion", () => {
   test("replaces the [package] version", () => {
@@ -17,24 +22,22 @@ describe("withCargoVersion", () => {
     expect(after.slice(after.indexOf("\n[dependencies]"))).toBe(before);
   });
 
-  // Split on both endings: a Windows checkout carries CRLF, which the rewrite preserves.
-  const lines = (source: string) => source.split(/\r?\n/);
-
   test("rewrites exactly one line", () => {
-    const original = lines(MANIFEST);
-    const changed = lines(withCargoVersion(MANIFEST, "1.24.8-alpha.1")).filter(
-      (line: string, i: number) => line !== original[i],
-    );
+    const original = MANIFEST.split("\n");
+    const changed = withCargoVersion(MANIFEST, "1.24.8-alpha.1")
+      .split("\n")
+      .filter((line: string, i: number) => line !== original[i]);
 
     expect(changed).toEqual(['version = "1.24.8-alpha.1"']);
   });
 
+  // The runner rewrites whatever git checked out, and on Windows that is CRLF.
   test("a CRLF manifest keeps its line endings", () => {
-    const crlf = MANIFEST.replace(/\n/g, "\r\n");
-    const out = withCargoVersion(crlf, "1.24.8-alpha.1");
+    const out = withCargoVersion(CRLF_MANIFEST, "1.24.8-alpha.1");
 
     expect(out).toContain('version = "1.24.8-alpha.1"\r\n');
     expect(out.match(/(?<!\r)\n/)).toBeNull();
+    expect(out.replace(/\r\n/g, "\n")).toBe(withCargoVersion(MANIFEST, "1.24.8-alpha.1"));
   });
 
   test("refuses a version that is not SemVer", () => {

--- a/tests/unit/set-cargo-version.test.ts
+++ b/tests/unit/set-cargo-version.test.ts
@@ -46,9 +46,30 @@ describe("withCargoVersion", () => {
     }
   });
 
-  test("refuses a manifest whose first table is not [package]", () => {
+  // Valid TOML the rewrite must survive: failing here burns a tag the tag job already pushed.
+  test.each([
+    ['# header\n[package]\nversion = "1.0.0"\n', 'version = "1.24.8-alpha.1"'],
+    ['[package]\nversion = "1.0.0" # pinned\n', 'version = "1.24.8-alpha.1" # pinned'],
+    ["[package]\nversion = '1.0.0'\n", 'version = "1.24.8-alpha.1"'],
+    ['[package]\nversion="1.0.0"\n', 'version="1.24.8-alpha.1"'],
+    ['[package] # the crate\nversion = "1.0.0"\n', 'version = "1.24.8-alpha.1"'],
+  ])("rewrites %j", (source, expected) => {
+    expect(withCargoVersion(source, "1.24.8-alpha.1")).toContain(expected);
+  });
+
+  test("takes the version from [package], not from a table that precedes it", () => {
+    const out = withCargoVersion(
+      '[workspace.package]\nversion = "0.0.1"\n\n[package]\nversion = "1.0.0"\n',
+      "1.24.8-alpha.1",
+    );
+
+    expect(out).toContain('[workspace.package]\nversion = "0.0.1"');
+    expect(out).toContain('[package]\nversion = "1.24.8-alpha.1"');
+  });
+
+  test("refuses a manifest with no [package] table", () => {
     expect(() => withCargoVersion('[workspace]\nversion = "1.0.0"\n', "1.24.8-alpha.1")).toThrow(
-      /\[package\]/,
+      /no \[package\] table/,
     );
   });
 


### PR DESCRIPTION
Group 7 of the `alpha-release-channel` OpenSpec change. The CLI alpha lane shipped and works — `1.27.0-alpha.1` is on npm under the `alpha` dist-tag — but the engine lane could not be exercised at all.

## Why

Dispatching `v1.24.8-alpha.1` today would burn the tag and then fail:

```
Error: release tag v1.24.8-alpha.1 must match package.json#keshaEngine.version (1.24.7)
```

`release-manifest.mjs` demanded exact equality, and `package.json#keshaEngine.version` may never name an alpha (#738) — it names the *released* engine. The tag job creates the tag before the build, so the failure lands after a four-platform Rust build with the name permanently reserved.

Two further gaps: `build-engine.yml` drafted every tag, which contradicts the spec's "immediately consumable" requirement for an alpha, and nothing carried the alpha version into the binary, so `kesha-engine --version` would report `1.24.7`.

## What changed

- **Manifest rule**: equal to the pin, or an alpha above it. An alpha at or below a stable pin is still refused, so `v1.24.8-alpha.1` can never stand in for the stable `1.24.8`; a stable or beta tag ahead of the pin stays an error, where it means the bump was forgotten. The manifest's `engineVersion` now names the alpha it describes.
- **Draft policy** moves into `classify-release-tag.mjs`: alpha publishes live as a Prerelease, stable and beta keep their draft. Beta's hand-validation gate is the point of that channel, so it is untouched.
- **Version injection**: `set-cargo-version.mjs` writes the tag's version into `rust/Cargo.toml` in the runner, mirroring what `set-package-version.mjs` already does for the CLI tarball. Cargo re-locks on its own; the build does not pass `--locked`.

## Verification

- `bun test` 734 pass / 0 fail, `bunx tsc --noEmit` clean, `bun run check:versions` green.
- The original blocker, against real repo state (pin `1.24.7`): `node .github/scripts/release-manifest.mjs --tag v1.24.8-alpha.1` now emits a manifest with `engineVersion: 1.24.8-alpha.1`.
- Injection smoke: applied to `rust/Cargo.toml`, `cargo metadata --no-deps` reports `1.24.8-alpha.1`, reverted clean.
- New tests cover the manifest rule in both directions, the draft/prerelease policy per tag shape, the tag-gated injection step, and the `env:` passthrough that keeps `${{ }}` out of the `run:` block (#291).

Tasks 7.1, plus 7.5/7.6 added for the two gaps the implementation surfaced. 7.2-7.4 and 11.5 stay open — they are verified by dispatching a real engine alpha, which is the next step after this merges.

Refs #685