### PR TITLE
docs(openspec): close the engine-alpha verifications against a real alpha

### DIFF
--- a/openspec/changes/alpha-release-channel/design.md
+++ b/openspec/changes/alpha-release-channel/design.md
@@ -231,7 +231,11 @@ from the new capability.
   workflow.** Its version guard compares `package.json#version` against the tag and would
   fail on every Engine alpha, turning a routine action red. → The publish workflow must
   recognise an Engine-only tag and exit successfully without publishing, rather than failing
-  the version comparison.
+  the version comparison. *Observed on `v1.24.8-alpha.1`: the event never fires. The
+  workflow un-drafts with its own `GITHUB_TOKEN`, and GitHub does not let a token-raised
+  event start another workflow — the same rule that keeps a token tag push from starting the
+  Engine build. The decline path stays as the guard for a hand-published Engine release; for
+  an alpha there is nothing to decline.*
 
 - **Alpha Engine tags could leak into lanes that download the published Engine**, breaking
   unrelated pull requests. → Those lanes resolve the stable channel explicitly. The existing

--- a/openspec/changes/alpha-release-channel/tasks.md
+++ b/openspec/changes/alpha-release-channel/tasks.md
@@ -54,16 +54,16 @@
 ## 7. Publish Engine alphas on demand
 
 - [x] 7.1 Publish alpha tags as live Prereleases — created as a draft like every release, since immutable releases refuse an asset upload after publication, then un-drafted by a following step; beta keeps its draft, whose hand-validation gate is the point of that channel
-- [ ] 7.2 Confirm an Engine alpha tag passes the widened validators from group 2 end to end, including manifest generation
-- [ ] 7.3 Verify `kesha install --engine-version <alpha>` installs the Engine alpha, and that `kesha install` afterwards restores the pin — the pin itself may never name an alpha (#736 rule 3), so the old plan of matching `keshaEngine.version` to the alpha tag is not available (#738)
-- [ ] 7.4 Confirm publishing an Engine alpha does not publish a CLI package and does not leave a red workflow run
+- [x] 7.2 Confirm an Engine alpha tag passes the widened validators from group 2 end to end, including manifest generation — `v1.24.8-alpha.1` built and released, its manifest naming `engineVersion 1.24.8-alpha.1`
+- [x] 7.3 Verify `kesha install --engine-version <alpha>` installs the Engine alpha, and that `kesha install` afterwards restores the pin — the pin itself may never name an alpha (#736 rule 3), so the old plan of matching `keshaEngine.version` to the alpha tag is not available (#738)
+- [x] 7.4 Confirm publishing an Engine alpha does not publish a CLI package and does not leave a red workflow run — satisfied, though not by the `engine_only` decline the design expected: a `GITHUB_TOKEN` un-draft raises no `release: published`, so no publish workflow runs at all
 - [x] 7.5 Let the release manifest accept an alpha tag above the pin, since the pin may never name one (#738), while still rejecting an alpha at or below it
 - [x] 7.6 Apply the alpha tag's version to `rust/Cargo.toml` in the runner, so the binary does not report the pinned release it is meant to be tested against
 
 ## 8. Keep alpha artifacts out of stable lanes
 
 - [x] 8.1 Make the lanes that download the published Engine (`ci.yml:387`, `:448`, `:501`) resolve an explicit stable version rather than inheriting possibly-prerelease metadata — solved upstream of the lanes instead: `check-versions.ts` rule 3 refuses an alpha pin outright, so no lane can inherit one
-- [ ] 8.2 Verify an unrelated pull request is unaffected after an Engine alpha is published
+- [ ] 8.2 Verify an unrelated pull request is unaffected after an Engine alpha is published — no engine-downloading lane has run since `v1.24.8-alpha.1` went out; the pin rule holds, but nothing has exercised it yet
 
 ## 9. Retention
 
@@ -83,5 +83,5 @@
 - [x] 11.2 Install the alpha by naming the channel and confirm it runs
 - [x] 11.3 Confirm an unqualified install still resolves the newest stable version before and after that alpha
 - [ ] 11.4 Merge a docs-only change and confirm nothing publishes and the skip is visible
-- [ ] 11.5 Dispatch an Engine alpha and install it end to end
+- [x] 11.5 Dispatch an Engine alpha and install it end to end
 - [x] 11.6 Confirm a CLI alpha tag left the Engine build workflow untriggered


### PR DESCRIPTION
Follow-up to #743 and #744: the engine alpha lane has now been exercised for real. Ledger and design notes only — no behaviour change.

`v1.24.8-alpha.1` ([release](https://github.com/drakulavich/kesha-voice-kit/releases/tag/v1.24.8-alpha.1), [build](https://github.com/drakulavich/kesha-voice-kit/actions/runs/31005482599)):

| Check | Result |
|---|---|
| Release state | `draft=false`, `prerelease=true` — live, which is what #743 fixed |
| Latest release | still `v1.26.0-cli`; the alpha did not displace it |
| Assets | 3 engines, 2 darwin sidecars, manifest, SBOM, `SHA256SUMS`, each with its `.sigstore.json`; `.deb`/`.rpm` correctly skipped for a prerelease |
| Manifest | `tag=v1.24.8-alpha.1`, `engineVersion=1.24.8-alpha.1` — describes the alpha, not the pin |
| Checksum | `shasum -a 256 -c` on the downloaded darwin engine: OK |
| Binary version | `kesha-engine 1.24.8-alpha.1` — the runner-side `Cargo.toml` rewrite reaches the artifact |
| Install | `kesha install --engine-version 1.24.8-alpha.1` completes, ASR warms up on the ANE |
| Pin restore | a later plain `kesha install` returns to `v1.24.7`, marker and self-report agreeing |

Closes 7.2, 7.3, 7.4 and 11.5.

**7.4 holds for a reason the design did not anticipate**, so I recorded it rather than letting the ledger imply the expected path was exercised: the workflow un-drafts with its own `GITHUB_TOKEN`, and GitHub does not let a token-raised event start another workflow — the same rule that stops a token tag push from starting the Engine build. `release: published` therefore never fires and no publish workflow runs at all. The `engine_only` decline still guards a hand-published Engine release; for an alpha there is nothing to decline.

**8.2 stays open.** No engine-downloading lane has run since the alpha was published — the runs around it are docs-only, where those lanes are path-filtered out. The mechanism (`check-versions.ts` rule 3 refusing an alpha pin) is in place, but nothing has exercised it, and I would rather leave the box empty than tick it on reasoning.

Refs #685