### PR TITLE
fix(tts): synthesize past the 510-phoneme cap instead of cutting at it

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -676,8 +676,8 @@ dependencies = [
 
 [[package]]
 name = "fluidaudio-rs"
-version = "0.14.8"
-source = "git+https://github.com/drakulavich/fluidaudio-rs?rev=9b7ceda98c4b0485590c04805c62ebde76e66159#9b7ceda98c4b0485590c04805c62ebde76e66159"
+version = "0.15.5"
+source = "git+https://github.com/drakulavich/fluidaudio-rs?rev=dc931c5be72cf94700b8f53027391421ba0a0628#dc931c5be72cf94700b8f53027391421ba0a0628"
 dependencies = [
  "thiserror 1.0.69",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -77,10 +77,11 @@ ndarray = { version = "0.17" }
 # prepare the program). Retire the fork once both land upstream.
 # Trade-off to know: this rev trails `FluidInference/main`, so upstream commits
 # after the previous pin are not present. Everything kesha calls is verified to
-# build against it.
+# build against it. Tracks FluidAudio Swift 0.15.5 (#709); the fork's `qwen3_*`
+# bindings are gone because 0.15.3 removed the backend upstream.
 # `init_kokoro` still takes `lang` → `zh` selects `.mandarin` (tone-aware
 # Mandarin G2P), else `.english` (#492); `--rate` stays model-native (#475).
-fluidaudio-rs = { git = "https://github.com/drakulavich/fluidaudio-rs", rev = "9b7ceda98c4b0485590c04805c62ebde76e66159", optional = true }
+fluidaudio-rs = { git = "https://github.com/drakulavich/fluidaudio-rs", rev = "dc931c5be72cf94700b8f53027391421ba0a0628", optional = true }
 audioadapter-buffers = "3.0.0"
 
 # TTS (Kokoro + SSML parser; G2P via ONNX ByT5 at runtime, see #123)

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -342,7 +342,7 @@ fn kokoro_manifest_for(langs: &[&str]) -> Vec<ModelFile> {
 
 /// FluidAudio ANE Kokoro voice packs (`system_kokoro` darwin path, #475).
 ///
-/// FluidAudio 0.14.7's `KokoroAneManager` resolves `<voice>.bin` LOCAL-FIRST
+/// FluidAudio 0.15.5's `KokoroAneManager` resolves `<voice>.bin` LOCAL-FIRST
 /// from its own cache (`~/.cache/fluidaudio/Models/kokoro-82m-coreml/ANE/`)
 /// before any download. The ANE bundle only ships `af_heart`, so `am_michael`
 /// (kesha's male brand default) and the rest of the advertised Kokoro catalog
@@ -350,7 +350,7 @@ fn kokoro_manifest_for(langs: &[&str]) -> Vec<ModelFile> {
 /// the standard onnx-community Kokoro packs kesha used on the ONNX path — so we
 /// download them from onnx-community and stage them into the ANE cache at install
 /// time (see [`stage_ane_kokoro_voices`]). `af_heart` is intentionally EXCLUDED:
-/// FluidAudio 0.14.7 auto-downloads its own `af_heart.bin` into the ANE dir on
+/// FluidAudio 0.15.5 auto-downloads its own `af_heart.bin` into the ANE dir on
 /// first synth, and staging our own copy would risk an SHA mismatch overwriting
 /// FluidAudio's authoritative pack. Kesha only stages the voices the ANE bundle
 /// LACKS (`am_michael` and the rest of the advertised catalog).
@@ -396,7 +396,7 @@ const ANE_KOKORO_VOICES: &[ModelFile] = &[
         "af_bella",
         "f69d836209b78eb8c66e75e3cda491e26ea838a3674257e9d4e5703cbaf55c8b"
     ),
-    // `af_heart` intentionally excluded: FluidAudio 0.14.7 ships/auto-downloads
+    // `af_heart` intentionally excluded: FluidAudio 0.15.5 ships/auto-downloads
     // its own `af_heart.bin` into this ANE dir. Staging our own copy would risk
     // overwriting FluidAudio's authoritative pack if the upstream hash ever
     // drifted.
@@ -494,7 +494,7 @@ const ANE_KOKORO_VOICES: &[ModelFile] = &[
     ),
     // re-pinned (#492): removed the flat `zm_yunjian.bin`
     // (was sha de48a00bdbf3649f07162269a2b6e0513604389bfac8a2e6c75cb34b323ad6fa).
-    // zh (Mandarin) voices are NOT staged here — the FluidAudio 0.14.8 `.mandarin`
+    // zh (Mandarin) voices are NOT staged here — the FluidAudio 0.15.5 `.mandarin`
     // KokoroAne variant fetches its own `ANE-zh/` bundle (nested `voices/<id>.bin`)
     // on first synth, and those ids are numbered (e.g. zm_050), not the
     // onnx-community names. A flat kesha-staged pack would be unused. See
@@ -540,7 +540,7 @@ fn ane_voices_for(langs: &[&str]) -> Vec<&'static ModelFile> {
 }
 
 /// FluidAudio's Kokoro ANE voice-pack cache directory. NOT under
-/// `KESHA_CACHE_DIR` — FluidAudio 0.14.7 owns this path and reads voice packs
+/// `KESHA_CACHE_DIR` — FluidAudio 0.15.5 owns this path and reads voice packs
 /// from here local-first. We pre-stage onnx-community packs here so the full
 /// advertised Kokoro catalog (and the male `am_michael` default) resolve
 /// without a 404 against the ANE bundle.
@@ -617,14 +617,55 @@ fn fluidaudio_asr_ready_in(dir: &Path) -> bool {
     target_arch = "aarch64"
 ))]
 pub fn stage_ane_kokoro_voices(langs: &[&str], no_cache: bool) -> Result<()> {
+    let ane_dir = fluidaudio_ane_kokoro_dir();
+    // Ahead of the empty-manifest exit: a zh-only install stages no flat packs but still needs the repair.
+    purge_incomplete_ane_bundles(&ane_dir)?;
     let manifest = ane_voices_for(langs);
     if manifest.is_empty() {
         return Ok(());
     }
-    let ane_dir = fluidaudio_ane_kokoro_dir();
     fs::create_dir_all(&ane_dir)
         .with_context(|| format!("create FluidAudio ANE dir {}", ane_dir.display()))?;
     parallel_download(&ane_dir, &manifest, no_cache)
+}
+
+/// Delete `.mlmodelc` bundles in FluidAudio's ANE cache that are missing
+/// `model.mil`, so FluidAudio refetches them instead of failing to load.
+///
+/// FluidAudio's "already downloaded" check is directory-name based, so a bundle
+/// left half-fetched by an older version is never repaired: 0.14.8 fully fetched
+/// the `KokoroNoise.mlmodelc` it loaded and only partially fetched its
+/// `KokoroNoise_v2.mlmodelc` sibling, and 0.15.5 loads `_v2` — turning an
+/// upgrade on an existing cache into `Error in reading the MIL network` (#709,
+/// upstream #821/#826). Every Kokoro ANE bundle is CoreML ML Program format, so
+/// a missing `model.mil` means incomplete, never a valid alternative encoding.
+#[cfg(all(
+    feature = "system_kokoro",
+    target_os = "macos",
+    target_arch = "aarch64"
+))]
+fn purge_incomplete_ane_bundles(ane_dir: &Path) -> Result<()> {
+    let entries = match fs::read_dir(ane_dir) {
+        Ok(e) => e,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => {
+            return Err(e).with_context(|| format!("read FluidAudio ANE dir {}", ane_dir.display()))
+        }
+    };
+    for entry in entries {
+        let path = entry
+            .with_context(|| format!("read entry in {}", ane_dir.display()))?
+            .path();
+        let is_bundle = path.is_dir() && path.extension().is_some_and(|x| x == "mlmodelc");
+        if !is_bundle || path.join("model.mil").exists() {
+            continue;
+        }
+        let name = path.file_name().unwrap_or_default().to_string_lossy();
+        with_stderr(|| eprintln!("REPAIR {name} (incomplete, will refetch on first synth)"));
+        fs::remove_dir_all(&path)
+            .with_context(|| format!("remove incomplete CoreML bundle {}", path.display()))?;
+    }
+    Ok(())
 }
 
 /// Vosk-TTS multi-speaker Russian model, mirrored to HF at
