### PR TITLE
refactor(release): one script creates every annotated tag

### DIFF
--- a/.github/scripts/alpha-tag.sh
+++ b/.github/scripts/alpha-tag.sh
@@ -1,10 +1,7 @@
 #!/usr/bin/env bash
 # The tag carries the notes: a CLI alpha creates no Release to hold them, and the tag is the
-# one record pruning can never remove (#685). `-F -` keeps a subject line's metachars literal.
+# one record pruning can never remove (#685).
 set -euo pipefail
-
-git config user.name "github-actions[bot]"
-git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
 # This channel's release shapes only: `audio-244` exists here, and so do the other artifact's tags.
 if [ "${TAG%-cli}" != "$TAG" ]; then
@@ -28,6 +25,5 @@ else
   body="No earlier tag in this commit's history to count from."
 fi
 
-printf 'Alpha %s\n\n%s\n' "$TAG" "$body" | git tag -a "$TAG" --cleanup=verbatim -F - "$SHA"
-
-git push origin "refs/tags/$TAG"
+# Sibling, not cwd-relative: the caller's working directory is the repository being tagged.
+printf 'Alpha %s\n\n%s\n' "$TAG" "$body" | "$(dirname "$0")/push-annotated-tag.sh"

--- a/.github/scripts/push-annotated-tag.sh
+++ b/.github/scripts/push-annotated-tag.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Create an annotated tag from a message on stdin and push it. `TAG` names it; `SHA` picks the
+# commit, defaulting to HEAD.
+#
+# `-F -` reads the message from stdin, so newlines and shell metacharacters in it survive
+# untouched — passing it through argv with `-m` would re-expose what `env:` was protecting
+# (#291). `--cleanup=verbatim` keeps the `#` heading lines a release body needs (#651).
+set -euo pipefail
+
+git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+git tag -a "$TAG" --cleanup=verbatim -F - ${SHA:+"$SHA"}
+git push origin "refs/tags/$TAG"

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -64,18 +64,11 @@ jobs:
       # `contents: write`; an attacker-controlled value containing `$(cmd)` or
       # `;` would otherwise execute arbitrary code with that permission. Pattern
       # mirrors `.github/workflows/npm-publish.yml::Resolve tag` (post-#291).
-      # `git tag -F -` reads the message from stdin so newlines/shell metachars
-      # in INPUT_NOTES survive untouched (argv via `-m` would be a re-exposure).
-      # Default cleanup would strip the `#` heading lines the release body needs (#651).
       - name: Create and push annotated tag
         env:
