### PR TITLE
deps(rust): bump fluidaudio-rs to FluidAudio 0.15.5

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -676,8 +676,8 @@ dependencies = [
 
 [[package]]
 name = "fluidaudio-rs"
-version = "0.14.8"
-source = "git+https://github.com/drakulavich/fluidaudio-rs?rev=9b7ceda98c4b0485590c04805c62ebde76e66159#9b7ceda98c4b0485590c04805c62ebde76e66159"
+version = "0.15.5"
+source = "git+https://github.com/drakulavich/fluidaudio-rs?rev=dc931c5be72cf94700b8f53027391421ba0a0628#dc931c5be72cf94700b8f53027391421ba0a0628"
 dependencies = [
  "thiserror 1.0.69",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -77,10 +77,11 @@ ndarray = { version = "0.17" }
 # prepare the program). Retire the fork once both land upstream.
 # Trade-off to know: this rev trails `FluidInference/main`, so upstream commits
 # after the previous pin are not present. Everything kesha calls is verified to
-# build against it.
+# build against it. Tracks FluidAudio Swift 0.15.5 (#709); the fork's `qwen3_*`
+# bindings are gone because 0.15.3 removed the backend upstream.
 # `init_kokoro` still takes `lang` → `zh` selects `.mandarin` (tone-aware
 # Mandarin G2P), else `.english` (#492); `--rate` stays model-native (#475).
-fluidaudio-rs = { git = "https://github.com/drakulavich/fluidaudio-rs", rev = "9b7ceda98c4b0485590c04805c62ebde76e66159", optional = true }
+fluidaudio-rs = { git = "https://github.com/drakulavich/fluidaudio-rs", rev = "dc931c5be72cf94700b8f53027391421ba0a0628", optional = true }
 audioadapter-buffers = "3.0.0"
 
 # TTS (Kokoro + SSML parser; G2P via ONNX ByT5 at runtime, see #123)

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -540,6 +540,23 @@ fn ane_voices_for(langs: &[&str]) -> Vec<&'static ModelFile> {
         .collect()
 }
 
+/// FluidAudio's Kokoro CoreML cache root. Each KokoroAne variant gets its own
+/// subdirectory of bundles here (`ANE` for English/Latin, `ANE-zh` for the
+/// Mandarin variant, and so on per `ModelNames.Repo.subPath`).
+#[cfg(all(
+    feature = "system_kokoro",
+    target_os = "macos",
+    target_arch = "aarch64"
+))]
+pub fn fluidaudio_kokoro_cache_dir() -> PathBuf {
+    dirs::home_dir()
+        .expect("cannot determine home directory")
+        .join(".cache")
+        .join("fluidaudio")
+        .join("Models")
+        .join("kokoro-82m-coreml")
+}
+
 /// FluidAudio's Kokoro ANE voice-pack cache directory. NOT under
 /// `KESHA_CACHE_DIR` — FluidAudio 0.15.5 owns this path and reads voice packs
 /// from here local-first. We pre-stage onnx-community packs here so the full
@@ -551,13 +568,7 @@ fn ane_voices_for(langs: &[&str]) -> Vec<&'static ModelFile> {
     target_arch = "aarch64"
 ))]
 pub fn fluidaudio_ane_kokoro_dir() -> PathBuf {
-    dirs::home_dir()
-        .expect("cannot determine home directory")
-        .join(".cache")
-        .join("fluidaudio")
-        .join("Models")
-        .join("kokoro-82m-coreml")
-        .join("ANE")
+    fluidaudio_kokoro_cache_dir().join("ANE")
 }
 
 /// FluidAudio's ASR bundle directory. Not under `KESHA_CACHE_DIR` — FluidAudio
@@ -618,55 +629,145 @@ fn fluidaudio_asr_ready_in(dir: &Path) -> bool {
     target_arch = "aarch64"
 ))]
 pub fn stage_ane_kokoro_voices(langs: &[&str], no_cache: bool) -> Result<()> {
-    let ane_dir = fluidaudio_ane_kokoro_dir();
-    // Ahead of the empty-manifest exit: a zh-only install stages no flat packs but still needs the repair.
-    purge_incomplete_ane_bundles(&ane_dir)?;
     let manifest = ane_voices_for(langs);
     if manifest.is_empty() {
         return Ok(());
     }
+    let ane_dir = fluidaudio_ane_kokoro_dir();
     fs::create_dir_all(&ane_dir)
         .with_context(|| format!("create FluidAudio ANE dir {}", ane_dir.display()))?;
     parallel_download(&ane_dir, &manifest, no_cache)
 }
 