@@ -1107,6 +1148,53 @@ mod manifest_tests {
     }
 }
 
+#[cfg(all(
+    test,
+    feature = "system_kokoro",
+    target_os = "macos",
+    target_arch = "aarch64"
+))]
+mod ane_bundle_repair_tests {
+    use super::*;
+
+    fn bundle(dir: &Path, name: &str, with_mil: bool) -> Result<PathBuf> {
+        let path = dir.join(name);
+        fs::create_dir_all(&path)?;
+        fs::write(path.join("coremldata.bin"), b"x")?;
+        if with_mil {
+            fs::write(path.join("model.mil"), b"x")?;
+        }
+        Ok(path)
+    }
+
+    #[test]
+    fn purge_removes_only_bundles_missing_model_mil() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let dir = tmp.path();
+        let complete = bundle(dir, "KokoroVocoder.mlmodelc", true)?;
+        let incomplete = bundle(dir, "KokoroNoise_v2.mlmodelc", false)?;
+        // Staged voice packs and the loose vocab share the directory and must survive.
+        let voice = dir.join("am_michael.bin");
+        fs::write(&voice, b"voice")?;
+        let vocab = dir.join("vocab.json");
+        fs::write(&vocab, b"{}")?;
+
+        purge_incomplete_ane_bundles(dir)?;
+
+        assert!(complete.exists(), "complete bundle must be kept");
+        assert!(!incomplete.exists(), "incomplete bundle must be removed");
+        assert!(voice.exists(), "staged voice packs must survive the repair");
+        assert!(vocab.exists(), "vocab.json must survive the repair");
+        Ok(())
+    }
+
+    #[test]
+    fn purge_is_a_noop_on_a_missing_directory() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        purge_incomplete_ane_bundles(&tmp.path().join("absent"))
+    }
+}
+
 #[cfg(all(test, feature = "system_diarize"))]
 mod diarize_sidecar_tests {
     use super::*;
@@ -1293,7 +1381,7 @@ mod tts_tests {
         }
         // Every FluidAudio Kokoro voice kesha advertises must have a staged
         // pack, or `--voice <lang>-<x>` resolves then 404s on the ANE bundle —
-        // EXCEPT `af_heart`, which FluidAudio 0.14.7 auto-provides into the
+        // EXCEPT `af_heart`, which FluidAudio 0.15.5 auto-provides into the
         // same ANE dir on first synth, so kesha must NOT stage its own copy.
         for v in crate::tts::fluid_kokoro::available_voice_ids() {
             let bare = v

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -539,6 +539,23 @@ fn ane_voices_for(langs: &[&str]) -> Vec<&'static ModelFile> {
         .collect()
 }
 
+/// FluidAudio's Kokoro CoreML cache root. Each KokoroAne variant gets its own
+/// subdirectory of bundles here (`ANE` for English/Latin, `ANE-zh` for the
+/// Mandarin variant, and so on per `ModelNames.Repo.subPath`).
+#[cfg(all(
+    feature = "system_kokoro",
+    target_os = "macos",
+    target_arch = "aarch64"
+))]
+pub fn fluidaudio_kokoro_cache_dir() -> PathBuf {
+    dirs::home_dir()
+        .expect("cannot determine home directory")
+        .join(".cache")
+        .join("fluidaudio")
+        .join("Models")
+        .join("kokoro-82m-coreml")
+}
+
 /// FluidAudio's Kokoro ANE voice-pack cache directory. NOT under
 /// `KESHA_CACHE_DIR` — FluidAudio 0.15.5 owns this path and reads voice packs
 /// from here local-first. We pre-stage onnx-community packs here so the full
