### PR TITLE
docs(release): state the policy for both prerelease channels

### DIFF
--- a/.claude/skills/release-mechanics/SKILL.md
+++ b/.claude/skills/release-mechanics/SKILL.md
@@ -65,19 +65,43 @@ npm view @drakulavich/kesha-voice-kit version   # within ~60s, expect X.Y.Z
 7. Publish: `gh release edit vX.Y.Z --draft=false`. This fires `📦 npm Publish`; verify `npm view @drakulavich/kesha-voice-kit version` within ~60s. Manual fallback: `npm publish --access public` from the maintainer laptop.
 8. Stable `vX.Y.Z` engine releases also update `drakulavich/homebrew-tap` via `🍺 Homebrew Tap` using `HOMEBREW_TAP_TOKEN` scoped only to the tap repo, and attach Linux x64 `.deb`/`.rpm` packages covered by `SHA256SUMS` + Sigstore. CLI-only marker releases skip Homebrew/packages.
 
-**Beta engine release** (unstable channel):
+**Prerelease channels.** The validators accept two shapes beside stable — `vX.Y.Z-beta.N` and `vX.Y.Z-alpha.N` (a CLI alpha adds the `-cli` marker) — and the grammar has one home, `release-tags.mjs`. Neither channel can reach `latest`: `npm-dist-tag.mjs` derives the dist-tag from the SemVer prerelease identifier, returns `latest` only for a version that has none, and *refuses* one whose identifier decodes to `latest` (`1.27.0-latest.1`) rather than handing a prerelease to everyone who never asked for a channel.
+
+| | alpha | beta |
+| --- | --- | --- |
+| for | rehearsing the publish path continuously — every merge that ships | a candidate you want people to install and test |
+| version | derived from tags at publish time, never committed | committed in all three version fields |
+| dist-tag | `alpha` | `beta` |
+| reaches | whoever asked: `bun add -g @drakulavich/kesha-voice-kit@alpha` | `…@beta` |
+| skips | Linux `.deb`/`.rpm`, Homebrew, **and the human un-draft gate** | Linux `.deb`/`.rpm`, Homebrew |
+| promotion | none — it is evidence, not a candidate; cut a beta or a stable | a later stable `vX.Y.Z` |
+| Releases | engine alphas pruned after 30 days; tags kept | kept |
+
+**Beta engine release** (deliberate, human-gated):
 
 - Use SemVer prerelease versions in all three places: `package.json#version`, `package.json#keshaEngine.version`, and `rust/Cargo.toml`, for example `1.18.7-beta.1`; tag as `v1.18.7-beta.1`.