-/// Delete `.mlmodelc` bundles in FluidAudio's ANE cache that are missing
-/// `model.mil`, so FluidAudio refetches them instead of failing to load.
+/// `.mlmodelc` bundles in FluidAudio's Kokoro cache that are missing
+/// `model.mil`, i.e. left half-fetched by an earlier version.
 ///
-/// FluidAudio's "already downloaded" check is directory-name based, so a bundle
-/// left half-fetched by an older version is never repaired: 0.14.8 fully fetched
-/// the `KokoroNoise.mlmodelc` it loaded and only partially fetched its
+/// FluidAudio's "already downloaded" check is directory-name based, so such a
+/// bundle is never repaired on its own: 0.14.8 fully fetched the
+/// `KokoroNoise.mlmodelc` it loaded and only partially fetched its
 /// `KokoroNoise_v2.mlmodelc` sibling, and 0.15.5 loads `_v2` — turning an
 /// upgrade on an existing cache into `Error in reading the MIL network` (#709,
 /// upstream #821/#826). Every Kokoro ANE bundle is CoreML ML Program format, so
 /// a missing `model.mil` means incomplete, never a valid alternative encoding.
-#[cfg(all(
-    feature = "system_kokoro",
-    target_os = "macos",
-    target_arch = "aarch64"
+///
+/// Scans every `ANE*` variant directory (`ANE`, `ANE-zh`, …), which share the
+/// same required bundle set, and one extension-less level below each so the
+/// Mandarin variant's nested `g2pw/g2pw.mlmodelc` is covered. `.mlpackage`
+/// sources, `.bin` voice packs and `vocab.json` are never candidates.
+#[cfg(any(
+    all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    ),
+    test
 ))]
