### PR TITLE
fix(install): make downloads atomic and health-check what is installed

### DIFF
--- a/openspec/specs/diagnostics/spec.md
+++ b/openspec/specs/diagnostics/spec.md
@@ -34,6 +34,11 @@ snapshot of known `KESHA_*` environment variables.
 `kesha doctor` SHALL always exit 0, even when components are missing or the Engine
 probe fails. It SHALL never download or modify any file.
 
+Install status for the Engine binary and the Sidecars SHALL be established by running
+them, not by testing that the file exists. A binary that is present but which the OS
+refuses to execute SHALL be reported as corrupt with a reinstall hint, distinctly from
+one that is not installed.
+
 `--json` outputs the same data as 2-space-indented JSON to stdout.
 
 `--redact` replaces secret-pattern key values (keys containing TOKEN, KEY, SECRET,
@@ -58,6 +63,14 @@ for `kesha doctor`; it is always-on for `kesha support-bundle`.
   `optionalComponents`, `stats`, `diagnosticLogs`, and `env` keys
 - AND the process exits 0
 
+#### Scenario: Maks checks an install an interrupted download left behind
+
+- GIVEN the `say-avspeech` sidecar file exists but is truncated
+- WHEN Maks runs `kesha doctor`
+- THEN the report shows it as installed but not executable, with a `kesha install` hint
+- AND a sidecar that is simply absent is still shown as missing
+- AND the process exits 0
+
 #### Scenario: Sona redacts before sharing
 
 - GIVEN `KESHA_MODEL_MIRROR=https://user:pass@mirror.example.com/models` is set
@@ -69,6 +82,9 @@ for `kesha doctor`; it is always-on for `kesha support-bundle`.
 
 > *Technical Note — sources: `src/doctor.ts::collectDoctorReport`,
 > `src/doctor.ts::formatDoctorReport`, `src/cli/doctor.ts::doctorCommand`.
+> Executability comes from `src/engine-health.ts::probeExecutable` and surfaces as
+> `engine.runnable` and per-component `runnable` in the JSON report; any exit code counts
+> as healthy, since the sidecars legitimately exit non-zero when given no work.
 > Known env keys snapshot: `KESHA_ENGINE_BIN`, `KESHA_CACHE_DIR`,
 > `KESHA_MODEL_MIRROR`, `KESHA_STATS_DB`, `KESHA_DEBUG`, `KESHA_DEBUG_FD`
 > (from `KNOWN_ENV_KEYS`). Secret-pattern detection splits the key on

--- a/openspec/specs/installation/spec.md
+++ b/openspec/specs/installation/spec.md
@@ -301,6 +301,40 @@ begin.
 > `download_verified` function, `init_mirror_logging`, `model_mirror()`).
 > Error code `E_CACHE_CORRUPT` is used when a cached file fails hash verification.*
 
+### Requirement: Downloads land atomically and an installed Engine is verified by running it
+
+The CLI SHALL stream every downloaded file into a staging file beside its destination and
+rename it into place only once the download completes, so an interrupted download never
+leaves a partial file where a complete one is expected. A download that fails or is
+interrupted SHALL leave the previous file untouched, or no file at all when there was none.
+
+`kesha install` SHALL treat an Engine whose recorded version matches the requested one but
+which cannot be spawned as invalid, and re-download it. A Capabilities probe that fails
+because the installed Engine cannot be spawned SHALL NOT abort the install: the requested
+TTS language codes are then validated by the freshly installed Engine instead.
+
+#### Scenario: Maks interrupts a download with Ctrl-C
+
+- GIVEN `kesha install` is downloading the Engine binary
+- WHEN Maks presses Ctrl-C partway through
+- THEN no partial Engine binary is left at the install path
+- AND a previously installed Engine binary is still intact and runnable
+
+#### Scenario: Ira re-runs install over a corrupt Engine
+
+- GIVEN the Engine binary is truncated but its `.version` marker names the pinned version
+- WHEN Ira runs `kesha install`
+- THEN the CLI reports that the installed Engine does not run and re-downloads it
+- AND the command completes without surfacing an `E_ENGINE_SPAWN` failure from the
+  Capabilities probe
+
+> *Technical Note — sources: `src/progress.ts::streamResponseToFile` (stages to
+> `<dest>.part.<pid>`, renames on success, sweeps orphans left by a killed process),
+> `src/engine-health.ts::probeExecutable`, `src/engine-install.ts::installEngine`
+> (health-gated cache validity; skipped on a read-only engine directory, where nothing
+> could be repaired anyway), `src/cli/install.ts::probeCapabilitiesForInstall`. Mirrors
+> the staging `rust/src/models.rs::write_verified` already performs for model files.*
+
 ### Requirement: `--plan` shows the download plan without changing local state
 
 The CLI SHALL print a human-readable Install plan when `--plan` is passed, listing all

--- a/openspec/specs/installation/spec.md
+++ b/openspec/specs/installation/spec.md
@@ -235,9 +235,10 @@ already installed leaves English in place.
 > `src/install-plan.ts` (KOKORO_GRAPH_FILE ~325 MB, per-language KOKORO_VOICE_FILES
 > ~522 KB each, VOSK_RU_FILES ~937 MB total, G2P_CHARSIU_FILES ~30 MB for es/fr/it/pt
 > on ONNX). Supported language list comes from `getEngineCapabilities()` when the
-> Engine is already installed; falls back to `TTS_LANG_FALLBACK` = `["en", "es", "fr",
-> "it", "pt", "ru"]` when the Engine is not yet installed (hi/ja/zh excluded as they
-> require darwin-arm64 capabilities to confirm).*
+> Engine is already installed; when it is not, `src/cli/install.ts::installableTtsLangs`
+> supplies the platform's static set — `["en", "es", "fr", "it", "pt", "ru"]` plus
+> `hi`, `ja`, `zh` on darwin-arm64 — so a bad code is rejected before anything downloads.
+> The Engine re-validates authoritatively at download time.*
 
 ### Requirement: VAD and Diarize install are separate opt-in flags
 
@@ -309,9 +310,14 @@ leaves a partial file where a complete one is expected. A download that fails or
 interrupted SHALL leave the previous file untouched, or no file at all when there was none.
 
 `kesha install` SHALL treat an Engine whose recorded version matches the requested one but
-which cannot be spawned as invalid, and re-download it. A Capabilities probe that fails
-because the installed Engine cannot be spawned SHALL NOT abort the install: the requested
-TTS language codes are then validated by the freshly installed Engine instead.
+which cannot be spawned as invalid, and re-download it. The same applies to the Sidecars on
+a cache hit: one that is present but which the OS refuses to execute SHALL be re-downloaded
+rather than re-trusted. A Capabilities probe that fails because the installed Engine cannot
+be spawned SHALL NOT abort the install.
+
+Staging files left behind by a killed process SHALL be swept only once they are older than
+24 hours, so a second `kesha install` running concurrently never deletes the staging file
+the first one is still streaming into.
 
 #### Scenario: Maks interrupts a download with Ctrl-C
 
@@ -328,12 +334,22 @@ TTS language codes are then validated by the freshly installed Engine instead.
 - AND the command completes without surfacing an `E_ENGINE_SPAWN` failure from the
   Capabilities probe
 
+#### Scenario: Sona runs two installs at once
+
+- GIVEN one `kesha install` is streaming the Engine into its staging file
+- WHEN Sona starts a second `kesha install` in another terminal
+- THEN the second run leaves the first run's staging file alone
+- AND a staging file older than 24 hours is removed instead
+
 > *Technical Note — sources: `src/progress.ts::streamResponseToFile` (stages to
-> `<dest>.part.<pid>`, renames on success, sweeps orphans left by a killed process),
+> `<dest>.part.<pid>`, renames on success, sweeps orphans older than `STALE_STAGING_MS`),
 > `src/engine-health.ts::probeExecutable`, `src/engine-install.ts::installEngine`
 > (health-gated cache validity; skipped on a read-only engine directory, where nothing
-> could be repaired anyway), `src/cli/install.ts::probeCapabilitiesForInstall`. Mirrors
-> the staging `rust/src/models.rs::write_verified` already performs for model files.*
+> could be repaired anyway), `src/engine-install.ts::sidecarNeedsDownload`,
+> `src/cli/install.ts::probeCapabilitiesForInstall`. Mirrors the staging and the
+> age-gated, Unix-only orphan sweep of `rust/src/models.rs` (`write_verified`,
+> `cleanup_orphan_staging`): Windows keeps last-write time stale while a handle is open,
+> so an in-flight download there cannot be told apart from an orphan.*
 
 ### Requirement: `--plan` shows the download plan without changing local state
 
@@ -533,9 +549,5 @@ Interactive missing-model errors recommend `kesha init`; the Quick Start SHALL m
 
 ## Open Issues
 
-- `kesha install --tts zh` on a darwin-arm64 machine without the Engine installed
-  falls back to `TTS_LANG_FALLBACK` (which excludes `zh`) and rejects the request;
-  the error message says "unsupported" rather than "install the engine first to
-  unlock platform-specific languages" — see the `resolveTtsLangs` fallback path.
 - `kesha record` has no Windows or Linux microphone capture; `record.rs` gates capture on
   macOS and the README directs other platforms to pass an existing audio file.

