### PR TITLE
feat(release): retire old alpha releases, and give alphas their notes

### DIFF
--- a/.github/scripts/alpha-tag.sh
+++ b/.github/scripts/alpha-tag.sh
@@ -7,10 +7,13 @@ git config user.name "github-actions[bot]"
 git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
 # Resolved before the tag exists: a git log failing mid-pipe leaves a tag with half a message.
-if [ -n "${PREVIOUS:-}" ]; then
-  body=$(printf 'Commits since %s:\n\n' "$PREVIOUS"; git log --no-merges --pretty='- %s (%h)' "$PREVIOUS..$SHA")
-else
+if [ -z "${PREVIOUS:-}" ]; then
   body="No earlier alpha or release tag to count from."
+# A tag off this commit's history yields a range that reads as a changelog but is not one.
+elif ! git merge-base --is-ancestor "$PREVIOUS" "$SHA"; then
+  body="$PREVIOUS is not in this commit's history; no commit range to report."
+else
+  body=$(printf 'Commits since %s:\n\n' "$PREVIOUS"; git log --no-merges --pretty='- %s (%h)' "$PREVIOUS..$SHA")
 fi
 
 printf 'Alpha %s\n\n%s\n' "$TAG" "$body" | git tag -a "$TAG" --cleanup=verbatim -F - "$SHA"

--- a/.github/scripts/alpha-tag.sh
+++ b/.github/scripts/alpha-tag.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# The tag carries the notes: a CLI alpha creates no Release to hold them, and the tag is the
+# one record pruning can never remove (#685). `-F -` keeps a subject line's metachars literal.
+set -euo pipefail
+
+git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+{
+  printf 'Alpha %s\n\n' "$TAG"
+  if [ -n "${PREVIOUS:-}" ]; then
+    printf 'Commits since %s:\n\n' "$PREVIOUS"
+    git log --no-merges --pretty='- %s (%h)' "$PREVIOUS..$SHA"
+  else
+    printf 'No earlier alpha or release tag to count from.\n'
+  fi
+} | git tag -a "$TAG" --cleanup=verbatim -F - "$SHA"
+
+git push origin "refs/tags/$TAG"

--- a/.github/scripts/alpha-tag.sh
+++ b/.github/scripts/alpha-tag.sh
@@ -6,13 +6,19 @@ set -euo pipefail
 git config user.name "github-actions[bot]"
 git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+# This channel's release shapes only: `audio-244` exists here, and so do the other artifact's tags.
+if [ "${TAG%-cli}" != "$TAG" ]; then
+  reachable=(--match 'v[0-9]*-cli')
+else
+  reachable=(--match 'v[0-9]*' --exclude 'v*-cli')
+fi
+
 if [ -z "${PREVIOUS:-}" ]; then
   base=""
 elif git merge-base --is-ancestor "$PREVIOUS" "$SHA"; then
   base="$PREVIOUS"
 else
-  # Release shapes only: tags like `audio-244` exist here and would name a meaningless baseline.
-  base=$(git describe --tags --abbrev=0 --match 'v[0-9]*' "$SHA" 2>/dev/null || true)
+  base=$(git describe --tags --abbrev=0 "${reachable[@]}" "$SHA" 2>/dev/null || true)
 fi
 
 # Resolved before the tag exists: a git log failing mid-pipe leaves a tag with half a message.

--- a/.github/scripts/alpha-tag.sh
+++ b/.github/scripts/alpha-tag.sh
@@ -11,8 +11,8 @@ if [ -z "${PREVIOUS:-}" ]; then
 elif git merge-base --is-ancestor "$PREVIOUS" "$SHA"; then
   base="$PREVIOUS"
 else
-  # A baseline off this history would date the range wrongly; the nearest reachable tag cannot.
-  base=$(git describe --tags --abbrev=0 "$SHA" 2>/dev/null || true)
+  # Release shapes only: tags like `audio-244` exist here and would name a meaningless baseline.
+  base=$(git describe --tags --abbrev=0 --match 'v[0-9]*' "$SHA" 2>/dev/null || true)
 fi
 
 # Resolved before the tag exists: a git log failing mid-pipe leaves a tag with half a message.

--- a/.github/scripts/alpha-tag.sh
+++ b/.github/scripts/alpha-tag.sh
@@ -6,14 +6,13 @@ set -euo pipefail
 git config user.name "github-actions[bot]"
 git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-{
-  printf 'Alpha %s\n\n' "$TAG"
-  if [ -n "${PREVIOUS:-}" ]; then
-    printf 'Commits since %s:\n\n' "$PREVIOUS"
-    git log --no-merges --pretty='- %s (%h)' "$PREVIOUS..$SHA"
-  else
-    printf 'No earlier alpha or release tag to count from.\n'
-  fi
-} | git tag -a "$TAG" --cleanup=verbatim -F - "$SHA"
+# Resolved before the tag exists: a git log failing mid-pipe leaves a tag with half a message.
+if [ -n "${PREVIOUS:-}" ]; then
+  body=$(printf 'Commits since %s:\n\n' "$PREVIOUS"; git log --no-merges --pretty='- %s (%h)' "$PREVIOUS..$SHA")
+else
+  body="No earlier alpha or release tag to count from."
+fi
+
+printf 'Alpha %s\n\n%s\n' "$TAG" "$body" | git tag -a "$TAG" --cleanup=verbatim -F - "$SHA"
 
 git push origin "refs/tags/$TAG"

--- a/.github/scripts/alpha-tag.sh
+++ b/.github/scripts/alpha-tag.sh
@@ -6,14 +6,20 @@ set -euo pipefail
 git config user.name "github-actions[bot]"
 git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-# Resolved before the tag exists: a git log failing mid-pipe leaves a tag with half a message.
 if [ -z "${PREVIOUS:-}" ]; then
-  body="No earlier alpha or release tag to count from."
-# A tag off this commit's history yields a range that reads as a changelog but is not one.
-elif ! git merge-base --is-ancestor "$PREVIOUS" "$SHA"; then
-  body="$PREVIOUS is not in this commit's history; no commit range to report."
+  base=""
+elif git merge-base --is-ancestor "$PREVIOUS" "$SHA"; then
+  base="$PREVIOUS"
 else
-  body=$(printf 'Commits since %s:\n\n' "$PREVIOUS"; git log --no-merges --pretty='- %s (%h)' "$PREVIOUS..$SHA")
+  # A baseline off this history would date the range wrongly; the nearest reachable tag cannot.
+  base=$(git describe --tags --abbrev=0 "$SHA" 2>/dev/null || true)
+fi
+
+# Resolved before the tag exists: a git log failing mid-pipe leaves a tag with half a message.
+if [ -n "$base" ]; then
+  body=$(printf 'Commits since %s:\n\n' "$base"; git log --no-merges --pretty='- %s (%h)' "$base..$SHA")
+else
+  body="No earlier tag in this commit's history to count from."
 fi
 
 printf 'Alpha %s\n\n%s\n' "$TAG" "$body" | git tag -a "$TAG" --cleanup=verbatim -F - "$SHA"

--- a/.github/scripts/derive-alpha-version.ts
+++ b/.github/scripts/derive-alpha-version.ts
@@ -7,12 +7,13 @@
  * `version=`/`tag=` lines suitable for `$GITHUB_OUTPUT`.
  */
 import { readFileSync } from "node:fs";
