### PR TITLE
fix(ci): let the release smoke lane read the seeded model cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -588,7 +588,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: ${{ matrix.timeout }}
     env:
-      KESHA_CACHE_DIR: ${{ github.workspace }}/.kesha-release-smoke
       KESHA_ENGINE_BIN: ${{ github.workspace }}/rust/target/release/${{ matrix.engine-bin }}
     steps:
       - name: 📥 Checkout
@@ -645,13 +644,14 @@ jobs:
             await Bun.write(`${process.env.KESHA_ENGINE_BIN}.version`, `${pkg.keshaEngine.version}\n`);
           '
 
+      # Its own key was restore-only and nothing ever wrote it, so every run cold-downloaded ~3.5GB.
       - name: 🔊 Install models through local backend
         uses: ./.github/actions/install-kesha-backend
         with:
           cache-path: |
-            ${{ github.workspace }}/.kesha-release-smoke
-          cache-key: ${{ runner.os }}-kesha-release-smoke-v1
-          cache-restore-keys: ${{ runner.os }}-kesha-release-smoke-
+            ~/.cache/kesha
+          cache-key: ${{ runner.os }}-kesha-models-tts-v1
+          cache-restore-keys: ${{ runner.os }}-kesha-models-tts-
           ffmpeg-provider: ${{ matrix.ffmpeg-provider }}
           install-args: --onnx --tts en ru
           cache-write: "false"


### PR DESCRIPTION
`release-branch-engine-smoke` was the only lane cold-downloading models on every run, and it is what stalled the v1.24.8 release (#776) for hours.

## What was wrong

The lane pointed at a private cache:

```yaml
KESHA_CACHE_DIR: ${{ github.workspace }}/.kesha-release-smoke
cache-key:       ${{ runner.os }}-kesha-release-smoke-v1
cache-write:     "false"
```

Restore-only, under a key **nothing ever writes**. So every run fetched ~3.5 GB from HuggingFace from scratch. `cache-seed.yml` exists to prevent exactly this — its own comment says so:

> The smoke lanes read `${{ runner.os }}-kesha-models-tts-v1` restore-only, so without this seed they cold-download ~3.5 GB every run; with it, one main-scoped copy serves every PR.

Every other smoke lane already reads that seeded key. This one didn't.

## What it cost

Five runs of the v1.24.8 release PR died fetching `models/vosk-ru/bert/model.onnx` — 654 MB, our largest artifact — with `E_MODEL_DOWNLOAD: timeout: receive response`, reproducibly on ubuntu while the windows runner in the same matrix fetched it fine. That asymmetry sent me after a header-timeout theory (#778) that turned out to be wrong and was reverted (#779).

Why one runner succeeds and the other does not is still unexplained, and this PR does not claim to explain it. It removes the need to find out: the lane verifies a **locally built engine**, not model downloading, so there is no reason for it to be fetching from HuggingFace at all.

## The change

Same cache path and keys as the other smoke lanes, `cache-write: false` kept — this lane consumes the seed, it does not produce it. `KESHA_ENGINE_BIN` still points at the locally built binary, so what the lane actually tests is unchanged.

The separate question of using the Xet protocol rather than HuggingFace's legacy LFS bridge is tracked in #780.