-fn purge_incomplete_ane_bundles(ane_dir: &Path) -> Result<()> {
-    let entries = match fs::read_dir(ane_dir) {
-        Ok(e) => e,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
-        Err(e) => {
-            return Err(e).with_context(|| format!("read FluidAudio ANE dir {}", ane_dir.display()))
+fn incomplete_ane_bundles_in(kokoro_dir: &Path) -> Result<Vec<PathBuf>> {
+    let mut found = Vec::new();
+    for variant in read_dir_paths(kokoro_dir)? {
+        let is_variant = variant.is_dir()
+            && variant
+                .file_name()
+                .is_some_and(|n| n.to_string_lossy().starts_with("ANE"));
+        if is_variant {
+            collect_incomplete_bundles(&variant, 1, &mut found)?;
         }
-    };
-    for entry in entries {
-        let path = entry
-            .with_context(|| format!("read entry in {}", ane_dir.display()))?
-            .path();
-        let is_bundle = path.is_dir() && path.extension().is_some_and(|x| x == "mlmodelc");
-        if !is_bundle || path.join("model.mil").exists() {
+    }
+    Ok(found)
+}
+
+#[cfg(any(
+    all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    ),
+    test
+))]
+fn collect_incomplete_bundles(dir: &Path, depth: u32, found: &mut Vec<PathBuf>) -> Result<()> {
+    for path in read_dir_paths(dir)? {
+        if !path.is_dir() {
             continue;
         }
+        if path.extension().is_some_and(|x| x == "mlmodelc") {
+            if !path.join("model.mil").exists() {
+                found.push(path);
+            }
+        } else if depth > 0 && path.extension().is_none() {
+            collect_incomplete_bundles(&path, depth - 1, found)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(any(
+    all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    ),
+    test
+))]
+fn read_dir_paths(dir: &Path) -> Result<Vec<PathBuf>> {
+    let entries = match fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(e).with_context(|| format!("read {}", dir.display())),
+    };
+    entries
+        .map(|e| {
+            Ok(
+                e.with_context(|| format!("read entry in {}", dir.display()))?
+                    .path(),
+            )
+        })
+        .collect()
+}
+
+/// Delete the bundles [`incomplete_ane_bundles_in`] finds so FluidAudio
+/// refetches them instead of failing to load. Filesystem-only: it never
+/// downloads, so every `kesha install` can run it (#709).
+#[cfg(any(
+    all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    ),
+    test
+))]
+fn purge_incomplete_ane_bundles_in(kokoro_dir: &Path) -> Result<()> {
+    for path in incomplete_ane_bundles_in(kokoro_dir)? {
         let name = path.file_name().unwrap_or_default().to_string_lossy();
         with_stderr(|| eprintln!("REPAIR {name} (incomplete, will refetch on first synth)"));
         fs::remove_dir_all(&path)
             .with_context(|| format!("remove incomplete CoreML bundle {}", path.display()))?;
     }
     Ok(())
+}
+
+#[cfg(all(
+    feature = "system_kokoro",
+    target_os = "macos",
+    target_arch = "aarch64"
+))]
+pub fn purge_incomplete_ane_bundles() -> Result<()> {
+    purge_incomplete_ane_bundles_in(&fluidaudio_kokoro_cache_dir())
+}
+
+/// Names of the incomplete bundles currently in the cache, for the hint
+/// `tts::fluid_kokoro` attaches to a Kokoro init failure. Best-effort: it runs
+/// while another error is being reported, so a scan failure must not mask it.
+#[cfg(all(
+    feature = "system_kokoro",
+    target_os = "macos",
+    target_arch = "aarch64"
+))]
+pub fn incomplete_ane_bundle_names() -> Vec<String> {
+    incomplete_ane_bundles_in(&fluidaudio_kokoro_cache_dir())
+        .unwrap_or_default()
+        .iter()
+        .filter_map(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
+        .collect()
 }
 
 /// Vosk-TTS multi-speaker Russian model, mirrored to HF at
@@ -885,6 +986,15 @@ fn has_all_files(dir: &Path, files: &[ModelFile]) -> bool {
 
 pub fn install(no_cache: bool) -> Result<()> {
     let cache = cache_dir();
+
+    // Every install repairs the ANE cache, not just `--tts`: a user who already had
+    // TTS and only upgrades the engine still carries the incomplete bundle (#709).
+    #[cfg(all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    ))]
+    purge_incomplete_ane_bundles()?;
 
     // Always hash-verify even on cache hits — catches silent corruption (#174).
     // 4-worker pool (#178) overlaps ASR + lang-id round-trips within HF's per-IP tolerance.
@@ -1172,12 +1282,7 @@ mod manifest_tests {
     }
 }
 
-#[cfg(all(
-    test,
-    feature = "system_kokoro",
-    target_os = "macos",
-    target_arch = "aarch64"
-))]
+#[cfg(test)]
 mod ane_bundle_repair_tests {
     use super::*;
 
@@ -1194,28 +1299,73 @@ mod ane_bundle_repair_tests {
     #[test]
     fn purge_removes_only_bundles_missing_model_mil() -> Result<()> {
         let tmp = tempfile::tempdir()?;
-        let dir = tmp.path();
-        let complete = bundle(dir, "KokoroVocoder.mlmodelc", true)?;
-        let incomplete = bundle(dir, "KokoroNoise_v2.mlmodelc", false)?;
-        // Staged voice packs and the loose vocab share the directory and must survive.
-        let voice = dir.join("am_michael.bin");
+        let ane = tmp.path().join("ANE");
+        let complete = bundle(&ane, "KokoroVocoder.mlmodelc", true)?;
+        let incomplete = bundle(&ane, "KokoroNoise_v2.mlmodelc", false)?;
+        // Staged voice packs, the loose vocab and the .mlpackage sources share the
+        // directory and must survive.
+        let voice = ane.join("am_michael.bin");
         fs::write(&voice, b"voice")?;
-        let vocab = dir.join("vocab.json");
+        let vocab = ane.join("vocab.json");
         fs::write(&vocab, b"{}")?;
+        let package = ane.join("KokoroNoise_v2.mlpackage");
+        fs::create_dir_all(&package)?;
 
-        purge_incomplete_ane_bundles(dir)?;
+        purge_incomplete_ane_bundles_in(tmp.path())?;
 
         assert!(complete.exists(), "complete bundle must be kept");
         assert!(!incomplete.exists(), "incomplete bundle must be removed");
         assert!(voice.exists(), "staged voice packs must survive the repair");
         assert!(vocab.exists(), "vocab.json must survive the repair");
+        assert!(
+            package.exists(),
+            ".mlpackage sources must survive the repair"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn purge_covers_sibling_variant_caches() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let zh = bundle(&tmp.path().join("ANE-zh"), "KokoroNoise_v2.mlmodelc", false)?;
+        let g2pw = bundle(&tmp.path().join("ANE-zh/g2pw"), "g2pw.mlmodelc", false)?;
+        let ja = bundle(&tmp.path().join("ANE-ja"), "KokoroNoise_v2.mlmodelc", false)?;
+        let voices = tmp.path().join("ANE-zh/voices/zf_001.bin");
+        fs::create_dir_all(voices.parent().expect("voices dir"))?;
+        fs::write(&voices, b"voice")?;
+
+        purge_incomplete_ane_bundles_in(tmp.path())?;
+
+        assert!(!zh.exists(), "ANE-zh bundle must be repaired too");
+        assert!(!g2pw.exists(), "nested g2pw bundle must be repaired too");
+        assert!(!ja.exists(), "ANE-ja bundle must be repaired too");
+        assert!(
+            voices.exists(),
+            "nested voice packs must survive the repair"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn purge_ignores_directories_outside_the_ane_variants() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let other = bundle(&tmp.path().join("GPU"), "KokoroNoise_v2.mlmodelc", false)?;
+        let loose = bundle(tmp.path(), "KokoroNoise_v2.mlmodelc", false)?;
+
+        purge_incomplete_ane_bundles_in(tmp.path())?;
+
+        assert!(
+            other.exists(),
+            "non-ANE variant dirs are not ours to repair"
+        );
+        assert!(loose.exists(), "only variant subdirectories are scanned");
         Ok(())
     }
 
     #[test]
     fn purge_is_a_noop_on_a_missing_directory() -> Result<()> {
         let tmp = tempfile::tempdir()?;
-        purge_incomplete_ane_bundles(&tmp.path().join("absent"))
+        purge_incomplete_ane_bundles_in(&tmp.path().join("absent"))
     }
 }
 

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -343,7 +343,7 @@ fn kokoro_manifest_for(langs: &[&str]) -> Vec<ModelFile> {
 
 /// FluidAudio ANE Kokoro voice packs (`system_kokoro` darwin path, #475).
 ///
-/// FluidAudio 0.14.7's `KokoroAneManager` resolves `<voice>.bin` LOCAL-FIRST
+/// FluidAudio 0.15.5's `KokoroAneManager` resolves `<voice>.bin` LOCAL-FIRST
 /// from its own cache (`~/.cache/fluidaudio/Models/kokoro-82m-coreml/ANE/`)
 /// before any download. The ANE bundle only ships `af_heart`, so `am_michael`
 /// (kesha's male brand default) and the rest of the advertised Kokoro catalog
@@ -351,7 +351,7 @@ fn kokoro_manifest_for(langs: &[&str]) -> Vec<ModelFile> {
 /// the standard onnx-community Kokoro packs kesha used on the ONNX path — so we
 /// download them from onnx-community and stage them into the ANE cache at install
 /// time (see [`stage_ane_kokoro_voices`]). `af_heart` is intentionally EXCLUDED:
-/// FluidAudio 0.14.7 auto-downloads its own `af_heart.bin` into the ANE dir on
+/// FluidAudio 0.15.5 auto-downloads its own `af_heart.bin` into the ANE dir on
 /// first synth, and staging our own copy would risk an SHA mismatch overwriting
 /// FluidAudio's authoritative pack. Kesha only stages the voices the ANE bundle
 /// LACKS (`am_michael` and the rest of the advertised catalog).
@@ -397,7 +397,7 @@ const ANE_KOKORO_VOICES: &[ModelFile] = &[
         "af_bella",
         "f69d836209b78eb8c66e75e3cda491e26ea838a3674257e9d4e5703cbaf55c8b"
     ),
-    // `af_heart` intentionally excluded: FluidAudio 0.14.7 ships/auto-downloads
+    // `af_heart` intentionally excluded: FluidAudio 0.15.5 ships/auto-downloads
     // its own `af_heart.bin` into this ANE dir. Staging our own copy would risk
     // overwriting FluidAudio's authoritative pack if the upstream hash ever
     // drifted.
@@ -495,7 +495,7 @@ const ANE_KOKORO_VOICES: &[ModelFile] = &[
     ),
     // re-pinned (#492): removed the flat `zm_yunjian.bin`
     // (was sha de48a00bdbf3649f07162269a2b6e0513604389bfac8a2e6c75cb34b323ad6fa).
-    // zh (Mandarin) voices are NOT staged here — the FluidAudio 0.14.8 `.mandarin`
+    // zh (Mandarin) voices are NOT staged here — the FluidAudio 0.15.5 `.mandarin`
     // KokoroAne variant fetches its own `ANE-zh/` bundle (nested `voices/<id>.bin`)
     // on first synth, and those ids are numbered (e.g. zm_050), not the
     // onnx-community names. A flat kesha-staged pack would be unused. See
@@ -541,7 +541,7 @@ fn ane_voices_for(langs: &[&str]) -> Vec<&'static ModelFile> {
 }
 
 /// FluidAudio's Kokoro ANE voice-pack cache directory. NOT under
-/// `KESHA_CACHE_DIR` — FluidAudio 0.14.7 owns this path and reads voice packs
+/// `KESHA_CACHE_DIR` — FluidAudio 0.15.5 owns this path and reads voice packs
 /// from here local-first. We pre-stage onnx-community packs here so the full
 /// advertised Kokoro catalog (and the male `am_michael` default) resolve
 /// without a 404 against the ANE bundle.
@@ -618,14 +618,55 @@ fn fluidaudio_asr_ready_in(dir: &Path) -> bool {
     target_arch = "aarch64"
 ))]
 pub fn stage_ane_kokoro_voices(langs: &[&str], no_cache: bool) -> Result<()> {
+    let ane_dir = fluidaudio_ane_kokoro_dir();
+    // Ahead of the empty-manifest exit: a zh-only install stages no flat packs but still needs the repair.
+    purge_incomplete_ane_bundles(&ane_dir)?;
     let manifest = ane_voices_for(langs);
     if manifest.is_empty() {
         return Ok(());
     }
-    let ane_dir = fluidaudio_ane_kokoro_dir();
     fs::create_dir_all(&ane_dir)
         .with_context(|| format!("create FluidAudio ANE dir {}", ane_dir.display()))?;
     parallel_download(&ane_dir, &manifest, no_cache)
+}
+
+/// Delete `.mlmodelc` bundles in FluidAudio's ANE cache that are missing
+/// `model.mil`, so FluidAudio refetches them instead of failing to load.
+///
+/// FluidAudio's "already downloaded" check is directory-name based, so a bundle
+/// left half-fetched by an older version is never repaired: 0.14.8 fully fetched
+/// the `KokoroNoise.mlmodelc` it loaded and only partially fetched its
+/// `KokoroNoise_v2.mlmodelc` sibling, and 0.15.5 loads `_v2` — turning an
+/// upgrade on an existing cache into `Error in reading the MIL network` (#709,
+/// upstream #821/#826). Every Kokoro ANE bundle is CoreML ML Program format, so
+/// a missing `model.mil` means incomplete, never a valid alternative encoding.
+#[cfg(all(
+    feature = "system_kokoro",
+    target_os = "macos",
+    target_arch = "aarch64"
+))]
+fn purge_incomplete_ane_bundles(ane_dir: &Path) -> Result<()> {
+    let entries = match fs::read_dir(ane_dir) {
+        Ok(e) => e,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => {
+            return Err(e).with_context(|| format!("read FluidAudio ANE dir {}", ane_dir.display()))
+        }
+    };
+    for entry in entries {
+        let path = entry
+            .with_context(|| format!("read entry in {}", ane_dir.display()))?
+            .path();
+        let is_bundle = path.is_dir() && path.extension().is_some_and(|x| x == "mlmodelc");
+        if !is_bundle || path.join("model.mil").exists() {
+            continue;
+        }
+        let name = path.file_name().unwrap_or_default().to_string_lossy();
+        with_stderr(|| eprintln!("REPAIR {name} (incomplete, will refetch on first synth)"));
+        fs::remove_dir_all(&path)
+            .with_context(|| format!("remove incomplete CoreML bundle {}", path.display()))?;
+    }
+    Ok(())
 }
 
 /// Vosk-TTS multi-speaker Russian model, mirrored to HF at