@@ -550,13 +567,7 @@ fn ane_voices_for(langs: &[&str]) -> Vec<&'static ModelFile> {
     target_arch = "aarch64"
 ))]
 pub fn fluidaudio_ane_kokoro_dir() -> PathBuf {
-    dirs::home_dir()
-        .expect("cannot determine home directory")
-        .join(".cache")
-        .join("fluidaudio")
-        .join("Models")
-        .join("kokoro-82m-coreml")
-        .join("ANE")
+    fluidaudio_kokoro_cache_dir().join("ANE")
 }
 
 /// FluidAudio's ASR bundle directory. Not under `KESHA_CACHE_DIR` — FluidAudio
@@ -617,55 +628,145 @@ fn fluidaudio_asr_ready_in(dir: &Path) -> bool {
     target_arch = "aarch64"
 ))]
 pub fn stage_ane_kokoro_voices(langs: &[&str], no_cache: bool) -> Result<()> {
-    let ane_dir = fluidaudio_ane_kokoro_dir();
-    // Ahead of the empty-manifest exit: a zh-only install stages no flat packs but still needs the repair.
-    purge_incomplete_ane_bundles(&ane_dir)?;
     let manifest = ane_voices_for(langs);
     if manifest.is_empty() {
         return Ok(());
     }
+    let ane_dir = fluidaudio_ane_kokoro_dir();
     fs::create_dir_all(&ane_dir)
         .with_context(|| format!("create FluidAudio ANE dir {}", ane_dir.display()))?;
     parallel_download(&ane_dir, &manifest, no_cache)
 }
 
-/// Delete `.mlmodelc` bundles in FluidAudio's ANE cache that are missing
-/// `model.mil`, so FluidAudio refetches them instead of failing to load.
+/// `.mlmodelc` bundles in FluidAudio's Kokoro cache that are missing
+/// `model.mil`, i.e. left half-fetched by an earlier version.
 ///
-/// FluidAudio's "already downloaded" check is directory-name based, so a bundle
-/// left half-fetched by an older version is never repaired: 0.14.8 fully fetched
-/// the `KokoroNoise.mlmodelc` it loaded and only partially fetched its
+/// FluidAudio's "already downloaded" check is directory-name based, so such a
+/// bundle is never repaired on its own: 0.14.8 fully fetched the
+/// `KokoroNoise.mlmodelc` it loaded and only partially fetched its
 /// `KokoroNoise_v2.mlmodelc` sibling, and 0.15.5 loads `_v2` — turning an
 /// upgrade on an existing cache into `Error in reading the MIL network` (#709,
 /// upstream #821/#826). Every Kokoro ANE bundle is CoreML ML Program format, so
 /// a missing `model.mil` means incomplete, never a valid alternative encoding.
-#[cfg(all(
-    feature = "system_kokoro",
-    target_os = "macos",
-    target_arch = "aarch64"
+///
+/// Scans every `ANE*` variant directory (`ANE`, `ANE-zh`, …), which share the
+/// same required bundle set, and one extension-less level below each so the
+/// Mandarin variant's nested `g2pw/g2pw.mlmodelc` is covered. `.mlpackage`
+/// sources, `.bin` voice packs and `vocab.json` are never candidates.
+#[cfg(any(
+    all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    ),
+    test
 ))]
