### PR TITLE
chore(mcp): add glama.json to claim the Glama server listing

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["drakulavich"]
+}


### PR DESCRIPTION
Adds `glama.json` at the repo root so the Glama MCP directory can associate the listing with `drakulavich`.

## Why

[glama.ai](https://glama.ai) indexes MCP servers and reads this file to verify maintainership. Kesha is **not currently listed** there (`glama.ai/mcp/servers/drakulavich/kesha-voice-kit` → 404).

This unblocks a concrete win: [punkpeye/awesome-mcp-servers#6499](https://github.com/punkpeye/awesome-mcp-servers/pull/6499) (91.8k★) was closed **for inactivity, not on merit** — the bot asked for the server to be listed and claimed on Glama plus a score badge, and got no reply for 68 days. The maintainer explicitly invited a re-submission.

```json
{
  "$schema": "https://glama.ai/mcp/schemas/server.json",
  "maintainers": ["drakulavich"]
}
```

## Feasibility, checked rather than assumed

Glama's check is that the server starts and answers introspection. I probed the real binary with an empty cache:

```
KESHA_CACHE_DIR=/tmp/kesha-empty-cache kesha mcp
→ initialize  OK (serverInfo kesha-voice-kit)
→ tools/list  OK (synthesize_speech, transcribe_audio, list_voices, list_languages)
```

So the check passes **without** baking multi-GB models into the image — `src/cli/mcp.ts` does no engine check at startup. Glama also generates its own Dockerfile from the repo tree, and this repo already ships one.

## Remaining steps (need a Glama login, not doable from CI)

1. Submit the server at https://glama.ai/mcp/servers
2. Run the "Claim" workflow so Glama re-reads this file
3. Add the score badge and re-open the awesome-mcp-servers PR

One caveat for step 2: `Dockerfile` has `ENTRYPOINT ["kesha"]` + `CMD ["--help"]`. `docker run <image> mcp` works, but a generated config that overrides only `CMD` would start the help output instead of the server — worth checking in the Docker settings during claim.

## Verification

`bun test` → 767 pass / 0 fail · `bunx tsc --noEmit` → clean.

One `cli-contracts` install test timed out on the first local run; it is the known macOS Gatekeeper flake, confirmed by 5/5 clean re-runs with this file present, not a regression from it.

Metadata-only; no runtime code touched.