@@ -1131,6 +1172,53 @@ mod manifest_tests {
     }
 }
 
+#[cfg(all(
+    test,
+    feature = "system_kokoro",
+    target_os = "macos",
+    target_arch = "aarch64"
+))]
+mod ane_bundle_repair_tests {
+    use super::*;
+
+    fn bundle(dir: &Path, name: &str, with_mil: bool) -> Result<PathBuf> {
+        let path = dir.join(name);
+        fs::create_dir_all(&path)?;
+        fs::write(path.join("coremldata.bin"), b"x")?;
+        if with_mil {
+            fs::write(path.join("model.mil"), b"x")?;
+        }
+        Ok(path)
+    }
+
+    #[test]
+    fn purge_removes_only_bundles_missing_model_mil() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let dir = tmp.path();
+        let complete = bundle(dir, "KokoroVocoder.mlmodelc", true)?;
+        let incomplete = bundle(dir, "KokoroNoise_v2.mlmodelc", false)?;
+        // Staged voice packs and the loose vocab share the directory and must survive.
+        let voice = dir.join("am_michael.bin");
+        fs::write(&voice, b"voice")?;
+        let vocab = dir.join("vocab.json");
+        fs::write(&vocab, b"{}")?;
+
+        purge_incomplete_ane_bundles(dir)?;
+
+        assert!(complete.exists(), "complete bundle must be kept");
+        assert!(!incomplete.exists(), "incomplete bundle must be removed");
+        assert!(voice.exists(), "staged voice packs must survive the repair");
+        assert!(vocab.exists(), "vocab.json must survive the repair");
+        Ok(())
+    }
+
+    #[test]
+    fn purge_is_a_noop_on_a_missing_directory() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        purge_incomplete_ane_bundles(&tmp.path().join("absent"))
+    }
+}
+
 #[cfg(all(test, feature = "system_diarize"))]
 mod diarize_sidecar_tests {
     use super::*;
@@ -1372,7 +1460,7 @@ mod tts_tests {
         }
         // Every FluidAudio Kokoro voice kesha advertises must have a staged
         // pack, or `--voice <lang>-<x>` resolves then 404s on the ANE bundle —
-        // EXCEPT `af_heart`, which FluidAudio 0.14.7 auto-provides into the
+        // EXCEPT `af_heart`, which FluidAudio 0.15.5 auto-provides into the
         // same ANE dir on first synth, so kesha must NOT stage its own copy.
         for v in crate::tts::fluid_kokoro::available_voice_ids() {
             let bare = v

--- a/rust/src/tts/fluid_kokoro.rs
+++ b/rust/src/tts/fluid_kokoro.rs
@@ -43,7 +43,7 @@ macro_rules! fluid_voice {
     };
 }
 
-// FluidAudio 0.14.8 voice snapshot plus the multilingual Kokoro voice packs
+// FluidAudio 0.15.5 voice snapshot plus the multilingual Kokoro voice packs
 // validated against the ANE cache. Keep this list in sync with the FluidAudio
 // pin in the fluidaudio-rs git rev (rust/Cargo.toml) whenever it changes.
 const VOICES: &[VoiceSpec] = &[
@@ -105,9 +105,11 @@ fn is_han(c: char) -> bool {
 }
 
 /// FluidAudio's Kokoro G2P handles Latin (en/es/fr/it/pt) and, since the
-/// FluidAudio 0.14.8 `.mandarin` KokoroAne variant, Chinese (Han). For the other
+/// FluidAudio 0.15.5 `.mandarin` KokoroAne variant, Chinese (Han). For the other
 /// non-Latin languages it ships voices for (hi/ja) native-script text is not
 /// converted to phonemes and synthesizes as noise rather than speech (#492).
+/// FluidAudio 0.15.5 added a `.japanese` variant, but the binding still routes
+/// only `zh` away from `.english`, so `ja` keeps bailing until that is wired.
 /// Returns the human-facing script name when `text` actually contains characters
 /// of the script `fluid_id`'s language is written in — romanized (Latin) input
 /// for the same voice returns `None` because it works.
@@ -117,7 +119,7 @@ fn unsupported_native_script(text: &str, fluid_id: &str) -> Option<&'static str>
         "hi" => any(|c| ('\u{0900}'..='\u{097F}').contains(&c)).then_some("Devanagari"),
         "ja" => any(|c| matches!(c, '\u{3040}'..='\u{30FF}') || is_han(c))
             .then_some("Japanese (kana/kanji)"),
-        // zh (Han) is supported via FluidAudio 0.14.8's Mandarin KokoroAne variant.
+        // zh (Han) is supported via FluidAudio 0.15.5's Mandarin KokoroAne variant.
         _ => None,
     }
 }
