### PR TITLE
fix(voice-routing): auto-route --lang fr on darwin-arm64

### DIFF
--- a/docs/languages.md
+++ b/docs/languages.md
@@ -54,10 +54,10 @@ Languages marked **darwin-arm64** below require a darwin-arm64 engine build (Flu
 |---:|----------|------|---|------------------------|----------|-------|
 | 1 | English | `en` | 🇬🇧 | Kokoro (`en-*`) | all | default `en-am_michael` |
 | 2 | Russian | `ru` | 🇷🇺 | Vosk-TTS (`ru-*`) | all | default `ru-vosk-m02`; macOS also offers `macos-*` Milena |
-| 3 | Spanish | `es` | 🇪🇸 | Kokoro (`es-*`) | darwin-arm64 | FluidAudio CoreML |
-| 4 | French | `fr` | 🇫🇷 | Kokoro (`fr-*`) | darwin-arm64 | female voice only (`fr-ff_siwis`) |
-| 5 | Italian | `it` | 🇮🇹 | Kokoro (`it-*`) | darwin-arm64 | FluidAudio CoreML |
-| 6 | Portuguese | `pt` | 🇧🇷 | Kokoro (`pt-*`) | darwin-arm64 | Brazilian (`pt-pm_alex`) |
+| 3 | Spanish | `es` | 🇪🇸 | Kokoro (`es-*`) | all | FluidAudio CoreML on darwin-arm64, CharsiuG2P ONNX elsewhere |
+| 4 | French | `fr` | 🇫🇷 | Kokoro (`fr-*`) | all | female voice only (`fr-ff_siwis`) |
+| 5 | Italian | `it` | 🇮🇹 | Kokoro (`it-*`) | all | FluidAudio CoreML on darwin-arm64, CharsiuG2P ONNX elsewhere |
+| 6 | Portuguese | `pt` | 🇧🇷 | Kokoro (`pt-*`) | all | Brazilian (`pt-pm_alex`) |
 | 7 | Hindi | `hi` | 🇮🇳 | Kokoro (`hi-*`) | darwin-arm64 | **romanized (Latin) input only** — native Devanagari is rejected with `E_SCRIPT_UNSUPPORTED` ([#492](https://github.com/drakulavich/kesha-voice-kit/issues/492)) |
 | 8 | Japanese | `ja` | 🇯🇵 | Kokoro (`ja-*`) | darwin-arm64 | **romaji (Latin) input only** — native kana/kanji is rejected ([#492](https://github.com/drakulavich/kesha-voice-kit/issues/492)) |
 | 9 | Chinese | `zh` | 🇨🇳 | Kokoro (`zh-*`) | darwin-arm64 | **pinyin (Latin) input only** — native Han is rejected ([#492](https://github.com/drakulavich/kesha-voice-kit/issues/492)) |

--- a/docs/tts.md
+++ b/docs/tts.md
@@ -15,7 +15,7 @@ kesha say --lang es "Hola, mundo" > hola.wav   # route by stated language, skip 
 kesha say --list-voices
 ```
 
-Voice selection precedence: `--voice <id>` (explicit) → `--lang <code>` (route to that language's default voice, skipping detection — also the way to route on Linux/Windows, where text-language detection is macOS-only) → macOS text-language auto-detection → engine default (`en-am_michael`). A `--lang` whose language has no mapped male voice (e.g. French) falls to the engine default rather than re-detecting.
+Voice selection precedence: `--voice <id>` (explicit) → `--lang <code>` (route to that language's default voice, skipping detection — also the way to route on Linux/Windows, where text-language detection is macOS-only) → macOS text-language auto-detection → engine default (`en-am_michael`). A `--lang` whose language has no mapped voice on the current platform (e.g. `hi` on Linux) falls to the engine default rather than re-detecting.
 
 Output format: WAV (default, mono float32 — 24 kHz for Kokoro, 22.05 kHz for Vosk), OGG/Opus (`--format ogg-opus`), and FLAC (`--format flac`) are all supported. MP3/AAC output were evaluated and rejected on licensing/patent grounds — see [docs/decision-log.md](decision-log.md).
 

--- a/docs/tts.md
+++ b/docs/tts.md
@@ -59,7 +59,7 @@ Default voices are **male** per CLAUDE.md "DEFAULT TTS VOICES MUST BE MALE": `am
 
 **Supported voices:**
 - English: `en-am_michael` (default). Darwin FluidAudio builds expose the supported FluidAudio Kokoro English voices via `kesha say --list-voices`; ONNX builds also see any `.bin` voice you add under `~/.cache/kesha/models/kokoro-82m/voices/`.
-- Apple Silicon Kokoro multilingual voices: `es-em_alex`, `hi-hm_omega`, `it-im_nicola`, `ja-jm_kumo`, `pt-pm_alex`, `zh-zm_050`, and `fr-ff_siwis`. The Spanish, Hindi, Italian, Japanese, Portuguese, and Chinese defaults are male; upstream Kokoro currently has no native male French voice, so French remains explicit-only.
+- Apple Silicon Kokoro multilingual voices: `es-em_alex`, `hi-hm_omega`, `it-im_nicola`, `ja-jm_kumo`, `pt-pm_alex`, `zh-zm_050`, and `fr-ff_siwis`. The Spanish, Hindi, Italian, Japanese, Portuguese, and Chinese defaults are male; French auto-routes to `fr-ff_siwis` (female) because upstream Kokoro ships no native male French voice.
 - Russian: 5 Vosk-TTS speakers baked into the multi-speaker model — `ru-vosk-m02` (default, male), `ru-vosk-m01` (male), `ru-vosk-f01`/`f02`/`f03` (female).
 - macOS system voices: `macos-<identifier-or-language>` routes to `AVSpeechSynthesizer`. Zero install, any of the 180+ voices already on your Mac.
 

--- a/openspec/specs/tts-synthesis/spec.md
+++ b/openspec/specs/tts-synthesis/spec.md
@@ -138,7 +138,7 @@ Voice id SHALL fail with `E_VOICE_UNKNOWN` and exit 1.
 > | `en` | `en-am_michael` | `en-am_michael` | `en-am_michael` |
 > | `ru` | `macos-com.apple.voice.compact.ru-RU.Milena` | `macos-com.apple.voice.compact.ru-RU.Milena` | `ru-vosk-m02` |
 > | `es` | `es-em_alex` | `es-em_alex` | `es-em_alex` |
-> | `fr` | *(unmapped → engine default)* | `fr-ff_siwis` | `fr-ff_siwis` |
+> | `fr` | `fr-ff_siwis` | `fr-ff_siwis` | `fr-ff_siwis` |
 > | `hi` | `hi-hm_omega` | *(unmapped)* | *(unmapped)* |
 > | `it` | `it-im_nicola` | `it-im_nicola` | `it-im_nicola` |
 > | `ja` | `ja-jm_kumo` | *(unmapped)* | *(unmapped)* |

--- a/src/cli/say.ts
+++ b/src/cli/say.ts
@@ -25,10 +25,9 @@ async function autoRouteVoice(text: string): Promise<string | undefined> {
  * Resolve the voice for `kesha say`. Precedence: explicit `--voice` > explicit
  * `--lang` (route by the stated language, skipping detection — also the path on
  * Linux/Windows where text-language detection is unavailable) > macOS
- * text-language auto-detection > engine default (`undefined`). A `--lang` with
- * no mapped voice (an unsupported language, or French which has no male Kokoro
- * voice) resolves to `undefined` (engine default) rather than re-running
- * detection — the user stated the language explicitly.
+ * text-language auto-detection > engine default (`undefined`). A `--lang` the
+ * build has no voice for resolves to `undefined` (engine default) rather than
+ * re-running detection — the user stated the language explicitly.
  */
 export async function resolveSayVoice(
   explicitVoice: string | undefined,

--- a/src/voice-routing.ts
+++ b/src/voice-routing.ts
@@ -5,8 +5,15 @@
  */
 const RU_DARWIN_FALLBACK_VOICE = "macos-com.apple.voice.compact.ru-RU.Milena";
 
+/**
+ * darwin-arm64 (FluidAudio ANE voice pack) defaults. Must cover every code
+ * `tts_languages()` advertises on a system_kokoro build — a missing entry
+ * silently drops `--voice` and the engine falls back to English (#769).
+ * fr is the documented brand-rule exception (no male French voice in Kokoro v1.0).
+ */
 const DARWIN_KOKORO_DEFAULTS: Record<string, string> = {
   es: "es-em_alex",
+  fr: "fr-ff_siwis",
   hi: "hi-hm_omega",
   it: "it-im_nicola",
   ja: "ja-jm_kumo",
@@ -40,7 +47,6 @@ export function pickVoiceForLang(
     case "ru":
       return platform === "darwin" ? RU_DARWIN_FALLBACK_VOICE : "ru-vosk-m02";
     default:
-      // darwin-arm64: FluidAudio ANE voice pack (full multilingual set).
       if (platform === "darwin" && arch === "arm64") return DARWIN_KOKORO_DEFAULTS[baseCode];
       // ONNX: es/fr/it/pt via CharsiuG2P; hi/ja/zh have no ONNX pack → undefined.
       return ONNX_KOKORO_DEFAULTS[baseCode];

--- a/src/voice-routing.ts
+++ b/src/voice-routing.ts
@@ -6,9 +6,10 @@
 const RU_DARWIN_FALLBACK_VOICE = "macos-com.apple.voice.compact.ru-RU.Milena";
 
 /**
- * darwin-arm64 (FluidAudio ANE voice pack) defaults. Must cover every code
- * `tts_languages()` advertises on a system_kokoro build — a missing entry
- * silently drops `--voice` and the engine falls back to English (#769).
+ * darwin-arm64 (FluidAudio ANE voice pack) defaults. This table plus the
+ * `en`/`ru` switch arms must together cover every code `tts_languages()`
+ * advertises on a system_kokoro build — a missing entry silently drops
+ * `--voice` and the engine falls back to English (#769).
  * fr is the documented brand-rule exception (no male French voice in Kokoro v1.0).
  */
 const DARWIN_KOKORO_DEFAULTS: Record<string, string> = {

--- a/tests/unit/voice-routing.test.ts
+++ b/tests/unit/voice-routing.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from "bun:test";
 import { pickVoiceForLang } from "../../src/voice-routing";
 
+/** Mirrors `rust/src/models.rs::tts_languages()` — keep in sync when adding a language. */
+const ADVERTISED_TTS_LANGS = {
+  systemKokoro: ["en", "es", "fr", "hi", "it", "ja", "pt", "zh", "ru"],
+  onnx: ["en", "es", "fr", "it", "pt", "ru"],
+};
+
 describe("pickVoiceForLang (auto-routing)", () => {
   it("returns en-am_michael for English with high confidence", () => {
     expect(pickVoiceForLang("en", 0.95)).toBe("en-am_michael");
@@ -21,6 +27,9 @@ describe("pickVoiceForLang (auto-routing)", () => {
     expect(pickVoiceForLang("es", 0.95, "darwin", "arm64")).toBe("es-em_alex");
     expect(pickVoiceForLang("es-ES", 0.95, "darwin", "arm64")).toBe("es-em_alex");
     expect(pickVoiceForLang("hi", 0.95, "darwin", "arm64")).toBe("hi-hm_omega");
+    // fr is female — the documented brand-rule exception, Kokoro v1.0 has no male fr voice.
+    expect(pickVoiceForLang("fr", 0.95, "darwin", "arm64")).toBe("fr-ff_siwis");
+    expect(pickVoiceForLang("fr-CA", 0.95, "darwin", "arm64")).toBe("fr-ff_siwis");
     expect(pickVoiceForLang("it", 0.95, "darwin", "arm64")).toBe("it-im_nicola");
     expect(pickVoiceForLang("ja", 0.95, "darwin", "arm64")).toBe("ja-jm_kumo");
     expect(pickVoiceForLang("pt-BR", 0.95, "darwin", "arm64")).toBe("pt-pm_alex");
@@ -68,8 +77,26 @@ describe("pickVoiceForLang (auto-routing)", () => {
     // de/ko have no Kokoro voice on either the ONNX or the darwin path.
     expect(pickVoiceForLang("de", 0.95, "linux", "x64")).toBeUndefined();
     expect(pickVoiceForLang("ko", 0.95, "darwin", "arm64")).toBeUndefined();
-    // fr maps on the ONNX path (ff_siwis) but NOT on darwin/FluidAudio — no fr voice there.
-    expect(pickVoiceForLang("fr", 0.95, "darwin", "arm64")).toBeUndefined();
+  });
+
+  it("routes every language the darwin-arm64 build advertises in --capabilities-json", () => {
+    const unrouted = ADVERTISED_TTS_LANGS.systemKokoro.filter(
+      (lang) => pickVoiceForLang(lang, 0.95, "darwin", "arm64") === undefined,
+    );
+    expect(unrouted).toEqual([]);
+  });
+
+  it("routes every language ONNX builds advertise in --capabilities-json", () => {
+    for (const [platform, arch] of [
+      ["linux", "x64"],
+      ["win32", "x64"],
+      ["darwin", "x64"],
+    ] as const) {
+      const unrouted = ADVERTISED_TTS_LANGS.onnx.filter(
+        (lang) => pickVoiceForLang(lang, 0.95, platform, arch) === undefined,
+      );
+      expect(unrouted).toEqual([]);
+    }
   });
 
   it("returns undefined when code is missing", () => {

--- a/tests/unit/voice-routing.test.ts
+++ b/tests/unit/voice-routing.test.ts
@@ -1,11 +1,28 @@
 import { describe, it, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { pickVoiceForLang } from "../../src/voice-routing";
 
-/** Mirrors `rust/src/models.rs::tts_languages()` — keep in sync when adding a language. */
-const ADVERTISED_TTS_LANGS = {
-  systemKokoro: ["en", "es", "fr", "hi", "it", "ja", "pt", "zh", "ru"],
-  onnx: ["en", "es", "fr", "it", "pt", "ru"],
-};
+const MODELS_RS = readFileSync(
+  join(import.meta.dir, "..", "..", "rust", "src", "models.rs"),
+  "utf8",
+).replace(/\r\n/g, "\n");
+
+// Parsed, not copied: a language added to tts_languages() alone must turn these guards red (#769).
+function advertisedTtsLangs(): { systemKokoro: string[]; onnx: string[] } {
+  const body = MODELS_RS.match(/pub fn tts_languages\(\)[^{]*\{\n([\s\S]*?)\n\}/)?.[1];
+  const arms = body ? [...body.matchAll(/#\[cfg\((not\()?[\s\S]*?vec!\[([^\]]*)\]/g)] : [];
+  const langsOf = (negated: boolean) =>
+    [...(arms.find((m) => Boolean(m[1]) === negated)?.[2] ?? "").matchAll(/"([^"]+)"/g)].map(
+      (m) => m[1]!,
+    );
+  const systemKokoro = langsOf(false);
+  const onnx = langsOf(true);
+  if (systemKokoro.length === 0 || onnx.length === 0) {
+    throw new Error("could not parse tts_languages() — did rust/src/models.rs change shape?");
+  }
+  return { systemKokoro, onnx };
+}
 
 describe("pickVoiceForLang (auto-routing)", () => {
   it("returns en-am_michael for English with high confidence", () => {
@@ -23,7 +40,7 @@ describe("pickVoiceForLang (auto-routing)", () => {
     expect(pickVoiceForLang("ru", 0.95, "win32")).toBe("ru-vosk-m02");
   });
 
-  it("routes supported Kokoro languages to male FluidAudio voices on darwin-arm64", () => {
+  it("routes supported Kokoro languages on darwin-arm64 (male defaults; fr is the documented female exception)", () => {
     expect(pickVoiceForLang("es", 0.95, "darwin", "arm64")).toBe("es-em_alex");
     expect(pickVoiceForLang("es-ES", 0.95, "darwin", "arm64")).toBe("es-em_alex");
     expect(pickVoiceForLang("hi", 0.95, "darwin", "arm64")).toBe("hi-hm_omega");
@@ -80,7 +97,7 @@ describe("pickVoiceForLang (auto-routing)", () => {
   });
 
   it("routes every language the darwin-arm64 build advertises in --capabilities-json", () => {
-    const unrouted = ADVERTISED_TTS_LANGS.systemKokoro.filter(
+    const unrouted = advertisedTtsLangs().systemKokoro.filter(
       (lang) => pickVoiceForLang(lang, 0.95, "darwin", "arm64") === undefined,
     );
     expect(unrouted).toEqual([]);
@@ -92,7 +109,7 @@ describe("pickVoiceForLang (auto-routing)", () => {
       ["win32", "x64"],
       ["darwin", "x64"],
     ] as const) {
-      const unrouted = ADVERTISED_TTS_LANGS.onnx.filter(
+      const unrouted = advertisedTtsLangs().onnx.filter(
         (lang) => pickVoiceForLang(lang, 0.95, platform, arch) === undefined,
       );
       expect(unrouted).toEqual([]);


### PR DESCRIPTION
## Problem

On darwin-arm64, `kesha say --lang fr "bonjour"` synthesized with the **English** voice. French is fully supported by that build — `--capabilities-json` lists `fr` under kokoro, `--list-voices` shows `fr-ff_siwis`, and explicit `--voice fr-ff_siwis` works — so only the auto-routing path was broken.

## Root cause

`DARWIN_KOKORO_DEFAULTS` in `src/voice-routing.ts` had entries for es/hi/it/ja/pt/zh but **no `fr`**, while `ONNX_KOKORO_DEFAULTS` did. On darwin-arm64 `pickVoiceForLang` returns `DARWIN_KOKORO_DEFAULTS[baseCode]` without falling through to the ONNX table, so `fr` → `undefined` → the CLI spawned the engine with no `--voice` at all → the engine fell back to `rust/src/tts/voices.rs` `DEFAULT_VOICE_ID = en-am_michael`. `--lang fr` survived only as a phonemization locale hint.

The comment above the table called it the "full multilingual set", which is what made the omission easy to miss. It has been removed.

## Brand rule note

`fr-ff_siwis` is **female**, and CLAUDE.md's "DEFAULT TTS VOICES MUST BE MALE" rule applies to auto-routing fallbacks. This is the **already-documented exception**: Kokoro v1.0 ships no male French voice, which is why `ONNX_KOKORO_DEFAULTS`, `rust/src/tts/voices.rs:224`, and CLAUDE.md itself all already carry it. This PR makes darwin-arm64 consistent with the ONNX path rather than introducing a new exception. Please do not "fix" it to a male voice — there isn't one.

## Was `fr` the only gap?

Yes. Diffing routing coverage against `rust/src/models.rs::tts_languages()`, the authoritative per-build list:

- **darwin-arm64** (`system_kokoro`, per the `build-engine.yml` matrix): `en es fr hi it ja pt zh ru` — every code routed except `fr`.
- **ONNX** (linux / windows / Intel macOS): `en es fr it pt ru` — already complete.

## Class-killing test

Two tests assert that **every** language a build advertises resolves to a defined voice, one per build shape. `pickVoiceForLang` is pure TS, so they run against fixed lists mirroring `tts_languages()` — no live engine, no downloads. Adding a language to capabilities without a routing entry now fails CI, and the failure names the offending code:

```
- []
+ [ "fr" ]
```

That output is from re-running the suite with the `fr` entry removed, to confirm the guard actually catches the regression rather than passing vacuously.

Two stale assertions were flipped: the old suite explicitly encoded the bug (`expect(pickVoiceForLang("fr", 0.95, "darwin", "arm64")).toBeUndefined()`, commented "no fr voice there" — contradicted by `fluid_voice!("fr", "ff_siwis", "fr-fr")` in `rust/src/tts/fluid_kokoro.rs:77`).

Also corrected two stale prose claims that described the buggy behaviour as intended: `docs/tts.md` ("French remains explicit-only") and the `resolveSayVoice` doc comment in `src/cli/say.ts`.

## Verification

- `bun test` → 806 pass, 5 skip, 0 fail
- `bunx tsc --noEmit` → clean
- Guard test verified to fail (naming `fr`) when the entry is removed
- TS-only change; no `rust/` files touched, so the Rust gates do not apply

**Live acceptance not run:** this machine has no `kesha-engine` binary installed and only `am_michael.bin` under `models/kokoro-82m/voices/`, so the `KESHA_DEBUG=1 … --lang fr` spawn check would have required downloading an engine and the French voice pack. Per the no-auto-download rule nothing was downloaded; the unit tests carry acceptance.

Closes #769
