### PR TITLE
fix(ci): drop rust-cache from the Parakeet seed job

### DIFF
--- a/.github/workflows/cache-seed.yml
+++ b/.github/workflows/cache-seed.yml
@@ -121,11 +121,9 @@ jobs:
         if: steps.probe.outputs.cache-hit != 'true'
         with:
           toolchain: stable
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        if: steps.probe.outputs.cache-hit != 'true'
-        with:
-          workspaces: rust
 
+      # Deliberately no rust-cache: this job builds only on a miss, and its artifacts
+      # cost 716 MB of a budget whose pressure already evicts the bundle it seeds.
       - name: Install system audio deps (Opus)
         if: steps.probe.outputs.cache-hit != 'true'
         run: brew install opus pkg-config


### PR DESCRIPTION
The seed job inherited `Swatinem/rust-cache` from `coreml-regression`, where it earns its keep because that job runs on every CoreML-touching PR. In the seed job the trade is inverted: it builds only on a cache miss, so the entry buys a few minutes a handful of times a month — while costing 716 MB, more than the 446 MB bundle the job exists to seed. A seed job whose own build cache helps evict its own output is working against itself.

**State of the cache as of opening this PR**, since the numbers in the commit message were measured earlier and one of them has moved:

| | |
|---|---|
| Total | 8,082 MB across 40 entries (was 10,771 MB against the 10 GB cap when the commit was written) |
| `parakeet-*` / `kokoro-*` entries | **none** — the bundle this job exists to seed is not there |
| Third largest entry | 719 MB `v0-rust-build-Darwin-arm64-…`, the same rust-cache class this removes from the seed |

So the pressure has eased since the measurement, but the outcome it predicted already happened: nothing of what the seed job produces survives in the cache today.

Refs #675.