### PR TITLE
chore(release): v1.24.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     }
   },
   "keshaEngine": {
-    "version": "1.24.7"
+    "version": "1.24.8"
   },
   "scripts": {
     "test": "bun test --timeout 30000",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "kesha-engine"
-version = "1.24.7"
+version = "1.24.8"
 dependencies = [
  "anyhow",
  "audioadapter-buffers",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesha-engine"
-version = "1.24.7"
+version = "1.24.8"
 edition = "2021"
 description = "Inference engine for Kesha Voice Kit: ASR + language detection"
 # Not for crates.io. The library target (`src/lib.rs`) exists only for the


### PR DESCRIPTION
Bumps the engine line to 1.24.8 ahead of the `v1.24.8` tag. Engine fields only — `rust/Cargo.toml`, `rust/Cargo.lock`, `package.json#keshaEngine.version`. `package.json#version` stays at 1.27.0 (the next unreleased CLI version); dragging it down would publish that as npm `latest` and downgrade every user (#729). An engine tag publishes no npm package — users get this engine when the following `-cli` release ships the bumped pin.

## What v1.24.8 contains

Twelve commits under `rust/` since v1.24.7, all fixes:

- #771 — measure duration when the container declares none; fixes `--timestamps` on every file in the Russian benchmark corpus
- #772 — engage VAD windowing for `--speakers` at any duration
- #761 — retry model downloads through a 429 instead of dying, per-file retry budgets
- #706 — stop downloading ONNX ASR weights a CoreML build cannot read (~2.4 GB saved on that path)
- #681 — stream model-install output instead of buffering it
- #694 — point fluidaudio-rs at the fork for the models-dir and compute-unit APIs
- #659 — share install-plan model metadata

## Pre-flight

- feature matrix vs cargo `default = ["onnx", "tts"]`: `tts` present in every row, backends correctly mutually exclusive
- CI green on main at 87b7557
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`: clean
- `cargo check --features coreml --no-default-features`: ok
- `cargo nextest`: 425/425
- `bunx tsc --noEmit`, `bun run check:versions`, `bun test` (838 pass): clean

`integration-tests-full` is expected to skip on `release/*` — that job downloads the *published* engine, whose tag does not exist yet.