-          INPUT_TAG: ${{ inputs.tag }}
+          TAG: ${{ inputs.tag }}
           INPUT_NOTES: ${{ inputs.notes }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          printf '%s' "$INPUT_NOTES" | git tag -a "$INPUT_TAG" --cleanup=verbatim -F -
-          git push origin "refs/tags/$INPUT_TAG"
+        run: printf '%s' "$INPUT_NOTES" | .github/scripts/push-annotated-tag.sh
 
       # A GITHUB_TOKEN push never fires `on.push.tags`; workflow_dispatch is the exception (#651).
       - name: Trigger build + release for the new tag

--- a/tests/helpers/git-repo.ts
+++ b/tests/helpers/git-repo.ts
@@ -1,0 +1,40 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const created: string[] = [];
+
+export async function git(cwd: string, ...args: string[]): Promise<string> {
+  const proc = Bun.spawn(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe" });
+  const out = await new Response(proc.stdout).text();
+  if ((await proc.exited) !== 0) {
+    throw new Error(`git ${args.join(" ")} failed: ${await new Response(proc.stderr).text()}`);
+  }
+  return out.trim();
+}
+
+/** A work tree with a real bare remote, so a script's push is exercised rather than stubbed. */
+export async function gitRepoWithRemote(): Promise<string> {
+  const dir = mkdtempSync(join(tmpdir(), "kesha-git-"));
+  created.push(dir);
+  const work = join(dir, "work");
+
+  await git(dir, "init", "--bare", "-q", join(dir, "remote.git"));
+  await git(dir, "init", "-q", work);
+  await git(work, "config", "user.email", "test@example.com");
+  await git(work, "config", "user.name", "test");
+  await git(work, "remote", "add", "origin", join(dir, "remote.git"));
+  await Bun.write(join(work, "f"), "base\n");
+  await git(work, "add", "-A");
+  await git(work, "commit", "-qm", "base");
+  return work;
+}
+
+export async function commit(work: string, subject: string): Promise<void> {
+  await Bun.write(join(work, "f"), `${subject}\n`);
+  await git(work, "commit", "-qam", subject);
+}
+
+export function cleanupGitRepos(): void {
+  for (const dir of created.splice(0)) rmSync(dir, { recursive: true, force: true });
+}

--- a/tests/integration/alpha-tag.test.ts
+++ b/tests/integration/alpha-tag.test.ts
@@ -1,44 +1,10 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { cleanupGitRepos, commit, git, gitRepoWithRemote } from "../helpers/git-repo";
 
 const SCRIPT = `${import.meta.dir}/../../.github/scripts/alpha-tag.sh`;
 
-const repos: string[] = [];
-afterEach(() => {
-  for (const dir of repos.splice(0)) rmSync(dir, { recursive: true, force: true });
-});
-
-async function git(cwd: string, ...args: string[]): Promise<string> {
-  const proc = Bun.spawn(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe" });
-  const [out, code] = [await new Response(proc.stdout).text(), await proc.exited];
-  if (code !== 0) throw new Error(`git ${args.join(" ")} failed: ${await new Response(proc.stderr).text()}`);
-  return out.trim();
-}
-
-/** A real remote, so the script's push is exercised rather than stubbed out. */
-async function repo(): Promise<string> {
-  const dir = mkdtempSync(join(tmpdir(), "kesha-alpha-tag-"));
-  repos.push(dir);
-  const remote = join(dir, "remote.git");
-  const work = join(dir, "work");
-
-  await git(dir, "init", "--bare", "-q", remote);
-  await git(dir, "init", "-q", work);
-  await git(work, "config", "user.email", "test@example.com");
-  await git(work, "config", "user.name", "test");
-  await git(work, "remote", "add", "origin", remote);
-  await Bun.write(join(work, "f"), "base\n");
-  await git(work, "add", "-A");
-  await git(work, "commit", "-qm", "base");
-  return work;
-}
-
-async function commit(work: string, subject: string): Promise<void> {
-  await Bun.write(join(work, "f"), `${subject}\n`);
-  await git(work, "commit", "-qam", subject);
-}
+afterEach(cleanupGitRepos);
 
 async function runTag(work: string, tag: string, previous: string): Promise<string> {
   const sha = await git(work, "rev-parse", "HEAD");
@@ -48,14 +14,15 @@ async function runTag(work: string, tag: string, previous: string): Promise<stri
     stdout: "pipe",
     stderr: "pipe",
   });
-  const code = await proc.exited;
-  if (code !== 0) throw new Error(`alpha-tag.sh exited ${code}: ${await new Response(proc.stderr).text()}`);
+  if ((await proc.exited) !== 0) {
+    throw new Error(`alpha-tag.sh failed: ${await new Response(proc.stderr).text()}`);
+  }
   return git(work, "tag", "-l", "--format=%(contents)", tag);
 }
 
 describe("alpha-tag.sh", () => {
   test("lists the commits since an ancestral baseline", async () => {
-    const work = await repo();
+    const work = await gitRepoWithRemote();
     await git(work, "tag", "v1.26.0-cli");
     await commit(work, "first change");
     await commit(work, "second change");
@@ -68,7 +35,7 @@ describe("alpha-tag.sh", () => {
   });
 
   test("pushes the tag it created", async () => {
-    const work = await repo();
+    const work = await gitRepoWithRemote();
     await git(work, "tag", "v1.26.0-cli");
     await commit(work, "change");
     await runTag(work, "v1.27.0-alpha.1-cli", "v1.26.0-cli");
@@ -78,7 +45,7 @@ describe("alpha-tag.sh", () => {
 
   // A baseline off this history would date the range wrongly rather than merely oddly.
   test("falls back to a reachable tag when the baseline is not an ancestor", async () => {
-    const work = await repo();
+    const work = await gitRepoWithRemote();
     await git(work, "tag", "v1.26.0-cli");
     await git(work, "checkout", "-qb", "other");
     await commit(work, "other branch work");
@@ -94,7 +61,7 @@ describe("alpha-tag.sh", () => {
   });
 
   test("ignores tags that are not releases of this channel", async () => {
-    const work = await repo();
+    const work = await gitRepoWithRemote();
     await git(work, "tag", "v1.26.0-cli");
     await commit(work, "tagged by something else");
     await git(work, "tag", "audio-244");
@@ -107,7 +74,7 @@ describe("alpha-tag.sh", () => {
   });
 
   test("says there is nothing to count from when no release tag is reachable", async () => {
-    const work = await repo();
+    const work = await gitRepoWithRemote();
     await commit(work, "only change");
 
     const message = await runTag(work, "v1.27.0-alpha.1-cli", "");
@@ -117,7 +84,7 @@ describe("alpha-tag.sh", () => {
 
   // Subjects reach git tag through -F -, never through the shell.
   test("keeps shell metacharacters in a commit subject literal", async () => {
-    const work = await repo();
+    const work = await gitRepoWithRemote();
     await git(work, "tag", "v1.26.0-cli");
     await commit(work, "fix: $(touch pwned) and `touch pwned2`");
 

--- a/tests/integration/push-annotated-tag.test.ts
+++ b/tests/integration/push-annotated-tag.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanupGitRepos, commit, git, gitRepoWithRemote } from "../helpers/git-repo";
+
+const SCRIPT = `${import.meta.dir}/../../.github/scripts/push-annotated-tag.sh`;
+
+afterEach(cleanupGitRepos);
+
+async function pushTag(work: string, message: string, env: Record<string, string>): Promise<number> {
+  const proc = Bun.spawn(["bash", SCRIPT], {
+    cwd: work,
+    env: { ...process.env, ...env },
+    stdin: new TextEncoder().encode(message),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return proc.exited;
+}
+
+describe("push-annotated-tag.sh", () => {
+  // Default cleanup strips them, and an engine release body is written in headings (#651).
+  test("keeps heading lines the release body needs", async () => {
+    const work = await gitRepoWithRemote();
+    const notes = "# Engine v1.24.8\n\n## Features\n\n- something\n";
+
+    expect(await pushTag(work, notes, { TAG: "v1.24.8" })).toBe(0);
+    expect(await git(work, "tag", "-l", "--format=%(contents)", "v1.24.8")).toContain("# Engine v1.24.8");
+    expect(await git(work, "tag", "-l", "--format=%(contents)", "v1.24.8")).toContain("## Features");
+  });
+
+  test("annotates rather than leaving a lightweight tag", async () => {
+    const work = await gitRepoWithRemote();
+    await pushTag(work, "notes\n", { TAG: "v1.24.8" });
+
+    expect(await git(work, "for-each-ref", "refs/tags/v1.24.8", "--format=%(objecttype)")).toBe("tag");
+  });
+
+  test("pushes the tag to origin", async () => {
+    const work = await gitRepoWithRemote();
+    await pushTag(work, "notes\n", { TAG: "v1.24.8" });
+
+    expect(await git(work, "ls-remote", "--tags", "origin")).toContain("refs/tags/v1.24.8");
+  });
+
+  test("tags HEAD when no commit is named", async () => {
+    const work = await gitRepoWithRemote();
+    await commit(work, "later work");
+    await pushTag(work, "notes\n", { TAG: "v1.24.8" });
+
+    expect(await git(work, "rev-list", "-n", "1", "v1.24.8")).toBe(await git(work, "rev-parse", "HEAD"));
+  });
+
+  test("tags the named commit when one is given", async () => {
+    const work = await gitRepoWithRemote();
+    const first = await git(work, "rev-parse", "HEAD");
+    await commit(work, "later work");
+    await pushTag(work, "notes\n", { TAG: "v1.24.8", SHA: first });
+
+    expect(await git(work, "rev-list", "-n", "1", "v1.24.8")).toBe(first);
+  });
+
+  // The message reaches git through stdin; argv would re-expose what `env:` protects (#291).
+  test("keeps shell metacharacters in the message literal", async () => {
+    const work = await gitRepoWithRemote();
+    await pushTag(work, "notes $(touch pwned) and `touch pwned2`\n", { TAG: "v1.24.8" });
+
+    expect(await git(work, "tag", "-l", "--format=%(contents)", "v1.24.8")).toContain("$(touch pwned)");
+    expect(await Bun.file(`${work}/pwned`).exists()).toBe(false);
+    expect(await Bun.file(`${work}/pwned2`).exists()).toBe(false);
+  });
+});


### PR DESCRIPTION
`build-engine.yml`'s tag job and `alpha-tag.sh` each carried the same four steps and the same two rationales for them: the bot identity, `git tag -a "$TAG" --cleanup=verbatim -F -`, and the push. Two copies of a mechanism that decides what a release tag contains, where a fix to one silently misses the other.

Both now call `.github/scripts/push-annotated-tag.sh` — message on stdin, name in `TAG`, optional `SHA` defaulting to HEAD. The workflow's inline block was four lines, over the repo's three-line rule for CI scripts; it is one line now.

## The rationale becomes tests

Both call sites explained in comments why `-F -` and `--cleanup=verbatim` matter. Comments do not fail when someone removes a flag, so the properties are now exercised against a throwaway repository with a real bare remote:

| Property | Why it matters |
|---|---|
| Heading lines survive | Default cleanup strips `#` lines, which is how engine release bodies are written (#651) |
| Tag is annotated, not lightweight | The message has nowhere to live otherwise |
| Tag reaches `origin` | The push is what reserves the version |
| Lands on HEAD, or on the named commit | `build-engine.yml` relies on the first, `alpha-tag.sh` on the second |
| Shell metacharacters stay literal | Message goes through stdin; argv would re-expose what `env:` protects (#291) |

Checked the first one can fail: removing `--cleanup=verbatim` turns it red.

The scratch-repo helper that both tag test files wanted moved to `tests/helpers/git-repo.ts`.

## About the label

Labelled `alpha` as requested. This PR touches only `.github/` and `tests/`, neither of which npm packs, so the alpha pipeline should log `Not publishing: nothing that ships changed. Labels: [alpha]` and publish nothing. That combination — label present, nothing shippable changed — is the one gate pairing the channel has not exercised yet; every skip so far had no label at all. It does **not** close task 11.1, which needs a merge that changes packed files.

## Verification

`bun test` 772 passed, `tsc --noEmit` clean, `shellcheck` clean on both scripts.

One pre-existing failure locally, `cli-contracts > diagnostic logs record successful install events without content`: it reproduces identically on `main` with none of these changes, and is the known macOS Gatekeeper timing flake, not a regression here.