-fn purge_incomplete_ane_bundles(ane_dir: &Path) -> Result<()> {
-    let entries = match fs::read_dir(ane_dir) {
-        Ok(e) => e,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
-        Err(e) => {
-            return Err(e).with_context(|| format!("read FluidAudio ANE dir {}", ane_dir.display()))
+fn incomplete_ane_bundles_in(kokoro_dir: &Path) -> Result<Vec<PathBuf>> {
+    let mut found = Vec::new();
+    for variant in read_dir_paths(kokoro_dir)? {
+        let is_variant = variant.is_dir()
+            && variant
+                .file_name()
+                .is_some_and(|n| n.to_string_lossy().starts_with("ANE"));
+        if is_variant {
+            collect_incomplete_bundles(&variant, 1, &mut found)?;
         }
-    };
-    for entry in entries {
-        let path = entry
-            .with_context(|| format!("read entry in {}", ane_dir.display()))?
-            .path();
-        let is_bundle = path.is_dir() && path.extension().is_some_and(|x| x == "mlmodelc");
-        if !is_bundle || path.join("model.mil").exists() {
+    }
+    Ok(found)
+}
+
+#[cfg(any(
+    all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    ),
+    test
+))]
+fn collect_incomplete_bundles(dir: &Path, depth: u32, found: &mut Vec<PathBuf>) -> Result<()> {
+    for path in read_dir_paths(dir)? {
+        if !path.is_dir() {
             continue;
         }
+        if path.extension().is_some_and(|x| x == "mlmodelc") {
+            if !path.join("model.mil").exists() {
+                found.push(path);
+            }
+        } else if depth > 0 && path.extension().is_none() {
+            collect_incomplete_bundles(&path, depth - 1, found)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(any(
+    all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    ),
+    test
+))]
+fn read_dir_paths(dir: &Path) -> Result<Vec<PathBuf>> {
+    let entries = match fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(e).with_context(|| format!("read {}", dir.display())),
+    };
+    entries
+        .map(|e| {
+            Ok(
+                e.with_context(|| format!("read entry in {}", dir.display()))?
+                    .path(),
+            )
+        })
+        .collect()
+}
+
+/// Delete the bundles [`incomplete_ane_bundles_in`] finds so FluidAudio
+/// refetches them instead of failing to load. Filesystem-only: it never
+/// downloads, so every `kesha install` can run it (#709).
+#[cfg(any(
+    all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    ),
+    test
+))]
+fn purge_incomplete_ane_bundles_in(kokoro_dir: &Path) -> Result<()> {
+    for path in incomplete_ane_bundles_in(kokoro_dir)? {
         let name = path.file_name().unwrap_or_default().to_string_lossy();
         with_stderr(|| eprintln!("REPAIR {name} (incomplete, will refetch on first synth)"));
         fs::remove_dir_all(&path)
             .with_context(|| format!("remove incomplete CoreML bundle {}", path.display()))?;
     }
     Ok(())
+}
+
+#[cfg(all(
+    feature = "system_kokoro",
+    target_os = "macos",
+    target_arch = "aarch64"
+))]
+pub fn purge_incomplete_ane_bundles() -> Result<()> {
+    purge_incomplete_ane_bundles_in(&fluidaudio_kokoro_cache_dir())
+}
+
+/// Names of the incomplete bundles currently in the cache, for the hint
+/// `tts::fluid_kokoro` attaches to a Kokoro init failure. Best-effort: it runs
+/// while another error is being reported, so a scan failure must not mask it.
+#[cfg(all(
+    feature = "system_kokoro",
+    target_os = "macos",
+    target_arch = "aarch64"
+))]
+pub fn incomplete_ane_bundle_names() -> Vec<String> {
+    incomplete_ane_bundles_in(&fluidaudio_kokoro_cache_dir())
+        .unwrap_or_default()
+        .iter()
+        .filter_map(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
+        .collect()
 }
 
 /// Vosk-TTS multi-speaker Russian model, mirrored to HF at
@@ -884,6 +985,15 @@ fn has_all_files(dir: &Path, files: &[ModelFile]) -> bool {
 
 pub fn install(no_cache: bool) -> Result<()> {
     let cache = cache_dir();
+
+    // Every install repairs the ANE cache, not just `--tts`: a user who already had
+    // TTS and only upgrades the engine still carries the incomplete bundle (#709).
+    #[cfg(all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    ))]
+    purge_incomplete_ane_bundles()?;
 
     // Always hash-verify even on cache hits — catches silent corruption (#174).
     // 4-worker pool (#178) overlaps ASR + lang-id round-trips within HF's per-IP tolerance.
@@ -1148,12 +1258,7 @@ mod manifest_tests {
     }
 }
 
-#[cfg(all(
-    test,
-    feature = "system_kokoro",
-    target_os = "macos",
-    target_arch = "aarch64"
-))]
+#[cfg(test)]
 mod ane_bundle_repair_tests {
     use super::*;
 
@@ -1170,28 +1275,73 @@ mod ane_bundle_repair_tests {
     #[test]
     fn purge_removes_only_bundles_missing_model_mil() -> Result<()> {
         let tmp = tempfile::tempdir()?;
-        let dir = tmp.path();
-        let complete = bundle(dir, "KokoroVocoder.mlmodelc", true)?;
-        let incomplete = bundle(dir, "KokoroNoise_v2.mlmodelc", false)?;
-        // Staged voice packs and the loose vocab share the directory and must survive.
-        let voice = dir.join("am_michael.bin");
+        let ane = tmp.path().join("ANE");
+        let complete = bundle(&ane, "KokoroVocoder.mlmodelc", true)?;
+        let incomplete = bundle(&ane, "KokoroNoise_v2.mlmodelc", false)?;
+        // Staged voice packs, the loose vocab and the .mlpackage sources share the
+        // directory and must survive.
+        let voice = ane.join("am_michael.bin");
         fs::write(&voice, b"voice")?;
-        let vocab = dir.join("vocab.json");
+        let vocab = ane.join("vocab.json");
         fs::write(&vocab, b"{}")?;
+        let package = ane.join("KokoroNoise_v2.mlpackage");
+        fs::create_dir_all(&package)?;
 
-        purge_incomplete_ane_bundles(dir)?;
+        purge_incomplete_ane_bundles_in(tmp.path())?;
 
         assert!(complete.exists(), "complete bundle must be kept");
         assert!(!incomplete.exists(), "incomplete bundle must be removed");
         assert!(voice.exists(), "staged voice packs must survive the repair");
         assert!(vocab.exists(), "vocab.json must survive the repair");
+        assert!(
+            package.exists(),
+            ".mlpackage sources must survive the repair"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn purge_covers_sibling_variant_caches() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let zh = bundle(&tmp.path().join("ANE-zh"), "KokoroNoise_v2.mlmodelc", false)?;
+        let g2pw = bundle(&tmp.path().join("ANE-zh/g2pw"), "g2pw.mlmodelc", false)?;
+        let ja = bundle(&tmp.path().join("ANE-ja"), "KokoroNoise_v2.mlmodelc", false)?;
+        let voices = tmp.path().join("ANE-zh/voices/zf_001.bin");
+        fs::create_dir_all(voices.parent().expect("voices dir"))?;
+        fs::write(&voices, b"voice")?;
+
+        purge_incomplete_ane_bundles_in(tmp.path())?;
+
+        assert!(!zh.exists(), "ANE-zh bundle must be repaired too");
+        assert!(!g2pw.exists(), "nested g2pw bundle must be repaired too");
+        assert!(!ja.exists(), "ANE-ja bundle must be repaired too");
+        assert!(
+            voices.exists(),
+            "nested voice packs must survive the repair"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn purge_ignores_directories_outside_the_ane_variants() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let other = bundle(&tmp.path().join("GPU"), "KokoroNoise_v2.mlmodelc", false)?;
+        let loose = bundle(tmp.path(), "KokoroNoise_v2.mlmodelc", false)?;
+
+        purge_incomplete_ane_bundles_in(tmp.path())?;
+
+        assert!(
+            other.exists(),
+            "non-ANE variant dirs are not ours to repair"
+        );
+        assert!(loose.exists(), "only variant subdirectories are scanned");
         Ok(())
     }
 
     #[test]
     fn purge_is_a_noop_on_a_missing_directory() -> Result<()> {
         let tmp = tempfile::tempdir()?;
-        purge_incomplete_ane_bundles(&tmp.path().join("absent"))
+        purge_incomplete_ane_bundles_in(&tmp.path().join("absent"))
     }
 }
 

--- a/rust/src/tts/fluid_kokoro.rs
+++ b/rust/src/tts/fluid_kokoro.rs
@@ -200,6 +200,24 @@ fn compute_units_from_env() -> Result<KokoroComputeUnits> {
     )
 }
 
+/// Suffix naming the one Kokoro init failure kesha can repair: a `.mlmodelc`
+/// left incomplete in FluidAudio's cache by an older version (#709). The Swift
+/// bridge collapses every init failure into `-1` and logs the CoreML reason
+/// (`Error in reading the MIL network`) to stderr itself, so the cause is not in
+/// the Rust error — the cache is what we can inspect. Empty when the cache is
+/// clean, so a healthy install never gets misleading advice.
+fn incomplete_bundle_hint() -> String {
+    let names = crate::models::incomplete_ane_bundle_names();
+    if names.is_empty() {
+        return String::new();
+    }
+    format!(
+        "; FluidAudio's CoreML cache has incomplete bundle(s) ({}) — re-run \
+         `kesha install --tts` to repair",
+        names.join(", ")
+    )
+}
+
 /// Initialize a FluidAudio Kokoro bridge for `voice_id` and run `f` against it
 /// with the process's stdout silenced for the whole bridge lifetime (create →
 /// call → drop). FluidAudio's CoreML pipeline writes diagnostics to stdout that
@@ -216,11 +234,12 @@ fn with_kokoro<R>(voice_id: &str, f: impl FnOnce(&FluidAudio) -> Result<R>) -> R
         let audio = FluidAudio::new().context("init FluidAudio bridge")?;
         audio
             .init_kokoro_with_compute_units(voice_id, lang, compute_units)
-            .with_context(|| {
-                format!(
-                    "init FluidAudio Kokoro on {} compute units (downloads the model on first run)",
-                    preset_name(compute_units)
-                )
+            .map_err(|e| {
+                anyhow::Error::new(e).context(format!(
+                    "init FluidAudio Kokoro on {} compute units (downloads the model on first run){}",
+                    preset_name(compute_units),
+                    incomplete_bundle_hint()
+                ))
             })?;
         f(&audio)
     })

--- a/rust/src/tts/fluid_kokoro.rs
+++ b/rust/src/tts/fluid_kokoro.rs
@@ -43,7 +43,7 @@ macro_rules! fluid_voice {
     };
 }
 
-// FluidAudio 0.14.8 voice snapshot plus the multilingual Kokoro voice packs
+// FluidAudio 0.15.5 voice snapshot plus the multilingual Kokoro voice packs
 // validated against the ANE cache. Keep this list in sync with the FluidAudio
 // pin in the fluidaudio-rs git rev (rust/Cargo.toml) whenever it changes.
 const VOICES: &[VoiceSpec] = &[
@@ -105,9 +105,11 @@ fn is_han(c: char) -> bool {
 }
 
 /// FluidAudio's Kokoro G2P handles Latin (en/es/fr/it/pt) and, since the
-/// FluidAudio 0.14.8 `.mandarin` KokoroAne variant, Chinese (Han). For the other
+/// FluidAudio 0.15.5 `.mandarin` KokoroAne variant, Chinese (Han). For the other
 /// non-Latin languages it ships voices for (hi/ja) native-script text is not
 /// converted to phonemes and synthesizes as noise rather than speech (#492).
+/// FluidAudio 0.15.5 added a `.japanese` variant, but the binding still routes
+/// only `zh` away from `.english`, so `ja` keeps bailing until that is wired.
 /// Returns the human-facing script name when `text` actually contains characters
 /// of the script `fluid_id`'s language is written in — romanized (Latin) input
 /// for the same voice returns `None` because it works.
@@ -117,7 +119,7 @@ fn unsupported_native_script(text: &str, fluid_id: &str) -> Option<&'static str>
         "hi" => any(|c| ('\u{0900}'..='\u{097F}').contains(&c)).then_some("Devanagari"),
         "ja" => any(|c| matches!(c, '\u{3040}'..='\u{30FF}') || is_han(c))
             .then_some("Japanese (kana/kanji)"),
-        // zh (Han) is supported via FluidAudio 0.14.8's Mandarin KokoroAne variant.
+        // zh (Han) is supported via FluidAudio 0.15.5's Mandarin KokoroAne variant.
         _ => None,
     }
 }
