### PR TITLE
fix(raycast): measure the loudest input channel, not their average

### DIFF
--- a/openspec/changes/raycast-meter-loudest-channel/.openspec.yaml
+++ b/openspec/changes/raycast-meter-loudest-channel/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-07

--- a/openspec/changes/raycast-meter-loudest-channel/proposal.md
+++ b/openspec/changes/raycast-meter-loudest-channel/proposal.md
@@ -1,0 +1,86 @@
+## Why
+
+The Signal meter's AVAudioEngine tap pooled the squared samples of every input
+channel and divided by the total sample count
+(`raycast/src/lib/signal-meter.ts` lines 28–44 before this change), so the rms it
+reported was averaged across channels. A microphone on one input of a
+multi-channel device is therefore attenuated by `sqrt(channelCount)` before
+`SPEECH_RMS_THRESHOLD` sees it — the other channels are digitally silent and
+still count toward the divisor.
+
+Against the levels measured in #648, that moves audible speech under the
+threshold:
+
+| channels | factor | speech p90 `0.0139` → | vs `SPEECH_RMS_THRESHOLD = 0.01` |
+|---|---|---|---|
+| 1 | 1.000 | 0.0139 | above |
+| 2 | 0.707 | 0.0098 | **under** |
+| 4 | 0.500 | 0.0069 | **under** |
+
+The consequence is Idle auto-stop ending a Dictation session while Maks is still
+talking. That is the failure direction #670 explicitly chose against when it
+dropped the adaptive noise floor for a constant: failing to auto-stop is
+recoverable, cutting a speaker off mid-sentence is not.
+
+Found by review on the upstream mirror PR (`raycast/extensions#29936`), not by a
+user report — no one has reported it, and it needs a multi-channel input device
+to reproduce.
+
+## What Changes
+
+- The Signal meter classifies **signal** vs **listening** from the input channel
+  actually carrying the voice, instead of from an average across all channels,
+  so channel count no longer changes whether the same speech counts as speech.
+- The meter helper reports one rms per channel; the reduction to a single level
+  moves out of the Swift helper into TypeScript, beside the threshold it feeds.
+  The helper's output is an implementation surface with exactly one consumer, so
+  this is not a compatibility break.
+- A meter sample carrying no usable channel level reads as **listening** rather
+  than as an arbitrary number.
+- The displayed level is untouched: it derives from peak, which was already the
+  maximum across channels.
+
+No behaviour changes for a single-channel input, which is every built-in
+microphone.
+
+## Capabilities
+
+### New Capabilities
+
+None. This corrects an existing requirement's guarantee.
+
+### Modified Capabilities
+
+- `raycast-extension`: the Signal meter requirement gains an explicit guarantee
+  that classification is independent of the input device's channel count, and
+  its Technical Note is corrected — it still names `SILENCE_PEAK_THRESHOLD` as
+  the classifier, which #670 replaced with `SPEECH_RMS_THRESHOLD`, and its line
+  ranges predate that change.
+
+## Impact
+
+- `raycast/src/lib/signal-meter.ts` — the Swift tap accumulates per channel and
+  emits `channelRms`; new `loudestChannelRms` reduces it; `parseMeterLine` reads
+  the array.
+- `raycast/tests/signal-meter.test.ts` — fixtures move to the new meter output;
+  two tests added for multichannel attenuation and unusable channel data.
+- `raycast/` is mirrored into `raycast/extensions`: the upstream half of this
+  change is `raycast/extensions#29936` commit `6908e88`, already reviewed and
+  green there. Both files here are byte-identical to it.
+- No CLI, Engine, or model surface is touched.
+
+## Non-goals
+
+- No change to `SPEECH_RMS_THRESHOLD` itself. The constant from #670 is correct
+  once it is applied to an undiluted level; this fixes the level, not the
+  threshold.
+- No return to the adaptive noise floor #670 removed. Its trade-off is unchanged
+  by this fix, and the reasoning that retired it still holds.
+- No per-channel selection policy beyond "loudest". Deciding which input a user
+  *meant* to speak into is a device-picker concern, not a meter concern.
+- No change to `SILENCE_PEAK_THRESHOLD`, which `raycast/src/lib/wav.ts` lines 71
+  and 87 still use to reject an all-silent recording — that is what −80 dBFS is
+  genuinely right for.
+- No change to the displayed level or its dB scale.
+- No `raycast/CHANGELOG.md` entry. The section this belongs under does not exist
+  in this copy at all — see Open Issues in the delta spec.