-- `build-engine.yml` accepts `vX.Y.Z-beta.N`, creates a **draft prerelease**, and uploads engine binaries, sidecars, `SHA256SUMS`, manifest, SBOM, and Sigstore bundles. It intentionally skips Homebrew and Linux `.deb`/`.rpm` packages for beta tags.
-- After draft asset validation, publish with `gh release edit vX.Y.Z-beta.N --draft=false`. `📦 npm Publish` publishes prerelease package versions with `npm publish --tag beta`, so `@latest` stays on the latest stable release.
-- Verify beta with `npm view @drakulavich/kesha-voice-kit@beta version`; user-facing beta install is `bun add -g @drakulavich/kesha-voice-kit@beta && kesha install`.
+- `build-engine.yml` creates a **draft prerelease** and uploads engine binaries, sidecars, `SHA256SUMS`, manifest, SBOM, and Sigstore bundles.
+- Verify before promoting exactly as for stable — engine-release step 5, authenticated `gh release download` against the draft — then `gh release edit vX.Y.Z-beta.N --draft=false`, then `npm view @drakulavich/kesha-voice-kit@beta version`. User-facing install is `bun add -g @drakulavich/kesha-voice-kit@beta && kesha install`.
 - Promote by cutting a later stable `vX.Y.Z` release; do not reuse the beta tag or try to retag it as stable.
 
 **Alpha channel** (#685) — versions are derived from tags at publish time and never committed, so `main` carries the *next* unreleased CLI version as the alpha base:
 
-- **CLI alphas** publish themselves. Label a PR `alpha`; on merge `release-alpha.yml` derives `vX.Y.Z-alpha.N-cli`, pushes the tag, then dispatches `npm-publish.yml` (npm Trusted Publishing validates the *entry* workflow name, so an alpha must publish through that one). Install with `bun add -g @drakulavich/kesha-voice-kit@alpha`. `workflow_dispatch` skips the label gate for a PR merged without one.
-- **Engine alphas** are dispatched by hand, tagged `vX.Y.Z-alpha.N` (no `-cli`), and end up **live, not draft** — an alpha behind the un-draft gate is not installable. The build still creates a draft and un-drafts it after upload: releases here are immutable, so an asset uploaded to a published release 422s. Beta keeps its draft.
+- **CLI alphas** publish themselves. Label a PR `alpha`; on merge `release-alpha.yml` derives `vX.Y.Z-alpha.N-cli`, pushes the tag, then dispatches `npm-publish.yml` (npm Trusted Publishing validates the *entry* workflow name, so an alpha must publish through that one). Install with `bun add -g @drakulavich/kesha-voice-kit@alpha`. `workflow_dispatch` skips the label gate for a PR merged without one. No GitHub Release is created — the annotated tag carries the notes.
+- A labelled PR that changed nothing npm packs publishes nothing: `alpha-publishable.ts` judges the changed paths against `npm pack --dry-run`.
+- **Engine alphas** are dispatched by hand, tagged `vX.Y.Z-alpha.N` (no `-cli`), and end up **live, not draft** — an alpha behind the un-draft gate is not installable. The build still creates a draft and un-drafts it after upload: releases here are immutable, so an asset uploaded to a published release 422s. Beta keeps its draft. Verify by installing from the channel, not from a draft asset.
 - An engine alpha leads the pin instead of matching it: `package.json#keshaEngine.version` may never name an alpha (#738), so pick a base above it, and leave all three version fields alone. The build writes the tag's version into `rust/Cargo.toml` in the runner, so `kesha-engine --version` reports the alpha.
+
+**Recovering a failed alpha publish.** `reserve-tag` runs *before* the publish on purpose: npm holding a version no tag records lets the next derivation reuse it, and the prior-publish guard turns that reuse into a green no-op. The cost of that ordering is the opposite failure — a publish that dies after the tag exists leaves an orphan tag, and the sequence is derived from tags alone.
+
+| | outcome |
+| --- | --- |
+| re-run **failed jobs only** | `decide` outputs are kept, the same version is retried — correct |
+| re-run **all jobs** | the new tag is now visible, the sequence advances, the orphan is never filled |
+| do nothing | the orphan stays; later merges continue past it |
+
+So: **re-run failed jobs only, or delete the orphan tag first.** A gap in the alpha sequence is expected and harmless — `nextSequence` only reads the highest.
+
+**The `alpha` label is read live, not frozen at merge.** `alpha-requested.sh` calls `GET /commits/{sha}/pulls`, which returns the merged PR's *current* labels. Between merge and the `decide` job, removing the label skips the publish and adding it causes one. Treat it as a soft gate — "I removed the label right after merging" is a real explanation for a missing alpha.
 
 ```bash
 gh workflow run "🔨 Build Engine" -R drakulavich/kesha-voice-kit \
@@ -110,10 +134,10 @@ git push origin vX.Y.Z
 
 Post-#291 happy path: publishing a GitHub release runs `.github/workflows/npm-publish.yml` → `npm publish --provenance --access public` in GHA. Do not publish from a maintainer laptop unless the workflow is broken.
 
-- Trigger: `release: published` (engine un-draft or published `v*-cli` marker) plus `workflow_dispatch` re-runs.
+- Trigger: `release: published` (engine un-draft or published `v*-cli` marker), `workflow_dispatch` re-runs, and the alpha lane's dispatch. Only `-cli` tags publish a CLI; a bare tag names the engine (#729).
 - Provenance: `permissions.id-token: write` gives npm the GHA OIDC chain (`commit SHA` → built tarball) and the npm "verified" badge.
-- Guards: tag must match `package.json#version` after stripping leading `v` and trailing `-cli`; already-published versions skip publish and exit 0.
-- Dist-tags: stable package versions publish to `latest`; SemVer prerelease package versions publish to `beta`.
+- Guards: tag must match `package.json#version` after stripping leading `v` and trailing `-cli`; already-published versions skip publish and exit 0. An alpha version is minted at publish time, so it is injected into `package.json` instead of verified against it.
+- Dist-tags: resolved by `npm-dist-tag.mjs` from the prerelease identifier — stable → `latest`, `-beta.N` → `beta`, `-alpha.N` → `alpha`, and a prerelease never lands on `latest`.
 - Injection rule: route `inputs.tag` / `github.event.release.tag_name` through `env:`, never directly into `run:` while the job holds `id-token: write`.
 - Required secret: `NPM_TOKEN` (granular publish-only token for `@drakulavich/kesha-voice-kit`), set with `gh secret set NPM_TOKEN -R drakulavich/kesha-voice-kit`. If missing, the release remains published but the publish step fails; fallback is `npm publish --access public` from a laptop.
 - Release implication: un-draft is the commit-to-publish point. Validate draft assets via authenticated `gh release download` before un-drafting; npm publish is effectively permanent (72 h unpublish window, noisy provenance). If validation fails before publish: delete release + tag, bump patch, retry.

--- a/.claude/skills/release-mechanics/SKILL.md
+++ b/.claude/skills/release-mechanics/SKILL.md
@@ -65,33 +65,36 @@ npm view @drakulavich/kesha-voice-kit version   # within ~60s, expect X.Y.Z
 7. Publish: `gh release edit vX.Y.Z --draft=false`. This fires `📦 npm Publish`; verify `npm view @drakulavich/kesha-voice-kit version` within ~60s. Manual fallback: `npm publish --access public` from the maintainer laptop.
 8. Stable `vX.Y.Z` engine releases also update `drakulavich/homebrew-tap` via `🍺 Homebrew Tap` using `HOMEBREW_TAP_TOKEN` scoped only to the tap repo, and attach Linux x64 `.deb`/`.rpm` packages covered by `SHA256SUMS` + Sigstore. CLI-only marker releases skip Homebrew/packages.
 
-**Prerelease channels.** The validators accept two shapes beside stable — `vX.Y.Z-beta.N` and `vX.Y.Z-alpha.N` (a CLI alpha adds the `-cli` marker) — and the grammar has one home, `release-tags.mjs`. Neither channel can reach `latest`: `npm-dist-tag.mjs` derives the dist-tag from the SemVer prerelease identifier, returns `latest` only for a version that has none, and *refuses* one whose identifier decodes to `latest` (`1.27.0-latest.1`) rather than handing a prerelease to everyone who never asked for a channel.
+**Prerelease channels.** The validators accept two shapes beside stable — `vX.Y.Z-beta.N` and `vX.Y.Z-alpha.N` (a CLI release on either channel adds the `-cli` marker) — and the grammar has one home, `release-tags.mjs`. Neither channel can reach `latest`: `npm-dist-tag.mjs` derives the dist-tag from the SemVer prerelease identifier, returns `latest` only for a version that has none, and *refuses* one whose identifier decodes to `latest` (`1.27.0-latest.1`) rather than handing a prerelease to everyone who never asked for a channel.
 
 | | alpha | beta |
 | --- | --- | --- |
-| for | rehearsing the publish path continuously — every merge that ships | a candidate you want people to install and test |
+| for | rehearsing the publish path — a merged PR labelled `alpha` that changed something npm packs | a candidate you want people to install and test |
 | version | derived from tags at publish time, never committed | committed in all three version fields |
 | dist-tag | `alpha` | `beta` |
-| reaches | whoever asked: `bun add -g @drakulavich/kesha-voice-kit@alpha` | `…@beta` |
+| reaches | CLI: whoever asked, `bun add -g @drakulavich/kesha-voice-kit@alpha`. Engine: `kesha install --engine-version X.Y.Z-alpha.N` | the same two, with `@beta` / `-beta.N` |
 | skips | Linux `.deb`/`.rpm`, Homebrew, **and the human un-draft gate** | Linux `.deb`/`.rpm`, Homebrew |
 | promotion | none — it is evidence, not a candidate; cut a beta or a stable | a later stable `vX.Y.Z` |
 | Releases | engine alphas pruned after 30 days; tags kept | kept |
+
+The dist-tag rows are about **CLI** tags. Only a `-cli` tag publishes to npm; a bare `vX.Y.Z[-beta.N|-alpha.N]` names the engine and reaches users through the GitHub Release, never through a channel (#729).
 
 **Beta engine release** (deliberate, human-gated):
 
 - Use SemVer prerelease versions in all three places: `package.json#version`, `package.json#keshaEngine.version`, and `rust/Cargo.toml`, for example `1.18.7-beta.1`; tag as `v1.18.7-beta.1`.
 - `build-engine.yml` creates a **draft prerelease** and uploads engine binaries, sidecars, `SHA256SUMS`, manifest, SBOM, and Sigstore bundles.
-- Verify before promoting exactly as for stable — engine-release step 5, authenticated `gh release download` against the draft — then `gh release edit vX.Y.Z-beta.N --draft=false`, then `npm view @drakulavich/kesha-voice-kit@beta version`. User-facing install is `bun add -g @drakulavich/kesha-voice-kit@beta && kesha install`.
+- Verify before promoting exactly as for stable — engine-release step 5, authenticated `gh release download` against the draft — then `gh release edit vX.Y.Z-beta.N --draft=false`. Testers install the binary with `kesha install --engine-version X.Y.Z-beta.N`.
+- Un-drafting a beta engine tag publishes **nothing** to npm: `cliPublishTarget` marks every bare tag `engineOnly` and `npm-publish.yml` gates its publish job on `engine_only != 'true'` (#729). Moving the `beta` dist-tag takes its own `vX.Y.Z-beta.N-cli` marker release, with `package.json#version` at that same beta SemVer — the publish job verifies the two agree. Only after that does `bun add -g @drakulavich/kesha-voice-kit@beta` deliver the CLI.
 - Promote by cutting a later stable `vX.Y.Z` release; do not reuse the beta tag or try to retag it as stable.
 
 **Alpha channel** (#685) — versions are derived from tags at publish time and never committed, so `main` carries the *next* unreleased CLI version as the alpha base:
 
-- **CLI alphas** publish themselves. Label a PR `alpha`; on merge `release-alpha.yml` derives `vX.Y.Z-alpha.N-cli`, pushes the tag, then dispatches `npm-publish.yml` (npm Trusted Publishing validates the *entry* workflow name, so an alpha must publish through that one). Install with `bun add -g @drakulavich/kesha-voice-kit@alpha`. `workflow_dispatch` skips the label gate for a PR merged without one. No GitHub Release is created — the annotated tag carries the notes.
+- **CLI alphas** publish themselves. Label a PR `alpha`; on merge `release-alpha.yml` derives `vX.Y.Z-alpha.N-cli`, pushes the tag, then dispatches `npm-publish.yml` (npm Trusted Publishing validates the *entry* workflow name, so an alpha must publish through that one). Install with `bun add -g @drakulavich/kesha-voice-kit@alpha`. `workflow_dispatch` publishes unconditionally — `alpha-requested.sh` returns `publish=true` on a manual run before either gate, label or packed-path — which is the escape hatch for a PR merged without the label. No GitHub Release is created — the annotated tag carries the notes.
 - A labelled PR that changed nothing npm packs publishes nothing: `alpha-publishable.ts` judges the changed paths against `npm pack --dry-run`.
-- **Engine alphas** are dispatched by hand, tagged `vX.Y.Z-alpha.N` (no `-cli`), and end up **live, not draft** — an alpha behind the un-draft gate is not installable. The build still creates a draft and un-drafts it after upload: releases here are immutable, so an asset uploaded to a published release 422s. Beta keeps its draft. Verify by installing from the channel, not from a draft asset.
+- **Engine alphas** are dispatched by hand, tagged `vX.Y.Z-alpha.N` (no `-cli`), and end up **live, not draft** — an alpha behind the un-draft gate is not installable. The build still creates a draft and un-drafts it after upload: releases here are immutable, so an asset uploaded to a published release 422s. Beta keeps its draft. Verify with `kesha install --engine-version X.Y.Z-alpha.N` once the release is live — a bare engine alpha never reaches npm, so there is no channel to install from.
 - An engine alpha leads the pin instead of matching it: `package.json#keshaEngine.version` may never name an alpha (#738), so pick a base above it, and leave all three version fields alone. The build writes the tag's version into `rust/Cargo.toml` in the runner, so `kesha-engine --version` reports the alpha.
 
-**Recovering a failed alpha publish.** `reserve-tag` runs *before* the publish on purpose: npm holding a version no tag records lets the next derivation reuse it, and the prior-publish guard turns that reuse into a green no-op. The cost of that ordering is the opposite failure — a publish that dies after the tag exists leaves an orphan tag, and the sequence is derived from tags alone.
+**Recovering a failed CLI alpha publish.** This covers `release-alpha.yml` only; an engine alpha is a `build-engine.yml` run and fails like any other engine build. There, `reserve-tag` runs *before* the publish on purpose: npm holding a version no tag records lets the next derivation reuse it, and the prior-publish guard turns that reuse into a green no-op. The cost of that ordering is the opposite failure — a publish that dies after the tag exists leaves an orphan tag, and the sequence is derived from tags alone.
 
 | | outcome |
 | --- | --- |

--- a/docs/release-manifest.md
+++ b/docs/release-manifest.md
@@ -22,8 +22,13 @@ For stable `vX.Y.Z` releases, the manifest records:
 - supported platform status for package managers
 - checksum and Sigstore bundle naming conventions
 
-For prerelease tags such as `vX.Y.Z-beta.1`, Linux `.deb` and `.rpm` package
-assets are omitted.
+The manifest accepts three tag shapes — `vX.Y.Z`, `vX.Y.Z-beta.N`, and
+`vX.Y.Z-alpha.N` — and rejects anything else. For the two prerelease shapes,
+Linux `.deb` and `.rpm` package assets are omitted. `engineVersion` comes from
+the tag rather than from `package.json#keshaEngine.version`: an alpha ships a
+version no commit carries, and it must outrank the pin rather than equal it
+(#738). Channel policy — what each prerelease is for and how it reaches users —
+lives in the `release-mechanics` skill.
 
 `SHA256SUMS` and Sigstore bundles cover the manifest itself, so downstream
 packaging can verify the metadata before consuming it.


### PR DESCRIPTION
Closes #697

Since #692 and #695 the machinery accepts three release shapes and routes each to its own npm dist-tag, but only beta was written down as a *decision*. Alpha passed every validator with no rule stated anywhere — and release procedure in this repo deliberately lives in skills, so "the validators accept it" was not the same as "it is a supported thing to do".

## `.claude/skills/release-mechanics/SKILL.md`

The **Beta engine release** section becomes **Prerelease channels**, opening with the rule that binds both: `npm-dist-tag.mjs` derives the dist-tag from the SemVer prerelease identifier, returns `latest` only for a version that has none, and refuses one whose identifier decodes to `latest`. A prerelease can never reach `@latest`.

A table states, per channel, what it is for, where its version comes from, its dist-tag, who receives it, what it skips, how it is promoted, and what happens to its Releases:

| | alpha | beta |
| --- | --- | --- |
| for | rehearsing the publish path on every merge that ships | a candidate you want people to install and test |
| version | derived from tags at publish time, never committed | committed in all three version fields |
| dist-tag | `alpha` | `beta` |
| skips | Linux packages, Homebrew, **and the human un-draft gate** | Linux packages, Homebrew |
| promotion | none — it is evidence, not a candidate | a later stable `vX.Y.Z` |

The two per-channel sections keep their existing content; beta gains the verification step it was missing (draft-asset validation is engine-release step 5, same as stable), and alpha gains the `alpha-publishable.ts` packed-path gate and the note that a CLI alpha creates no Release at all.

Two operational behaviours from the issue's follow-up comment, both correct by design:

- **A failed alpha publish leaves an orphan tag.** `reserve-tag` runs before the publish deliberately — npm holding a version no tag records lets the next derivation reuse it, and the prior-publish guard turns that into a green no-op. A recovery table covers the three moves (re-run failed jobs only → same version retried, correct; re-run all jobs → sequence advances, orphan never filled; do nothing → orphan stays). Runbook line: re-run failed jobs only, or delete the orphan tag first. A gap in the sequence is harmless.
- **The `alpha` label is read live, not frozen at merge.** `alpha-requested.sh` calls `GET /commits/{sha}/pulls`, which returns current labels, so removing the label between merge and `decide` skips a publish. Documented as a soft gate.

Also corrects a stale bullet in the npm-publish section that still said every SemVer prerelease publishes to `beta` — untrue since #695, and exactly the misreading that would send an alpha to beta subscribers.

## `docs/release-manifest.md`

Names all three accepted shapes instead of `vX.Y.Z-beta.1` alone, records that both prerelease shapes omit the Linux `.deb`/`.rpm` assets, and explains that `engineVersion` comes from the tag rather than the pin because an alpha ships a version no commit carries and must outrank the pin (#738). Points at the skill for channel policy rather than restating it.

## Verification

Docs-only; no workflow or script touched.

```
 775 pass
 5 skip
 0 fail
Ran 780 tests across 76 files. [34.10s]
```

`bunx tsc --noEmit` clean.

## One note on the issue text

The issue said alpha had "no rule written down anywhere". By the time this was picked up, an **Alpha channel (#685)** section already existed in SKILL.md — added alongside the later alpha PRs (#700, #703, #738). What was genuinely missing is what this PR adds: the comparison between the channels, the basis for choosing one, the dist-tag/promotion/verification story stated per channel, and the two operational behaviours above. Everything documented here was read off `release-tags.mjs`, `npm-dist-tag.mjs`, `classify-release-tag.mjs`, `derive-alpha-version.ts`, `alpha-requested.sh`, `alpha-tag.sh`, `prune-alpha-releases.ts`, `release-alpha.yml`, `release-npm-publish.yml`, `npm-publish.yml`, `build-engine.yml`, and `homebrew-tap.yml` as they exist on main — the alpha lane has fully landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBTpJjqyYFW6W8LHJ2nwy