@@ -351,7 +353,7 @@ mod tests {
             unsupported_native_script("日本語", "jm_kumo"),
             Some("Japanese (kana/kanji)")
         );
-        // zh (Han) is now SUPPORTED via FluidAudio 0.14.8's Mandarin KokoroAne
+        // zh (Han) is now SUPPORTED via FluidAudio 0.15.5's Mandarin KokoroAne
         // variant (#492) — native-script Chinese must NOT be flagged.
         assert_eq!(unsupported_native_script("你好我叫凯沙", "zm_050"), None);
         assert_eq!(unsupported_native_script("\u{20000}", "zm_050"), None);
@@ -393,7 +395,8 @@ mod tests {
 
     #[test]
     fn ensure_script_supported_bails_with_code_on_native_script() {
-        // hi/ja native script still bails (no FluidAudio 0.14.8 KokoroAne variant).
+        // hi/ja native script still bails: no hi variant upstream, and the binding
+        // does not route ja to 0.15.5's `.japanese` variant.
         for (text, voice) in [("नमस्ते", "hm_omega"), ("こんにちは", "jm_kumo")] {
             let err =
                 ensure_script_supported(voice, text).expect_err("should reject native script");

--- a/rust/src/tts/fluid_kokoro.rs
+++ b/rust/src/tts/fluid_kokoro.rs
@@ -199,6 +199,24 @@ fn compute_units_from_env() -> Result<KokoroComputeUnits> {
     )
 }
 
+/// Suffix naming the one Kokoro init failure kesha can repair: a `.mlmodelc`
+/// left incomplete in FluidAudio's cache by an older version (#709). The Swift
+/// bridge collapses every init failure into `-1` and logs the CoreML reason
+/// (`Error in reading the MIL network`) to stderr itself, so the cause is not in
+/// the Rust error — the cache is what we can inspect. Empty when the cache is
+/// clean, so a healthy install never gets misleading advice.
+fn incomplete_bundle_hint() -> String {
+    let names = crate::models::incomplete_ane_bundle_names();
+    if names.is_empty() {
+        return String::new();
+    }
+    format!(
+        "; FluidAudio's CoreML cache has incomplete bundle(s) ({}) — re-run \
+         `kesha install --tts` to repair",
+        names.join(", ")
+    )
+}
+
 /// Initialize a FluidAudio Kokoro bridge for `voice_id` and run `f` against it
 /// with the process's stdout silenced for the whole bridge lifetime (create →
 /// call → drop). FluidAudio's CoreML pipeline writes diagnostics to stdout that
@@ -215,11 +233,12 @@ fn with_kokoro<R>(voice_id: &str, f: impl FnOnce(&FluidAudio) -> Result<R>) -> R
         let audio = FluidAudio::new().context("init FluidAudio bridge")?;
         audio
             .init_kokoro_with_compute_units(voice_id, lang, compute_units)
-            .with_context(|| {
-                format!(
-                    "init FluidAudio Kokoro on {} compute units (downloads the model on first run)",
-                    preset_name(compute_units)
-                )
+            .map_err(|e| {
+                anyhow::Error::new(e).context(format!(
+                    "init FluidAudio Kokoro on {} compute units (downloads the model on first run){}",
+                    preset_name(compute_units),
+                    incomplete_bundle_hint()
+                ))
             })?;
         f(&audio)
     })


### PR DESCRIPTION
Bumps the `fluidaudio-rs` pin from `9b7ceda` (FluidAudio Swift 0.14.8) to [`dc931c5`](https://github.com/drakulavich/fluidaudio-rs/commit/dc931c5be72cf94700b8f53027391421ba0a0628) on the fork branch `bump-fluidaudio-0.15.5`, which tracks **FluidAudio Swift 0.15.5**.

## Fork side (`drakulavich/fluidaudio-rs@dc931c5`)

- `Package.swift` pinned `exact: "0.15.5"`; `Package.resolved` resolves to `19600a4` / `0.15.5`.
- Removed the `qwen3_*` / `qwen3_streaming_*` bindings, their Swift FFI, two examples and their tests — FluidAudio 0.15.3 removed the backend upstream. kesha called none of them.
- The `DownloadUtils` → `ModelHub` rename (upstream #765/#779) does not reach the bridge: it never called the download surface directly, so the Swift target compiles against 0.15.5 unchanged.

## Cache invariants re-verified against 0.15.5

Both still hold, so `models::fluidaudio_ane_kokoro_dir()` and the deliberate `af_heart` exclusion are unchanged:

- `Repo.kokoroAne.folderName == "kokoro-82m-coreml/ANE"`, rooted at `~/.cache/fluidaudio/Models/` (`Sources/FluidAudio/ModelNames.swift`).
- `ModelNames.KokoroAne.requiredModels` still contains `af_heart.bin`, so FluidAudio keeps providing its own copy.

No model pin in `rust/src/models.rs` moved. kesha's ANE voice packs come from onnx-community and are independent of the FluidAudio version; the `KokoroNoise_v2` rename lives inside FluidAudio's own bundle, which kesha does not pin. All four Sortformer files re-verified against their existing SHA-256 pins.

## The upgrade-path break this bump exposed

FluidAudio's "already downloaded" check is directory-name based, and each version only fully fetches the noise bundle it actually loads (upstream #821/#826). A 0.14.8-staged cache has a complete `KokoroNoise.mlmodelc` and a `KokoroNoise_v2.mlmodelc` **missing `model.mil`** — and 0.15.5 loads `_v2`. So on every existing install, `kesha say` died with:

```
Kokoro init error: Error Domain=com.apple.CoreML Code=3 "Error in reading the MIL network."
```

and the name-based check meant it never repaired itself. Isolated with a three-way A/B on this machine (same cache, same fixture):

| build | result |
|---|---|
| old pin `9b7ceda` (FA 0.14.8) | exit 0, 99644-byte WAV |
| fork `forked-main` + FA 0.14.8 | exit 0, 99644-byte WAV |
| this PR (FA 0.15.5) | `Error in reading the MIL network` |
| this PR, fresh cache | exit 0, 87644-byte WAV |

So the fork's own changes are innocent; it is purely the stale bundle. `kesha install` now removes ANE `.mlmodelc` bundles missing `model.mil` so FluidAudio refetches them. Staged voice packs, `vocab.json` and FluidAudio's own `af_heart.bin` are left alone, and the repair runs ahead of the empty-manifest exit so a `--tts zh` install still gets it.

## Done-when evidence

**1. Fork builds against 0.15.5 with `qwen3_*` removed, rev bumped here.** `swift build -c release` → `Build complete! (100.46s)`; `cargo test --all-features --all-targets` → `16 passed; 0 failed`. `Cargo.lock` now reads `fluidaudio-rs 0.15.5 … rev=dc931c5b`.

**2. All three feature checks green** (from `rust/`):

```
cargo check --features coreml --no-default-features   Finished `dev` profile
cargo check --features system_kokoro                  Finished `dev` profile
cargo check --features system_diarize                 Finished `dev` profile
```

**3. `kesha install --tts` resolves every advertised voice, no 404, no overwrite.** `install --tts en es fr it pt hi ja zh` exited 0, staging the six not-yet-cached voices (`hm_omega`, `em_alex`, `jm_kumo`, `im_nicola`, `pm_alex`, `ff_siwis`) and short-circuiting the rest as `(cached)`. FluidAudio's `af_heart.bin` was byte-identical before and after — same SHA `d583ccff…`, same mode `600`, same mtime — versus mode `644` on all 26 kesha-staged packs.

**4. Diarization finds the pre-staged Sortformer model without a download.** `transcribe --json --vad --speakers` returned `"speaker":0` on every segment with clean stderr. FluidAudio's own model cache (`~/Library/Application Support/FluidAudio/Models/`) still holds only `parakeet-*` and `silero-vad` — no diarizer was fetched. The compiled-model cache still works: 19.4s cold, 6.7s warm.

## Gates

`bun test` 776 pass / 0 fail · `bunx tsc --noEmit` clean · `make rust-test` 402 passed / 0 failed · `cargo fmt --check` clean · `cargo clippy --all-targets -- -D warnings` 0 errors (also with `--features system_kokoro,system_diarize`).

Two new unit tests cover the repair: it removes only bundles missing `model.mil`, preserves voice packs and `vocab.json`, and no-ops on a missing directory.

## Notes

- **No libBNNS crash was observed.** Every synthesis either succeeded or failed with the CoreML MIL error above; nothing hit `BNNSGraphContextExecute_v2`. The documented macOS 26.5 hazard (upstream #818) did not fire on this run — this machine is 26.5.2.
- `bun test` shows one *pre-existing* flake once the diarize model is installed: the `--speakers` e2e can exceed its 30s limit on a cold ANE cache. It runs the separately-installed engine binary (`~/.cache/kesha/engine/bin/kesha-engine`, CoreML backend, dated Aug 4), which this diff cannot affect — that binary alone takes 24.3s cold and 5.2s warm. Passes once warm.
- **Follow-up worth an issue:** 0.15.5 adds a `.japanese` KokoroAne variant (`Repo.kokoroAneJa`), but the binding still routes only `zh` away from `.english`, so `ja` native script keeps bailing with `E_SCRIPT_UNSUPPORTED`. Wiring it would give kesha real Japanese TTS. Comments updated to state that reason rather than the now-false "no upstream variant".

Closes #709

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBTpJjqyYFW6W8LHJ2nwy