--- a/openspec/changes/raycast-meter-loudest-channel/specs/raycast-extension/spec.md
+++ b/openspec/changes/raycast-meter-loudest-channel/specs/raycast-extension/spec.md
@@ -1,0 +1,89 @@
+## MODIFIED Requirements
+
+### Requirement: Recording shows live elapsed time, input device, and Signal meter
+
+While recording, the extension SHALL show elapsed time, the default input
+device's name (with its sample rate and channel count when the system reports
+them), and a Signal meter that distinguishes **signal** from **listening**. When
+the meter cannot start, the session SHALL continue recording and report the
+meter as unavailable rather than failing.
+
+The **signal** / **listening** verdict SHALL depend only on how loudly Maks is
+speaking, never on how many channels his input device exposes. A device that
+carries his voice on one input and digital silence on the rest SHALL classify
+the same speech the same way a single-channel microphone does — otherwise Idle
+auto-stop ends a Dictation session while he is still talking, which is the
+failure this extension is least able to afford.
+
+A meter sample that carries no usable channel level SHALL read as **listening**.
+Absence of a measurement is not evidence of speech, and treating it as such
+would disable Idle auto-stop for the whole session.
+
+#### Scenario: Maks watches the level while dictating
+
+- GIVEN a Dictation session is recording and Maks is speaking
+- WHEN the meter samples the microphone
+- THEN the view shows a level that rises with his voice and a `Signal detected`
+  status
+- AND elapsed time keeps pace with the wall clock
+
+#### Scenario: Maks dictates through a multi-channel audio interface
+
+- GIVEN Maks records through an interface that exposes several inputs and his
+  microphone is plugged into one of them
+- WHEN he speaks at the same level that reads as **signal** on his built-in
+  microphone
+- THEN the meter reports **signal**
+- AND the Idle auto-stop countdown resets, so recording continues while he talks
+
+#### Scenario: The level meter fails to start
+
+- GIVEN the meter helper cannot be started or exits without emitting a sample
+- WHEN the Dictation session is recording
+- THEN the view reports the meter as `Meter unavailable`
+- AND recording continues normally and the transcript is still produced
+
+#### Scenario: A meter sample carries no usable level
+
+- GIVEN the meter emits a sample whose channel levels are missing or not numbers
+- WHEN the Dictation session is recording
+- THEN that sample reads as **listening** rather than as speech
+- AND recording continues, with Idle auto-stop still able to fire
+
+> *Technical Note — meter cadence `METER_INTERVAL_MS = 500`:
+> `raycast/src/lib/dictation-config.ts` line 3; ticking in
+> `startRecordingMonitor`, `raycast/src/lib/recording-monitor.ts` lines 20–54.
+> Device name/rate/channels come from `system_profiler SPAudioDataType -json`
+> (`resolveDefaultMicInfo` in the same file, lines 56–66, parsed by
+> `parseDefaultMicInfo` in `raycast/src/lib/mic-info.ts` lines 5–21). Level
+> source: an AVAudioEngine tap
+> run via `/usr/bin/swift -e`, `raycast/src/lib/signal-meter.ts` lines 9–54,
+> spawned and supervised at lines 111–150. The tap accumulates one rms per
+> channel (line 39) and emits them as `channelRms`; `loudestChannelRms` (line
+> 72) reduces that to the loudest, and `parseMeterLine` classifies it against
+> `SPEECH_RMS_THRESHOLD = 0.01` (`dictation-config.ts` line 8) at line 89. The
+> displayed percentage comes from peak, already a maximum across channels, via
+> `percentFromPeak` (line 63). Unavailable fallback: lines 133–141. Distinct
+> from `SILENCE_PEAK_THRESHOLD = 0.0001` (`dictation-config.ts` line 5), which
+> is not a speech test and is used only by `raycast/src/lib/wav.ts` lines 71 and
+> 87 to reject an all-silent recording.*
+
+## Open Issues
+
+- The multi-channel guarantee is verified by arithmetic and unit tests, not on
+  hardware: no multi-channel input device was available. The single-channel path
+  was measured on a real microphone (183 samples over 20 s, 1/183 classified as
+  speech in a quiet room, consistent with the 7/101 recorded in #648).
+- "Loudest channel" is a heuristic for "the channel Maks is speaking into". On a
+  device where a different input carries something louder than his voice — a
+  line input fed by music, say — the meter follows that instead, and Idle
+  auto-stop would not fire. This is the same direction of failure as a noisy
+  room, which #670 accepted deliberately, but it is now reachable through a
+  second route and nothing warns about it.
+- `raycast/CHANGELOG.md` in this repository has no `[Silence auto-stop now
+  works]` section at all: #670 backported the code from
+  `raycast/extensions#29936` without the changelog entry, so neither the
+  threshold fix nor this one is recorded for Store users on this side of the
+  mirror. The upstream copy does carry both. Left unresolved here rather than
+  guessed at, because the two copies' changelogs are reconciled at mirror-sync
+  time and the merge date placeholder is upstream's convention.

--- a/openspec/changes/raycast-meter-loudest-channel/tasks.md
+++ b/openspec/changes/raycast-meter-loudest-channel/tasks.md
@@ -1,0 +1,47 @@
+## 1. Measure per channel in the meter helper
+
+- [x] 1.1 Accumulate the sum of squares inside the per-channel loop in
+      `SWIFT_MIC_METER_SCRIPT` and divide by `frameCount`, not by
+      `channelCount * frameCount`
+- [x] 1.2 Emit the per-channel levels as `channelRms`, keeping `peak` as the
+      maximum across channels so the displayed level is unaffected
+- [x] 1.3 Confirm the script still compiles: `swiftc -typecheck` on the extracted
+      source
+
+## 2. Reduce and classify in TypeScript
+
+- [x] 2.1 Add `loudestChannelRms`, returning the maximum finite channel level and
+      `0` for anything that is not an array of numbers
+- [x] 2.2 Read `channelRms` in `parseMeterLine` and classify the reduced level
+      against `SPEECH_RMS_THRESHOLD`; leave `percentFromPeak` on `peak`
+- [x] 2.3 Keep the reduction in TypeScript rather than Swift — the Swift half
+      cannot be exercised from vitest, so a decision living there is untestable
+
+## 3. Tests
+
+- [x] 3.1 Move the existing fixtures to the new meter output
+- [x] 3.2 Test: speech on one channel of a two- and a four-channel device
+      classifies as **signal**, and the reduced level is the speaking channel's
+- [x] 3.3 Test: missing, empty, and non-numeric channel data read as **listening**
+- [x] 3.4 Verify the new tests fail against the old pooled average, so they cover
+      the regression rather than merely passing beside it
+
+## 4. Verification
+
+- [x] 4.1 `npm test` and `npm run lint` under `raycast/` — the two commands the
+      `raycast-lint` CI job runs
+- [x] 4.2 Run the meter helper against a real microphone and confirm every line
+      parses and a quiet room classifies as **listening**
+- [~] 4.3 Exercise a real multi-channel input device. NOT done — none available.
+      The multi-channel path rests on the arithmetic and the unit tests; recorded
+      as an Open Issue in the delta spec rather than implied to be verified.
+
+## 5. Specs and mirror
+
+- [x] 5.1 Correct the Signal meter Technical Note, which still named
+      `SILENCE_PEAK_THRESHOLD` as the classifier after #670 replaced it and
+      whose line ranges predate that change
+- [x] 5.2 Land the upstream half in `raycast/extensions#29936` and keep both
+      files byte-identical to it, so the next mirror sync is a no-op on them
+- [ ] 5.3 After merge, fold this delta into
+      `openspec/specs/raycast-extension/spec.md` and archive the change

--- a/raycast/src/lib/signal-meter.ts
+++ b/raycast/src/lib/signal-meter.ts
@@ -25,23 +25,22 @@ input.installTap(onBus: 0, bufferSize: 2048, format: format) { buffer, _ in
   let frameCount = Int(buffer.frameLength)
   if channelCount == 0 || frameCount == 0 { return }
 
-  var sum: Float = 0
   var peak: Float = 0
-  var count = 0
+  var channelRms: [Float] = []
 
   for channel in 0..<channelCount {
     let samples = channels[channel]
+    var sum: Float = 0
     for frame in 0..<frameCount {
       let sample = samples[frame]
-      let absolute = abs(sample)
       sum += sample * sample
-      peak = max(peak, absolute)
-      count += 1
+      peak = max(peak, abs(sample))
     }
+    channelRms.append(sqrt(sum / Float(frameCount)))
   }
 
-  let rms = sqrt(sum / Float(max(count, 1)))
-  print("{\\"rms\\":\\(rms),\\"peak\\":\\(peak)}")
+  let levels = channelRms.map { "\\($0)" }.joined(separator: ",")
+  print("{\\"channelRms\\":[\\(levels)],\\"peak\\":\\(peak)}")
   fflush(stdout)
 }
 
@@ -67,10 +66,21 @@ export function percentFromPeak(peak: number): number {
   return Math.max(0, Math.min(100, Math.round(((dbfs + 50) / 50) * 100)));
 }
 
+// The loudest channel, never the pooled average: a multi-input device leaves its
+// unconnected channels digitally silent, and averaging those in divides real
+// speech by sqrt(channelCount) — enough to read 2-channel speech as silence.
+export function loudestChannelRms(levels: unknown): number {
+  if (!Array.isArray(levels)) return 0;
+  return levels.reduce<number>(
+    (loudest, level) => Math.max(loudest, numberValue(level) ?? 0),
+    0,
+  );
+}
+
 export function parseMeterLine(line: string): SignalLevel | null {
   try {
-    const parsed = JSON.parse(line) as Partial<SignalLevel>;
-    const rms = numberValue(parsed.rms) ?? 0;
+    const parsed = JSON.parse(line) as { channelRms?: unknown; peak?: unknown };
+    const rms = loudestChannelRms(parsed.channelRms);
     const peak = numberValue(parsed.peak) ?? 0;
     return {
       rms,

--- a/raycast/tests/signal-meter.test.ts
+++ b/raycast/tests/signal-meter.test.ts
@@ -12,6 +12,7 @@ import {
   signalStatusTone,
 } from "../src/lib/recording-view";
 import {
+  loudestChannelRms,
   parseMeterChunk,
   parseMeterLine,
   percentFromPeak,
@@ -24,15 +25,30 @@ import { FakeProcess } from "./helpers/fake-process";
 describe("signal parsing", () => {
   // Thresholds are the rms percentiles measured on a built-in mic (#648).
   it("separates a quiet room from speech", () => {
-    expect(parseMeterLine('{"rms":0.0075,"peak":0.02}')?.state).toBe("listening");
-    expect(parseMeterLine('{"rms":0.0021,"peak":0.0085}')?.state).toBe("listening");
-    expect(parseMeterLine('{"rms":0.0352,"peak":0.09}')?.state).toBe("signal");
-    expect(parseMeterLine('{"rms":0.012,"peak":0.03}')?.state).toBe("signal");
+    expect(parseMeterLine('{"channelRms":[0.0075],"peak":0.02}')?.state).toBe("listening");
+    expect(parseMeterLine('{"channelRms":[0.0021],"peak":0.0085}')?.state).toBe("listening");
+    expect(parseMeterLine('{"channelRms":[0.0352],"peak":0.09}')?.state).toBe("signal");
+    expect(parseMeterLine('{"channelRms":[0.012],"peak":0.03}')?.state).toBe("signal");
   });
 
   it("keeps a noisy room audible rather than cutting the speaker off", () => {
     // Auto-stop then never fires there — today's behaviour, and the safe way to be wrong.
-    expect(parseMeterLine('{"rms":0.027,"peak":0.078}')?.state).toBe("signal");
+    expect(parseMeterLine('{"channelRms":[0.027],"peak":0.078}')?.state).toBe("signal");
+  });
+
+  it("hears speech carried by one channel of a multi-input device", () => {
+    // Pooled across both channels this speech would read as 0.012/sqrt(2) = 0.0085,
+    // under the threshold, and the idle timer would stop an active recording.
+    expect(parseMeterLine('{"channelRms":[0.012,0],"peak":0.03}')?.rms).toBeCloseTo(0.012, 6);
+    expect(parseMeterLine('{"channelRms":[0.012,0],"peak":0.03}')?.state).toBe("signal");
+    expect(parseMeterLine('{"channelRms":[0,0,0.012,0],"peak":0.03}')?.state).toBe("signal");
+  });
+
+  it("reads no level when the meter reports no usable channels", () => {
+    expect(loudestChannelRms(undefined)).toBe(0);
+    expect(loudestChannelRms([])).toBe(0);
+    expect(loudestChannelRms(["0.5", null, 0.02])).toBe(0.02);
+    expect(parseMeterLine('{"peak":0.03}')?.state).toBe("listening");
   });
 
   it("ignores invalid lines", () => {
@@ -49,11 +65,11 @@ describe("signal parsing", () => {
   });
 
   it("handles partial chunks without losing complete signals", () => {
-    const first = parseMeterChunk("", '{"rms":0,"peak":0}\n{"rms":');
+    const first = parseMeterChunk("", '{"channelRms":[0],"peak":0}\n{"channelRms":');
     expect(first.signals).toHaveLength(1);
-    expect(first.remainder).toBe('{"rms":');
+    expect(first.remainder).toBe('{"channelRms":');
 
-    const second = parseMeterChunk(first.remainder, '0.02,"peak":0.1}\n');
+    const second = parseMeterChunk(first.remainder, '[0.02],"peak":0.1}\n');
     expect(second.signals).toHaveLength(1);
     expect(second.signals[0]).toMatchObject({ rms: 0.02, state: "signal" });
     expect(second.remainder).toBe("");
@@ -146,7 +162,7 @@ describe("startLiveMicMeter", () => {
   it("reports unavailable when the meter dies after delivering samples", () => {
     const { proc, signals } = startWithFakeProcess();
 
-    proc.emitStdout('{"rms":0.05,"peak":0.1}\n');
+    proc.emitStdout('{"channelRms":[0.05],"peak":0.1}\n');
     proc.emit("exit", 1, null);
 
     expect(signals.at(-2)?.state).toBe("signal");
@@ -156,7 +172,7 @@ describe("startLiveMicMeter", () => {
   it("stays quiet when the session stops the meter itself", () => {
     const { proc, signals, stop } = startWithFakeProcess();
 
-    proc.emitStdout('{"rms":0.05,"peak":0.1}\n');
+    proc.emitStdout('{"channelRms":[0.05],"peak":0.1}\n');
     stop();
     proc.emit("exit", 0, "SIGTERM");
 


### PR DESCRIPTION
Backport of [raycast/extensions#29936](https://github.com/raycast/extensions/pull/29936) commit `6908e88` into `raycast/`, keeping this copy in sync with the extension we ship, plus the OpenSpec change proposal that records it.

## Why

#670 replaced the broken `peak > 0.0001` silence test with a fixed `SPEECH_RMS_THRESHOLD = 0.01` on rms. Review on the upstream mirror PR flagged a real hole in that: the Swift tap pooled the squared samples of **every** input channel and divided by `channelCount * frameCount`, so the rms it reported was averaged across channels. A microphone on one input of a multi-channel device is therefore attenuated by `sqrt(channelCount)` before the threshold sees it — the other channels are digitally silent and still count toward the divisor.

Against the levels measured in #648:

| channels | factor | speech p90 `0.0139` → | verdict |
|---|---|---|---|
| 1 | 1.000 | 0.0139 | above 0.01 ✅ |
| 2 | 0.707 | **0.0098** | under 0.01 ❌ |
| 4 | 0.500 | **0.0069** | under 0.01 ❌ |

It does not stop a session instantly — 45 s of continuous sub-threshold is still needed — but the headroom #670 relied on is gone at two channels and absent at four. This is the failure direction #670's own commit message argued against: cutting a speaker off mid-sentence, rather than merely failing to auto-stop.

Found by review, not by a user report — reproducing it needs a multi-channel input device.

## What changed

**`49fea13` — the fix.** The tap reports one rms per channel and the reduction moved into TypeScript, next to the threshold it feeds:

```swift
channelRms.append(sqrt(sum / Float(frameCount)))   // per channel, not pooled
```
```ts
export function loudestChannelRms(levels: unknown): number { ... }   // max, not mean
```

That placement is the point, not a style choice: the Swift half cannot be exercised from vitest at all, so while the decision lived there it was untestable. `peak` was already the maximum across channels, so `percentFromPeak` and the displayed level are untouched, and mono inputs — every built-in microphone — behave exactly as before.

Both files are byte-identical to the upstream extension at `6908e88` (verified by sha256), so the next mirror sync is a no-op on them.

**`1933a58` — the OpenSpec change.** `openspec/changes/raycast-meter-loudest-channel/` with proposal, tasks, and a `raycast-extension` delta. The delta states the guarantee the fix restores — the **signal**/**listening** verdict depends on how loudly Maks speaks, never on how many channels his device exposes — and adds a scenario for a multi-channel interface and one for a sample with no usable level.

It also repairs the Signal meter Technical Note, which #670 left stale: it still named `SILENCE_PEAK_THRESHOLD` as the classifier after that PR replaced it with `SPEECH_RMS_THRESHOLD`, and its line ranges had drifted. Every reference in the new note was checked against the source rather than carried over, which turned up two more errors inherited from before this change (`startRecordingMonitor` 18–52 → 20–54, `resolveDefaultMicInfo` 54–64 → 56–66, in a file the note left ambiguous).

## Verification

- `npm test` 95 passed (was 93; +2 covering multichannel attenuation and non-numeric channel data), `npm run lint` clean — the same two commands `raycast-lint` runs.
- `openspec validate --changes --strict` and `--specs --strict` both pass.
- The new test is not decorative: restoring the pooled average makes it fail with `expected 0.00848528137423857 to be close to 0.012`, the exact value the review predicted.
- The Swift script `swiftc -typecheck`s clean and ran 20 s against a real microphone: 183 samples, valid `{"channelRms":[...],"peak":...}` on every line, quiet room classified as speech 1/183 — consistent with the 7/101 in #648.

No physical multi-channel interface was available, so that path rests on the arithmetic and the unit tests rather than on hardware. That, and the fact that "loudest channel" is a heuristic a loud unrelated input would defeat, are recorded as Open Issues in the delta rather than left implied.

## Still open

`raycast/CHANGELOG.md` here has no `[Silence auto-stop now works]` section at all — #670 backported the code from #29936 without the changelog entry, so neither the threshold fix nor this one is recorded on this side of the mirror. Left unresolved rather than guessed at, since the two copies reconcile at mirror-sync time and the `{PR_MERGE_DATE}` placeholder is upstream's convention. Recorded in the delta's Open Issues.

Refs #648