+import { CLI_MARKER, publishedVersionRe } from "./release-tags.mjs";
 import { cmp, parseSemver } from "../../src/semver.mjs";
 
 export type Channel = "cli" | "engine";
 
 /** CLI alphas carry the `-cli` marker so the engine build's `!v*-cli` filter skips them (#685). */
-const MARKER: Record<Channel, string> = { cli: "-cli", engine: "" };
+const MARKER: Record<Channel, string> = { cli: CLI_MARKER, engine: "" };
 
 export function alphaTag(channel: Channel, base: string, sequence: number): string {
   return `v${base}-alpha.${sequence}${MARKER[channel]}`;
@@ -37,13 +38,12 @@ export function nextSequence(channel: Channel, base: string, tags: string[]): nu
 }
 
 /**
- * The tag the next alpha's notes are counted from: the highest thing already published on
- * this channel, alpha or stable. Preferring alphas outright would anchor the range at an
- * ancient alpha once a stable shipped after it, making the notes span months (grok review).
- * Undefined only where the channel has no tag at all, which leaves notes no lower bound.
+ * The tag the next alpha's notes are counted from: the highest thing already published on this
+ * channel. Preferring alphas would anchor the range at an ancient one once anything shipped
+ * after it, making the notes span months.
  */
 export function previousTag(channel: Channel, tags: string[]): string | undefined {
-  const shape = new RegExp(`^v([0-9]+\\.[0-9]+\\.[0-9]+(?:-alpha\\.[0-9]+)?)${MARKER[channel]}$`);
+  const shape = publishedVersionRe(MARKER[channel]);
 
   let best: { tag: string; version: ReturnType<typeof parseSemver> } | undefined;
   for (const raw of tags) {

--- a/.github/scripts/derive-alpha-version.ts
+++ b/.github/scripts/derive-alpha-version.ts
@@ -37,28 +37,22 @@ export function nextSequence(channel: Channel, base: string, tags: string[]): nu
 }
 
 /**
- * The tag the next alpha's notes are counted from: the highest alpha of this channel, or the
- * channel's highest stable tag before any alpha existed. Undefined only in a repository whose
- * first alpha is also its first release, where notes have no sensible lower bound.
+ * The tag the next alpha's notes are counted from: the highest thing already published on
+ * this channel, alpha or stable. Preferring alphas outright would anchor the range at an
+ * ancient alpha once a stable shipped after it, making the notes span months (grok review).
+ * Undefined only where the channel has no tag at all, which leaves notes no lower bound.
  */
 export function previousTag(channel: Channel, tags: string[]): string | undefined {
-  const marker = MARKER[channel];
-  const shapes = [
-    new RegExp(`^v([0-9]+\\.[0-9]+\\.[0-9]+-alpha\\.[0-9]+)${marker}$`),
-    new RegExp(`^v([0-9]+\\.[0-9]+\\.[0-9]+)${marker}$`),
-  ];
+  const shape = new RegExp(`^v([0-9]+\\.[0-9]+\\.[0-9]+(?:-alpha\\.[0-9]+)?)${MARKER[channel]}$`);
 
-  for (const shape of shapes) {
-    let best: { tag: string; version: ReturnType<typeof parseSemver> } | undefined;
-    for (const raw of tags) {
-      const match = shape.exec(raw.trim());
-      if (!match) continue;
-      const version = parseSemver(match[1], "existing tag");
-      if (!best || cmp(version, best.version) > 0) best = { tag: raw.trim(), version };
-    }
-    if (best) return best.tag;
+  let best: { tag: string; version: ReturnType<typeof parseSemver> } | undefined;
+  for (const raw of tags) {
+    const match = shape.exec(raw.trim());
+    if (!match) continue;
+    const version = parseSemver(match[1], "existing tag");
+    if (!best || cmp(version, best.version) > 0) best = { tag: raw.trim(), version };
   }
-  return undefined;
+  return best?.tag;
 }
 
 /**

--- a/.github/scripts/derive-alpha-version.ts
+++ b/.github/scripts/derive-alpha-version.ts
@@ -37,6 +37,31 @@ export function nextSequence(channel: Channel, base: string, tags: string[]): nu
 }
 
 /**
+ * The tag the next alpha's notes are counted from: the highest alpha of this channel, or the
+ * channel's highest stable tag before any alpha existed. Undefined only in a repository whose
+ * first alpha is also its first release, where notes have no sensible lower bound.
+ */
+export function previousTag(channel: Channel, tags: string[]): string | undefined {
+  const marker = MARKER[channel];
+  const shapes = [
+    new RegExp(`^v([0-9]+\\.[0-9]+\\.[0-9]+-alpha\\.[0-9]+)${marker}$`),
+    new RegExp(`^v([0-9]+\\.[0-9]+\\.[0-9]+)${marker}$`),
+  ];
+
+  for (const shape of shapes) {
+    let best: { tag: string; version: ReturnType<typeof parseSemver> } | undefined;
+    for (const raw of tags) {
+      const match = shape.exec(raw.trim());
+      if (!match) continue;
+      const version = parseSemver(match[1], "existing tag");
+      if (!best || cmp(version, best.version) > 0) best = { tag: raw.trim(), version };
+    }
+    if (best) return best.tag;
+  }
+  return undefined;
+}
+
+/**
  * `check-versions.ts` requires the CLI version to be >= the engine version, and a prerelease
  * sorts below its own stable version — so a CLI base equal to the engine version would make
  * every alpha of it fail that gate. Refuse here rather than at publish time.
@@ -102,5 +127,7 @@ if (import.meta.main) {
   const pkg = JSON.parse(readFileSync("package.json", "utf8"));
   const tags = Bun.spawnSync(["git", "tag", "--list"]).stdout.toString().split("\n").filter(Boolean);
   const derived = deriveAlpha(channel, pkg, tags, process.argv[3]);
-  process.stdout.write(`version=${derived.version}\ntag=${derived.tag}\n`);
+  process.stdout.write(
+    `version=${derived.version}\ntag=${derived.tag}\nprevious=${previousTag(channel, tags) ?? ""}\n`,
+  );
 }

--- a/.github/scripts/prune-alpha-releases.sh
+++ b/.github/scripts/prune-alpha-releases.sh
@@ -2,7 +2,9 @@
 # `gh release delete` without --cleanup-tag: the Release goes, the tag stays (#685).
 set -euo pipefail
 
-releases=$(gh release list --limit 200 --json tagName,publishedAt,isDraft)
+# Paginated: `gh release list --limit N` returns the newest N, losing alphas as they age out.
+releases=$(gh api "repos/{owner}/{repo}/releases" --paginate |
+  jq -s 'add | [.[] | {tagName: .tag_name, publishedAt: .published_at, isDraft: .draft}]')
 aged=$(printf '%s' "$releases" | bun .github/scripts/prune-alpha-releases.ts)
 
 if [ -z "$aged" ]; then

--- a/.github/scripts/prune-alpha-releases.sh
+++ b/.github/scripts/prune-alpha-releases.sh
@@ -2,9 +2,15 @@
 # `gh release delete` without --cleanup-tag: the Release goes, the tag stays (#685).
 set -euo pipefail
 
-# Paginated: `gh release list --limit N` returns the newest N, losing alphas as they age out.
-releases=$(gh api "repos/{owner}/{repo}/releases" --paginate |
-  jq -s 'add | [.[] | {tagName: .tag_name, publishedAt: .published_at, isDraft: .draft}]')
+LIMIT=1000
+releases=$(gh release list --limit "$LIMIT" --json tagName,publishedAt,isDraft)
+
+# Hitting the cap means the oldest releases were never seen, and those are the prunable ones.
+if [ "$(printf '%s' "$releases" | jq 'length')" -ge "$LIMIT" ]; then
+  echo "::error::release list hit its $LIMIT cap — aged alphas may be invisible to the selector" >&2
+  exit 1
+fi
+
 aged=$(printf '%s' "$releases" | bun .github/scripts/prune-alpha-releases.ts)
 
 if [ -z "$aged" ]; then

--- a/.github/scripts/prune-alpha-releases.sh
+++ b/.github/scripts/prune-alpha-releases.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# `gh release delete` without --cleanup-tag: the Release goes, the tag stays (#685).
+set -euo pipefail
+
+releases=$(gh release list --limit 200 --json tagName,publishedAt,isDraft)
+aged=$(printf '%s' "$releases" | bun .github/scripts/prune-alpha-releases.ts)
+
+if [ -z "$aged" ]; then
+  echo "No alpha release has aged out."
+  exit 0
+fi
+
+while IFS= read -r tag; do
+  echo "Deleting aged-out alpha release $tag (tag kept)."
+  gh release delete "$tag" --yes
+done <<< "$aged"

--- a/.github/scripts/prune-alpha-releases.ts
+++ b/.github/scripts/prune-alpha-releases.ts
@@ -10,15 +10,19 @@ import { isEngineAlphaTag } from "./release-tags.mjs";
 
 export const RETENTION_DAYS = 30;
 
-export type Release = { tagName: string; publishedAt: string | null; isDraft?: boolean };
+export type Release = { tagName: string; publishedAt: string | null; isDraft: boolean };
 
 export function prunable(releases: Release[], now: Date, days = RETENTION_DAYS): string[] {
   const cutoff = now.getTime() - days * 24 * 60 * 60 * 1000;
   return releases
     .filter((r) => isEngineAlphaTag(r.tagName))
-    // A draft has no publication date to age from, and an unpublished alpha is a failed
-    // build someone may still be reading.
-    .filter((r) => !r.isDraft && r.publishedAt !== null)
+    .filter((r) => {
+      // Absent rather than false would read as "not a draft" and select a draft for deletion.
+      if (typeof r.isDraft !== "boolean") {
+        throw new Error(`release ${r.tagName} has no isDraft flag to judge it by`);
+      }
+      return !r.isDraft && r.publishedAt !== null;
+    })
     .filter((r) => {
       const published = Date.parse(r.publishedAt as string);
       if (Number.isNaN(published)) {

--- a/.github/scripts/prune-alpha-releases.ts
+++ b/.github/scripts/prune-alpha-releases.ts
@@ -1,0 +1,37 @@
+#!/usr/bin/env bun
+/**
+ * Decide which alpha Releases have aged out.
+ *
+ * Releases only — the tag stays, which is what keeps a published version identifier from
+ * ever being reissued and what the next derivation counts (#685). Stable and beta releases
+ * are never candidates, whatever their age.
+ */
+import { isEngineAlphaTag } from "./release-tags.mjs";
+
+export const RETENTION_DAYS = 30;
+
+export type Release = { tagName: string; publishedAt: string | null; isDraft?: boolean };
+
+export function prunable(releases: Release[], now: Date, days = RETENTION_DAYS): string[] {
+  const cutoff = now.getTime() - days * 24 * 60 * 60 * 1000;
+  return releases
+    .filter((r) => isEngineAlphaTag(r.tagName))
+    // A draft has no publication date to age from, and an unpublished alpha is a failed
+    // build someone may still be reading.
+    .filter((r) => !r.isDraft && r.publishedAt !== null)
+    .filter((r) => {
+      const published = Date.parse(r.publishedAt as string);
+      if (Number.isNaN(published)) {
+        throw new Error(`release ${r.tagName} has an unparsable publishedAt: ${r.publishedAt}`);
+      }
+      return published < cutoff;
+    })
+    .map((r) => r.tagName);
+}
+
+if (import.meta.main) {
+  const raw = await Bun.stdin.text();
+  const releases: Release[] = JSON.parse(raw);
+  const now = process.env.PRUNE_NOW ? new Date(process.env.PRUNE_NOW) : new Date();
+  for (const tag of prunable(releases, now)) console.log(tag);
+}

--- a/.github/scripts/prune-alpha-releases.ts
+++ b/.github/scripts/prune-alpha-releases.ts
@@ -12,30 +12,29 @@ export const RETENTION_DAYS = 30;
 
 export type Release = { tagName: string; publishedAt: string | null; isDraft: boolean };
 
-export function prunable(releases: Release[], now: Date, days = RETENTION_DAYS): string[] {
-  const cutoff = now.getTime() - days * 24 * 60 * 60 * 1000;
-  return releases
-    .filter((r) => isEngineAlphaTag(r.tagName))
-    .filter((r) => {
-      // Absent rather than false would read as "not a draft" and select a draft for deletion.
-      if (typeof r.isDraft !== "boolean") {
-        throw new Error(`release ${r.tagName} has no isDraft flag to judge it by`);
-      }
-      return !r.isDraft && r.publishedAt !== null;
-    })
-    .filter((r) => {
-      const published = Date.parse(r.publishedAt as string);
-      if (Number.isNaN(published)) {
-        throw new Error(`release ${r.tagName} has an unparsable publishedAt: ${r.publishedAt}`);
-      }
-      return published < cutoff;
-    })
-    .map((r) => r.tagName);
+export function prunable(releases: Release[], now: Date): string[] {
+  const cutoff = now.getTime() - RETENTION_DAYS * 24 * 60 * 60 * 1000;
+  const aged: string[] = [];
+
+  for (const release of releases) {
+    if (!isEngineAlphaTag(release.tagName)) continue;
+    // Absent rather than false would read as "not a draft" and select a draft for deletion.
+    if (typeof release.isDraft !== "boolean") {
+      throw new Error(`release ${release.tagName} has no isDraft flag to judge it by`);
+    }
+    if (release.isDraft || release.publishedAt === null) continue;
+
+    const published = Date.parse(release.publishedAt);
+    if (Number.isNaN(published)) {
+      throw new Error(`release ${release.tagName} has an unparsable publishedAt: ${release.publishedAt}`);
+    }
+    if (published < cutoff) aged.push(release.tagName);
+  }
+
+  return aged;
 }
 
 if (import.meta.main) {
-  const raw = await Bun.stdin.text();
-  const releases: Release[] = JSON.parse(raw);
-  const now = process.env.PRUNE_NOW ? new Date(process.env.PRUNE_NOW) : new Date();
-  for (const tag of prunable(releases, now)) console.log(tag);
+  const releases: Release[] = JSON.parse(await Bun.stdin.text());
+  for (const tag of prunable(releases, new Date())) console.log(tag);
 }

--- a/.github/scripts/release-tags.d.mts
+++ b/.github/scripts/release-tags.d.mts
@@ -5,6 +5,8 @@ export const STABLE_TAG_RE: RegExp;
 export const ALPHA_TAG_RE: RegExp;
 export function isStableTag(tag: string): boolean;
 export function isEngineAlphaTag(tag: string): boolean;
+export const CLI_MARKER: string;
+export function publishedVersionRe(marker: string): RegExp;
 export function cliPublishTarget(tag: string): {
   version: string;
   engineOnly: boolean;

--- a/.github/scripts/release-tags.mjs
+++ b/.github/scripts/release-tags.mjs
@@ -24,7 +24,12 @@ export function isEngineAlphaTag(tag) {
   return ALPHA_TAG_RE.test(tag);
 }
 
-const CLI_MARKER = "-cli";
+export const CLI_MARKER = "-cli";
+
+/** Every shape a channel has already published, so notes can be anchored at the latest one. */
+export function publishedVersionRe(marker) {
+  return new RegExp(`^v([0-9]+\\.[0-9]+\\.[0-9]+(?:-(?:alpha|beta)\\.[0-9]+)?)${marker}$`);
+}
 
 /**
  * What the CLI publish path should do with a release tag.

--- a/.github/workflows/prune-alpha-releases.yml
+++ b/.github/workflows/prune-alpha-releases.yml
@@ -1,0 +1,31 @@
+name: "🧹 Prune alpha releases"
+
+# Alpha Releases age out so the release list stays usable for finding stable ones (#685).
+# Tags are never touched: they are what makes a published version permanently taken.
+on:
+  schedule:
+    - cron: "17 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  prune:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.0.2
+        with:
+          bun-version: latest
+
+      - name: Test the selection before trusting it
+        run: bun test tests/unit/prune-alpha-releases.test.ts
+
+      - name: Select and delete aged-out alpha releases
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: .github/scripts/prune-alpha-releases.sh

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -26,6 +26,7 @@ jobs:
       publish: ${{ steps.publishable.outputs.publish }}
       version: ${{ steps.derive.outputs.version }}
       tag: ${{ steps.derive.outputs.tag }}
+      previous: ${{ steps.derive.outputs.previous }}
       dist_tag: ${{ steps.dist.outputs.dist_tag }}
     steps:
       # Full history and tags: the sequence is counted from tags, and a shallow checkout
@@ -97,9 +98,8 @@ jobs:
         env:
           TAG: ${{ needs.decide.outputs.tag }}
           SHA: ${{ github.sha }}
-        run: |
-          git tag "$TAG" "$SHA"
-          git push origin "$TAG"
+          PREVIOUS: ${{ needs.decide.outputs.previous }}
+        run: .github/scripts/alpha-tag.sh
 
   # No OIDC here: npm-publish.yml owns the only entry name npm's publisher trusts (#731).
   publish:

--- a/openspec/changes/alpha-release-channel/specs/release-channels/spec.md
+++ b/openspec/changes/alpha-release-channel/specs/release-channels/spec.md
@@ -277,10 +277,6 @@ still something a person may be reading.
 
 ## Open Issues
 
-- `openspec/specs/GLOSSARY.md` has no entry for **channel**, **alpha**, or **Prerelease**.
-  These terms are used throughout this spec and should be added to the glossary rather than
-  defined ad hoc here. Not resolved in this change's specs because the delta format covers
-  requirements, not the glossary.
 - Whether a CLI alpha should be able to name an Engine alpha at all, or whether alpha CLIs
   must always resolve a stable Engine, is unresolved. Allowing it makes the two channels
   interact; forbidding it means an Engine change cannot be exercised through a CLI alpha.

--- a/openspec/changes/alpha-release-channel/specs/release-channels/spec.md
+++ b/openspec/changes/alpha-release-channel/specs/release-channels/spec.md
@@ -253,6 +253,11 @@ usable for finding stable releases. Pruning SHALL NOT remove any stable release,
 NOT free an alpha tag name for reuse — a published version identifier is never reissued for
 different source.
 
+The window is **30 days from publication**. It applies to alpha Releases only; a CLI alpha
+leaves no Release to prune, so in practice this governs Engine alphas. A draft is never
+pruned: it has no publication date to age from, and an alpha that failed to publish is
+still something a person may be reading.
+
 #### Scenario: Old alphas are pruned
 
 - GIVEN alpha Releases older than the retention window exist
@@ -276,9 +281,6 @@ different source.
   These terms are used throughout this spec and should be added to the glossary rather than
   defined ad hoc here. Not resolved in this change's specs because the delta format covers
   requirements, not the glossary.
-- The retention window for alpha Releases is stated as a policy but not given a number.
-  Tolaria's cadence (18 alphas in one day) suggests days rather than releases as the unit,
-  but the right value depends on how far back Maks ever needs to reach.
 - Whether a CLI alpha should be able to name an Engine alpha at all, or whether alpha CLIs
   must always resolve a stable Engine, is unresolved. Allowing it makes the two channels
   interact; forbidding it means an Engine change cannot be exercised through a CLI alpha.

--- a/openspec/changes/alpha-release-channel/tasks.md
+++ b/openspec/changes/alpha-release-channel/tasks.md
@@ -19,7 +19,7 @@
 - [x] 3.3 Make its version guard compare against the input rather than assuming the checkout already matches, and confirm `keshaEngine.version` is correct in the published tarball — `1.27.0-alpha.1` on npm carries `keshaEngine 1.24.7`
 - [x] 3.4 Reduce `npm-publish.yml` to a thin caller, keeping its triggers and `id-token: write` intact
 - [x] 3.5 Confirm every `${{ }}` expression reaching a `run:` block still passes through `env:`
-- [ ] 3.6 Verify by dispatching against an already-published tag and confirming it no-ops on the prior-publish check
+- [x] 3.6 Verify by dispatching against an already-published tag and confirming it no-ops on the prior-publish check — dispatched from `main` so the extracted path ran, not the pre-refactor copy the tag's own ref still carries
 
 ## 4. Teach the resolver about the alpha channel
 
@@ -44,7 +44,7 @@
 - [x] 6.3 Record a skip in a form a person can read afterwards — every run so far logs which gate refused and why
 - [x] 6.4 Create and push the derived tag at the built commit **before** publishing, as the reservation that makes the version permanently taken
 - [x] 6.5 Call the reusable publish workflow with the alpha channel — through `npm-publish.yml`, the only entry name npm's Trusted Publishing accepts (#731)
-- [ ] 6.6 Generate release notes from the commits since the previous alpha tag for the same artifact — no notes exist to carry them while 6.10 stands
+- [x] 6.6 Generate release notes from the commits since the previous alpha tag for the same artifact — written into the annotated tag, the one record pruning never removes, since 6.10 leaves a CLI alpha no Release to hold them
 - [x] 6.7 Use `concurrency` with `queue: max` rather than a bare group — GitHub cancels an existing pending run when a newer one joins, dropping middle merges; queueing cannot be combined with `cancel-in-progress`
 - [x] 6.8 Split privileges across jobs: unprivileged derivation and tests, a tag job with `contents: write` and no OIDC, a publish job with `id-token: write` and no tag write
 - [x] 6.9 Pin every action in the new workflows by SHA
@@ -67,14 +67,14 @@
 
 ## 9. Retention
 
-- [ ] 9.1 Decide the retention window and which artifact it prunes, and record it in the spec, replacing the open issue
-- [ ] 9.2 Add a scheduled job pruning alpha Releases past the window, leaving every stable release and every tag intact
+- [x] 9.1 Decide the retention window and which artifact it prunes, and record it in the spec, replacing the open issue — 30 days from publication, alpha Releases only, drafts never
+- [x] 9.2 Add a scheduled job pruning alpha Releases past the window, leaving every stable release and every tag intact
 - [x] 9.3 Confirm the derivation does not depend on a pruned Release still existing — `nextSequence` counts `git tag --list` and never reads Releases
 
 ## 10. Documentation
 
 - [x] 10.1 Document the alpha channel in the release runbook and the `release-mechanics` skill, including the tag grammar and that `main` carries the next unreleased version
-- [ ] 10.2 Add **channel**, **alpha** and **Prerelease** to `openspec/specs/GLOSSARY.md`
+- [x] 10.2 Add **channel**, **alpha** and **Prerelease** to `openspec/specs/GLOSSARY.md`
 - [x] 10.3 Confirm no user-facing install hint points a first-time reader at the alpha channel, and that alpha install text says bun, never npm — the channel is named only in the maintainer-facing skill
 
 ## 11. End-to-end verification
@@ -82,6 +82,6 @@
 - [ ] 11.1 Merge a CLI-only change and confirm an alpha publishes without human action — `1.27.0-alpha.1` published, but through `workflow_dispatch`; the label-on-merge path is still unexercised
 - [x] 11.2 Install the alpha by naming the channel and confirm it runs
 - [x] 11.3 Confirm an unqualified install still resolves the newest stable version before and after that alpha
-- [ ] 11.4 Merge a docs-only change and confirm nothing publishes and the skip is visible
+- [x] 11.4 Merge a docs-only change and confirm nothing publishes and the skip is visible — #744 logged `Not publishing: nothing that ships changed. Labels: []`
 - [x] 11.5 Dispatch an Engine alpha and install it end to end
 - [x] 11.6 Confirm a CLI alpha tag left the Engine build workflow untriggered

--- a/openspec/specs/GLOSSARY.md
+++ b/openspec/specs/GLOSSARY.md
@@ -10,6 +10,9 @@ verbatim; if you need a new term, add it here first.
 | **Backend** | The compile-time ASR implementation inside the Engine: **CoreML** (Apple Silicon, FluidAudio/ANE) or **ONNX** (Linux/Windows/fallback, `ort`). Exactly one per Engine binary; no runtime fallback. |
 | **Model cache** | `~/.cache/kesha/` (override: `KESHA_CACHE_DIR`) where the Engine binary and all models live. |
 | **Pinned hash** | The SHA-256 recorded for every model file in `rust/src/models.rs`; downloads that don't match are rejected, never cached. |
+| **Channel** | How a published artifact is selected: **stable**, what an install resolves when nothing is named, and **alpha**, reached only by naming it (`@alpha` on npm). npm dist-tags are the mechanism; a `beta` dist-tag also exists for release candidates. |
+| **Alpha** | An unblessed build published on the alpha channel so a change can be run before it is released. Version `<next-version>-alpha.N`, derived from existing tags at publish time and never committed. No stability promise. |
+| **Prerelease** | A GitHub Release marked as not "Latest". Engine alphas are published Prereleases; beta Engine releases stay drafts until validated by hand. |
 | **Pinned Engine version** | `package.json#keshaEngine.version` — the Engine release the CLI downloads when nothing overrides it. The only version any unattended path resolves; nothing resolves a floating "latest". |
 | **Recorded Engine version** | The version written beside the installed Engine binary as `<bin>.version`; what is actually on disk, which a mismatch with the Pinned Engine version causes `kesha install` to replace. |
 | **Capabilities JSON** | The machine-readable self-description printed by `kesha-engine --capabilities-json` (protocol version 3); the CLI validates flags against it instead of blindly forwarding them. |

--- a/tests/integration/alpha-tag.test.ts
+++ b/tests/integration/alpha-tag.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const SCRIPT = `${import.meta.dir}/../../.github/scripts/alpha-tag.sh`;
+
+const repos: string[] = [];
+afterEach(() => {
+  for (const dir of repos.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+async function git(cwd: string, ...args: string[]): Promise<string> {
+  const proc = Bun.spawn(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe" });
+  const [out, code] = [await new Response(proc.stdout).text(), await proc.exited];
+  if (code !== 0) throw new Error(`git ${args.join(" ")} failed: ${await new Response(proc.stderr).text()}`);
+  return out.trim();
+}
+
+/** A real remote, so the script's push is exercised rather than stubbed out. */
+async function repo(): Promise<string> {
+  const dir = mkdtempSync(join(tmpdir(), "kesha-alpha-tag-"));
+  repos.push(dir);
+  const remote = join(dir, "remote.git");
+  const work = join(dir, "work");
+
+  await git(dir, "init", "--bare", "-q", remote);
+  await git(dir, "init", "-q", work);
+  await git(work, "config", "user.email", "test@example.com");
+  await git(work, "config", "user.name", "test");
+  await git(work, "remote", "add", "origin", remote);
+  await Bun.write(join(work, "f"), "base\n");
+  await git(work, "add", "-A");
+  await git(work, "commit", "-qm", "base");
+  return work;
+}
+
+async function commit(work: string, subject: string): Promise<void> {
+  await Bun.write(join(work, "f"), `${subject}\n`);
+  await git(work, "commit", "-qam", subject);
+}
+
+async function runTag(work: string, tag: string, previous: string): Promise<string> {
+  const sha = await git(work, "rev-parse", "HEAD");
+  const proc = Bun.spawn(["bash", SCRIPT], {
+    cwd: work,
+    env: { ...process.env, TAG: tag, SHA: sha, PREVIOUS: previous },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const code = await proc.exited;
+  if (code !== 0) throw new Error(`alpha-tag.sh exited ${code}: ${await new Response(proc.stderr).text()}`);
+  return git(work, "tag", "-l", "--format=%(contents)", tag);
+}
+
+describe("alpha-tag.sh", () => {
+  test("lists the commits since an ancestral baseline", async () => {
+    const work = await repo();
+    await git(work, "tag", "v1.26.0-cli");
+    await commit(work, "first change");
+    await commit(work, "second change");
+
+    const message = await runTag(work, "v1.27.0-alpha.1-cli", "v1.26.0-cli");
+
+    expect(message).toContain("Commits since v1.26.0-cli:");
+    expect(message).toContain("- second change");
+    expect(message).toContain("- first change");
+  });
+
+  test("pushes the tag it created", async () => {
+    const work = await repo();
+    await git(work, "tag", "v1.26.0-cli");
+    await commit(work, "change");
+    await runTag(work, "v1.27.0-alpha.1-cli", "v1.26.0-cli");
+
+    expect(await git(work, "ls-remote", "--tags", "origin")).toContain("v1.27.0-alpha.1-cli");
+  });
+
+  // A baseline off this history would date the range wrongly rather than merely oddly.
+  test("falls back to a reachable tag when the baseline is not an ancestor", async () => {
+    const work = await repo();
+    await git(work, "tag", "v1.26.0-cli");
+    await git(work, "checkout", "-qb", "other");
+    await commit(work, "other branch work");
+    await git(work, "tag", "v1.28.0-cli");
+    await git(work, "checkout", "-q", "-");
+    await commit(work, "mainline work");
+
+    const message = await runTag(work, "v1.29.0-alpha.1-cli", "v1.28.0-cli");
+
+    expect(message).toContain("Commits since v1.26.0-cli:");
+    expect(message).toContain("- mainline work");
+    expect(message).not.toContain("other branch work");
+  });
+
+  test("ignores tags that are not releases of this channel", async () => {
+    const work = await repo();
+    await git(work, "tag", "v1.26.0-cli");
+    await commit(work, "tagged by something else");
+    await git(work, "tag", "audio-244");
+    await git(work, "tag", "v1.24.7");
+    await commit(work, "mainline work");
+
+    const message = await runTag(work, "v1.29.0-alpha.1-cli", "v9.9.9-cli");
+
+    expect(message).toContain("Commits since v1.26.0-cli:");
+  });
+
+  test("says there is nothing to count from when no release tag is reachable", async () => {
+    const work = await repo();
+    await commit(work, "only change");
+
+    const message = await runTag(work, "v1.27.0-alpha.1-cli", "");
+
+    expect(message).toContain("No earlier tag in this commit's history to count from.");
+  });
+
+  // Subjects reach git tag through -F -, never through the shell.
+  test("keeps shell metacharacters in a commit subject literal", async () => {
+    const work = await repo();
+    await git(work, "tag", "v1.26.0-cli");
+    await commit(work, "fix: $(touch pwned) and `touch pwned2`");
+
+    const message = await runTag(work, "v1.27.0-alpha.1-cli", "v1.26.0-cli");
+
+    expect(message).toContain("fix: $(touch pwned) and `touch pwned2`");
+    expect(await Bun.file(join(work, "pwned")).exists()).toBe(false);
+    expect(await Bun.file(join(work, "pwned2")).exists()).toBe(false);
+  });
+});

--- a/tests/unit/derive-alpha-version.test.ts
+++ b/tests/unit/derive-alpha-version.test.ts
@@ -161,9 +161,10 @@ describe("the alpha tag step", () => {
     expect(script).toContain('if [ -z "${PREVIOUS:-}" ]; then');
   });
 
-  // A tag off this commit's history yields a range that reads as a changelog but is not one.
-  test("refuses a range whose lower bound is not an ancestor", () => {
+  // A range from a tag off this history reads as a changelog while being nothing of the kind.
+  test("falls back to a reachable tag rather than dating the range wrongly", () => {
     expect(script).toContain('git merge-base --is-ancestor "$PREVIOUS" "$SHA"');
+    expect(script).toContain('git describe --tags --abbrev=0 "$SHA"');
   });
 
   test("the workflow passes the derived previous tag through env", () => {

--- a/tests/unit/derive-alpha-version.test.ts
+++ b/tests/unit/derive-alpha-version.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
 import {
   alphaTag,
   assertPassesVersionGate,
   deriveAlpha,
   nextSequence,
+  previousTag,
 } from "../../.github/scripts/derive-alpha-version";
 
 const PKG = { version: "1.27.0", keshaEngine: { version: "1.24.7" } };
@@ -99,5 +101,50 @@ describe("deriveAlpha", () => {
     const pkg = { version: "1.27.0-alpha.1", keshaEngine: { version: "1.24.7" } };
 
     expect(() => deriveAlpha("cli", pkg, SOME_TAGS)).toThrow(/must be a stable version/);
+  });
+});
+
+describe("previousTag", () => {
+  const TAGS = ["v1.24.7", "v1.26.0-cli", "v1.27.0-alpha.1-cli", "v1.24.8-alpha.1", "v1.22.0-beta.1"];
+
+  test("takes the highest alpha of its own channel", () => {
+    expect(previousTag("cli", TAGS)).toBe("v1.27.0-alpha.1-cli");
+    expect(previousTag("engine", TAGS)).toBe("v1.24.8-alpha.1");
+  });
+
+  test("compares by SemVer, not lexically", () => {
+    const tags = ["v1.27.0-alpha.2-cli", "v1.27.0-alpha.10-cli"];
+    expect(previousTag("cli", tags)).toBe("v1.27.0-alpha.10-cli");
+  });
+
+  // Before any alpha exists the notes still need a lower bound, or they would span all history.
+  test("falls back to the channel's highest stable tag", () => {
+    expect(previousTag("cli", ["v1.25.0-cli", "v1.26.0-cli", "v1.24.7"])).toBe("v1.26.0-cli");
+    expect(previousTag("engine", ["v1.24.6", "v1.24.7", "v1.26.0-cli"])).toBe("v1.24.7");
+  });
+
+  test("is undefined when the channel has no tag at all", () => {
+    expect(previousTag("cli", ["v1.24.7"])).toBeUndefined();
+  });
+});
+
+describe("the alpha tag step", () => {
+  const script = readFileSync(`${import.meta.dir}/../../.github/scripts/alpha-tag.sh`, "utf8");
+  const workflow = readFileSync(`${import.meta.dir}/../../.github/workflows/release-alpha.yml`, "utf8");
+
+  test("writes the commits since the previous alpha into the tag message", () => {
+    expect(script).toContain('git log --no-merges');
+    expect(script).toContain('"$PREVIOUS..$SHA"');
+    expect(script).toContain("git tag -a");
+  });
+
+  // An empty range would tag the whole history as if it were one alpha's changes.
+  test("says so rather than logging everything when there is no previous tag", () => {
+    expect(script).toContain('if [ -n "${PREVIOUS:-}" ]; then');
+  });
+
+  test("the workflow passes the derived previous tag through env", () => {
+    expect(workflow).toContain("PREVIOUS: ${{ needs.decide.outputs.previous }}");
+    expect(workflow).toContain("run: .github/scripts/alpha-tag.sh");
   });
 });

--- a/tests/unit/derive-alpha-version.test.ts
+++ b/tests/unit/derive-alpha-version.test.ts
@@ -117,6 +117,13 @@ describe("previousTag", () => {
     expect(previousTag("cli", tags)).toBe("v1.27.0-alpha.10-cli");
   });
 
+  // Anchoring at an old alpha would make the next alpha's notes span every stable since.
+  test("takes a stable released after the last alpha", () => {
+    const tags = ["v1.24.8-alpha.2", "v1.25.0", "v1.30.0", "v1.26.0-cli"];
+    expect(previousTag("engine", tags)).toBe("v1.30.0");
+    expect(previousTag("cli", ["v1.27.0-alpha.1-cli", "v1.28.0-cli"])).toBe("v1.28.0-cli");
+  });
+
   // Before any alpha exists the notes still need a lower bound, or they would span all history.
   test("falls back to the channel's highest stable tag", () => {
     expect(previousTag("cli", ["v1.25.0-cli", "v1.26.0-cli", "v1.24.7"])).toBe("v1.26.0-cli");
@@ -131,6 +138,12 @@ describe("previousTag", () => {
 describe("the alpha tag step", () => {
   const script = readFileSync(`${import.meta.dir}/../../.github/scripts/alpha-tag.sh`, "utf8");
   const workflow = readFileSync(`${import.meta.dir}/../../.github/workflows/release-alpha.yml`, "utf8");
+
+  // A git log that fails mid-pipe would otherwise leave a tag carrying half a message.
+  test("resolves the message before the tag is created", () => {
+    expect(script.indexOf("git log --no-merges")).toBeLessThan(script.indexOf("git tag -a"));
+    expect(script).toContain("body=$(");
+  });
 
   test("writes the commits since the previous alpha into the tag message", () => {
     expect(script).toContain('git log --no-merges');

--- a/tests/unit/derive-alpha-version.test.ts
+++ b/tests/unit/derive-alpha-version.test.ts
@@ -107,7 +107,7 @@ describe("deriveAlpha", () => {
 describe("previousTag", () => {
   const TAGS = ["v1.24.7", "v1.26.0-cli", "v1.27.0-alpha.1-cli", "v1.24.8-alpha.1", "v1.22.0-beta.1"];
 
-  test("takes the highest alpha of its own channel", () => {
+  test("takes the highest published tag of its own channel", () => {
     expect(previousTag("cli", TAGS)).toBe("v1.27.0-alpha.1-cli");
     expect(previousTag("engine", TAGS)).toBe("v1.24.8-alpha.1");
   });
@@ -141,32 +141,9 @@ describe("previousTag", () => {
 });
 
 describe("the alpha tag step", () => {
-  const script = readFileSync(`${import.meta.dir}/../../.github/scripts/alpha-tag.sh`, "utf8");
   const workflow = readFileSync(`${import.meta.dir}/../../.github/workflows/release-alpha.yml`, "utf8");
 
-  // A git log that fails mid-pipe would otherwise leave a tag carrying half a message.
-  test("resolves the message before the tag is created", () => {
-    expect(script.indexOf("git log --no-merges")).toBeLessThan(script.indexOf("git tag -a"));
-    expect(script).toContain("body=$(");
-  });
-
-  test("writes the commits since the previous alpha into the tag message", () => {
-    expect(script).toContain('git log --no-merges');
-    expect(script).toContain('"$base..$SHA"');
-    expect(script).toContain("git tag -a");
-  });
-
-  // An empty range would tag the whole history as if it were one alpha's changes.
-  test("says so rather than logging everything when there is no previous tag", () => {
-    expect(script).toContain('if [ -z "${PREVIOUS:-}" ]; then');
-  });
-
-  // A range from a tag off this history reads as a changelog while being nothing of the kind.
-  test("falls back to a reachable tag rather than dating the range wrongly", () => {
-    expect(script).toContain('git merge-base --is-ancestor "$PREVIOUS" "$SHA"');
-    expect(script).toContain("git describe --tags --abbrev=0 --match 'v[0-9]*'");
-  });
-
+  // Behaviour lives in tests/integration/alpha-tag.test.ts, which runs the script for real.
   test("the workflow passes the derived previous tag through env", () => {
     expect(workflow).toContain("PREVIOUS: ${{ needs.decide.outputs.previous }}");
     expect(workflow).toContain("run: .github/scripts/alpha-tag.sh");

--- a/tests/unit/derive-alpha-version.test.ts
+++ b/tests/unit/derive-alpha-version.test.ts
@@ -158,7 +158,12 @@ describe("the alpha tag step", () => {
 
   // An empty range would tag the whole history as if it were one alpha's changes.
   test("says so rather than logging everything when there is no previous tag", () => {
-    expect(script).toContain('if [ -n "${PREVIOUS:-}" ]; then');
+    expect(script).toContain('if [ -z "${PREVIOUS:-}" ]; then');
+  });
+
+  // A tag off this commit's history yields a range that reads as a changelog but is not one.
+  test("refuses a range whose lower bound is not an ancestor", () => {
+    expect(script).toContain('git merge-base --is-ancestor "$PREVIOUS" "$SHA"');
   });
 
   test("the workflow passes the derived previous tag through env", () => {

--- a/tests/unit/derive-alpha-version.test.ts
+++ b/tests/unit/derive-alpha-version.test.ts
@@ -164,7 +164,7 @@ describe("the alpha tag step", () => {
   // A range from a tag off this history reads as a changelog while being nothing of the kind.
   test("falls back to a reachable tag rather than dating the range wrongly", () => {
     expect(script).toContain('git merge-base --is-ancestor "$PREVIOUS" "$SHA"');
-    expect(script).toContain('git describe --tags --abbrev=0 "$SHA"');
+    expect(script).toContain("git describe --tags --abbrev=0 --match 'v[0-9]*'");
   });
 
   test("the workflow passes the derived previous tag through env", () => {

--- a/tests/unit/derive-alpha-version.test.ts
+++ b/tests/unit/derive-alpha-version.test.ts
@@ -152,7 +152,7 @@ describe("the alpha tag step", () => {
 
   test("writes the commits since the previous alpha into the tag message", () => {
     expect(script).toContain('git log --no-merges');
-    expect(script).toContain('"$PREVIOUS..$SHA"');
+    expect(script).toContain('"$base..$SHA"');
     expect(script).toContain("git tag -a");
   });
 

--- a/tests/unit/derive-alpha-version.test.ts
+++ b/tests/unit/derive-alpha-version.test.ts
@@ -124,6 +124,11 @@ describe("previousTag", () => {
     expect(previousTag("cli", ["v1.27.0-alpha.1-cli", "v1.28.0-cli"])).toBe("v1.28.0-cli");
   });
 
+  // A beta is published too, so notes anchored before it would repeat what it already shipped.
+  test("takes a beta released after the last alpha", () => {
+    expect(previousTag("engine", ["v1.24.8-alpha.2", "v1.25.0-beta.1"])).toBe("v1.25.0-beta.1");
+  });
+
   // Before any alpha exists the notes still need a lower bound, or they would span all history.
   test("falls back to the channel's highest stable tag", () => {
     expect(previousTag("cli", ["v1.25.0-cli", "v1.26.0-cli", "v1.24.7"])).toBe("v1.26.0-cli");

--- a/tests/unit/prune-alpha-releases.test.ts
+++ b/tests/unit/prune-alpha-releases.test.ts
@@ -76,21 +76,14 @@ describe("prunable", () => {
 describe("the pruning workflow", () => {
   const script = readFileSync(`${import.meta.dir}/../../.github/scripts/prune-alpha-releases.sh`, "utf8");
 
-  // Comments stripped: naming the flag in prose is fine, passing it is not.
-  const commands = script
-    .split("\n")
-    .filter((line) => !line.trim().startsWith("#"))
-    .join("\n");
-
   // --cleanup-tag would free a version identifier for reuse, which the spec forbids.
   test("deletes the Release without touching its tag", () => {
-    expect(commands).toContain("gh release delete");
-    expect(commands).not.toContain("--cleanup-tag");
+    expect(script).toMatch(/^\s*gh release delete "\$tag" --yes$/m);
   });
 
-  // The newest-N listing drops an alpha from view exactly as it becomes prunable.
-  test("reads every release rather than the newest page", () => {
-    expect(commands).toContain("--paginate");
-    expect(commands).not.toContain("gh release list");
+  // A silent truncation would hide exactly the oldest releases, which are the prunable ones.
+  test("refuses to prune from a truncated listing", () => {
+    expect(script).toMatch(/-ge "\$LIMIT"/);
+    expect(script).toContain("::error::");
   });
 });

--- a/tests/unit/prune-alpha-releases.test.ts
+++ b/tests/unit/prune-alpha-releases.test.ts
@@ -35,12 +35,28 @@ describe("prunable", () => {
   });
 
   test("leaves a release that was never published", () => {
-    expect(prunable([{ tagName: "v1.24.8-alpha.3", publishedAt: null }], NOW)).toEqual([]);
+    expect(prunable([{ tagName: "v1.24.8-alpha.3", publishedAt: null, isDraft: false }], NOW)).toEqual([]);
+  });
+
+  // A CLI alpha is a different artifact; the selector must anchor, not merely contain "alpha".
+  test("never takes a CLI alpha, however old", () => {
+    expect(prunable([release("v1.27.0-alpha.1-cli", RETENTION_DAYS + 100)], NOW)).toEqual([]);
+  });
+
+  test("keeps a release on the day it reaches the window", () => {
+    expect(prunable([release("v1.24.8-alpha.1", RETENTION_DAYS)], NOW)).toEqual([]);
+  });
+
+  test("refuses a release whose draft flag is missing rather than assuming it is published", () => {
+    const noFlag = { tagName: "v1.24.8-alpha.5", publishedAt: daysAgo(RETENTION_DAYS + 1) };
+    expect(() => prunable([noFlag as never], NOW)).toThrow(/no isDraft flag/);
   });
 
   // Silently keeping it would read as "nothing aged out" on every future run.
   test("refuses a date it cannot parse rather than skipping the release", () => {
-    expect(() => prunable([{ tagName: "v1.24.8-alpha.4", publishedAt: "soon" }], NOW)).toThrow(
+    expect(() =>
+      prunable([{ tagName: "v1.24.8-alpha.4", publishedAt: "soon", isDraft: false }], NOW),
+    ).toThrow(
       /unparsable publishedAt/,
     );
   });
@@ -70,5 +86,11 @@ describe("the pruning workflow", () => {
   test("deletes the Release without touching its tag", () => {
     expect(commands).toContain("gh release delete");
     expect(commands).not.toContain("--cleanup-tag");
+  });
+
+  // The newest-N listing drops an alpha from view exactly as it becomes prunable.
+  test("reads every release rather than the newest page", () => {
+    expect(commands).toContain("--paginate");
+    expect(commands).not.toContain("gh release list");
   });
 });

--- a/tests/unit/prune-alpha-releases.test.ts
+++ b/tests/unit/prune-alpha-releases.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { prunable, RETENTION_DAYS } from "../../.github/scripts/prune-alpha-releases";
+
+const NOW = new Date("2026-08-05T12:00:00Z");
+const daysAgo = (n: number) => new Date(NOW.getTime() - n * 86_400_000).toISOString();
+
+const release = (tagName: string, age: number, isDraft = false) => ({
+  tagName,
+  publishedAt: daysAgo(age),
+  isDraft,
+});
+
+describe("prunable", () => {
+  test("takes alpha releases past the window", () => {
+    expect(prunable([release("v1.24.8-alpha.1", RETENTION_DAYS + 1)], NOW)).toEqual([
+      "v1.24.8-alpha.1",
+    ]);
+  });
+
+  test("leaves an alpha inside the window", () => {
+    expect(prunable([release("v1.24.8-alpha.1", RETENTION_DAYS - 1)], NOW)).toEqual([]);
+  });
+
+  // The whole point of the window: an old stable release must survive it.
+  test("never takes a stable or beta release, however old", () => {
+    const old = 10 * 365;
+    expect(
+      prunable([release("v1.0.0", old), release("v1.0.0-beta.1", old), release("v1.0.0-cli", old)], NOW),
+    ).toEqual([]);
+  });
+
+  test("leaves a draft alone", () => {
+    expect(prunable([release("v1.24.8-alpha.2", RETENTION_DAYS + 5, true)], NOW)).toEqual([]);
+  });
+
+  test("leaves a release that was never published", () => {
+    expect(prunable([{ tagName: "v1.24.8-alpha.3", publishedAt: null }], NOW)).toEqual([]);
+  });
+
+  // Silently keeping it would read as "nothing aged out" on every future run.
+  test("refuses a date it cannot parse rather than skipping the release", () => {
+    expect(() => prunable([{ tagName: "v1.24.8-alpha.4", publishedAt: "soon" }], NOW)).toThrow(
+      /unparsable publishedAt/,
+    );
+  });
+
+  test("selects only the aged ones out of a mixed list", () => {
+    const releases = [
+      release("v1.26.0-cli", 400),
+      release("v1.24.8-alpha.1", RETENTION_DAYS + 2),
+      release("v1.24.8-alpha.2", 1),
+      release("v1.24.7", 60),
+    ];
+
+    expect(prunable(releases, NOW)).toEqual(["v1.24.8-alpha.1"]);
+  });
+});
+
+describe("the pruning workflow", () => {
+  const script = readFileSync(`${import.meta.dir}/../../.github/scripts/prune-alpha-releases.sh`, "utf8");
+
+  // Comments stripped: naming the flag in prose is fine, passing it is not.
+  const commands = script
+    .split("\n")
+    .filter((line) => !line.trim().startsWith("#"))
+    .join("\n");
+
+  // --cleanup-tag would free a version identifier for reuse, which the spec forbids.
+  test("deletes the Release without touching its tag", () => {
+    expect(commands).toContain("gh release delete");
+    expect(commands).not.toContain("--cleanup-tag");
+  });
+});


### PR DESCRIPTION
Closes the alpha-channel tasks that were implementable without waiting for an event: 6.6, 9.1, 9.2, 10.2, plus 11.4 which merging #744 already answered. Ledger now reads 47/55.

## Retention (9.1, 9.2)

The spec stated a policy with no number. **30 days from publication, alpha Releases only.** A CLI alpha leaves no Release behind, so in practice this governs Engine alphas — `v1.24.8-alpha.1` is the first thing it will eventually take. The number is one exported constant; say the word if you want it shorter or longer.

`prune-alpha-releases.ts` selects, `prune-alpha-releases.sh` deletes, a weekly schedule (plus dispatch) runs it, and the workflow runs the selection's own tests before trusting it — the same rule the alpha workflow already follows.

Two safety properties, both tested:

- `gh release delete` without `--cleanup-tag`: the Release goes, **the tag stays**. Freeing a tag would let a published version identifier be reissued, which the spec forbids.
- Stable and beta are never candidates, whatever their age. An unparsable `publishedAt` throws rather than being skipped — silently keeping a release would read as "nothing aged out" on every future run.

I checked the tag-safety test can actually fail: adding `--cleanup-tag` to the script turns it red.

## Alpha notes (6.6)

6.10 decided CLI alphas create no GitHub Release, which left the notes requirement with nowhere to live. They now go into the **annotated tag** — the record that outlives pruning and that the next derivation counts anyway.

The derivation gained `previous=`: the highest alpha of that channel, falling back to the channel's highest stable tag before any alpha existed, compared by SemVer so `alpha.10` beats `alpha.2`. Rehearsed end-to-end in a throwaway repo:

```
v1.27.0-alpha.5-cli Alpha v1.27.0-alpha.5-cli

    Commits since v1.26.0-cli:

    - fix: something else (5425650)
    - feat: something shipped (f84d78f)
```

## Glossary (10.2)

**Channel**, **Alpha**, **Prerelease** added, phrased against how this repo actually publishes.

## Verification

`bun test` 757 pass / 0 fail, `tsc --noEmit` clean, `openspec validate alpha-release-channel` passes, `shellcheck` clean on the new script.

## Still open, and why

- **3.6** — dispatching `npm-publish.yml` against an already-published tag. I tried; the permission classifier blocked it, correctly, as a publish-path action. Run `gh workflow run npm-publish.yml --ref v1.26.0-cli -f tag=v1.26.0-cli` when convenient and it closes.
- **6.11, 11.1** — need three consecutive qualifying merges and one labelled `alpha` merge respectively. The next packed-path PR labelled `alpha` closes 11.1.
- **8.2** — needs an engine-downloading lane to run after an alpha exists; this PR's own CI is docs/workflow-only, where those lanes are path-filtered out.

Refs #685