### PR TITLE
fix(ci): run a script's unit tests when that script changes

### DIFF
--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -11,7 +11,7 @@
  * action references; stays silent on success so it composes cleanly with other
  * pre-push checks.
  */
-import { readdirSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { parse, YAMLParseError } from "yaml";
 
@@ -73,8 +73,54 @@ export function requirePreUploadSynthesisSmoke(path: string, document: unknown):
   return [];
 }
 
+/**
+ * Fails when a script covered by a unit test sits outside ci.yml's `code` filter.
+ * `check:versions` and the unit tests run inside `unit-tests`, which that filter gates,
+ * so an uncovered script means edits to a gate skip the tests that prove it works.
+ */
+export function requireTestedScriptsInCodeFilter(
+  path: string,
+  document: unknown,
+  testedScripts: string[],
+): string[] {
+  if (!path.endsWith("ci.yml")) return [];
+
+  const raw = (document as { jobs?: { changes?: { steps?: Array<{ with?: { filters?: unknown } }> } } })?.jobs?.changes
+    ?.steps?.find((step) => typeof step?.with?.filters === "string")?.with?.filters;
+  if (typeof raw !== "string") return [`${path}: expected a \`changes\` job with inline paths-filter filters`];
+
+  const code = (parse(raw) as Record<string, string[]>)?.code;
+  if (!Array.isArray(code)) return [`${path}: paths-filter is missing a \`code\` list`];
+
+  const covers = (file: string) =>
+    code.some((pattern) => (pattern.endsWith("/**") ? file.startsWith(pattern.slice(0, -2)) : pattern === file));
+
+  return testedScripts
+    .filter((file) => !covers(file))
+    .map((file) => `${path}: ${file} has a unit test but no matching path in the \`code\` filter, so edits to it skip that test`);
+}
+
+function collectTestedScripts(): string[] {
+  const tests = readdirSync("tests/unit", { recursive: true })
+    .filter((entry): entry is string => typeof entry === "string" && entry.endsWith(".test.ts"))
+    .map((entry) => readFileSync(join("tests/unit", entry), "utf8"));
+
+  // A TS import drops the extension, a spawned script keeps it — so try both and keep what exists on disk.
+  const found = new Set<string>();
+  for (const contents of tests) {
+    for (const match of contents.matchAll(/\.github\/scripts\/([\w.-]+)/g)) {
+      for (const candidate of [match[1], `${match[1]}.ts`]) {
+        const file = join(".github/scripts", candidate);
+        if (existsSync(file)) found.add(file);
+      }
+    }
+  }
+  return [...found].sort();
+}
+
 function main(): void {
   const files = dirs.flatMap((dir) => collectYamlFiles(dir)).sort();
+  const testedScripts = collectTestedScripts();
 
   if (files.length === 0) {
     console.error(`no workflow or action files found in ${dirs.join(", ")}`);
@@ -89,6 +135,7 @@ function main(): void {
       const errors = [
         ...requirePinnedActions(path, contents),
         ...requirePreUploadSynthesisSmoke(path, document),
+        ...requireTestedScriptsInCodeFilter(path, document, testedScripts),
       ];
       if (errors.length > 0) {
         failed += errors.length;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,8 @@ jobs:
               - 'server.json'
               - '.github/workflows/ci.yml'
               - '.github/actions/**'
+              # 16 of these scripts have unit tests; without this a script-only edit skips the tests that cover it (check-workflows.ts enforces it).
+              - '.github/scripts/**'
             integration:
               - 'src/**'
               - 'tests/integration/**'

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { parse } from "yaml";
-import { requirePreUploadSynthesisSmoke } from "../../.github/scripts/check-workflows";
+import {
+  requirePreUploadSynthesisSmoke,
+  requireTestedScriptsInCodeFilter,
+} from "../../.github/scripts/check-workflows";
 
 const PATH = ".github/workflows/build-engine.yml";
 
@@ -62,5 +65,51 @@ describe("requirePreUploadSynthesisSmoke", () => {
   test("fails when the build job is gone", () => {
     const errors = requirePreUploadSynthesisSmoke(PATH, { jobs: { release: {} } });
     expect(errors[0]).toContain("expected a `build` job");
+  });
+});
+
+const CI = ".github/workflows/ci.yml";
+
+function filterJob(code: string[]) {
+  return { jobs: { changes: { steps: [{ with: { filters: `code:\n${code.map((p) => `  - '${p}'`).join("\n")}\n` } }] } } };
+}
+
+describe("requireTestedScriptsInCodeFilter", () => {
+  test("passes on the real ci.yml", () => {
+    const document = parse(readFileSync(CI, "utf8"));
+    expect(requireTestedScriptsInCodeFilter(CI, document, [".github/scripts/check-versions.ts"])).toEqual([]);
+  });
+
+  test("ignores every other workflow", () => {
+    expect(requireTestedScriptsInCodeFilter(PATH, filterJob([]), [".github/scripts/check-versions.ts"])).toEqual([]);
+  });
+
+  test("fails when a tested script sits outside the filter", () => {
+    const errors = requireTestedScriptsInCodeFilter(CI, filterJob(["src/**"]), [".github/scripts/check-versions.ts"]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("check-versions.ts has a unit test but no matching path");
+  });
+
+  test("a directory wildcard covers the scripts under it", () => {
+    const document = filterJob([".github/scripts/**"]);
+    expect(requireTestedScriptsInCodeFilter(CI, document, [".github/scripts/alpha-tag.sh"])).toEqual([]);
+  });
+
+  // An exact path covers only itself, so listing one script silently leaves its neighbours unguarded.
+  test("an exact path covers only that script", () => {
+    const document = filterJob([".github/scripts/smoke-synthesis.ts"]);
+    const scripts = [".github/scripts/smoke-synthesis.ts", ".github/scripts/check-versions.ts"];
+    const errors = requireTestedScriptsInCodeFilter(CI, document, scripts);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("check-versions.ts");
+  });
+
+  test("fails when the code list is gone", () => {
+    const document = { jobs: { changes: { steps: [{ with: { filters: "integration:\n  - 'src/**'\n" } }] } } };
+    expect(requireTestedScriptsInCodeFilter(CI, document, [])[0]).toContain("missing a `code` list");
+  });
+
+  test("fails when the changes job has no inline filters", () => {
+    expect(requireTestedScriptsInCodeFilter(CI, { jobs: { changes: {} } }, [])[0]).toContain("expected a `changes` job");
   });
 });


### PR DESCRIPTION
Follow-up to the Greptile P1 on #751, which I flagged there but left out of scope.

## The gap

`check:versions` and the unit tests run inside the `unit-tests` job, gated on the `code` path filter. That filter listed `.github/workflows/ci.yml` and `.github/actions/**` — but **not** `.github/scripts/**`.

16 scripts there have unit tests, including the two gates themselves:

```
alpha-publishable.ts   check-versions.ts    check-workflows.ts   smoke-synthesis.ts
alpha-tag.sh           classify-release-tag.mjs   derive-alpha-version.ts   ...
```

So a PR editing only `check-versions.ts` never ran `check-versions.test.ts`. #751 ran them purely by accident — it also touched `tests/**`.

## Two parts

**1. The path.** `.github/scripts/**` added to the `code` superset. `integration` stays a strict subset, so the documented invariant holds.

**2. A guard, so it cannot reopen.** This is the *third* instance of the same gap — `rust/Cargo.toml` (#315) and `server.json` (#751) were both caught by human/bot review, never by CI. `check-workflows.ts` now derives the rule instead of hardcoding a string:

- scan `tests/unit/**` for `.github/scripts/<name>` references
- keep the candidates that actually exist on disk (a TS import drops the extension, a spawned script keeps it — this is why `.sh` and `.mjs` scripts are covered too)
- require the `code` filter to cover each one; `/**` covers the subtree, an exact path covers only itself

Negative-tested: removing the new line makes `check:workflows` fail with all 16 scripts named, one per line.

## A bug the guard caught in itself

My first regex appended `.ts` unconditionally, producing phantom names like `alpha-tag.sh.ts`. It passed — `**` covers everything — but would have mis-reported the moment anyone used exact paths. Fixed by keeping only files that exist; that also corrected my initial "8 scripts" count to the real 16.

## Verification

`bun test` → 782 pass / 0 fail · `bunx tsc --noEmit` → clean · `check:workflows` and `check:versions` → pass. 7 new tests cover the guard, including the exact-path-vs-wildcard distinction.