### PR TITLE
feat(mcp): declare the server in the official MCP registry format

### DIFF
--- a/.claude/skills/release-engine/SKILL.md
+++ b/.claude/skills/release-engine/SKILL.md
@@ -19,7 +19,7 @@ Cuts a kesha-engine release. **NEVER auto-runs** — user invokes via `/release-
 
 For docs/TS/plugin tweaks where the engine binary is unchanged.
 
-1. Bump only `package.json#version`. Leave `package.json#keshaEngine.version` and `rust/Cargo.toml` untouched.
+1. Bump `package.json#version`, plus `server.json#version` and `server.json#packages[0].version` to the same value. Leave `package.json#keshaEngine.version` and `rust/Cargo.toml` untouched.
 2. PR through CI (integration tests reuse the existing engine binary at the pinned `keshaEngine.version`).
 3. Merge.
 4. `gh release create $TAG --title "$VERSION (CLI-only)" --notes "Engine: v<keshaEngine.version> (unchanged)."`

--- a/.claude/skills/release-mechanics/SKILL.md
+++ b/.claude/skills/release-mechanics/SKILL.md
@@ -14,7 +14,7 @@ Version drift gate: `bun .github/scripts/check-versions.ts` (`bun run check:vers
 1. `keshaEngine.version === rust/Cargo.toml#version` — one engine version stored twice; drift makes `kesha install` fetch the wrong source/release.
 2. `package.json#version >= keshaEngine.version` — CLI may lead for CLI-only patches, never lag.
 
-**CLI-only patch** (docs, TS, plugin): bump only `package.json#version`; leave `keshaEngine.version` + `rust/Cargo.toml`; PR CI uses the existing engine; merge; create a marker release:
+**CLI-only patch** (docs, TS, plugin): bump `package.json#version` and the two `server.json` versions with it (rule 4 rejects the commit otherwise); leave `keshaEngine.version` + `rust/Cargo.toml`; PR CI uses the existing engine; merge; create a marker release:
 
 CLI-only is allowed only when the changed CLI surface works against the already-published engine pinned by `package.json#keshaEngine.version`. If a CLI command delegates to a new engine subcommand, capability flag, feature behavior, or output contract, it is an **engine release**: bump `package.json#keshaEngine.version`, `rust/Cargo.toml`, and `rust/Cargo.lock` together. Before cutting any `v*-cli` marker, smoke-test new/changed CLI commands against the published pinned engine, not only a repo-local engine build. The `v1.18.2-cli` / `v1.18.3-cli` mistake was exposing `kesha record` while the pinned published engine was still `v1.18.0` and did not implement `kesha-engine record`.
 

--- a/.github/scripts/check-versions.ts
+++ b/.github/scripts/check-versions.ts
@@ -1,11 +1,14 @@
 #!/usr/bin/env bun
 /**
- * Verify the three version sources stay aligned (#267 F16 / #313 P0):
+ * Verify the version sources stay aligned (#267 F16 / #313 P0):
  *
  *   - `package.json#version`              — npm-published CLI version
  *   - `package.json#keshaEngine.version`  — engine binary version the CLI
  *                                            downloads from GitHub Releases
  *   - `rust/Cargo.toml#version`           — engine crate version
+ *   - `server.json#version` + `#packages[].version` — the MCP registry
+ *                                            manifest, which points at an
+ *                                            npm version that must exist
  *
  * A silent drift between (b) and (c) means `kesha install` downloads a
  * release that doesn't match the source the engine was built from —
@@ -27,6 +30,16 @@ function parseOrExit(raw: string, label: string): SemVer {
 
 const pkgRaw = JSON.parse(readFileSync("package.json", "utf8"));
 const cargoToml = readFileSync("rust/Cargo.toml", "utf8");
+let serverJson: { version?: string; packages?: Array<{ version?: string }> };
+try {
+  serverJson = JSON.parse(readFileSync("server.json", "utf8"));
+} catch (err) {
+  console.error(
+    `server.json: unreadable (${err instanceof Error ? err.message : String(err)}). ` +
+      `It is the MCP registry manifest and must stay in the repo root.`,
+  );
+  process.exit(1);
+}
 
 // Anchor to column-zero `version` to avoid matching workspace-member or dependency version fields.
 const cargoVersionMatch = cargoToml.match(/^version\s*=\s*"([^"]+)"$/m);
@@ -79,9 +92,34 @@ if (engine.prerelease.some((id) => id.toLowerCase().startsWith("alpha"))) {
   failed = true;
 }
 
+const serverVersions: Array<[string, string]> = [
+  ["server.json#version", serverJson.version ?? ""],
+  ...(serverJson.packages ?? []).map(
+    (pkg: { version?: string }, i: number): [string, string] => [
+      `server.json#packages[${i}].version`,
+      pkg.version ?? "",
+    ],
+  ),
+];
+
+for (const [label, raw] of serverVersions) {
+  const parsed = parseOrExit(raw, label);
+  if (cmp(parsed, cli) !== 0) {
+    console.error(
+      `rule 4 violated: ${label} (${fmt(parsed)}) must equal package.json#version ` +
+        `(${fmt(cli)}). server.json is the MCP registry manifest: its version tells ` +
+        `registries which npm release to resolve, so a stale value points clients at ` +
+        `a version that was never published.`,
+    );
+    failed = true;
+  }
+}
+
 if (failed) {
   console.error(
-    `\nResolved sources:\n  package.json#version:              ${fmt(cli)}\n  package.json#keshaEngine.version: ${fmt(engine)}\n  rust/Cargo.toml#version:          ${fmt(cargo)}`,
+    `\nResolved sources:\n  package.json#version:              ${fmt(cli)}\n  package.json#keshaEngine.version: ${fmt(engine)}\n  rust/Cargo.toml#version:          ${fmt(cargo)}\n${serverVersions
+      .map(([label, raw]) => `  ${label}:${" ".repeat(Math.max(1, 34 - label.length))}${raw}`)
+      .join("\n")}`,
   );
   process.exit(1);
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,8 @@ jobs:
               # skipped entirely and the drift merged undetected
               # (Greptile P1 on #315).
               - 'rust/Cargo.toml'
+              # Same reason as `rust/Cargo.toml`: a version source (rule 4), so a manifest-only bump must still reach `check:versions`.
+              - 'server.json'
               - '.github/workflows/ci.yml'
               - '.github/actions/**'
             integration:

--- a/server.json
+++ b/server.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.drakulavich/kesha-voice-kit",
+  "title": "Kesha Voice Kit",
+  "description": "Offline speech-to-text in 25 languages, text-to-speech in 9, and language detection.",
+  "repository": {
+    "url": "https://github.com/drakulavich/kesha-voice-kit",
+    "source": "github"
+  },
+  "version": "1.27.0",
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "@drakulavich/kesha-voice-kit",
+      "version": "1.27.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "mcp",
+          "description": "Starts the MCP server over stdio; without it the binary is a plain CLI."
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit/check-versions.test.ts
+++ b/tests/unit/check-versions.test.ts
@@ -7,7 +7,7 @@ const REPO = `${import.meta.dir}/../..`;
 const SCRIPT = `${REPO}/.github/scripts/check-versions.ts`;
 
 // Nothing here is symlinked to the repo, so the fixture is safe to remove recursively.
-async function check(cli: string, engine: string, cargo = engine) {
+async function check(cli: string, engine: string, cargo = engine, server: string | null = cli) {
   const dir = mkdtempSync(join(tmpdir(), "kesha-versions-"));
   try {
     mkdirSync(join(dir, "rust"));
@@ -16,6 +16,12 @@ async function check(cli: string, engine: string, cargo = engine) {
       JSON.stringify({ version: cli, keshaEngine: { version: engine } }),
     );
     writeFileSync(join(dir, "rust/Cargo.toml"), `version = "${cargo}"\n`);
+    if (server !== null) {
+      writeFileSync(
+        join(dir, "server.json"),
+        JSON.stringify({ version: server, packages: [{ version: server }] }),
+      );
+    }
     const proc = Bun.spawn(["bun", SCRIPT], { cwd: dir, stdout: "ignore", stderr: "pipe" });
     const stderr = await new Response(proc.stderr).text();
     return { accepted: (await proc.exited) === 0, stderr };
@@ -54,10 +60,28 @@ describe("engine pin channel", () => {
       expect((await check("1.27.0", pin)).accepted).toBe(true);
     }
   });
+});
+
+// A stale server.json advertises an npm version that was never published.
+describe("MCP registry manifest", () => {
+  test("a server.json version lagging package.json#version is rejected", async () => {
+    const { accepted, stderr } = await check("1.27.0", "1.24.8", "1.24.8", "1.26.0");
+
+    expect(accepted).toBe(false);
+    expect(stderr).toContain("rule 4 violated");
+    expect(stderr).toContain("server.json#version");
+  });
+
+  test("a missing server.json is reported, not thrown", async () => {
+    const { accepted, stderr } = await check("1.27.0", "1.24.8", "1.24.8", null);
+
+    expect(accepted).toBe(false);
+    expect(stderr).toContain("server.json: unreadable");
+  });
 
   // In the real cwd, so rule 1 reads the actual rust/Cargo.toml rather than a fixture
   // written to agree with the pin by construction.
-  test("the repository itself passes every rule, Cargo.toml included", async () => {
+  test("the repository itself passes every rule, Cargo.toml and server.json included", async () => {
     const proc = Bun.spawn(["bun", SCRIPT], { cwd: REPO, stdout: "ignore", stderr: "pipe" });
     const stderr = await new Response(proc.stderr).text();
 


### PR DESCRIPTION
Adds `server.json` so MCP directories can tell **how to actually start the server**, and wires its version into the drift gate.

## The problem it fixes

`kesha` with no arguments is a plain CLI. The MCP server lives behind a subcommand, `kesha mcp` — and nothing machine-readable says so:

```json
"bin": { "kesha": "bin/kesha.js" }   // no scripts.mcp, no mcpName
```

Directories that infer a start command therefore launch the CLI and never reach an MCP handshake. Glama does exactly this — it builds a container from the repo tree and tries to connect — which is why our [listing](https://glama.ai/mcp/servers/drakulavich/kesha-voice-kit) shows **"This server cannot be installed"** and Quality `–`, while License and Maintenance are both `A`.

The repo `Dockerfile` compounds it: `ENTRYPOINT ["kesha"]` + `CMD ["--help"]` starts the help text.

## What it declares

The spec has this exact case — *"a server that requires specific command-line arguments to start in server mode"* — expressed as a positional argument:

```json
"packageArguments": [{ "type": "positional", "value": "mcp" }]
```

Validated against the published `2025-12-11` schema with `jsonschema`: **valid**. (The description is capped at 100 chars by the schema, hence the terse wording.)

Beyond Glama, this is the format the official MCP Registry consumes, so it is useful on its own rather than a vendor workaround.

## Why check-versions.ts changed

`server.json` names an npm version, making it a **fourth version source and a fourth way to drift** — a stale value advertises a release that was never published. Rather than leave that to vigilance:

- **rule 4**: `server.json#version` and every `packages[].version` must equal `package.json#version`
- a missing/unparseable `server.json` reports a clear message instead of an ENOENT stack
- the two release procedures that bump the CLI version now bump it too (`release-mechanics`, `release-engine`); the engine-release path leaves `package.json#version` alone, so it needs no change

Negative-tested both ways: desynced `packages[0].version` → rejected, desynced top-level → rejected, restored → passes. Two new unit tests cover rule 4 and the missing-file path.

## Verification

`bun test` → 775 pass / 0 fail · `bunx tsc --noEmit` → clean · `bun run check:versions` → passes.

Note the existing fixture in `tests/unit/check-versions.test.ts` had to grow a `server.json`, since the script now requires one — that is the 4-test failure this change would otherwise cause, fixed here rather than left for CI.

## After merge

Does not fix the Glama score by itself — the Dockerfile still has to be registered there with `CMD ["mcp"]`. This removes the ambiguity that made the automation guess wrong in the first place.