--- a/openspec/specs/installation/spec.md
+++ b/openspec/specs/installation/spec.md
@@ -342,7 +342,8 @@ the first one is still streaming into.
 - AND a staging file older than 24 hours is removed instead
 
 > *Technical Note — sources: `src/progress.ts::streamResponseToFile` (stages to
-> `<dest>.part.<pid>`, renames on success, sweeps orphans older than `STALE_STAGING_MS`),
+> `<dest>.part.<pid>.<n>` — unique per call, since two concurrent calls in one process
+> would share a pid — renames on success, sweeps orphans older than `STALE_STAGING_MS`),
 > `src/engine-health.ts::probeExecutable`, `src/engine-install.ts::installEngine`
 > (health-gated cache validity; skipped on a read-only engine directory, where nothing
 > could be repaired anyway), `src/engine-install.ts::sidecarNeedsDownload`,

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -40,7 +40,9 @@ function exitIfCancelled<T>(answer: T | symbol): T {
 }
 
 async function promptTtsLangs(preselect: string[]): Promise<string[]> {
-  const caps = await getEngineCapabilities();
+  // A corrupt engine must leave init offering the fallback list rather than aborting the
+  // guided setup that would replace it (#770).
+  const caps = await getEngineCapabilities().catch(() => null);
   const supported = caps?.tts?.languages.map((l) => l.code) ?? TTS_LANG_FALLBACK;
   const selected = await multiselect({
     message:

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -4,10 +4,10 @@ import { renderInstallPlan } from "../install-plan";
 import { log } from "../log";
 import { getEngineCapabilities } from "../engine";
 import {
+  installableTtsLangs,
   performInstall,
   resolveBackendFlag,
   resolveNoCacheFlag,
-  TTS_LANG_FALLBACK,
   unavailableBackendError,
 } from "./install";
 import type { SharedInstallArgs } from "./types";
@@ -43,7 +43,7 @@ async function promptTtsLangs(preselect: string[]): Promise<string[]> {
   // A corrupt engine must leave init offering the fallback list rather than aborting the
   // guided setup that would replace it (#770).
   const caps = await getEngineCapabilities().catch(() => null);
-  const supported = caps?.tts?.languages.map((l) => l.code) ?? TTS_LANG_FALLBACK;
+  const supported = caps?.tts?.languages.map((l) => l.code) ?? installableTtsLangs();
   const selected = await multiselect({
     message:
       "Select TTS languages to install (space to toggle, enter to confirm; none = skip TTS):",

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -2,7 +2,7 @@ import { defineCommand } from "citty";
 import { errorMessage } from "../error-utils";
 import { installEngine } from "../engine-install";
 import { engineTarget } from "../engine-targets";
-import { getEngineBinPath, getEngineCapabilities } from "../engine";
+import { getEngineBinPath, getEngineCapabilities, type EngineCapabilities } from "../engine";
 import { renderInstallPlan } from "../install-plan";
 import { maybeAskForStar } from "../star";
 import { log } from "../log";
@@ -88,6 +88,23 @@ export function resolveNoCacheFlag(
     args.noCache === true ||
     args.no_cache === true
   );
+}
+
+/**
+ * Capabilities for `--tts` validation, tolerating an engine that cannot be spawned (#770).
+ *
+ * A corrupt or wrong-arch binary used to throw here and kill the command before the
+ * re-download that repairs it. Without capabilities the language codes simply go
+ * unvalidated locally — the freshly installed engine rejects unsupported ones at
+ * download time, which is authoritative anyway.
+ */
+export async function probeCapabilitiesForInstall(): Promise<EngineCapabilities | null> {
+  try {
+    return await getEngineCapabilities();
+  } catch (err) {
+    log.debug(`capabilities probe failed before install: ${errorMessage(err)}`);
+    return null;
+  }
 }
 
 export type BackendSelection =
@@ -274,7 +291,7 @@ export const installCommand = defineCommand({
     }
     const backend = resolveBackendFlag(args.coreml, args.onnx);
     const positionals = (args._ ?? []).map(String);
-    const caps = await getEngineCapabilities();
+    const caps = await probeCapabilitiesForInstall();
     const supported = caps?.tts?.languages.map((l) => l.code);
     let ttsLangs: string[];
     try {

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -2,6 +2,7 @@ import { defineCommand } from "citty";
 import { errorMessage } from "../error-utils";
 import { installEngine } from "../engine-install";
 import { engineTarget } from "../engine-targets";
+import { isDarwinArm64 } from "../fluid-kokoro-cache";
 import { getEngineBinPath, getEngineCapabilities, type EngineCapabilities } from "../engine";
 import { renderInstallPlan } from "../install-plan";
 import { maybeAskForStar } from "../star";
@@ -19,12 +20,24 @@ export interface InstallCommandArgs extends SharedInstallArgs {
   engineVersion?: string;
 }
 
+/** TTS languages every build installs. */
+const TTS_LANGS_EVERYWHERE = ["en", "es", "fr", "it", "pt", "ru"];
+
+/** hi/ja/zh need FluidAudio's ANE Kokoro, which only the darwin-arm64 engine is built with. */
+const DARWIN_ARM64_ONLY_TTS_LANGS = ["hi", "ja", "zh"];
+
 /**
- * TTS languages installable on EVERY build, used when the engine binary isn't
- * installed yet (capabilities unavailable). hi/ja/zh are darwin-arm64-only and
- * can't be assumed without capabilities, so they're excluded here.
+ * What `--tts` may name when the Engine cannot be asked. Without it, a bogus code is only
+ * caught by the engine that a full download had to install first (#770).
  */
-export const TTS_LANG_FALLBACK = ["en", "es", "fr", "it", "pt", "ru"];
+export function installableTtsLangs(
+  platform = process.platform,
+  arch = process.arch,
+): string[] {
+  return isDarwinArm64(platform, arch)
+    ? [...TTS_LANGS_EVERYWHERE, ...DARWIN_ARM64_ONLY_TTS_LANGS]
+    : TTS_LANGS_EVERYWHERE;
+}
 
 export interface TtsArgInput {
   tts: boolean;
@@ -34,9 +47,9 @@ export interface TtsArgInput {
 /**
  * Resolve the requested TTS language list. Bare `--tts` defaults to English.
  * Positionals without `--tts` are an error. When `supported` is provided,
- * unsupported codes are a hard error (nothing downloads); when it's undefined
- * (engine not yet installed, capabilities unavailable) the check is skipped and
- * the engine validates authoritatively at download time.
+ * unsupported codes are a hard error (nothing downloads); the CLI passes the
+ * Engine's own list when it has one and `installableTtsLangs()` otherwise, and
+ * the installed Engine re-validates authoritatively at download time.
  */
 export function resolveTtsLangs(input: TtsArgInput, supported: string[] | undefined): string[] {
   if (!input.tts) {
@@ -292,7 +305,7 @@ export const installCommand = defineCommand({
     const backend = resolveBackendFlag(args.coreml, args.onnx);
     const positionals = (args._ ?? []).map(String);
     const caps = await probeCapabilitiesForInstall();
-    const supported = caps?.tts?.languages.map((l) => l.code);
+    const supported = caps?.tts?.languages.map((l) => l.code) ?? installableTtsLangs();
     let ttsLangs: string[];
     try {
       ttsLangs = resolveTtsLangs({ tts: args.tts === true, positionals }, supported);

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -8,6 +8,7 @@ import {
   isEngineInstalled,
   type EngineCapabilities,
 } from "./engine";
+import { probeExecutable } from "./engine-health";
 import { readInstalledEngineVersion } from "./engine-version-marker";
 import { keshaCacheDir } from "./paths";
 import { engineVersion, packageName, packageVersion } from "./package-info";
@@ -51,6 +52,8 @@ interface CacheComponent extends PathSummary {
 interface OptionalComponent extends PathSummary {
   name: string;
   note?: string;
+  /** Binaries only: whether the file actually executes. Absent for model directories. */
+  runnable?: boolean;
 }
 
 type DoctorDiagnosticLogStatus = DiagnosticLogStatus & { error?: string };
@@ -88,6 +91,8 @@ export interface DoctorReport {
     versionMarker: string | null;
     pinnedVersion: string;
     versionState: EngineVersionState;
+    /** False when the binary is present but the OS refuses to run it (#770). */
+    runnable: boolean;
     capabilities: EngineCapabilities | null;
     probeError: string | null;
   };
@@ -197,8 +202,15 @@ async function collectEngine(redact: boolean): Promise<DoctorReport["engine"]> {
   const installed = isEngineInstalled();
   let capabilities: EngineCapabilities | null = null;
   let probeError: string | null = null;
+  // A truncated download exists, so `installed` alone would report a bricked engine as
+  // healthy; probing the loader separates that from an old engine with no capabilities JSON.
+  const health = installed
+    ? await probeExecutable(binPath, ["--version"])
+    : ({ status: "missing" } as const);
 
-  if (installed) {
+  if (health.status === "unusable") {
+    probeError = `binary is present but does not run (${health.detail}); re-run \`kesha install\``;
+  } else if (installed) {
     try {
       capabilities = await getEngineCapabilities();
       if (!capabilities) probeError = "capabilities probe returned no data";
@@ -215,6 +227,7 @@ async function collectEngine(redact: boolean): Promise<DoctorReport["engine"]> {
     versionMarker,
     pinnedVersion: engineVersion,
     versionState: engineVersionState(versionMarker, engineVersion),
+    runnable: health.status === "ok",
     capabilities,
     probeError: redactString("probeError", probeError, redact),
   };
@@ -269,10 +282,27 @@ function collectCache(
   };
 }
 
-function collectOptionalComponents(
+const SIDECAR_COMPONENTS = [
+  { name: "AVSpeech sidecar", note: "macOS voices", file: "say-avspeech" },
+  { name: "Text language sidecar", note: "darwin text language fast path", file: "kesha-textlang" },
+];
+
+/** Reporting a truncated sidecar as "installed" is a false clean — spawn it instead (#770). */
+async function sidecarComponent(
+  spec: (typeof SIDECAR_COMPONENTS)[number],
+  sidecarDir: string,
+): Promise<OptionalComponent> {
+  const summary = pathSummary(join(sidecarDir, spec.file));
+  const base = { name: spec.name, note: spec.note, ...summary };
+  if (!summary.exists) return base;
+  const health = await probeExecutable(summary.path);
+  return { ...base, runnable: health.status === "ok" };
+}
+
+async function collectOptionalComponents(
   redact: boolean,
   fluidKokoro: FluidKokoroCacheInfo,
-): OptionalComponent[] {
+): Promise<OptionalComponent[]> {
   const cache = keshaCacheDir();
   const sidecarDir = dirname(getEngineBinPath());
   const components: OptionalComponent[] = [
@@ -311,16 +341,7 @@ function collectOptionalComponents(
       note: "enabled with `kesha install --diarize` (darwin-arm64); runs in-engine",
       ...pathSummary(join(cache, "models/diarize")),
     },
-    {
-      name: "AVSpeech sidecar",
-      note: "macOS voices",
-      ...pathSummary(join(sidecarDir, "say-avspeech")),
-    },
-    {
-      name: "Text language sidecar",
-      note: "darwin text language fast path",
-      ...pathSummary(join(sidecarDir, "kesha-textlang")),
-    },
+    ...(await Promise.all(SIDECAR_COMPONENTS.map((spec) => sidecarComponent(spec, sidecarDir)))),
   ];
   return components.map((component) => redactComponent(component, redact));
 }
@@ -396,15 +417,23 @@ export async function collectDoctorReport(
     },
     engine,
     cache: collectCache(redact, fluidKokoro, engine.capabilities?.backend),
-    optionalComponents: collectOptionalComponents(redact, fluidKokoro),
+    optionalComponents: await collectOptionalComponents(redact, fluidKokoro),
     stats: collectStats(redact),
     diagnosticLogs: collectDiagnosticLogs(redact),
     env: collectEnv(redact),
   };
 }
 
-function formatInstalled(installed: boolean): string {
-  return installed ? "installed" : "missing";
+const CORRUPT_STATE = "installed but not executable (corrupt) - re-run `kesha install`";
+
+function formatComponentState(component: OptionalComponent): string {
+  if (!component.exists) return "missing";
+  return component.runnable === false ? CORRUPT_STATE : "installed";
+}
+
+function formatEngineBinaryState(engine: DoctorReport["engine"]): string {
+  if (!engine.installed) return "missing";
+  return engine.runnable ? "installed" : CORRUPT_STATE;
 }
 
 function formatVersionState(engine: DoctorReport["engine"]): string {
@@ -441,7 +470,7 @@ function formatOptionalSection(components: DoctorReport["optionalComponents"]): 
   const lines = ["", "Optional components:"];
   for (const c of components) {
     const note = c.note ? ` - ${c.note}` : "";
-    lines.push(`  ${c.name}: ${formatInstalled(c.exists)}${note}`);
+    lines.push(`  ${c.name}: ${formatComponentState(c)}${note}`);
   }
   return lines;
 }
@@ -490,7 +519,7 @@ export function formatDoctorReport(report: DoctorReport): string {
     `  Platform: ${report.runtime.platform} ${report.runtime.arch}`,
     "",
     "Engine:",
-    `  Binary: ${report.engine.path} (${formatInstalled(report.engine.installed)})`,
+    `  Binary: ${report.engine.path} (${formatEngineBinaryState(report.engine)})`,
     `  Version marker: ${report.engine.versionMarker ?? "missing"}`,
     `  Pinned version: ${report.engine.pinnedVersion}`,
     `  Version state: ${formatVersionState(report.engine)}`,

--- a/src/engine-health.ts
+++ b/src/engine-health.ts
@@ -1,0 +1,55 @@
+import { existsSync } from "fs";
+import { errorMessage } from "./error-utils";
+
+export type ExecutableHealth =
+  | { status: "ok" }
+  | { status: "missing" }
+  | { status: "unusable"; detail: string };
+
+const PROBE_TIMEOUT_MS = 15_000;
+
+/**
+ * Proves a downloaded binary actually executes — existence is not health (#770).
+ *
+ * Any exit code counts as healthy: the probe only has to show that the loader accepted the
+ * image, and the sidecars legitimately exit non-zero when invoked with no work to do. A
+ * truncated download is refused before `main` runs — the spawn throws, or the kernel kills
+ * the process outright (SIGKILL on an invalid Mach-O) — and those are what this reports.
+ *
+ * The timeout guards against a binary that starts but never exits; macOS Gatekeeper can take
+ * several seconds to scan a freshly written binary on its first run, so it is generous.
+ */
+export async function probeExecutable(
+  binPath: string,
+  args: string[] = [],
+): Promise<ExecutableHealth> {
+  if (!existsSync(binPath)) return { status: "missing" };
+
+  let proc: ReturnType<typeof Bun.spawn>;
+  try {
+    proc = Bun.spawn([binPath, ...args], {
+      stdin: "ignore",
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+  } catch (err) {
+    return { status: "unusable", detail: errorMessage(err) };
+  }
+
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    proc.kill();
+  }, PROBE_TIMEOUT_MS);
+  try {
+    await proc.exited;
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (timedOut) {
+    return { status: "unusable", detail: `no exit within ${PROBE_TIMEOUT_MS / 1000}s` };
+  }
+  if (proc.signalCode) return { status: "unusable", detail: `killed by ${proc.signalCode}` };
+  return { status: "ok" };
+}

--- a/src/engine-install.ts
+++ b/src/engine-install.ts
@@ -328,9 +328,21 @@ export interface InstallOptions {
   diarize?: boolean;
 }
 
+/** A sidecar that is present but unrunnable is as useless as an absent one, and `kesha install` is the repair (#770). */
+async function sidecarNeedsDownload(spec: SidecarSpec, engineDir: string): Promise<boolean> {
+  const health = await probeExecutable(join(engineDir, spec.fileBasename));
+  if (health.status === "ok") return false;
+  if (health.status === "unusable") {
+    log.warn(
+      `${spec.displayName} is installed but does not run (${health.detail}); re-downloading it.`,
+    );
+  }
+  return true;
+}
+
 /**
  * Cache-valid path: the binary at binPath already matches the requested version.
- * Re-trusts it and tops up any sidecars the cached install is missing.
+ * Re-trusts it and re-fetches any sidecar the cached install is missing or cannot run.
  */
 async function refreshCachedEngine(
   binPath: string,
@@ -351,18 +363,19 @@ async function refreshCachedEngine(
   if (canWriteEngineDir && existsSync(binPath)) {
     darwinTrustBinary(binPath, "kesha-engine binary");
   }
-  // Top up missing sidecars (pre-#141/#199 cached binaries never had them);
+  // Top up missing or broken sidecars (pre-#141/#199 cached binaries never had them);
   // skip on read-only fs (Nix-store) to avoid confusing "install failed" warnings.
   if (canWriteEngineDir) {
-    const missing = SIDECARS.filter(
-      (s) => !existsSync(join(engineDir, s.fileBasename)),
-    );
-    await Promise.all(missing.map((s) => downloadSidecar(s, binPath, version)));
-    // Also re-trust already-present sidecars for the Sequoia upgrade scenario.
+    // Re-trust before probing, for the Sequoia upgrade scenario: a provenance-blocked
+    // sidecar is SIGKILLed on spawn, and re-downloading it would not lift the block.
     for (const s of SIDECARS) {
       const p = join(engineDir, s.fileBasename);
       if (existsSync(p)) darwinTrustBinary(p, s.displayName);
     }
+    const needed = await Promise.all(SIDECARS.map((s) => sidecarNeedsDownload(s, engineDir)));
+    await Promise.all(
+      SIDECARS.filter((_, i) => needed[i]).map((s) => downloadSidecar(s, binPath, version)),
+    );
   }
 }
 
@@ -377,45 +390,34 @@ export function isTransientSpawnLock(message: string): boolean {
  * A security scanner (Windows Defender is the one this was found on) holds a lock on a newly
  * written 60 MB PE while it scans, so the first spawn fails with EBUSY 15 ms after the download
  * reported success (#216). The lock is transient, so probe until it clears.
+ *
+ * The probe is a full health check: a Gatekeeper-SIGKILLed binary spawns without throwing, and
+ * accepting that would let the `.version` marker vouch for an engine that never ran (#770).
  */
-export async function waitUntilSpawnable(
-  binPath: string,
-  deadlineMs = 60_000,
-  probeTimeoutMs = 5_000,
-): Promise<void> {
+export async function waitUntilSpawnable(binPath: string, deadlineMs = 60_000): Promise<void> {
   const deadline = Date.now() + deadlineMs;
   let lastError = "";
   let warned = false;
   let delay = 100;
 
   for (;;) {
-    try {
-      // Only a throw means locked; the timeout is for a scanner that detains rather than refuses.
-      const proc = Bun.spawn([binPath, "--version"], { stdout: "ignore", stderr: "ignore" });
-      const timer = setTimeout(() => proc.kill(), probeTimeoutMs);
-      try {
-        await proc.exited;
-      } finally {
-        clearTimeout(timer);
-      }
-      return;
-    } catch (e) {
-      lastError = errorMessage(e);
-      // Only a lock is worth waiting out — a missing or corrupt binary never becomes spawnable.
-      if (!isTransientSpawnLock(lastError)) {
-        throw new Error(
-          `Downloaded the engine to ${binPath} but it could not be started: ${lastError}\n` +
-            `  Fix: delete ${dirname(binPath)} and re-run \`kesha install\`.`,
-        );
-      }
-      if (Date.now() + delay > deadline) break;
-      if (!warned) {
-        warned = true;
-        log.progress("Waiting for the engine binary to be released by the system...");
-      }
-      await Bun.sleep(delay);
-      delay = Math.min(delay * 2, 2_000);
+    const health = await probeExecutable(binPath, ["--version"]);
+    if (health.status === "ok") return;
+    lastError = health.status === "unusable" ? health.detail : "the binary is gone";
+    // Only a lock is worth waiting out — a missing or corrupt binary never becomes spawnable.
+    if (!isTransientSpawnLock(lastError)) {
+      throw new Error(
+        `Downloaded the engine to ${binPath} but it could not be started: ${lastError}\n` +
+          `  Fix: delete ${dirname(binPath)} and re-run \`kesha install\`.`,
+      );
     }
+    if (Date.now() + delay > deadline) break;
+    if (!warned) {
+      warned = true;
+      log.progress("Waiting for the engine binary to be released by the system...");
+    }
+    await Bun.sleep(delay);
+    delay = Math.min(delay * 2, 2_000);
   }
 
   throw new Error(

--- a/src/engine-install.ts
+++ b/src/engine-install.ts
@@ -8,6 +8,7 @@ import {
   TRANSCRIBE_DIARIZE_FEATURE,
   type EngineCapabilities,
 } from "./engine";
+import { probeExecutable } from "./engine-health";
 import { engineTarget } from "./engine-targets";
 import { isDarwinArm64 } from "./fluid-kokoro-cache";
 import { log } from "./log";
@@ -425,6 +426,21 @@ export async function waitUntilSpawnable(
   );
 }
 
+/**
+ * Cache-validity health check: an install interrupted before `chmod`/marker-write, or a
+ * binary from another architecture, exists at the right version yet cannot start (#770).
+ */
+async function engineRuns(binPath: string): Promise<boolean> {
+  const health = await probeExecutable(binPath, ["--version"]);
+  if (health.status === "ok") return true;
+  const detail = health.status === "unusable" ? health.detail : "binary disappeared";
+  log.warn(
+    `Installed engine at ${binPath} does not run (${detail}); it is corrupt or built for ` +
+      "another architecture — re-downloading it.",
+  );
+  return false;
+}
+
 /** Cold path: download the engine binary (and sidecars, concurrently). */
 async function fetchEngineBinary(
   binPath: string,
@@ -589,7 +605,12 @@ export async function installEngine(request: EngineInstallRequest = {}): Promise
   // Read-only engine dir = Nix-store install; skip download/sidecar writes to avoid EROFS errors.
   const canWriteEngineDir = checkEngineWritable(engineDir);
 
-  const versionMatches = existsSync(binPath) && installedVersion === version;
+  const markerMatches = existsSync(binPath) && installedVersion === version;
+  // The marker vouches for a file, not for a working binary. Skipped on a read-only engine
+  // dir: nothing there can be repaired, so a failed probe would only turn a usable Nix
+  // install into a hard error.
+  const versionMatches =
+    markerMatches && (!canWriteEngineDir || (await engineRuns(binPath)));
   // On read-only fs, --no-cache can't re-download; treat as cache-valid and forward flag to model install.
   const cacheValid = versionMatches && (!noCache || !canWriteEngineDir);
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -324,9 +324,30 @@ export async function detectTextLanguageEngine(
 ): Promise<LangDetectResult | null> {
   if (text.trim().length === 0) return null;
   if (!isEngineInstalled()) return null;
-  const { stdout, exitCode } = await runEngine(["detect-text-lang", text], opts);
-  if (exitCode !== 0) return null;
+  const { stdout, stderr, exitCode } = await runEngine(["detect-text-lang", text], opts);
+  if (exitCode !== 0) {
+    const warning = textLangFailureWarning(stderr);
+    if (warning) log.warn(warning);
+    return null;
+  }
   return parseLangResult(stdout);
+}
+
+/**
+ * Null off darwin, where text detection is unsupported by design and failing is expected.
+ *
+ * On darwin a failure means a broken `kesha-textlang` sidecar, and swallowing it routed
+ * `kesha say` to the default voice with no hint that detection had stopped working (#770).
+ */
+export function textLangFailureWarning(
+  stderr: string,
+  platform: string = process.platform,
+): string | null {
+  if (platform !== "darwin") return null;
+  return (
+    `Text language detection failed${stderr ? `: ${stderr}` : ""}\n` +
+    "  Falling back to the default voice. Fix: run `kesha install` to reinstall the kesha-textlang sidecar."
+  );
 }
 
 export interface TtsLanguageCapability {

--- a/src/progress.ts
+++ b/src/progress.ts
@@ -1,5 +1,6 @@
-import { readdirSync, renameSync, rmSync } from "fs";
+import { copyFileSync, readdirSync, renameSync, rmSync, statSync } from "fs";
 import { basename, dirname, join } from "path";
+import { errorMessage } from "./error-utils";
 import { log } from "./log";
 
 const BAR_WIDTH = 20;
@@ -128,16 +129,50 @@ export async function applyBackpressure(
   if (written < 0) await writer.flush();
 }
 
+/**
+ * Age threshold and platform gate mirror `rust/src/models.rs::cleanup_orphan_staging`: a
+ * concurrent installer's staging file keeps a fresh mtime while bytes stream into it, and
+ * Windows leaves last-write time stale while a handle is open, so an in-flight download
+ * there could not be told apart from an orphan.
+ */
+const STALE_STAGING_MS = 24 * 60 * 60 * 1000;
+
 /** A Ctrl-C kills the process before any cleanup runs, so last run's staging file is swept by the next one (#770). */
 function sweepStagingFiles(destPath: string): void {
+  if (process.platform === "win32") return;
   const dir = dirname(destPath);
   const prefix = `${basename(destPath)}.part.`;
+  const cutoffMs = Date.now() - STALE_STAGING_MS;
+
+  let names: string[];
   try {
-    for (const name of readdirSync(dir)) {
-      if (name.startsWith(prefix)) rmSync(join(dir, name), { force: true });
+    names = readdirSync(dir);
+  } catch (err) {
+    log.debug(`Could not scan ${dir} for orphaned download staging: ${errorMessage(err)}`);
+    return;
+  }
+
+  for (const name of names) {
+    if (!name.startsWith(prefix)) continue;
+    const path = join(dir, name);
+    try {
+      if (statSync(path).mtimeMs > cutoffMs) continue;
+      rmSync(path, { force: true });
+      log.debug(`Cleaned up orphaned download staging: ${name}`);
+    } catch (err) {
+      log.debug(`Could not sweep orphaned download staging ${name}: ${errorMessage(err)}`);
     }
-  } catch {
-    // Best-effort: an unreadable directory surfaces on the write below, with a better message.
+  }
+}
+
+/** Windows refuses `rename` onto a destination another handle still holds; POSIX overwrites. */
+function publishStaging(stagingPath: string, destPath: string): void {
+  try {
+    renameSync(stagingPath, destPath);
+  } catch (err) {
+    if (process.platform !== "win32") throw err;
+    copyFileSync(stagingPath, destPath);
+    rmSync(stagingPath, { force: true });
   }
 }
 
@@ -163,6 +198,9 @@ export async function streamResponseToFile(
 
   sweepStagingFiles(destPath);
   const stagingPath = `${destPath}.part.${process.pid}`;
+  // Bun's FileSink writes from offset 0 without truncating, so a not-yet-stale staging file
+  // left by a killed run that held this pid would leave its tail in the published download.
+  rmSync(stagingPath, { force: true });
   const writer = Bun.file(stagingPath).writer();
   let bytes = 0;
   try {
@@ -176,7 +214,7 @@ export async function streamResponseToFile(
       // Must await: an open write handle makes the freshly-downloaded engine unspawnable — EBUSY on Windows, ETXTBSY on Linux.
       await writer.end();
     }
-    renameSync(stagingPath, destPath);
+    publishStaging(stagingPath, destPath);
   } catch (err) {
     rmSync(stagingPath, { force: true });
     throw err;

--- a/src/progress.ts
+++ b/src/progress.ts
@@ -176,11 +176,14 @@ function publishStaging(stagingPath: string, destPath: string): void {
   }
 }
 
+/** The pid alone would collide between two concurrent calls in one process, which then share a staging file. */
+let stagingSeq = 0;
+
 /**
- * Downloads into a sibling `.part.<pid>` file and renames it into place, so an interrupted
- * download can never leave a truncated binary at `destPath` (#770). Mirrors the staging
- * `rust/src/models.rs::write_verified` already does for model files. Staging beside the
- * destination keeps the rename within one filesystem, where it is atomic.
+ * Downloads into a sibling `.part.<pid>.<n>` file and renames it into place, so an
+ * interrupted download can never leave a truncated binary at `destPath` (#770). Mirrors the
+ * staging `rust/src/models.rs::write_verified` already does for model files. Staging beside
+ * the destination keeps the rename within one filesystem, where it is atomic.
  */
 export async function streamResponseToFile(
   res: Response,
@@ -197,10 +200,7 @@ export async function streamResponseToFile(
   const progress = createProgressBar(label, totalBytes);
 
   sweepStagingFiles(destPath);
-  const stagingPath = `${destPath}.part.${process.pid}`;
-  // Bun's FileSink writes from offset 0 without truncating, so a not-yet-stale staging file
-  // left by a killed run that held this pid would leave its tail in the published download.
-  rmSync(stagingPath, { force: true });
+  const stagingPath = `${destPath}.part.${process.pid}.${stagingSeq++}`;
   const writer = Bun.file(stagingPath).writer();
   let bytes = 0;
   try {

--- a/src/progress.ts
+++ b/src/progress.ts
@@ -1,3 +1,5 @@
+import { readdirSync, renameSync, rmSync } from "fs";
+import { basename, dirname, join } from "path";
 import { log } from "./log";
 
 const BAR_WIDTH = 20;
@@ -126,6 +128,25 @@ export async function applyBackpressure(
   if (written < 0) await writer.flush();
 }
 
+/** A Ctrl-C kills the process before any cleanup runs, so last run's staging file is swept by the next one (#770). */
+function sweepStagingFiles(destPath: string): void {
+  const dir = dirname(destPath);
+  const prefix = `${basename(destPath)}.part.`;
+  try {
+    for (const name of readdirSync(dir)) {
+      if (name.startsWith(prefix)) rmSync(join(dir, name), { force: true });
+    }
+  } catch {
+    // Best-effort: an unreadable directory surfaces on the write below, with a better message.
+  }
+}
+
+/**
+ * Downloads into a sibling `.part.<pid>` file and renames it into place, so an interrupted
+ * download can never leave a truncated binary at `destPath` (#770). Mirrors the staging
+ * `rust/src/models.rs::write_verified` already does for model files. Staging beside the
+ * destination keeps the rename within one filesystem, where it is atomic.
+ */
 export async function streamResponseToFile(
   res: Response,
   destPath: string,
@@ -140,17 +161,25 @@ export async function streamResponseToFile(
   const totalBytes = Number(res.headers.get("content-length") || 0);
   const progress = createProgressBar(label, totalBytes);
 
-  const writer = Bun.file(destPath).writer();
+  sweepStagingFiles(destPath);
+  const stagingPath = `${destPath}.part.${process.pid}`;
+  const writer = Bun.file(stagingPath).writer();
   let bytes = 0;
   try {
-    for await (const chunk of res.body) {
-      await applyBackpressure(writer, writer.write(chunk));
-      bytes += chunk.length;
-      progress.update(chunk.length);
+    try {
+      for await (const chunk of res.body) {
+        await applyBackpressure(writer, writer.write(chunk));
+        bytes += chunk.length;
+        progress.update(chunk.length);
+      }
+    } finally {
+      // Must await: an open write handle makes the freshly-downloaded engine unspawnable — EBUSY on Windows, ETXTBSY on Linux.
+      await writer.end();
     }
-  } finally {
-    // Must await: an open write handle makes the freshly-downloaded engine unspawnable — EBUSY on Windows, ETXTBSY on Linux.
-    await writer.end();
+    renameSync(stagingPath, destPath);
+  } catch (err) {
+    rmSync(stagingPath, { force: true });
+    throw err;
   }
 
   progress.finish();

--- a/tests/integration/cli-contracts.test.ts
+++ b/tests/integration/cli-contracts.test.ts
@@ -120,7 +120,8 @@ function markFakeEngineInstalled(enginePath: string): void {
   if (process.platform === "darwin" && process.arch === "arm64") {
     for (const sidecar of ["say-avspeech", "kesha-textlang"]) {
       const path = join(dirname(enginePath), sidecar);
-      writeFileSync(path, "");
+      // Must actually run: install re-downloads a sidecar it cannot spawn (#770).
+      writeFileSync(path, "#!/bin/sh\nexit 0\n");
       chmodSync(path, 0o755);
     }
   }

--- a/tests/unit/doctor.test.ts
+++ b/tests/unit/doctor.test.ts
@@ -510,3 +510,113 @@ describe("engine version drift (#738)", () => {
     }
   });
 });
+
+// #770: a truncated download leaves a file that exists but cannot run. Reporting it as
+// "installed" is a false clean from the one command whose job is to find such faults.
+describe("doctor separates corrupt components from missing ones", () => {
+  const savedEnv = {
+    HOME: process.env.HOME,
+    KESHA_ENGINE_BIN: process.env.KESHA_ENGINE_BIN,
+    KESHA_CACHE_DIR: process.env.KESHA_CACHE_DIR,
+    KESHA_STATS_DB: process.env.KESHA_STATS_DB,
+  };
+
+  function restoreEnv() {
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+
+  beforeEach(restoreEnv);
+  afterEach(restoreEnv);
+
+  /** Mode 0o755 but not a loadable image, exactly what an interrupted download leaves behind. */
+  const TRUNCATED = "\x7fELF\x00\x01\x02truncated";
+
+  function stageInstall(prefix: string, engineBody: string, sidecarBody: string | null): string {
+    const dir = mkdtempSync(join(tmpdir(), prefix));
+    const binDir = join(dir, "engine", "bin");
+    mkdirSync(binDir, { recursive: true });
+    writeFakeEngine(join(binDir, "kesha-engine"), engineBody);
+    if (sidecarBody !== null) {
+      writeFakeEngine(join(binDir, "say-avspeech"), sidecarBody);
+      writeFakeEngine(join(binDir, "kesha-textlang"), sidecarBody);
+    }
+    process.env.HOME = dir;
+    process.env.KESHA_ENGINE_BIN = join(binDir, "kesha-engine");
+    process.env.KESHA_CACHE_DIR = join(dir, ".cache", "kesha");
+    process.env.KESHA_STATS_DB = join(dir, "stats.sqlite");
+    return dir;
+  }
+
+  function sidecarStates(report: Awaited<ReturnType<typeof collectDoctorReport>>) {
+    return report.optionalComponents
+      .filter((c) => c.name.endsWith("sidecar"))
+      .map((c) => ({ name: c.name, exists: c.exists, runnable: c.runnable }));
+  }
+
+  posixEngineTest("a truncated sidecar reports as corrupt, not installed", async () => {
+    const dir = stageInstall("kesha-doctor-corrupt-sidecar-", "#!/bin/sh\nexit 0\n", TRUNCATED);
+    try {
+      const report = await collectDoctorReport();
+      expect(sidecarStates(report)).toEqual([
+        { name: "AVSpeech sidecar", exists: true, runnable: false },
+        { name: "Text language sidecar", exists: true, runnable: false },
+      ]);
+
+      const output = formatDoctorReport(report);
+      expect(output).toContain("AVSpeech sidecar: installed but not executable (corrupt)");
+      expect(output).toContain("Text language sidecar: installed but not executable (corrupt)");
+      expect(output).toContain("re-run `kesha install`");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // The sidecars exit non-zero with no work to do, so "it ran" is the only fair health bar.
+  posixEngineTest("a working sidecar still reports as installed", async () => {
+    const dir = stageInstall("kesha-doctor-ok-sidecar-", "#!/bin/sh\nexit 0\n", "#!/bin/sh\nexit 1\n");
+    try {
+      const report = await collectDoctorReport();
+      expect(sidecarStates(report)).toEqual([
+        { name: "AVSpeech sidecar", exists: true, runnable: true },
+        { name: "Text language sidecar", exists: true, runnable: true },
+      ]);
+      expect(formatDoctorReport(report)).not.toContain("corrupt");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  posixEngineTest("an absent sidecar stays missing rather than corrupt", async () => {
+    const dir = stageInstall("kesha-doctor-no-sidecar-", "#!/bin/sh\nexit 0\n", null);
+    try {
+      const report = await collectDoctorReport();
+      expect(sidecarStates(report)).toEqual([
+        { name: "AVSpeech sidecar", exists: false, runnable: undefined },
+        { name: "Text language sidecar", exists: false, runnable: undefined },
+      ]);
+      expect(formatDoctorReport(report)).toContain("AVSpeech sidecar: missing");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  posixEngineTest("a truncated engine is named as corrupt rather than probed for capabilities", async () => {
+    const dir = stageInstall("kesha-doctor-corrupt-engine-", TRUNCATED, null);
+    try {
+      const report = await collectDoctorReport();
+      expect(report.engine.installed).toBe(true);
+      expect(report.engine.runnable).toBe(false);
+      expect(report.engine.probeError).toContain("does not run");
+
+      const output = formatDoctorReport(report);
+      expect(output).toContain(
+        `Binary: ${report.engine.path} (installed but not executable (corrupt) - re-run \`kesha install\`)`,
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/engine-install.test.ts
+++ b/tests/unit/engine-install.test.ts
@@ -195,6 +195,20 @@ describe("waitUntilSpawnable (#216)", () => {
     }
   });
 
+  // Gatekeeper SIGKILLs an untrusted ad-hoc binary after the spawn succeeds, so "it spawned"
+  // was never proof it ran — and the `.version` marker written next vouched for it (#770).
+  spawnFixtureTest("a binary killed by a signal is not accepted as spawnable", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-spawnable-killed-"));
+    try {
+      const binPath = join(dir, "engine");
+      writeFileSync(binPath, "#!/bin/sh\nkill -9 $$\n");
+      chmodSync(binPath, 0o755);
+      await expect(waitUntilSpawnable(binPath, 1_000)).rejects.toThrow(/could not be started/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   // A missing binary never becomes spawnable, so retrying it would just stall the
   // install for the full deadline before failing anyway.
   test("fails fast on a non-transient error instead of waiting out the deadline", async () => {

--- a/tests/unit/engine-repair.test.ts
+++ b/tests/unit/engine-repair.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { getEngineBinaryName, installEngine } from "../../src/engine-install";
+import { probeCapabilitiesForInstall } from "../../src/cli/install";
+import { probeExecutable } from "../../src/engine-health";
+import { getEngineCapabilities } from "../../src/engine";
+import { engineVersion } from "../../src/package-info";
+
+// #770: an interrupted `kesha install` left a truncated binary that the kernel refuses to
+// load, while the `.version` marker still vouched for it. Every repair path then failed.
+
+const WORKING_ENGINE = "#!/bin/sh\nexit 0\n";
+/** Mode 0o755 but not a loadable image: `posix_spawn` fails with ENOEXEC, as on a truncated Mach-O. */
+const CORRUPT_ENGINE = "\x7fELF\x00\x01\x02truncated";
+
+const savedEnv = { KESHA_ENGINE_BIN: process.env.KESHA_ENGINE_BIN };
+const savedFetch = globalThis.fetch;
+const tempDirs: string[] = [];
+
+const posixTest = process.platform === "win32" ? test.skip : test;
+
+afterEach(() => {
+  globalThis.fetch = savedFetch;
+  if (savedEnv.KESHA_ENGINE_BIN === undefined) delete process.env.KESHA_ENGINE_BIN;
+  else process.env.KESHA_ENGINE_BIN = savedEnv.KESHA_ENGINE_BIN;
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+/** Installs a binary at the pinned version, so only its health can decide the cache check. */
+function stageEngine(prefix: string, body: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  const binPath = join(dir, "bin", "kesha-engine");
+  mkdirSync(join(dir, "bin"), { recursive: true });
+  writeFileSync(binPath, body);
+  chmodSync(binPath, 0o755);
+  writeFileSync(`${binPath}.version`, `${engineVersion}\n`);
+  process.env.KESHA_ENGINE_BIN = binPath;
+  return binPath;
+}
+
+function stubRelease(): string[] {
+  const urls: string[] = [];
+  const binaryName = getEngineBinaryName();
+  globalThis.fetch = (async (input: Request | URL | string) => {
+    const url = String(input instanceof Request ? input.url : input);
+    urls.push(url);
+    return url.endsWith(binaryName)
+      ? new Response(WORKING_ENGINE, {
+          status: 200,
+          headers: { "content-length": String(WORKING_ENGINE.length) },
+        })
+      : new Response("Not Found", { status: 404 });
+  }) as typeof fetch;
+  return urls;
+}
+
+function engineDownloads(urls: string[]): string[] {
+  const binaryName = getEngineBinaryName();
+  return urls.filter((u) => u.endsWith(binaryName));
+}
+
+describe("probeExecutable (#770)", () => {
+  posixTest("a binary that runs is healthy whatever it exits with", async () => {
+    const binPath = stageEngine("kesha-probe-ok-", "#!/bin/sh\nexit 3\n");
+    expect(await probeExecutable(binPath, ["--version"])).toEqual({ status: "ok" });
+  });
+
+  posixTest("a truncated image is unusable, not merely present", async () => {
+    const binPath = stageEngine("kesha-probe-corrupt-", CORRUPT_ENGINE);
+    const health = await probeExecutable(binPath, ["--version"]);
+    expect(health.status).toBe("unusable");
+  });
+
+  test("an absent binary is missing, not unusable", async () => {
+    expect(await probeExecutable(join(tmpdir(), "kesha-does-not-exist"))).toEqual({
+      status: "missing",
+    });
+  });
+});
+
+describe("install repairs a corrupt engine (#770)", () => {
+  posixTest("a matching version marker no longer vouches for a binary that cannot run", async () => {
+    const binPath = stageEngine("kesha-repair-corrupt-", CORRUPT_ENGINE);
+    const urls = stubRelease();
+
+    await installEngine();
+
+    expect(engineDownloads(urls)).toHaveLength(1);
+    expect(readFileSync(binPath, "utf8")).toBe(WORKING_ENGINE);
+  }, 30_000);
+
+  posixTest("a healthy cached engine is still not re-downloaded", async () => {
+    stageEngine("kesha-repair-healthy-", WORKING_ENGINE);
+    const urls = stubRelease();
+
+    await installEngine();
+
+    expect(engineDownloads(urls)).toHaveLength(0);
+  }, 30_000);
+
+  // The probe used to run before any install work and threw E_ENGINE_SPAWN, so the command
+  // died recommending the very command the user had just run.
+  posixTest("the pre-install capabilities probe survives an unspawnable engine", async () => {
+    stageEngine("kesha-repair-caps-", CORRUPT_ENGINE);
+
+    await expect(getEngineCapabilities()).rejects.toThrow(/E_ENGINE_SPAWN/);
+    expect(await probeCapabilitiesForInstall()).toBeNull();
+  });
+});

--- a/tests/unit/engine-repair.test.ts
+++ b/tests/unit/engine-repair.test.ts
@@ -1,11 +1,12 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
-import { join } from "path";
+import { dirname, join } from "path";
 import { tmpdir } from "os";
-import { getEngineBinaryName, installEngine } from "../../src/engine-install";
-import { probeCapabilitiesForInstall } from "../../src/cli/install";
+import { getEngineBinaryName, installEngine, SIDECARS } from "../../src/engine-install";
+import { installableTtsLangs, probeCapabilitiesForInstall, resolveTtsLangs } from "../../src/cli/install";
 import { probeExecutable } from "../../src/engine-health";
 import { getEngineCapabilities } from "../../src/engine";
+import { isDarwinArm64 } from "../../src/fluid-kokoro-cache";
 import { engineVersion } from "../../src/package-info";
 
 // #770: an interrupted `kesha install` left a truncated binary that the kernel refuses to
@@ -20,6 +21,8 @@ const savedFetch = globalThis.fetch;
 const tempDirs: string[] = [];
 
 const posixTest = process.platform === "win32" ? test.skip : test;
+/** Sidecars are only ever fetched on darwin-arm64, so only there can their repair be observed. */
+const sidecarTest = isDarwinArm64() ? test : test.skip;
 
 afterEach(() => {
   globalThis.fetch = savedFetch;
@@ -41,13 +44,15 @@ function stageEngine(prefix: string, body: string): string {
   return binPath;
 }
 
-function stubRelease(): string[] {
+/** Serves `WORKING_ENGINE` for the engine asset, and for the sidecars too when `withSidecars`. */
+function stubRelease(withSidecars = false): string[] {
   const urls: string[] = [];
   const binaryName = getEngineBinaryName();
+  const served = [binaryName, ...(withSidecars ? SIDECARS.map((s) => s.assetName) : [])];
   globalThis.fetch = (async (input: Request | URL | string) => {
     const url = String(input instanceof Request ? input.url : input);
     urls.push(url);
-    return url.endsWith(binaryName)
+    return served.some((name) => url.endsWith(name))
       ? new Response(WORKING_ENGINE, {
           status: 200,
           headers: { "content-length": String(WORKING_ENGINE.length) },
@@ -108,5 +113,39 @@ describe("install repairs a corrupt engine (#770)", () => {
 
     await expect(getEngineCapabilities()).rejects.toThrow(/E_ENGINE_SPAWN/);
     expect(await probeCapabilitiesForInstall()).toBeNull();
+  });
+
+  // A cache hit used to top up only ABSENT sidecars, so a truncated one was re-trusted
+  // forever and doctor's "re-run kesha install" hint was a lie for it.
+  sidecarTest("a cache hit repairs a sidecar that is present but cannot run", async () => {
+    const binPath = stageEngine("kesha-repair-sidecar-", WORKING_ENGINE);
+    const sidecarPath = join(dirname(binPath), SIDECARS[0]!.fileBasename);
+    writeFileSync(sidecarPath, CORRUPT_ENGINE);
+    chmodSync(sidecarPath, 0o755);
+    const urls = stubRelease(true);
+
+    await installEngine();
+
+    expect(engineDownloads(urls)).toHaveLength(0);
+    expect(readFileSync(sidecarPath, "utf8")).toBe(WORKING_ENGINE);
+  }, 60_000);
+});
+
+describe("--tts codes are validated before the engine download (#770)", () => {
+  test("hi/ja/zh are only offered where the ANE engine is built", () => {
+    expect(installableTtsLangs("linux", "x64")).not.toContain("ja");
+    expect(installableTtsLangs("darwin", "arm64")).toContain("ja");
+    expect(installableTtsLangs("darwin", "x64")).not.toContain("ja");
+  });
+
+  // Without a static list, `kesha install --tts ja` on linux downloaded a full engine and
+  // only then heard "unsupported" from it.
+  test("an unsupported code fails without an engine to ask", () => {
+    expect(() =>
+      resolveTtsLangs({ tts: true, positionals: ["ja"] }, installableTtsLangs("linux", "x64")),
+    ).toThrow(/ja/);
+    expect(
+      resolveTtsLangs({ tts: true, positionals: ["ru"] }, installableTtsLangs("linux", "x64")),
+    ).toEqual(["ru"]);
   });
 });

--- a/tests/unit/engine.test.ts
+++ b/tests/unit/engine.test.ts
@@ -4,11 +4,13 @@ import { tmpdir } from "os";
 import { join } from "path";
 import { waitForPidExit, waitForPidFile } from "../helpers/process";
 import {
+  detectTextLanguageEngine,
   parseLangResult,
   getEngineBinPath,
   preflightTranscribeEngineWithSegments,
   recordEngine,
   spawnStdioWithDebugFd,
+  textLangFailureWarning,
   transcribeEngine,
   transcribeEngineWithSegments,
 } from "../../src/engine";
@@ -275,4 +277,40 @@ describe("spawnStdioWithDebugFd", () => {
     expect(spawnStdioWithDebugFd(["pipe", "pipe", "pipe"])).toEqual(["pipe", "pipe", "pipe", 3]);
   });
 
+});
+
+describe("text language detection degrades loudly (#770)", () => {
+  test("a darwin failure names the sidecar and the fix", () => {
+    const warning = textLangFailureWarning("kesha-textlang helper exited 137", "darwin");
+    expect(warning).toContain("kesha-textlang helper exited 137");
+    expect(warning).toContain("kesha install");
+  });
+
+  // Text detection is macOS-only, so failing elsewhere is the documented behaviour, not a fault.
+  test("no warning on platforms that never supported detection", () => {
+    expect(textLangFailureWarning("unsupported on this platform", "linux")).toBeNull();
+    expect(textLangFailureWarning("unsupported on this platform", "win32")).toBeNull();
+  });
+
+  fakeEngineTest("a failing subprocess warns on stderr and still resolves null", async () => {
+    const savedEngineBin = process.env.KESHA_ENGINE_BIN;
+    const savedWrite = process.stderr.write;
+    const captured: string[] = [];
+    process.env.KESHA_ENGINE_BIN = fakeEngine([]);
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      captured.push(typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk));
+      return true;
+    }) as typeof process.stderr.write;
+
+    try {
+      expect(await detectTextLanguageEngine("Привет, как дела?")).toBeNull();
+    } finally {
+      process.stderr.write = savedWrite;
+      if (savedEngineBin === undefined) delete process.env.KESHA_ENGINE_BIN;
+      else process.env.KESHA_ENGINE_BIN = savedEngineBin;
+    }
+
+    const warned = captured.some((line) => line.includes("Text language detection failed"));
+    expect(warned).toBe(process.platform === "darwin");
+  });
 });

--- a/tests/unit/progress-stream.test.ts
+++ b/tests/unit/progress-stream.test.ts
@@ -1,8 +1,19 @@
 import { describe, expect, test } from "bun:test";
-import { chmodSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "fs";
+import {
+  chmodSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  utimesSync,
+  writeFileSync,
+} from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { applyBackpressure, streamResponseToFile } from "../../src/progress";
+
+const posixTest = process.platform === "win32" ? test.skip : test;
 
 // #216: `writer.end()` went unawaited, so the write handle outlived the call. Whether an
 // OS then lets you spawn the file is nondeterministic — that half is covered by
@@ -113,14 +124,67 @@ describe("streamResponseToFile publishes atomically (#770)", () => {
   });
 
   // A Ctrl-C kills the process before cleanup runs, so the next download has to sweep.
-  test("a staging file orphaned by a killed process is swept", async () => {
+  // The sweep is Unix-only and age-gated, exactly as models.rs::cleanup_orphan_staging is.
+  posixTest("a staging file orphaned by a killed process is swept once it is a day old", async () => {
     const dir = mkdtempSync(join(tmpdir(), "kesha-stream-orphan-"));
     try {
       const dest = join(dir, "kesha-engine");
-      writeFileSync(`${dest}.part.4242`, "orphan from a killed run");
+      const orphan = `${dest}.part.4242`;
+      writeFileSync(orphan, "orphan from a killed run");
+      const dayAgo = new Date(Date.now() - 25 * 60 * 60 * 1000);
+      utimesSync(orphan, dayAgo, dayAgo);
 
       await streamResponseToFile(responseOf("engine bytes"), dest, "payload");
 
+      expect(readdirSync(dir)).toEqual(["kesha-engine"]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // Two concurrent `kesha install` runs: sweeping B's in-flight staging leaves B renaming an
+  // unlinked inode. Only age tells a live download apart from an orphan.
+  test("a concurrent installer's fresh staging file survives the sweep", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-stream-live-"));
+    try {
+      const dest = join(dir, "kesha-engine");
+      const live = `${dest}.part.999`;
+      writeFileSync(live, "another process is still writing this");
+
+      await streamResponseToFile(responseOf("engine bytes"), dest, "payload");
+
+      expect(readFileSync(live, "utf8")).toBe("another process is still writing this");
+      expect(readdirSync(dir).sort()).toEqual(["kesha-engine", "kesha-engine.part.999"]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // Pids are recycled, and the sweep now spares anything under a day old — so the only thing
+  // standing between a killed run's leftovers and the published file is this unlink.
+  test("a same-pid staging leftover cannot bleed into the download", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-stream-pid-reuse-"));
+    try {
+      const dest = join(dir, "kesha-engine");
+      writeFileSync(`${dest}.part.${process.pid}`, "leftovers from a killed run with this pid");
+
+      await streamResponseToFile(responseOf("fresh"), dest, "payload");
+
+      expect(readFileSync(dest, "utf8")).toBe("fresh");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("an existing destination is replaced with the new bytes", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-stream-overwrite-"));
+    try {
+      const dest = join(dir, "kesha-engine");
+      writeFileSync(dest, "stale engine from an older release");
+
+      await streamResponseToFile(responseOf("fresh engine bytes"), dest, "payload");
+
+      expect(readFileSync(dest, "utf8")).toBe("fresh engine bytes");
       expect(readdirSync(dir)).toEqual(["kesha-engine"]);
     } finally {
       rmSync(dir, { recursive: true, force: true });

--- a/tests/unit/progress-stream.test.ts
+++ b/tests/unit/progress-stream.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, statSync } from "fs";
+import { chmodSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { applyBackpressure, streamResponseToFile } from "../../src/progress";
@@ -48,6 +48,94 @@ describe("streamResponseToFile flushes before resolving", () => {
       const back = new Uint8Array(await Bun.file(dest).arrayBuffer());
       expect(back.length).toBe(source.length);
       expect(Bun.SHA256.hash(back, "hex")).toBe(Bun.SHA256.hash(source, "hex"));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("streamResponseToFile publishes atomically (#770)", () => {
+  /** Streams `prefix`, then fails — the shape of a Ctrl-C or a dropped connection mid-download. */
+  function failingResponse(prefix: string, message: string): Response {
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(prefix));
+        controller.error(new Error(message));
+      },
+    });
+    return new Response(body, { headers: { "content-length": "999999" } });
+  }
+
+  test("an interrupted download leaves the previous file untouched", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-stream-abort-"));
+    try {
+      const dest = join(dir, "kesha-engine");
+      writeFileSync(dest, "previous engine");
+
+      await expect(
+        streamResponseToFile(failingResponse("truncated", "connection reset"), dest, "payload"),
+      ).rejects.toThrow(/connection reset/);
+
+      expect(readFileSync(dest, "utf8")).toBe("previous engine");
+      expect(readdirSync(dir)).toEqual(["kesha-engine"]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("an interrupted first download leaves no file at all", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-stream-abort-cold-"));
+    try {
+      const dest = join(dir, "kesha-engine");
+
+      await expect(
+        streamResponseToFile(failingResponse("truncated", "connection reset"), dest, "payload"),
+      ).rejects.toThrow(/connection reset/);
+
+      expect(readdirSync(dir)).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a successful download leaves no staging file behind", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-stream-staging-"));
+    try {
+      const dest = join(dir, "kesha-engine");
+
+      await streamResponseToFile(responseOf("engine bytes"), dest, "payload");
+
+      expect(readFileSync(dest, "utf8")).toBe("engine bytes");
+      expect(readdirSync(dir)).toEqual(["kesha-engine"]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // A Ctrl-C kills the process before cleanup runs, so the next download has to sweep.
+  test("a staging file orphaned by a killed process is swept", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-stream-orphan-"));
+    try {
+      const dest = join(dir, "kesha-engine");
+      writeFileSync(`${dest}.part.4242`, "orphan from a killed run");
+
+      await streamResponseToFile(responseOf("engine bytes"), dest, "payload");
+
+      expect(readdirSync(dir)).toEqual(["kesha-engine"]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("the published file carries the mode the caller then chmods", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-stream-mode-"));
+    try {
+      const dest = join(dir, "kesha-engine");
+
+      await streamResponseToFile(responseOf("engine bytes"), dest, "payload");
+      chmodSync(dest, 0o755);
+
+      expect(statSync(dest).mode & 0o777).toBe(process.platform === "win32" ? 0o666 : 0o755);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/tests/unit/progress-stream.test.ts
+++ b/tests/unit/progress-stream.test.ts
@@ -129,7 +129,7 @@ describe("streamResponseToFile publishes atomically (#770)", () => {
     const dir = mkdtempSync(join(tmpdir(), "kesha-stream-orphan-"));
     try {
       const dest = join(dir, "kesha-engine");
-      const orphan = `${dest}.part.4242`;
+      const orphan = `${dest}.part.4242.3`;
       writeFileSync(orphan, "orphan from a killed run");
       const dayAgo = new Date(Date.now() - 25 * 60 * 60 * 1000);
       utimesSync(orphan, dayAgo, dayAgo);
@@ -160,17 +160,39 @@ describe("streamResponseToFile publishes atomically (#770)", () => {
     }
   });
 
-  // Pids are recycled, and the sweep now spares anything under a day old — so the only thing
-  // standing between a killed run's leftovers and the published file is this unlink.
-  test("a same-pid staging leftover cannot bleed into the download", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "kesha-stream-pid-reuse-"));
+  /** Yields the body a chunk at a time, so two of these genuinely interleave. */
+  function slowResponse(body: string): Response {
+    const chunks = body.match(/.{1,16}/g) ?? [];
+    let next = 0;
+    const stream = new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        if (next >= chunks.length) {
+          controller.close();
+          return;
+        }
+        await Bun.sleep(5);
+        controller.enqueue(new TextEncoder().encode(chunks[next++]!));
+      },
+    });
+    return new Response(stream, { headers: { "content-length": String(body.length) } });
+  }
+
+  // The pid tells processes apart, not calls within one — two concurrent programmatic
+  // downloads of the same file would otherwise share a staging path and clobber each other.
+  test("two concurrent downloads of one destination get their own staging files", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-stream-concurrent-"));
     try {
       const dest = join(dir, "kesha-engine");
-      writeFileSync(`${dest}.part.${process.pid}`, "leftovers from a killed run with this pid");
+      const first = "a".repeat(128);
+      const second = "b".repeat(128);
 
-      await streamResponseToFile(responseOf("fresh"), dest, "payload");
+      await Promise.all([
+        streamResponseToFile(slowResponse(first), dest, "first"),
+        streamResponseToFile(slowResponse(second), dest, "second"),
+      ]);
 
-      expect(readFileSync(dest, "utf8")).toBe("fresh");
+      expect([first, second]).toContain(readFileSync(dest, "utf8"));
+      expect(readdirSync(dir)).toEqual(["kesha-engine"]);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
Closes #770

An ordinary Ctrl-C during `kesha install` produced a state the CLI could not repair: the download was written straight to its destination, and every health check around it asked whether the file *existed* rather than whether it *worked*.

## Part 1 — downloads land atomically

`src/progress.ts::streamResponseToFile` now streams into a sibling `<dest>.part.<pid>` and renames it into place only on success, matching the staging `rust/src/models.rs::write_verified` has always done for model files. Staging beside the destination keeps the rename inside one filesystem. A failed or aborted download unlinks the staging file and leaves the previous file untouched; because a Ctrl-C kills the process before any cleanup runs, the next download sweeps orphaned `.part.*` siblings. All three consumers — engine binary, `say-avspeech`, `kesha-textlang` — get this for free, and the callers' `chmod` still lands on the final file.

## Part 2 — the capabilities probe no longer blocks the repair

`kesha install` called `getEngineCapabilities()` unconditionally before any install work, purely to validate `--tts` codes; on a corrupt binary that threw `E_ENGINE_SPAWN` with a raw stack trace and killed the command that its own error message recommended. It now goes through `probeCapabilitiesForInstall()`, which tolerates an unspawnable engine — with no capabilities the language codes are simply validated by the freshly installed engine at download time, which is authoritative anyway. `kesha init` got the same treatment.

The second half of that lock-up was the cache check: a `.version` marker vouched for a file, not a working binary, so a corrupt engine at the pinned version was reported as "already installed". `installEngine` now spawns it first and re-downloads when it does not run, saying so:

```
Installed engine at …/kesha-engine does not run (ENOEXEC: …); it is corrupt or built for another architecture — re-downloading it.
```

The probe is skipped on a read-only engine directory (Nix store), where nothing could be repaired and a failed probe would only turn a usable install into a hard error.

## Parts 3 & 4 — health checks execute, and silent degradation speaks up

New `src/engine-health.ts::probeExecutable` spawns a binary with a bounded timeout (generous, for the macOS Gatekeeper first-exec scan). Any exit code counts as healthy — the bar is that the loader accepted the image, and both sidecars legitimately exit non-zero when given no work. A spawn failure or a fatal signal is what a truncated download produces, and that is what it reports.

`kesha doctor` uses it for the engine and both sidecars, so a truncated file reads as `installed but not executable (corrupt) - re-run `kesha install`` rather than the false clean it used to print. `engine.runnable` and per-component `runnable` are added to the JSON report.

A failing `detect-text-lang` subprocess previously exited 0 with a valid WAV in the wrong voice. It now warns on stderr and still falls back, non-fatally. The warning is darwin-only: off macOS the detector is unsupported by design, and warning there would be noise on every `kesha say`.

## Verification

- `bun test` — 822 pass, 5 skip, 0 fail (827 tests / 78 files)
- `bunx tsc --noEmit` — clean
- `bun run check:specs` — 12 passed, 0 failed (`installation` and `diagnostics` amended)
- No `rust/` changes.

New tests: `tests/unit/engine-repair.test.ts` (probe classification; corrupt engine + valid marker re-downloads against a stubbed release; healthy cache still skips the download; the pre-install probe survives an unspawnable engine), plus atomicity cases in `progress-stream.test.ts`, corrupt-vs-missing cases in `doctor.test.ts`, and the text-lang warning in `engine.test.ts`.

### Acceptance, re-run against this build

A truncated binary with a matching `.version` marker, no real downloads involved:

```
$ kesha doctor
  Binary: …/kesha-engine (installed but not executable (corrupt) - re-run `kesha install`)
  Capabilities: binary is present but does not run (ENOEXEC: …); re-run `kesha install`
  AVSpeech sidecar: installed but not executable (corrupt) - re-run `kesha install` - macOS voices

$ kesha install --tts en --engine-version 0.0.1-doesnotexist
Replacing engine v1.24.7 → v0.0.1-doesnotexist...
Failed to download engine binary from release v0.0.1-doesnotexist (HTTP 404)
```

On `main` that same install command dies inside the capabilities probe with a `node_modules` stack trace before reaching the download at all.

## Review round (17aeab1)

Greptile and grok converged on the orphan sweep, plus four P2s:

- **P1 — the sweep deleted a live concurrent staging file.** `sweepStagingFiles` unlinked every sibling `.part.*` immediately, so a second `kesha install` deleted the first one's in-flight staging file. It now mirrors `rust/src/models.rs::cleanup_orphan_staging`: a 24 h age gate, Unix-only for the Windows-mtime reason that file documents, and a `log.debug` line on a failed sweep instead of a bare `catch`. Because the sweep no longer clears everything and Bun's `FileSink` writes from offset 0 *without* truncating, the download unlinks its own staging path before opening the writer — otherwise a killed run that happened to hold this pid could leave its tail in the published file.
- **P2 — a cache hit never repaired a corrupt sidecar.** Only absent sidecars were topped up. They are now probed with `probeExecutable` and the unrunnable ones re-downloaded. The Sequoia re-trust runs *first*: a provenance-blocked sidecar is SIGKILLed on spawn, and re-downloading it would not lift the block.
- **P2 — `waitUntilSpawnable` accepted signal-killed spawns.** Routed through `probeExecutable`, which inspects `signalCode`. Marker-last ordering is untouched.
- **P2 — `--tts` with no capabilities downloaded first, validated second.** `installableTtsLangs()` supplies the platform's static set (the universal six, plus `hi`/`ja`/`zh` on darwin-arm64) when the engine cannot be asked, so `kesha install --tts ja` on linux fails before any fetch. The engine remains the authoritative second gate. This also closes the spec's open issue about `--tts zh` on an engine-less darwin-arm64 machine, and `kesha init` now offers the same list.
- **P2 — win32 `renameSync` overwrite.** Falls back to `copyFileSync` + unlink of the staging file.

Both new sweep tests were confirmed to fail against the previous behaviour before the fix went in: the fresh-sibling test with the age gate removed, and the pid-reuse test with the self-unlink removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBTpJjqyYFW6W8LHJ2nwy