@@ -352,7 +354,7 @@ mod tests {
             unsupported_native_script("日本語", "jm_kumo"),
             Some("Japanese (kana/kanji)")
         );
-        // zh (Han) is now SUPPORTED via FluidAudio 0.14.8's Mandarin KokoroAne
+        // zh (Han) is now SUPPORTED via FluidAudio 0.15.5's Mandarin KokoroAne
         // variant (#492) — native-script Chinese must NOT be flagged.
         assert_eq!(unsupported_native_script("你好我叫凯沙", "zm_050"), None);
         assert_eq!(unsupported_native_script("\u{20000}", "zm_050"), None);
@@ -394,7 +396,8 @@ mod tests {
 
     #[test]
     fn ensure_script_supported_bails_with_code_on_native_script() {
-        // hi/ja native script still bails (no FluidAudio 0.14.8 KokoroAne variant).
+        // hi/ja native script still bails: no hi variant upstream, and the binding
+        // does not route ja to 0.15.5's `.japanese` variant.
         for (text, voice) in [("नमस्ते", "hm_omega"), ("こんにちは", "jm_kumo")] {
             let err =
                 ensure_script_supported(voice, text).expect_err("should reject native script");

--- a/rust/src/tts/sessions.rs
+++ b/rust/src/tts/sessions.rs
@@ -17,7 +17,13 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-use super::{charsiu::Charsiu, kokoro::Kokoro, tokenizer::Tokenizer, voices, vosk::Vosk};
+use super::{
+    charsiu::Charsiu,
+    kokoro::Kokoro,
+    tokenizer::{self, Tokenizer},
+    voices,
+    vosk::Vosk,
+};
 
 /// Cached Kokoro inference state. One ONNX session, one tokenizer, one voice
 /// cache. Cheap to clone-key (`PathBuf`); the actual session is non-Clone.
@@ -70,26 +76,34 @@ impl KokoroSession {
     /// Returns an empty `Vec` (not an error) when the IPA contains no recognisable
     /// phonemes — callers decide whether that's a hard error (one-shot) or a
     /// silent skip (SSML segments).
+    ///
+    /// IPA past Kokoro's active-token cap is split with
+    /// [`tokenizer::chunk_ipa`] and the chunks' samples concatenated, so long
+    /// input synthesizes in full instead of being cut at the cap (#715).
     pub fn infer_ipa(
         &mut self,
         ipa: &str,
         voice_path: &Path,
         speed: f32,
     ) -> anyhow::Result<Vec<f32>> {
-        let ids = self.tokenizer.encode(ipa);
-        if ids.is_empty() {
-            return Ok(Vec::new());
-        }
-        let active = ids.len();
-        let padded = Tokenizer::pad_to_context(ids);
+        let mut samples = Vec::new();
+        for chunk in tokenizer::chunk_ipa(ipa, tokenizer::KOKORO_MAX_ACTIVE) {
+            let ids = self.tokenizer.encode(&chunk);
+            if ids.is_empty() {
+                continue;
+            }
+            let active = ids.len();
+            let padded = Tokenizer::pad_to_context(ids);
 
-        // Detach style row from the &self.voices borrow before we touch
-        // &mut self.kokoro — the row is 256 floats (~1 KB), copy is free.
-        let style: Vec<f32> = {
-            let voice = self.voice(voice_path)?;
-            voices::select_style(voice, active).to_vec()
-        };
-        self.kokoro.infer(&padded, &style, speed)
+            // Detach style row from the &self.voices borrow before we touch
+            // &mut self.kokoro — the row is 256 floats (~1 KB), copy is free.
+            let style: Vec<f32> = {
+                let voice = self.voice(voice_path)?;
+                voices::select_style(voice, active).to_vec()
+            };
+            samples.extend(self.kokoro.infer(&padded, &style, speed)?);
+        }
+        Ok(samples)
     }
 }
 

--- a/rust/src/tts/tokenizer.rs
+++ b/rust/src/tts/tokenizer.rs
@@ -31,9 +31,12 @@ impl Tokenizer {
     }
 
     /// Wrap with a single leading+trailing 0 — matches `kokoro-onnx` upstream
-    /// (`tokens = [[0, *tokens, 0]]`). Truncates beyond [`KOKORO_MAX_ACTIVE`]
-    /// silently. Earlier versions padded to 512 with trailing zeros, which the
-    /// model interpreted as additional silence/noise tokens — see #207.
+    /// (`tokens = [[0, *tokens, 0]]`). Earlier versions padded to 512 with
+    /// trailing zeros, which the model interpreted as additional silence/noise
+    /// tokens — see #207.
+    ///
+    /// The clamp to [`KOKORO_MAX_ACTIVE`] is a backstop: callers split long
+    /// input with [`chunk_ipa`] first, so nothing reaches it in practice (#715).
     pub fn pad_to_context(mut ids: Vec<i64>) -> Vec<i64> {
         if ids.len() > KOKORO_MAX_ACTIVE {
             ids.truncate(KOKORO_MAX_ACTIVE);
@@ -43,6 +46,62 @@ impl Tokenizer {
         out.extend(ids);
         out.push(0);
         out
+    }
+}
+
+/// Pause punctuation that marks a natural break point, mirroring FluidAudio's
+/// `PhonemeChunker.defaultBoundaryPunctuation` so the ONNX and ANE Kokoro paths
+/// split long input at the same places.
+const BOUNDARY_PUNCTUATION: [char; 8] = [',', '.', ';', ':', '!', '?', '…', '—'];
+
+/// Split an IPA string into chunks that each fit Kokoro's active-token cap.
+///
+/// Each break is taken at the latest whitespace or pause-punctuation boundary
+/// inside the `max_len` window, so words stay intact and punctuation stays with
+/// the preceding chunk; a boundary-less run is hard-split at the cap. Chunks are
+/// whitespace-trimmed and never empty. Input that already fits is returned
+/// verbatim, so short input synthesizes byte-for-byte as it did before #715.
+///
+/// `max_len` counts characters: [`Tokenizer::encode`] drops what the vocab does
+/// not cover and so never emits more ids than input characters.
+pub fn chunk_ipa(ipa: &str, max_len: usize) -> Vec<String> {
+    assert!(max_len > 0, "chunk_ipa: max_len must be positive");
+    let chars: Vec<char> = ipa.chars().collect();
+    if chars.len() <= max_len {
+        return vec![ipa.to_string()];
+    }
+
+    let is_boundary = |c: char| c.is_whitespace() || BOUNDARY_PUNCTUATION.contains(&c);
+    let skip_whitespace = |from: usize| {
+        let mut i = from;
+        while i < chars.len() && chars[i].is_whitespace() {
+            i += 1;
+        }
+        i
+    };
+
+    let mut chunks = Vec::new();
+    let mut start = skip_whitespace(0);
+    while chars.len() - start > max_len {
+        let window_end = start + max_len;
+        let break_at = (start + 1..window_end)
+            .rev()
+            .find(|&i| is_boundary(chars[i]))
+            .map_or(window_end, |i| i + 1);
+        push_trimmed(&chars[start..break_at], &mut chunks);
+        start = skip_whitespace(break_at);
+    }
+    if start < chars.len() {
+        push_trimmed(&chars[start..], &mut chunks);
+    }
+    chunks
+}
+
+fn push_trimmed(slice: &[char], chunks: &mut Vec<String>) {
+    let text: String = slice.iter().collect();
+    let trimmed = text.trim();
+    if !trimmed.is_empty() {
+        chunks.push(trimmed.to_string());
     }
 }
 
@@ -82,6 +141,46 @@ mod tests {
     fn wraps_with_leading_and_trailing_zero() {
         let padded = Tokenizer::pad_to_context(vec![1, 2, 3]);
         assert_eq!(padded, vec![0, 1, 2, 3, 0]);
+    }
+
+    #[test]
+    fn chunk_returns_short_input_verbatim() {
+        assert_eq!(chunk_ipa(" həlˈoʊ ", 510), vec![" həlˈoʊ "]);
+        assert_eq!(chunk_ipa("", 510), vec![""]);
+    }
+
+    #[test]
+    fn chunk_breaks_at_latest_whitespace_in_window() {
+        assert_eq!(chunk_ipa("aaa bbb ccc ddd", 8), vec!["aaa bbb", "ccc ddd"]);
+    }
+
+    #[test]
+    fn chunk_keeps_punctuation_with_preceding_chunk() {
+        assert_eq!(chunk_ipa("aaaa,bbb", 6), vec!["aaaa,", "bbb"]);
+    }
+
+    #[test]
+    fn chunk_hard_splits_a_boundary_less_run() {
+        assert_eq!(chunk_ipa("aaaaaaaaa", 4), vec!["aaaa", "aaaa", "a"]);
+    }
+
+    #[test]
+    fn chunk_preserves_every_phoneme() {
+        let ipa = (0..300)
+            .map(|i| format!("wɜrd{i}"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        let chunks = chunk_ipa(&ipa, KOKORO_MAX_ACTIVE);
+        assert!(chunks.len() > 1, "expected a split, got {}", chunks.len());
+        for c in &chunks {
+            assert!(
+                c.chars().count() <= KOKORO_MAX_ACTIVE,
+                "chunk over cap: {} chars",
+                c.chars().count()
+            );
+        }
+        let joined: String = chunks.join(" ");
+        assert_eq!(joined, ipa, "chunking dropped or reordered phonemes");
     }
 
     #[test]


### PR DESCRIPTION
Closes #715

Stacked on #755 (`deps/issue-709`).

## What was broken

A 130-word sentence with no internal punctuation (694 phonemes, cap 510) behaves three different ways depending on the build:

| build | before | after |
|---|---|---|
| darwin-arm64 `system_kokoro`, FluidAudio 0.14.8 | hard fail: `phonemeSequenceTooLong(694)`, `E_INTERNAL`, exit 4 | — (fixed by the 0.15.5 bump in #755) |
| darwin-arm64 `system_kokoro`, FluidAudio 0.15.5 | 42.83 s, full text | unchanged, byte-identical |
| ONNX Kokoro (Linux / Windows / non-`system_kokoro`) | **29.10 s, exit 0** — last 27% of the text silently dropped | 42.98 s, full text |

The ONNX case is the bad one. `infer_ipa` handed the whole IPA string to `pad_to_context`, which truncated to `KOKORO_MAX_ACTIVE` and reported success. Round-tripping the truncated WAV through the engine's own ASR shows both the loss and the artifact the abrupt token cut produces:

> … where the fence has been leaning for years without ever quite falling down **and the water and a little bit of a little bit of a little bit of** …

Everything after "falling down" — 35 words — never rendered, and the last few seconds are babble.

## The fix

`tokenizer::chunk_ipa` splits the resolved IPA at the latest whitespace or pause-punctuation boundary inside the cap window, keeps punctuation with the preceding chunk, and hard-splits a boundary-less run. That is a deliberate port of FluidAudio's `PhonemeChunker` (same boundary set, same window rule), so both Kokoro backends now break long input at the same places. `infer_ipa` loops the chunks and concatenates their samples; the ONNX path applies no per-utterance normalization, only `clamp_audio`, so concatenation cannot introduce a level step.

Input that already fits is returned verbatim rather than trimmed — upstream trims in its fast path too, but here that would change leading-whitespace IPA that works today, and this is a bugfix.

`pad_to_context`'s clamp stays as a backstop; its doc comment now says so.

### Why the ANE path needs no kesha code

`fluid_kokoro::synthesize` → `FluidAudio::synthesize_kokoro` → `fluidaudio_kokoro_synthesize` → `FluidAudioBridge.synthesizeKokoro` → `KokoroAneManager.synthesize(text:voice:speed:)` → `synthesizeDetailed`. That is exactly the high-level text API FluidAudio 0.15.5 wired `PhonemeChunker` into, and 0.15.5 normalizes once over the concatenated samples. The low-level `synthesizeFromPhonemes` that stays strict is not on this path.

## Verification

All runs use a 130-word / 701-char single sentence with no internal punctuation.

**Completeness** — engine ASR round-trip of the ONNX output recovers the full input text, no babble tail. Duration 42.98 s, matching the ANE path's 42.83 s.

**No regression on short input** — pre-change and post-change ONNX binaries produce byte-identical WAVs (`cmp` clean) for both a short sentence and `<speak>First part.<break time="500ms"/>Second part.</speak>`.

**SSML stitching** — two long segments plus a 700 ms `<break>`: ONNX 86.65 s vs 86.66 s expected, ANE 86.35 s vs 86.36 s expected. Break duration preserved, and each long segment chunks internally.

**Joins, RMS-window analysis** (50 ms windows, mean level of the 4 s of speech either side of the join):

| | join | pre | post | offset |
|---|---|---|---|---|
| ONNX | 27.95 s | −26.94 dB | −25.10 dB | **+1.84 dB** |
| ANE | 29.85 s | −23.92 dB | −22.37 dB | **+1.55 dB** |

For scale, the worst sustained 3 s/3 s level swing *within* a single un-chunked utterance is −3.60 dB (`h2`) and +2.60 dB (`h1`). Both joins sit below ordinary prosodic variation, so there is no level step attributable to chunking. A human listen is still the final word.

## Gates

- `bun test` — 776 pass, 4 skip, 0 fail
- `bunx tsc --noEmit` — clean
- `make rust-test` — 411 passed, 0 skipped
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` — clean
- `cargo check --features coreml --no-default-features` — clean
- `cargo check --features system_kokoro --no-default-features` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBTpJjqyYFW6W8LHJ2nwy
