### PR TITLE
fix(install): let a slow origin finish reconstructing a large model

### DIFF
--- a/openspec/changes/recv-response-timeout-xet/.openspec.yaml
+++ b/openspec/changes/recv-response-timeout-xet/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-08

--- a/openspec/changes/recv-response-timeout-xet/design.md
+++ b/openspec/changes/recv-response-timeout-xet/design.md
@@ -1,0 +1,61 @@
+## Context
+
+`download_attempt` in `rust/src/models.rs` configures ureq explicitly, because ureq ships no timeouts at all and a host that accepts a connection and then goes quiet would hang the install forever. Four phases are bounded today:
+
+| phase | bound | catches |
+| --- | --- | --- |
+| `timeout_resolve` | 10 s | DNS that does not answer |
+| `timeout_connect` | 10 s | unreachable host |
+| `timeout_send_request` | 10 s | connection that stalls mid-request |
+| `timeout_recv_response` | 30 s | origin that took the request, then went quiet |
+| body | *unbounded* | — deliberately: the 2.4 GB encoder legitimately streams for hours |
+
+In ureq, `recv_response` and `recv_body` are **separate phases**: the former bounds receiving the response *headers*, the latter the download. The existing comment reasons carefully about why the body must stay unbounded, but the same "large artifacts are legitimately slow" argument was never applied to header latency.
+
+HuggingFace stores large files Xet-deduplicated and reconstructs them from chunks before it can answer. For a 654 MB object that reconstruction exceeds 30 s. Measurements from #777:
+
+- `bert/model.onnx` (654 361 598 B) — failed 4/4 on ubuntu runners, every attempt exactly at the 30 s bound
+- `model.onnx` (179 314 533 B), `dictionary` (101 431 118 B), `bert/vocab.txt` (1 780 720 B) — all fine, same repository, same runners
+- the same file on a **windows** runner in the same matrix: headers arrived, then the body streamed for 3 m 40 s and completed
+- the same URL from a laptop: 20 MB in 3.9 s (~5 MB/s), so the origin is healthy, just slow to *start*
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- `kesha install --tts ru` completes against an origin that needs more than 30 s to produce headers.
+- An unreachable host still fails within seconds, not minutes.
+- The chosen number carries its reasoning in the source, so it survives future tidying.
+
+**Non-Goals:**
+
+- Bounding the response body. That decision stands.
+- Reworking the retry schedule, attempt counts, or `Retry-After` handling (#724 territory).
+- Mirroring model downloads in CI — a real option for the same symptom, tracked separately as #741, and orthogonal to the user-facing bug.
+- Per-file timeouts keyed on artifact size. Rejected below.
+
+## Decisions
+
+**Raise `timeout_recv_response` to 120 s.**
+
+Sized to clear the worst observed case with headroom, while staying far below anything a user would read as a hang. 60 s would clear the measured failures but leaves no margin on a slower path; 300 s stops being a timeout in any useful sense.
+
+*Alternative considered — keep 30 s and mirror the file.* That fixes CI and leaves every user hitting the same wall on `kesha install --tts ru`. The mirror is worth doing for CI throughput (#741), but it is not the fix for this defect.
+
+*Alternative considered — scale the timeout by expected file size.* `ModelFile` has no size field today, adding one duplicates a fact the server already reports, and the relationship between object size and reconstruction latency is not something we can predict. A single generous bound is simpler and no less safe.
+
+**Extract a named constant rather than editing the literal.**
+
+`RECV_RESPONSE_TIMEOUT` sits with the other download-tuning constants (`MAX_DOWNLOAD_ATTEMPTS`, `RETRY_MAX_DELAY`, `RETRY_AFTER_MAX`), each of which already carries a doc comment explaining its number. A bare `Duration::from_secs(120)` inline reads like an arbitrary bump and invites exactly the "that looks high, let me trim it" edit that would reintroduce the bug.
+
+**Leave resolve/connect/send-request at 10 s.**
+
+These are what make a dead host fail fast, and they are unaffected by origin-side reconstruction latency. Keeping them tight is what makes the longer header bound safe.
+
+## Risks / Trade-offs
+
+**A host that accepts the connection and then black-holes now takes 5 × 120 s = 10 min per file instead of 5 × 30 s.** → Accepted. Reaching that state means resolve and connect both succeeded, so the host is up and answering TCP — a genuinely rare failure mode, and one where the install is already doomed. The common unreachable-host cases still fail inside 10 s each. Shrinking the attempt count to compensate would trade a rare slow failure for a real loss of resilience against 429s, which is the failure mode we actually see (#724).
+
+**The number is empirical, not derived.** → It is pinned to a measurement recorded in the constant's doc comment and in #777, so a future reader can re-evaluate it against evidence rather than taste. If HuggingFace changes how Xet serves large objects, the comment says what to re-measure.
+
+**No automated test covers the timeout value.** → A test that genuinely exercises a 120 s header stall would take two minutes of wall clock to assert a constant. The behaviour is verified where it actually failed: `release-branch-engine-smoke` downloads this exact file, and its result on the release PR is the check.

--- a/openspec/changes/recv-response-timeout-xet/proposal.md
+++ b/openspec/changes/recv-response-timeout-xet/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+`kesha install --tts ru` fails with `E_MODEL_DOWNLOAD` on a healthy network. The download path bounds how long an origin may take to send response *headers* at 30 s, but HuggingFace reconstructs Xet-deduplicated objects before answering, and our largest artifact — the 654 MB vosk bert model — routinely needs longer than that to start responding. The retry budget then burns all five attempts against the same wall and the install gives up.
+
+It surfaced as a hard release blocker: `release-branch-engine-smoke` failed 4 of 4 runs over an hour on the v1.24.8 release PR, always on that one file, while every smaller file in the same HuggingFace repository downloaded fine on the same runners (#777).
+
+## What Changes
+
+- Raise the response-header timeout on model downloads from 30 s to 120 s, sized for Xet reconstruction of the largest artifact we host.
+- Name the value as a constant with the reasoning attached, so the next reader does not trim it back to a tidier-looking number.
+- Leave the resolve, connect, and send-request timeouts at 10 s: those are what actually catch an unreachable host, and they must keep failing fast.
+- Leave the response *body* unbounded, unchanged — that decision is already documented and correct.
+
+Not a breaking change: no interface, flag, or output moves.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `installation`: adds a requirement that model downloads tolerate an origin that is slow to *begin* responding, while still failing fast when the host is unreachable. The spec currently says what gets downloaded and when, but says nothing about resilience, so the 30 s bound was an undocumented implementation choice with user-visible consequences.
+
+## Impact
+
+- `rust/src/models.rs` — `download_attempt`'s ureq configuration and one new constant.
+- Affects every model download, not just the vosk bert file; the practical effect elsewhere is nil, because a fast origin never approaches either bound.
+- Failure latency for the rare "host accepts the connection, then black-holes" case grows from 5 × 30 s to 5 × 120 s per file. Accepted: resolve and connect already cover the common unreachable-host cases within 10 s each, and an install that reaches this state is already failing.
+- Unblocks the v1.24.8 engine release (#776).

--- a/openspec/changes/recv-response-timeout-xet/specs/installation/spec.md
+++ b/openspec/changes/recv-response-timeout-xet/specs/installation/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Model downloads tolerate a slow origin but not an unreachable one
+
+Model and Engine downloads SHALL distinguish an origin that is slow to *begin*
+responding from a host that cannot be reached. The Engine SHALL allow the origin at
+least 120 seconds to send response headers, because content-addressed stores
+reconstruct large objects before answering and our largest artifact needs longer than
+a minute to do so. DNS resolution, connection, and request submission SHALL each stay
+bounded at 10 seconds, so an unreachable host still fails within seconds. The response
+*body* SHALL remain unbounded: multi-gigabyte artifacts legitimately stream for hours
+on a slow link.
+
+#### Scenario: Ira installs Russian TTS over a slow-to-answer origin
+
+- GIVEN the origin needs more than 30 seconds to send response headers for the
+  654 MB vosk bert model
+- WHEN Ira runs `kesha install --tts ru`
+- THEN the Engine waits for the headers rather than treating the delay as a failure
+- AND the file downloads and its pinned SHA-256 is verified
+- AND the process exits 0
+
+#### Scenario: Maks installs while the download host is unreachable
+
+- GIVEN the download host does not accept connections
+- WHEN Maks runs `kesha install`
+- THEN each attempt fails within seconds rather than waiting out the header budget
+- AND the error names the file that could not be fetched
+- AND the process exits 1
+
+#### Scenario: Ira's connection is slow but steady
+
+- GIVEN the origin answers promptly but the link delivers the 2.4 GB encoder slowly
+- WHEN Ira runs `kesha install`
+- THEN the download is not interrupted by any deadline
+- AND the install completes however long the transfer takes
+
+> *Technical Note — source: `rust/src/models.rs::download_attempt`. The header budget is
+> `RECV_RESPONSE_TIMEOUT`; `timeout_resolve` / `timeout_connect` / `timeout_send_request`
+> hold the fast-failure guarantee. ureq treats `recv_response` (headers) and `recv_body`
+> (download) as separate phases, and only the former is bounded. Sized against
+> HuggingFace Xet reconstruction of `models/vosk-ru/bert/model.onnx` (#777).*

--- a/openspec/changes/recv-response-timeout-xet/tasks.md
+++ b/openspec/changes/recv-response-timeout-xet/tasks.md
@@ -1,0 +1,28 @@
+## 1. Diagnosis
+
+- [x] 1.1 Confirm the failure is the header phase, not the download, by checking ureq's `recv_response` vs `recv_body` semantics
+- [x] 1.2 Compare file sizes in the HuggingFace repo to isolate why only one file fails (654 MB vs 179 MB next largest)
+- [x] 1.3 Verify the origin is healthy from outside CI (direct fetch ~5 MB/s) so the fix targets latency-to-first-byte, not bandwidth
+- [x] 1.4 Confirm the same file succeeds on the windows runner, proving the body path is unaffected
+
+## 2. Implementation
+
+- [x] 2.1 Add `RECV_RESPONSE_TIMEOUT` alongside the other download-tuning constants, with a doc comment recording the measurement behind the number
+- [x] 2.2 Point `timeout_recv_response` at the constant in `download_attempt`
+- [x] 2.3 Extend the existing timeout comment to explain that `recv_response` bounds headers and why resolve/connect stay tight
+- [x] 2.4 Leave resolve, connect, send-request, and the unbounded body untouched
+
+## 3. Verification
+
+- [x] 3.1 `cargo fmt --check`
+- [x] 3.2 `cargo clippy --all-targets -- -D warnings`
+- [x] 3.3 `make rust-test` (nextest, 425/425)
+- [x] 3.4 `bunx tsc --noEmit` and `bun test`
+- [ ] 3.5 CI green on the PR, including `release-branch-engine-smoke`, which downloads the file that exposed the bug — this is the real assertion
+- [ ] 3.6 Greptile review clear of P1/P2
+
+## 4. Follow-through
+
+- [ ] 4.1 Merge, then bring `release/1.24.8` up to date so the v1.24.8 engine release carries the fix
+- [ ] 4.2 Confirm #777 auto-closed
+- [ ] 4.3 Archive this change once the release ships

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -1673,6 +1673,11 @@ const RETRY_MAX_DELAY: Duration = Duration::from_secs(30);
 /// A server asking for more than this is asking for longer than a user will
 /// wait at an install prompt; clamp rather than honour it literally.
 const RETRY_AFTER_MAX: Duration = Duration::from_secs(60);
+/// How long the origin may take to send response *headers*. Sized for the
+/// largest artifact we host: HuggingFace reconstructs the 654MB Xet-backed vosk
+/// bert model before answering, which took longer than 30s on every attempt
+/// (#777).
+const RECV_RESPONSE_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// One request+stream attempt that failed. `max_attempts` is the total the
 /// retry loop may spend on this kind of failure; 1 means fatal, which is what a
@@ -1714,13 +1719,18 @@ fn download_attempt(
     // deliberately left unbounded: the 2.4GB encoder legitimately streams for
     // hours on a slow link, and a deadline loose enough to survive that would
     // not catch a stall anyway.
+    //
+    // `recv_response` bounds the *headers*, not the download, and HuggingFace
+    // reconstructs Xet-deduplicated objects before it answers: the 654MB vosk
+    // bert model needs well over 30s to start responding (#777). Resolve and
+    // connect still fail fast, so an unreachable host never waits this long.
     let response = match ureq::get(url)
         .config()
         .http_status_as_error(false)
         .timeout_resolve(Some(Duration::from_secs(10)))
         .timeout_connect(Some(Duration::from_secs(10)))
         .timeout_send_request(Some(Duration::from_secs(10)))
-        .timeout_recv_response(Some(Duration::from_secs(30)))
+        .timeout_recv_response(Some(RECV_RESPONSE_TIMEOUT))
         .build()
         .call()
     {


### PR DESCRIPTION
`kesha install --tts ru` fails with `E_MODEL_DOWNLOAD` on a healthy network.

`timeout_recv_response` bounds how long the origin may take to send response **headers** — in ureq that is a separate phase from `recv_body`, which is the download. HuggingFace stores large files Xet-deduplicated and reconstructs them from chunks before answering; for our 654 MB vosk bert model that takes longer than the old 30 s budget, so all five retry attempts hit the same wall and the install gives up.

## Evidence

Surfaced by `release-branch-engine-smoke` on the v1.24.8 release PR (#776), which failed **4 of 4 runs over an hour**, always on that one file. Every smaller file in the *same* HuggingFace repo downloaded fine on the same runners:

| file | size | ubuntu |
| --- | --- | --- |
| `bert/model.onnx` | **654 361 598** | fails, every time |
| `model.onnx` | 179 314 533 | ok |
| `dictionary` | 101 431 118 | ok |
| `bert/vocab.txt` | 1 780 720 | ok |

Two datapoints rule out a dead origin: the **windows** runner in the same matrix got headers for that file and then streamed the body for 3 m 40 s successfully, and fetching the same URL directly runs at ~5 MB/s. The origin is healthy — just slow to *start*.

## The change

`timeout_recv_response` 30 s → 120 s, via a named constant carrying the measurement, so it does not get trimmed back to a tidier-looking number later.

Resolve, connect, and send-request stay at 10 s each — those are what make an unreachable host fail fast, and keeping them tight is what makes the longer header bound safe. The body stays unbounded, unchanged.

## Trade-off

A host that accepts the connection and then black-holes now costs 5 × 120 s per file instead of 5 × 30 s. Accepted: reaching that state means DNS and TCP both succeeded, which is a rare failure mode, and the common unreachable-host cases still fail inside 10 s. Cutting the attempt count to compensate would trade a rare slow failure for real resilience against 429s (#724), which is the failure we actually see.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `make rust-test` 425/425, `bunx tsc --noEmit`, `bun test` 838 pass. No unit test asserts the constant — a genuine 120 s header stall would burn two minutes of wall clock to check a number. The real assertion is `release-branch-engine-smoke` on this PR, which downloads the exact file that exposed the bug.

Planned through OpenSpec: `openspec/changes/recv-response-timeout-xet/`, adding a resilience requirement to the `installation` capability, which previously said what gets downloaded but nothing about tolerating a slow origin.

Closes #777