### PR TITLE
feat(release): publish Linux packages from the CLI's own release tag

### DIFF
--- a/.claude/skills/release-mechanics/SKILL.md
+++ b/.claude/skills/release-mechanics/SKILL.md
@@ -25,7 +25,17 @@ npm view @drakulavich/kesha-voice-kit version   # a few minutes, expect X.Y.Z
 
 `v*-cli` is excluded from `build-engine.yml` and picked up by `🚀 Release (CLI)` (`release-cli.yml`), which builds the Linux `.deb`/`.rpm`, creates the marker release as a **draft** with them plus `SHA256SUMS`, un-drafts it, then dispatches `📦 npm Publish` and waits for it. Un-drafting from a workflow fires no `release: published` (a `GITHUB_TOKEN` event does not cascade), so the dispatch is explicit — which is also why the tag must be pushed by a **human**: a token-pushed tag triggers nothing. That is by design for the alpha lane, whose `-cli` tags have no GitHub release.
 
-The lane refuses to proceed if `package.json#version` at the tag is not exactly the version the tag names — the packages carry that field, and nothing downstream re-checks it since #727 (#728). If npm fails after the release is public, re-run only the publish; it is idempotent:
+The lane refuses to proceed if `package.json#version` at the tag is not exactly the version the tag names — the packages carry that field, and nothing downstream re-checks it since #727 (#728). **Cut one stable CLI release at a time.** `npm-publish.yml`'s `concurrency: queue: max` serialises runs but does not order them by version, so two stable markers in flight together can still finish out of order and leave `latest` on the older one.
+
+**Recovering a failed lane run.** Which recovery applies depends on how far it got; the failing run prints the right one, and `gh release view vX.Y.Z-cli` tells you directly.
+
+| state | what happened | recovery |
+| --- | --- | --- |
+| no release | died in `plan` or during the build | fix the cause, re-run the lane |
+| **draft** | died between `create --draft` and `--draft=false` | assets all present → `gh release edit vX.Y.Z-cli --draft=false` then dispatch npm. Otherwise `gh release delete vX.Y.Z-cli --yes` (safe while draft — only publishing reserves the tag name) and re-run the lane |
+| published | the release is out, npm publish failed | re-run the publish alone |
+
+A leftover draft is not inert: `assert-release-absent.sh` counts drafts, so it blocks a re-run until it is finished or deleted. Re-running just the publish is idempotent — an already-published version exits 0 without republishing:
 
 ```bash
 gh workflow run npm-publish.yml --ref vX.Y.Z-cli -f tag=vX.Y.Z-cli

--- a/.claude/skills/release-mechanics/SKILL.md
+++ b/.claude/skills/release-mechanics/SKILL.md
@@ -19,12 +19,19 @@ Version drift gate: `bun .github/scripts/check-versions.ts` (`bun run check:vers
 CLI-only is allowed only when the changed CLI surface works against the already-published engine pinned by `package.json#keshaEngine.version`. If a CLI command delegates to a new engine subcommand, capability flag, feature behavior, or output contract, it is an **engine release**: bump `package.json#keshaEngine.version`, `rust/Cargo.toml`, and `rust/Cargo.lock` together. Before cutting any `v*-cli` marker, smoke-test new/changed CLI commands against the published pinned engine, not only a repo-local engine build. The `v1.18.2-cli` / `v1.18.3-cli` mistake was exposing `kesha record` while the pinned published engine was still `v1.18.0` and did not implement `kesha-engine record`.
 
 ```bash
-gh release create vX.Y.Z-cli --title "vX.Y.Z (CLI-only)" \
-  --notes "Engine: v<keshaEngine.version> (unchanged)."
-npm view @drakulavich/kesha-voice-kit version   # within ~60s, expect X.Y.Z
+git tag vX.Y.Z-cli && git push origin vX.Y.Z-cli
+npm view @drakulavich/kesha-voice-kit version   # a few minutes, expect X.Y.Z
 ```
 
-`v*-cli` is excluded from `build-engine.yml`; the published marker fires `📦 npm Publish` automatically.
+`v*-cli` is excluded from `build-engine.yml` and picked up by `🚀 Release (CLI)` (`release-cli.yml`), which builds the Linux `.deb`/`.rpm`, creates the marker release as a **draft** with them plus `SHA256SUMS`, un-drafts it, then dispatches `📦 npm Publish` and waits for it. Un-drafting from a workflow fires no `release: published` (a `GITHUB_TOKEN` event does not cascade), so the dispatch is explicit — which is also why the tag must be pushed by a **human**: a token-pushed tag triggers nothing. That is by design for the alpha lane, whose `-cli` tags have no GitHub release.
+
+The lane refuses to proceed if `package.json#version` at the tag is not exactly the version the tag names — the packages carry that field, and nothing downstream re-checks it since #727 (#728). If npm fails after the release is public, re-run only the publish; it is idempotent:
+
+```bash
+gh workflow run npm-publish.yml --ref vX.Y.Z-cli -f tag=vX.Y.Z-cli
+```
+
+Two things do *not* go through this lane. A **beta marker** (`vX.Y.Z-beta.N-cli`) is skipped with a notice — betas ship no Linux packages and keep the human un-draft gate, so cut them the legacy way with `gh release create vX.Y.Z-beta.N-cli --notes …`, which still fires `📦 npm Publish` on publication. **Alpha markers** are minted and published by `release-alpha.yml` and never get a GitHub release at all. The legacy `gh release create vX.Y.Z-cli` still works for a stable marker too, but ships no packages and leaves the tag unusable by this lane — do not use it.
 
 **Engine release** (anything under `rust/` or an engine bump):
 
@@ -63,7 +70,7 @@ npm view @drakulavich/kesha-voice-kit version   # within ~60s, expect X.Y.Z
 
 6. Treat `make smoke-test` as a local sanity check only; it can run the old globally installed CLI/engine. The release gate is draft-asset validation.
 7. Publish: `gh release edit vX.Y.Z --draft=false`. This fires `📦 npm Publish`; verify `npm view @drakulavich/kesha-voice-kit version` within ~60s. Manual fallback: `npm publish --access public` from the maintainer laptop.
-8. Stable `vX.Y.Z` engine releases also update `drakulavich/homebrew-tap` via `🍺 Homebrew Tap` using `HOMEBREW_TAP_TOKEN` scoped only to the tap repo. CLI-only marker releases skip Homebrew. **Engine releases no longer attach Linux `.deb`/`.rpm`**: those packages carry `package.json#version`, which `main` holds ahead of npm since #691, so naming them on an engine tag meant naming a CLI version npm had not published. The gate that checked this (`assert-npm-published.mjs`) made stable engine tags unreleasable and is gone; `linux-packages.yml` still builds and smoke-installs the pair on `main`, and #728 owns where they should be published.
+8. Stable `vX.Y.Z` engine releases also update `drakulavich/homebrew-tap` via `🍺 Homebrew Tap` using `HOMEBREW_TAP_TOKEN` scoped only to the tap repo. CLI-only marker releases skip Homebrew. **Engine releases no longer attach Linux `.deb`/`.rpm`**: those packages carry `package.json#version`, which `main` holds ahead of npm since #691, so naming them on an engine tag meant naming a CLI version npm had not published. The gate that checked this (`assert-npm-published.mjs`) made stable engine tags unreleasable and is gone. They ship from the stable `-cli` marker instead (#728) — the package *is* the CLI — which is the one release that publishes the same version to npm in the same run; `linux-packages.yml` keeps building and smoke-installing the pair on `main` as CI. `check-workflows.ts` holds both halves: `forbidLinuxPackaging` keeps them off engine tags, `requireNpmPublishAfterPackaging` keeps the `-cli` lane's npm publish downstream of the packaging job.
 
 **Prerelease channels.** The validators accept two shapes beside stable — `vX.Y.Z-beta.N` and `vX.Y.Z-alpha.N` (a CLI release on either channel adds the `-cli` marker) — and the grammar has one home, `release-tags.mjs`. Neither channel can reach `latest`: `npm-dist-tag.mjs` derives the dist-tag from the SemVer prerelease identifier, returns `latest` only for a version that has none, and *refuses* one whose identifier decodes to `latest` (`1.27.0-latest.1`) rather than handing a prerelease to everyone who never asked for a channel.
 
@@ -137,7 +144,7 @@ git push origin vX.Y.Z
 
 Post-#291 happy path: publishing a GitHub release runs `.github/workflows/npm-publish.yml` → `npm publish --provenance --access public` in GHA. Do not publish from a maintainer laptop unless the workflow is broken.
 
-- Trigger: `release: published` (engine un-draft or published `v*-cli` marker), `workflow_dispatch` re-runs, and the alpha lane's dispatch. Only `-cli` tags publish a CLI; a bare tag names the engine (#729).
+- Trigger: `release: published` (engine un-draft or a hand-cut `v*-cli` marker), `workflow_dispatch` re-runs, and the dispatches from `release-alpha.yml` and `release-cli.yml`. Only `-cli` tags publish a CLI; a bare tag names the engine (#729).
 - Provenance: `permissions.id-token: write` gives npm the GHA OIDC chain (`commit SHA` → built tarball) and the npm "verified" badge.
 - Guards: tag must match `package.json#version` after stripping leading `v` and trailing `-cli`; already-published versions skip publish and exit 0. An alpha version is minted at publish time, so it is injected into `package.json` instead of verified against it.
 - Dist-tags: resolved by `npm-dist-tag.mjs` from the prerelease identifier — stable → `latest`, `-beta.N` → `beta`, `-alpha.N` → `alpha`, and a prerelease never lands on `latest`.

--- a/.github/actions/linux-packages/action.yml
+++ b/.github/actions/linux-packages/action.yml
@@ -1,0 +1,25 @@
+name: Build Linux Packages
+description: Build the .deb/.rpm pair from package.json#version and prove the .deb installs
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Bun workspace
+      uses: ./.github/actions/setup-bun
+
+    - name: Setup Go
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+      with:
+        go-version: stable
+
+    - name: Install nFPM
+      run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.43.4
+      shell: bash
+
+    - name: Build packages
+      run: node .github/scripts/build-linux-packages.mjs
+      shell: bash
+
+    - name: Inspect and smoke-install the packages
+      run: .github/scripts/verify-linux-packages.sh
+      shell: bash

--- a/.github/scripts/assert-release-absent.sh
+++ b/.github/scripts/assert-release-absent.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Releases here are immutable, so neither attaching to nor replacing an existing one is
+# possible — the only thing this lane can do about it is say so before it builds anything.
+set -euo pipefail
+
+: "${TAG:?}"
+
+if gh release view "$TAG" >/dev/null 2>&1; then
+  echo "::error::A GitHub release already exists for $TAG (draft or published), and releases here are immutable — this lane cannot add the Linux packages to it. A release cut by hand with \`gh release create\` publishes npm but ships no packages; to get packages, bump the patch version and push a new vX.Y.Z-cli tag. Tag names are one-use." >&2
+  exit 1
+fi

--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -84,7 +84,8 @@ export function requirePreUploadSynthesisSmoke(path: string, document: unknown):
  * Fails when build-engine.yml mentions Linux packaging at all. The `.deb`/`.rpm` carry
  * `package.json#version`, which `main` holds ahead of npm since #691, so a stable engine tag can
  * never name them after a published CLI — the gate that checked this made engine releases
- * unreleasable instead (#728). Matched against the raw file, not the parsed steps: `nfpm package`
+ * unreleasable instead. They ship from release-cli.yml, on the tag that publishes the same
+ * version to npm (#728). Matched against the raw file, not the parsed steps: `nfpm package`
  * or `cp dist/*.deb` reintroduces publishing without ever naming the old script.
  */
 const PACKAGING_TOKENS = ["build-linux-packages", "linux-packages", "nfpm", ".deb", ".rpm"];
@@ -100,8 +101,34 @@ export function forbidLinuxPackaging(path: string, contents: string): string[] {
 
   return PACKAGING_TOKENS.filter((token) => code.includes(token)).map(
     (token) =>
-      `${path}: mentions \`${token}\`; engine releases must not attach Linux packages until #728 picks a channel`,
+      `${path}: mentions \`${token}\`; Linux packages ship from release-cli.yml, which publishes npm in the same run (#728)`,
   );
+}
+
+/**
+ * Fails when release-cli.yml could publish Linux packages without publishing the same version
+ * to npm in the same run. A `.deb` names `package.json#version` and npm is the only thing that
+ * makes that version real; the assertion that used to hold them together is gone (#727, #728).
+ */
+export function requireNpmPublishAfterPackaging(path: string, document: unknown): string[] {
+  if (!path.endsWith("release-cli.yml")) return [];
+
+  const tags = (document as { on?: { push?: { tags?: unknown } } })?.on?.push?.tags;
+  if (!Array.isArray(tags) || !tags.includes("v*-cli")) {
+    return [`${path}: must trigger on \`v*-cli\` tag pushes (#728)`];
+  }
+
+  const steps = jobSteps(document, "publish-npm");
+  if (!steps) return [`${path}: expected a \`publish-npm\` job with steps`];
+
+  const needs = (document as { jobs?: Record<string, { needs?: unknown }> })?.jobs?.["publish-npm"]?.needs;
+  if (!Array.isArray(needs) || !needs.includes("packages")) {
+    return [`${path}: \`publish-npm\` must \`needs: packages\`, so no .deb is published without the npm publish it names (#728)`];
+  }
+  if (runsMatching(steps, /dispatch-npm-publish\.sh/).length === 0) {
+    return [`${path}: \`publish-npm\` must run dispatch-npm-publish.sh — npm trusts one entry workflow (#731)`];
+  }
+  return [];
 }
 
 /**
@@ -166,6 +193,7 @@ function main(): void {
         ...requirePinnedActions(path, contents),
         ...requirePreUploadSynthesisSmoke(path, document),
         ...forbidLinuxPackaging(path, contents),
+        ...requireNpmPublishAfterPackaging(path, document),
         ...requireTestedScriptsInCodeFilter(path, document, testedScripts),
       ];
       if (errors.length > 0) {

--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -121,8 +121,9 @@ export function requireNpmPublishAfterPackaging(path: string, document: unknown)
   const steps = jobSteps(document, "publish-npm");
   if (!steps) return [`${path}: expected a \`publish-npm\` job with steps`];
 
+  // `needs:` is a string when it names one job, a list when it names several.
   const needs = (document as { jobs?: Record<string, { needs?: unknown }> })?.jobs?.["publish-npm"]?.needs;
-  if (!Array.isArray(needs) || !needs.includes("packages")) {
+  if (![needs].flat().includes("packages")) {
     return [`${path}: \`publish-npm\` must \`needs: packages\`, so no .deb is published without the npm publish it names (#728)`];
   }
   if (runsMatching(steps, /dispatch-npm-publish\.sh/).length === 0) {

--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -109,6 +109,9 @@ export function forbidLinuxPackaging(path: string, contents: string): string[] {
  * Fails when release-cli.yml could publish Linux packages without publishing the same version
  * to npm in the same run. A `.deb` names `package.json#version` and npm is the only thing that
  * makes that version real; the assertion that used to hold them together is gone (#727, #728).
+ *
+ * Both halves have to be real: `needs:` ordering alone is satisfied by a `packages` job that
+ * builds and publishes nothing, so the job's own two steps are required as well.
  */
 export function requireNpmPublishAfterPackaging(path: string, document: unknown): string[] {
   if (!path.endsWith("release-cli.yml")) return [];
@@ -116,6 +119,19 @@ export function requireNpmPublishAfterPackaging(path: string, document: unknown)
   const tags = (document as { on?: { push?: { tags?: unknown } } })?.on?.push?.tags;
   if (!Array.isArray(tags) || !tags.includes("v*-cli")) {
     return [`${path}: must trigger on \`v*-cli\` tag pushes (#728)`];
+  }
+
+  const packaging = jobSteps(document, "packages");
+  if (!packaging) return [`${path}: expected a \`packages\` job with steps`];
+
+  const builds = packaging.some(
+    (step) => typeof step?.uses === "string" && step.uses === "./.github/actions/linux-packages",
+  );
+  if (!builds) {
+    return [`${path}: \`packages\` must build through ./.github/actions/linux-packages, the composite the CI lane shares (#728)`];
+  }
+  if (runsMatching(packaging, /publish-cli-release\.sh/).length === 0) {
+    return [`${path}: \`packages\` must run publish-cli-release.sh — it is what attaches the packages to the release (#728)`];
   }
 
   const steps = jobSteps(document, "publish-npm");

--- a/.github/scripts/cli-release-plan.d.mts
+++ b/.github/scripts/cli-release-plan.d.mts
@@ -1,0 +1,5 @@
+// The module stays .mjs so release-cli.yml can run it under node, like its siblings.
+export function planCliRelease(
+  tag: string,
+  pkg: unknown,
+): { version: string; packages: boolean; engineVersion?: string };

--- a/.github/scripts/cli-release-plan.mjs
+++ b/.github/scripts/cli-release-plan.mjs
@@ -46,6 +46,8 @@ if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
     process.exit(2);
   }
 
+  // The tag is echoed back rather than written by the workflow: it reaches GITHUB_OUTPUT only
+  // once the grammar has accepted it, so a dispatch input carrying a newline cannot append keys.
   const plan = planCliRelease(tag, JSON.parse(readFileSync("package.json", "utf8")));
   if (!plan.packages) {
     console.error(
@@ -55,6 +57,6 @@ if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
     );
   }
   process.stdout.write(
-    `version=${plan.version}\npackages=${plan.packages}\nengine_version=${plan.engineVersion ?? ""}\n`,
+    `tag=${tag}\nversion=${plan.version}\npackages=${plan.packages}\nengine_version=${plan.engineVersion ?? ""}\n`,
   );
 }

--- a/.github/scripts/cli-release-plan.mjs
+++ b/.github/scripts/cli-release-plan.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+/**
+ * What `release-cli.yml` should do with the `-cli` marker tag it was pushed.
+ *
+ * Linux packages carry `package.json#version` and nothing downstream re-checks it, so the
+ * lane that attaches them is the only place the tag and the packaged version can be held
+ * to each other — the assertion #727 removed and #728 replaced with this lane.
+ */
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+import { validateLinuxPackageVersion } from "./linux-package-names.mjs";
+import { CLI_MARKER, CLI_TAG_RE, cliPublishTarget } from "./release-tags.mjs";
+import { isStableVersion } from "../../src/semver.mjs";
+
+export function planCliRelease(tag, pkg) {
+  if (!CLI_TAG_RE.test(tag)) {
+    throw new Error(
+      `release tag must be a CLI marker tag (vX.Y.Z${CLI_MARKER}, vX.Y.Z-beta.N${CLI_MARKER} or ` +
+        `vX.Y.Z-alpha.N${CLI_MARKER}), got: ${tag}`,
+    );
+  }
+
+  const { version } = cliPublishTarget(tag);
+  if (!isStableVersion(version)) return { version, packages: false };
+
+  if (pkg?.version !== version) {
+    throw new Error(
+      `tag ${tag} names CLI ${version} but package.json at that tag carries ${pkg?.version} — ` +
+        `the Linux packages would be named for a version this commit is not. Bump the patch, ` +
+        `re-tag, and push again; tag names are one-use.`,
+    );
+  }
+  const engineVersion = pkg.keshaEngine?.version;
+  if (typeof engineVersion !== "string") {
+    throw new Error(`package.json at ${tag} has no keshaEngine.version to name in the release notes`);
+  }
+
+  validateLinuxPackageVersion(version);
+  return { version, packages: true, engineVersion };
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  const tag = process.argv[2];
+  if (!tag) {
+    console.error("usage: node .github/scripts/cli-release-plan.mjs <tag>");
+    process.exit(2);
+  }
+
+  const plan = planCliRelease(tag, JSON.parse(readFileSync("package.json", "utf8")));
+  if (!plan.packages) {
+    console.error(
+      `::notice::${tag} is a prerelease marker — beta and alpha CLI markers ship no Linux ` +
+        `packages and no GitHub release from this lane. Publish it the legacy way: ` +
+        `gh release create ${tag} --title "${plan.version} (CLI-only)" --notes "…".`,
+    );
+  }
+  process.stdout.write(
+    `version=${plan.version}\npackages=${plan.packages}\nengine_version=${plan.engineVersion ?? ""}\n`,
+  );
+}

--- a/.github/scripts/explain-draft-recovery.sh
+++ b/.github/scripts/explain-draft-recovery.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Printed when the packaging job dies. The failure may have landed between `gh release create
+# --draft` and `--draft=false`, and that draft blocks a plain re-run — assert-release-absent
+# counts drafts too. Which of the three recoveries applies depends on state, so look it up.
+set -euo pipefail
+
+: "${TAG:?}"
+
+state=$(gh release view "$TAG" --json isDraft --jq 'if .isDraft then "draft" else "published" end' 2>/dev/null || echo none)
+
+case "$state" in
+  draft)
+    echo "::error::$TAG failed with a draft release left behind. It blocks a re-run of this lane, so clear it one of two ways." >&2
+    gh release view "$TAG" --json assets --jq '"Assets on the draft: " + ([.assets[].name] | join(", "))' >&2 || true
+    cat >&2 <<EOF
+  - The .deb, .rpm and SHA256SUMS are all there — finish it by hand:
+      gh release edit $TAG --draft=false
+      gh workflow run npm-publish.yml --ref $TAG -f tag=$TAG
+  - Anything missing or wrong — delete the draft and re-run the lane:
+      gh release delete $TAG --yes
+      gh workflow run release-cli.yml -f tag=$TAG
+    Deleting is safe while it is a draft: only publishing reserves the tag name permanently.
+EOF
+    ;;
+  published)
+    echo "::error::$TAG failed after its release went public. The packages are already out; npm is what is missing, and re-running the publish alone is idempotent: gh workflow run npm-publish.yml --ref $TAG -f tag=$TAG" >&2
+    ;;
+  *)
+    echo "::error::$TAG failed before any release was created, so there is nothing to clean up — fix the cause and re-run the lane: gh workflow run release-cli.yml -f tag=$TAG" >&2
+    ;;
+esac

--- a/.github/scripts/explain-draft-recovery.sh
+++ b/.github/scripts/explain-draft-recovery.sh
@@ -6,7 +6,17 @@ set -euo pipefail
 
 : "${TAG:?}"
 
-state=$(gh release view "$TAG" --json isDraft --jq 'if .isDraft then "draft" else "published" end' 2>/dev/null || echo none)
+err=$(mktemp)
+trap 'rm -f "$err"' EXIT
+
+# "not found" is a real answer; any other gh failure is not, and must not read as one.
+if state=$(gh release view "$TAG" --json isDraft --jq 'if .isDraft then "draft" else "published" end' 2>"$err"); then
+  :
+elif grep -qi "release not found" "$err"; then
+  state=none
+else
+  state=unknown
+fi
 
 case "$state" in
   draft)
@@ -25,7 +35,11 @@ EOF
   published)
     echo "::error::$TAG failed after its release went public. The packages are already out; npm is what is missing, and re-running the publish alone is idempotent: gh workflow run npm-publish.yml --ref $TAG -f tag=$TAG" >&2
     ;;
-  *)
+  none)
     echo "::error::$TAG failed before any release was created, so there is nothing to clean up — fix the cause and re-run the lane: gh workflow run release-cli.yml -f tag=$TAG" >&2
+    ;;
+  *)
+    echo "::error::$TAG failed, and the release state could not be read: $(tr '\n' ' ' < "$err")" >&2
+    echo "Check with \`gh release view $TAG\` before re-running — a draft left behind blocks the lane until it is finished or deleted." >&2
     ;;
 esac

--- a/.github/scripts/publish-cli-release.sh
+++ b/.github/scripts/publish-cli-release.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Releases in this repo are immutable: an asset uploaded to a published release 422s, so the
+# packages go onto a draft and the release is un-drafted only once they are all attached.
+set -euo pipefail
+
+: "${TAG:?}" "${VERSION:?}" "${ENGINE_VERSION:?}"
+DIR="${ASSET_DIR:-dist/linux-packages}"
+
+"$(dirname "$0")/assert-release-absent.sh"
+
+# Only the two packages and their checksums: the same directory holds the compiled wrapper
+# that nfpm consumed, which is not a release asset.
+( cd "$DIR" && sha256sum ./*.deb ./*.rpm > SHA256SUMS && cat SHA256SUMS )
+
+gh release create "$TAG" \
+  --draft \
+  --title "v$VERSION (CLI-only)" \
+  --notes "v$VERSION (CLI-only). Engine: v$ENGINE_VERSION (unchanged)." \
+  "$DIR"/*.deb "$DIR"/*.rpm "$DIR/SHA256SUMS"
+
+gh release edit "$TAG" --draft=false
+echo "Published $TAG with the Linux packages attached." >&2

--- a/.github/scripts/release-tags.d.mts
+++ b/.github/scripts/release-tags.d.mts
@@ -3,6 +3,7 @@ export const ENGINE_TAG_ERE: string;
 export const ENGINE_TAG_RE: RegExp;
 export const STABLE_TAG_RE: RegExp;
 export const ALPHA_TAG_RE: RegExp;
+export const CLI_TAG_RE: RegExp;
 export function isStableTag(tag: string): boolean;
 export function isEngineAlphaTag(tag: string): boolean;
 export const CLI_MARKER: string;

--- a/.github/scripts/release-tags.mjs
+++ b/.github/scripts/release-tags.mjs
@@ -8,12 +8,19 @@
 
 import { pathToFileURL } from "node:url";
 
+const VERSION_ERE = "[0-9]+\\.[0-9]+\\.[0-9]+(-(beta|alpha)\\.[0-9]+)?";
+
 /** Engine tags: `vX.Y.Z`, `vX.Y.Z-beta.N`, `vX.Y.Z-alpha.N`. CLI marker tags end in `-cli`. */
-export const ENGINE_TAG_ERE = "^v[0-9]+\\.[0-9]+\\.[0-9]+(-(beta|alpha)\\.[0-9]+)?$";
+export const ENGINE_TAG_ERE = `^v${VERSION_ERE}$`;
 
 export const ENGINE_TAG_RE = new RegExp(ENGINE_TAG_ERE);
 export const STABLE_TAG_RE = /^v[0-9]+\.[0-9]+\.[0-9]+$/;
 export const ALPHA_TAG_RE = /^v[0-9]+\.[0-9]+\.[0-9]+-alpha\.[0-9]+$/;
+
+export const CLI_MARKER = "-cli";
+
+/** The same version shapes as an engine tag, carrying the marker that makes them the CLI's. */
+export const CLI_TAG_RE = new RegExp(`^v${VERSION_ERE}${CLI_MARKER}$`);
 
 export function isStableTag(tag) {
   return STABLE_TAG_RE.test(tag);
@@ -23,8 +30,6 @@ export function isStableTag(tag) {
 export function isEngineAlphaTag(tag) {
   return ALPHA_TAG_RE.test(tag);
 }
-
-export const CLI_MARKER = "-cli";
 
 /** Every shape a channel has already published, so notes can be anchored at the latest one. */
 export function publishedVersionRe(marker) {

--- a/.github/scripts/verify-linux-packages.sh
+++ b/.github/scripts/verify-linux-packages.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Installs the built .deb for real rather than trusting nfpm's exit code: a package whose
+# payload path or dependency set is wrong builds cleanly and fails on the user's machine.
+set -euo pipefail
+
+DIR="${1:-dist/linux-packages}"
+
+dpkg-deb --info "$DIR"/*.deb
+dpkg-deb --contents "$DIR"/*.deb
+
+sudo apt-get update -qq
+sudo apt-get install -y --no-install-recommends rpm
+rpm -qip "$DIR"/*.rpm
+rpm -qlp "$DIR"/*.rpm
+
+sudo apt install -y "$DIR"/*.deb
+kesha --version
+kesha install --plan
+sudo apt remove -y kesha-voice-kit

--- a/.github/scripts/verify-linux-packages.sh
+++ b/.github/scripts/verify-linux-packages.sh
@@ -4,6 +4,8 @@
 set -euo pipefail
 
 DIR="${1:-dist/linux-packages}"
+# `apt install a/b.deb` reads `a/b` as package/suite, not a path; only a leading ./ or / is a file.
+case "$DIR" in /* | ./*) ;; *) DIR="./$DIR" ;; esac
 
 dpkg-deb --info "$DIR"/*.deb
 dpkg-deb --contents "$DIR"/*.deb

--- a/.github/scripts/verify-npm-version.sh
+++ b/.github/scripts/verify-npm-version.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# The registry serves a fresh version a beat after the publish run goes green, so poll.
+set -euo pipefail
+
+: "${VERSION:?}"
+PACKAGE="@drakulavich/kesha-voice-kit"
+
+for _ in $(seq 1 12); do
+  if [ "$(npm view "$PACKAGE@$VERSION" version 2>/dev/null || true)" = "$VERSION" ]; then
+    echo "$PACKAGE@$VERSION is on npm."
+    exit 0
+  fi
+  sleep 5
+done
+
+echo "::error::$PACKAGE@$VERSION is still not on npm a minute after the publish run succeeded. The GitHub release and its Linux packages are already public, so re-run the publish alone: gh workflow run npm-publish.yml --ref v$VERSION-cli -f tag=v$VERSION-cli" >&2
+exit 1

--- a/.github/workflows/linux-packages.yml
+++ b/.github/workflows/linux-packages.yml
@@ -7,9 +7,11 @@ on:
       - packaging/**
       - .github/scripts/build-linux-packages.mjs
       - .github/scripts/linux-package-names.mjs
+      - .github/scripts/verify-linux-packages.sh
       - .github/workflows/linux-packages.yml
       - .github/workflows/build-engine.yml
       - .github/actions/setup-bun/action.yml
+      - .github/actions/linux-packages/action.yml
       - package.json
       - bun.lock
       - tsconfig.json
@@ -19,6 +21,16 @@ on:
       - docs/linux-packages.md
       - LICENSE
       - NOTICES.md
+  # release-cli.yml shares this build and only ever runs on a tag, so a PR touching the shared
+  # machinery is the last place a broken step can surface before a release depends on it (#728).
+  pull_request:
+    paths:
+      - packaging/**
+      - .github/scripts/build-linux-packages.mjs
+      - .github/scripts/linux-package-names.mjs
+      - .github/scripts/verify-linux-packages.sh
+      - .github/workflows/linux-packages.yml
+      - .github/actions/linux-packages/action.yml
 
 permissions:
   contents: read
@@ -28,38 +40,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # CI only. The packages users install are cut from a `-cli` tag by release-cli.yml (#728).
   linux-packages:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Setup Bun workspace
-        uses: ./.github/actions/setup-bun
-
-      - name: Setup Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version: stable
-
-      - name: Install nFPM
-        run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.43.4
-
-      - name: Build packages
-        run: node .github/scripts/build-linux-packages.mjs
-
-      - name: Inspect package metadata
-        run: |
-          dpkg-deb --info dist/linux-packages/*.deb
-          dpkg-deb --contents dist/linux-packages/*.deb
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends rpm
-          rpm -qip dist/linux-packages/*.rpm
-          rpm -qlp dist/linux-packages/*.rpm
-
-      - name: Smoke deb install
-        run: |
-          sudo apt install -y ./dist/linux-packages/*.deb
-          kesha --version
-          kesha install --plan
-          sudo apt remove -y kesha-voice-kit
+      - name: Build and verify packages
+        uses: ./.github/actions/linux-packages

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,0 +1,113 @@
+name: "🚀 Release (CLI)"
+
+# Cuts the CLI release a `vX.Y.Z-cli` marker tag names: builds the Linux packages, publishes
+# them on that tag's release, then publishes the same version to npm (#728). The two must
+# happen in one run — the `.deb` is named from `package.json#version`, and nothing downstream
+# checks that npm ever served it since #727 deleted the assertion that did.
+#
+# A human pushes the tag. A GITHUB_TOKEN push fires no `on.push.tags`, which is why the alpha
+# lane's own `-cli` tags never reach this workflow — alphas have no GitHub release by design.
+on:
+  push:
+    tags:
+      - "v*-cli"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "CLI marker tag to release (must already exist, e.g. v1.27.0-cli)"
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-cli-${{ inputs.tag || github.ref_name }}
+
+jobs:
+  plan:
+    name: Classify the tag
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+      version: ${{ steps.plan.outputs.version }}
+      packages: ${{ steps.plan.outputs.packages }}
+      engine_version: ${{ steps.plan.outputs.engine_version }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.tag || github.ref_name }}
+
+      # Tags reach the shell via `env:`, never interpolation — `$(cmd)` in a tag would execute (#291).
+      - name: Resolve the tag
+        id: tag
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
+        run: echo "tag=${INPUT_TAG:-$REF_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Plan the release
+        id: plan
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: node .github/scripts/cli-release-plan.mjs "$TAG" >> "$GITHUB_OUTPUT"
+
+      # Before the build, not after it: nothing that follows can recover from this.
+      - name: Refuse a tag that already has a release
+        if: steps.plan.outputs.packages == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: .github/scripts/assert-release-absent.sh
+
+  packages:
+    name: Build and publish the Linux packages
+    needs: plan
+    if: needs.plan.outputs.packages == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.plan.outputs.tag }}
+
+      - name: Build and verify packages
+        uses: ./.github/actions/linux-packages
+
+      - name: Publish the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.plan.outputs.tag }}
+          VERSION: ${{ needs.plan.outputs.version }}
+          ENGINE_VERSION: ${{ needs.plan.outputs.engine_version }}
+        run: .github/scripts/publish-cli-release.sh
+
+  # Un-drafting from a workflow fires no `release: published`, so npm-publish.yml — the one
+  # entry workflow npm's trusted publisher accepts (#731) — has to be dispatched by hand.
+  publish-npm:
+    name: Publish to npm
+    needs: [plan, packages]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Dispatch the publish and wait for it
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.plan.outputs.tag }}
+        run: .github/scripts/dispatch-npm-publish.sh
+
+      - name: Verify the version is on npm
+        env:
+          VERSION: ${{ needs.plan.outputs.version }}
+        run: .github/scripts/verify-npm-version.sh
+
+      - name: Explain the recovery
+        if: failure()
+        env:
+          TAG: ${{ needs.plan.outputs.tag }}
+        run: |
+          echo "::error::npm publish failed for $TAG while its GitHub release is already public. Re-run the publish alone — it is idempotent, an already-published version exits 0 without republishing: gh workflow run npm-publish.yml --ref $TAG -f tag=$TAG"

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -27,8 +27,12 @@ jobs:
   plan:
     name: Classify the tag
     runs-on: ubuntu-latest
+    # Not for writing: a draft release is invisible to a read-only token, and a guard that
+    # cannot see the drafts it exists to catch would pass the build straight into one.
+    permissions:
+      contents: write
     outputs:
-      tag: ${{ steps.tag.outputs.tag }}
+      tag: ${{ steps.plan.outputs.tag }}
       version: ${{ steps.plan.outputs.version }}
       packages: ${{ steps.plan.outputs.packages }}
       engine_version: ${{ steps.plan.outputs.engine_version }}
@@ -37,26 +41,22 @@ jobs:
         with:
           ref: ${{ inputs.tag || github.ref_name }}
 
-      # Tags reach the shell via `env:`, never interpolation — `$(cmd)` in a tag would execute (#291).
-      - name: Resolve the tag
-        id: tag
-        env:
-          INPUT_TAG: ${{ inputs.tag }}
-          REF_NAME: ${{ github.ref_name }}
-        run: echo "tag=${INPUT_TAG:-$REF_NAME}" >> "$GITHUB_OUTPUT"
-
+      # Tags reach the shell via `env:`, never interpolation — `$(cmd)` in a tag would execute
+      # (#291) — and the script echoes the tag back rather than the workflow writing it, so a
+      # dispatch input carrying a newline cannot append its own keys to GITHUB_OUTPUT.
       - name: Plan the release
         id: plan
         env:
-          TAG: ${{ steps.tag.outputs.tag }}
-        run: node .github/scripts/cli-release-plan.mjs "$TAG" >> "$GITHUB_OUTPUT"
+          INPUT_TAG: ${{ inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
+        run: node .github/scripts/cli-release-plan.mjs "${INPUT_TAG:-$REF_NAME}" >> "$GITHUB_OUTPUT"
 
       # Before the build, not after it: nothing that follows can recover from this.
       - name: Refuse a tag that already has a release
         if: steps.plan.outputs.packages == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ steps.tag.outputs.tag }}
+          TAG: ${{ steps.plan.outputs.tag }}
         run: .github/scripts/assert-release-absent.sh
 
   packages:
@@ -81,6 +81,14 @@ jobs:
           VERSION: ${{ needs.plan.outputs.version }}
           ENGINE_VERSION: ${{ needs.plan.outputs.engine_version }}
         run: .github/scripts/publish-cli-release.sh
+
+      # A failure between `create --draft` and `--draft=false` leaves a draft that blocks a re-run.
+      - name: Explain the recovery
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.plan.outputs.tag }}
+        run: .github/scripts/explain-draft-recovery.sh
 
   # Un-drafting from a workflow fires no `release: published`, so npm-publish.yml — the one
   # entry workflow npm's trusted publisher accepts (#731) — has to be dispatched by hand.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Full per-file breakdown (Russian + English): [BENCHMARK.md](BENCHMARK.md).
 All of these install the Bun CLI wrapper; engine + models still download explicitly via `kesha install`.
 
 - **Homebrew** — `brew install drakulavich/tap/kesha-voice-kit` · [docs/homebrew.md](docs/homebrew.md)
-- **Linux packages** (`.deb`/`.rpm`, x64) — not currently published, see [docs/linux-packages.md](docs/linux-packages.md)
+- **Linux packages** (`.deb`/`.rpm`, x64) — published on CLI releases, see [docs/linux-packages.md](docs/linux-packages.md)
 - **Docker** (GHCR image) — [docs/docker.md](docs/docker.md)
 - **Nix** (`aarch64-darwin` / `x86_64-linux`) — `nix run github:drakulavich/kesha-voice-kit -- install` · [docs/nix-install.md](docs/nix-install.md)
 - **Shell completions + manpage** — `kesha completions bash|zsh|fish` and `kesha manpage` print the packaged files to install wherever your shell expects them.

--- a/docs/linux-packages.md
+++ b/docs/linux-packages.md
@@ -1,15 +1,14 @@
 # Linux Packages
 
-> **Not currently published.** `.deb` and `.rpm` used to be attached to stable
-> engine releases, where they were named after a CLI version npm had not
-> published yet — so they shipped a version that did not exist
-> ([#728](https://github.com/drakulavich/kesha-voice-kit/issues/728)). Engine
-> releases no longer carry them, and no channel has replaced that yet. The last
-> published pair is on
-> [v1.24.7](https://github.com/drakulavich/kesha-voice-kit/releases/tag/v1.24.7).
-> Install with `bun add -g @drakulavich/kesha-voice-kit`, the
-> [Docker image](docker.md), or [Nix](nix-install.md) in the meantime; #728
-> tracks where packages should live.
+> **Where to find them.** `.deb` and `.rpm` are attached to **CLI releases** —
+> the marker releases tagged `vX.Y.Z-cli` — because the package *is* the CLI.
+> They used to ride stable engine releases (`vX.Y.Z`), where they were named
+> after a CLI version npm had not published yet
+> ([#728](https://github.com/drakulavich/kesha-voice-kit/issues/728)). Releases
+> between `v1.24.7` and the first `-cli` release after that change carry no
+> packages; the
+> [releases page](https://github.com/drakulavich/kesha-voice-kit/releases)
+> shows which. Prereleases ship none at all.
 
 The packages install a standalone Bun-compiled CLI wrapper as `kesha`. Engine
 binaries and models are still downloaded explicitly with `kesha install`
@@ -19,33 +18,38 @@ The wrapper is compiled with Bun's glibc target (`bun-linux-x64`) — it won't
 run on musl-based distros (e.g. Alpine). Use the [Docker image](docker.md)
 there instead.
 
+## Download
+
+The newest release is often an engine release, which carries no packages, so
+resolve the latest `-cli` tag rather than asking for `latest`:
+
+```bash
+TAG=$(gh release list -R drakulavich/kesha-voice-kit --limit 50 --json tagName \
+  --jq '[.[] | select(.tagName | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-cli$"))][0].tagName')
+gh release download "$TAG" -R drakulavich/kesha-voice-kit \
+  -p 'kesha-voice-kit_*_amd64.deb' -p 'kesha-voice-kit-*.x86_64.rpm' -p SHA256SUMS
+sha256sum -c SHA256SUMS
+```
+
+No `gh` CLI? Pick the newest `vX.Y.Z-cli` release from the
+[releases page](https://github.com/drakulavich/kesha-voice-kit/releases) and
+download the assets by hand.
+
 ## Debian / Ubuntu
 
 ```bash
-gh release download \
-  -R drakulavich/kesha-voice-kit \
-  -p 'kesha-voice-kit_*_amd64.deb'
 sudo apt install ./kesha-voice-kit_*_amd64.deb
 kesha install
 kesha audio.ogg
 ```
 
-No `gh` CLI? Download the same `.deb` from the
-[latest release page](https://github.com/drakulavich/kesha-voice-kit/releases/latest).
-
 ## Fedora / RHEL
 
 ```bash
-gh release download \
-  -R drakulavich/kesha-voice-kit \
-  -p 'kesha-voice-kit-*.x86_64.rpm'
 sudo dnf install ./kesha-voice-kit-*.x86_64.rpm
 kesha install
 kesha audio.ogg
 ```
-
-No `gh` CLI? Download the same `.rpm` from the
-[latest release page](https://github.com/drakulavich/kesha-voice-kit/releases/latest).
 
 ## What Linux Gets
 
@@ -82,8 +86,9 @@ the same config.
 ```bash
 go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.43.4
 node .github/scripts/build-linux-packages.mjs
-sudo apt install ./dist/linux-packages/kesha-voice-kit_*_amd64.deb
-kesha --version
-kesha install --plan
-sudo apt remove kesha-voice-kit
+.github/scripts/verify-linux-packages.sh
 ```
+
+CI runs those same two commands through `.github/actions/linux-packages`, from
+both `linux-packages.yml` (on `main`) and `release-cli.yml` (on a
+`vX.Y.Z-cli` tag, which is what publishes them).

--- a/docs/release-manifest.md
+++ b/docs/release-manifest.md
@@ -25,7 +25,9 @@ The manifest accepts three tag shapes — `vX.Y.Z`, `vX.Y.Z-beta.N`, and
 `vX.Y.Z-alpha.N` — and rejects anything else. Linux `.deb`/`.rpm` assets were
 listed here until #728: they were named after a CLI version npm had not
 published, so engine releases stopped attaching them and the manifest stopped
-promising them. `engineVersion` comes from
+promising them. They now ship on the CLI's own `vX.Y.Z-cli` marker release,
+which carries no manifest — it is engine metadata, and a CLI-only release
+changes no engine asset. `engineVersion` comes from
 the tag rather than from `package.json#keshaEngine.version`: an alpha ships a
 version no commit carries, and it must outrank the pin rather than equal it
 (#738). Channel policy — what each prerelease is for and how it reaches users —

--- a/openspec/specs/installation/spec.md
+++ b/openspec/specs/installation/spec.md
@@ -189,6 +189,46 @@ SHALL NOT by itself be treated as evidence that the Engine initialises on that p
 > `.github/scripts/smoke-synthesis.ts`), `.github/scripts/assert-install-warmup.ts`, and
 > `rust/src/cli/install.rs` (warm-up warns and continues, #298).*
 
+### Requirement: Linux packages ship only from a release that publishes the same CLI version
+
+A `.deb` or `.rpm` SHALL be published only by the release of the CLI marker tag whose version it carries, and that release SHALL publish the same version to npm in the same run. A release lane that attaches the packages without publishing that version SHALL fail rather than ship a package naming a CLI version users cannot otherwise install.
+
+The packaged version is taken from `package.json#version` at the tag, so the lane SHALL refuse a tag whose version differs from it. Prerelease markers ship no packages.
+
+#### Scenario: Maks installs the CLI from apt
+
+- GIVEN a stable CLI marker tag `vX.Y.Z-cli` is pushed
+- WHEN the CLI release lane runs
+- THEN it attaches the `.deb`, the `.rpm`, and their `SHA256SUMS` to that tag's release
+- AND it publishes `X.Y.Z` to npm in the same run
+- AND `X.Y.Z` is the version `package.json` carries at that tag
+
+#### Scenario: The tag names a version the commit does not carry
+
+- GIVEN a CLI marker tag whose version differs from `package.json#version` at that tag
+- WHEN the CLI release lane runs
+- THEN it fails before building, naming both versions
+- AND no package and no GitHub release is produced
+
+#### Scenario: A prerelease marker is pushed
+
+- GIVEN a CLI marker tag on the beta or alpha channel
+- WHEN the CLI release lane runs
+- THEN it exits successfully having produced no packages
+- AND it states that prerelease markers carry none
+
+#### Scenario: An engine release is cut
+
+- GIVEN a stable engine tag `vX.Y.Z` with no CLI marker
+- WHEN the engine release lane runs
+- THEN it attaches no Linux package, because the engine version does not name the CLI the package contains
+
+> *Technical Note — sources: `.github/workflows/release-cli.yml`,
+> `.github/scripts/cli-release-plan.mjs::planCliRelease`,
+> `.github/scripts/publish-cli-release.sh`, and the two lane checks in
+> `.github/scripts/check-workflows.ts` (`forbidLinuxPackaging`,
+> `requireNpmPublishAfterPackaging`). Replaces the tag/version assertion #727 removed (#728).*
+
 ### Requirement: TTS install is opt-in and requires `--tts`
 
 The CLI SHALL install TTS models only when `--tts` is passed. Bare `--tts` installs

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -99,10 +99,15 @@ describe("forbidLinuxPackaging", () => {
 
 describe("requireNpmPublishAfterPackaging", () => {
   const DISPATCH = { name: "dispatch", run: ".github/scripts/dispatch-npm-publish.sh" };
-  const lane = (publishNpm: unknown) => ({
+  const PACKAGING = [
+    { name: "build", uses: "./.github/actions/linux-packages" },
+    { name: "publish", run: ".github/scripts/publish-cli-release.sh" },
+  ];
+  const lane = (publishNpm: unknown, packages: unknown[] = PACKAGING) => ({
     on: { push: { tags: ["v*-cli"] } },
-    jobs: { packages: { steps: [] }, "publish-npm": publishNpm },
+    jobs: { packages: { steps: packages }, "publish-npm": publishNpm },
   });
+  const withNpm = (packages: unknown[]) => lane({ needs: ["packages"], steps: [DISPATCH] }, packages);
 
   test("passes on the real release-cli.yml", () => {
     expect(requireNpmPublishAfterPackaging(RELEASE_CLI, parse(readFileSync(RELEASE_CLI, "utf8")))).toEqual([]);
@@ -115,6 +120,22 @@ describe("requireNpmPublishAfterPackaging", () => {
   test("fails when the tag filter would take in engine tags", () => {
     const document = { ...lane({ needs: ["packages"], steps: [DISPATCH] }), on: { push: { tags: ["v*"] } } };
     expect(requireNpmPublishAfterPackaging(RELEASE_CLI, document)[0]).toContain("must trigger on `v*-cli`");
+  });
+
+  // `needs: packages` on an empty packages job satisfies the ordering and ships nothing (grok).
+  test("fails when the packaging job builds nothing", () => {
+    const errors = requireNpmPublishAfterPackaging(RELEASE_CLI, withNpm([PACKAGING[1]]));
+    expect(errors[0]).toContain("must build through ./.github/actions/linux-packages");
+  });
+
+  test("fails when the packaging job publishes nothing", () => {
+    const errors = requireNpmPublishAfterPackaging(RELEASE_CLI, withNpm([PACKAGING[0]]));
+    expect(errors[0]).toContain("must run publish-cli-release.sh");
+  });
+
+  test("fails when the packaging job is gone", () => {
+    const document = { on: { push: { tags: ["v*-cli"] } }, jobs: { "publish-npm": { steps: [DISPATCH] } } };
+    expect(requireNpmPublishAfterPackaging(RELEASE_CLI, document)[0]).toContain("expected a `packages` job");
   });
 
   // Dropping the dependency lets a .deb reach users for a version npm never served (#728).
@@ -133,7 +154,7 @@ describe("requireNpmPublishAfterPackaging", () => {
   });
 
   test("fails when the publish job is gone", () => {
-    const document = { on: { push: { tags: ["v*-cli"] } }, jobs: { packages: { steps: [] } } };
+    const document = { on: { push: { tags: ["v*-cli"] } }, jobs: { packages: { steps: PACKAGING } } };
     expect(requireNpmPublishAfterPackaging(RELEASE_CLI, document)[0]).toContain("expected a `publish-npm` job");
   });
 });

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -123,6 +123,10 @@ describe("requireNpmPublishAfterPackaging", () => {
     expect(errors[0]).toContain("must `needs: packages`");
   });
 
+  test("accepts the single-job spelling of needs", () => {
+    expect(requireNpmPublishAfterPackaging(RELEASE_CLI, lane({ needs: "packages", steps: [DISPATCH] }))).toEqual([]);
+  });
+
   test("fails when nothing dispatches npm-publish.yml", () => {
     const errors = requireNpmPublishAfterPackaging(RELEASE_CLI, lane({ needs: ["plan", "packages"], steps: [] }));
     expect(errors[0]).toContain("must run dispatch-npm-publish.sh");

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -3,12 +3,14 @@ import { readFileSync } from "node:fs";
 import { parse } from "yaml";
 import {
   forbidLinuxPackaging,
+  requireNpmPublishAfterPackaging,
   requirePreUploadSynthesisSmoke,
   requireTestedScriptsInCodeFilter,
 } from "../../.github/scripts/check-workflows";
 
 const PATH = ".github/workflows/build-engine.yml";
 const CI = ".github/workflows/ci.yml";
+const RELEASE_CLI = ".github/workflows/release-cli.yml";
 
 function job(name: string, steps: unknown[]) {
   return { jobs: { [name]: { steps } } };
@@ -92,6 +94,43 @@ describe("forbidLinuxPackaging", () => {
   test("prose about the policy is not packaging", () => {
     const comment = "      # packages (.deb/.rpm) moved off engine tags; see nfpm notes in #728";
     expect(forbidLinuxPackaging(PATH, comment)).toEqual([]);
+  });
+});
+
+describe("requireNpmPublishAfterPackaging", () => {
+  const DISPATCH = { name: "dispatch", run: ".github/scripts/dispatch-npm-publish.sh" };
+  const lane = (publishNpm: unknown) => ({
+    on: { push: { tags: ["v*-cli"] } },
+    jobs: { packages: { steps: [] }, "publish-npm": publishNpm },
+  });
+
+  test("passes on the real release-cli.yml", () => {
+    expect(requireNpmPublishAfterPackaging(RELEASE_CLI, parse(readFileSync(RELEASE_CLI, "utf8")))).toEqual([]);
+  });
+
+  test("ignores every other workflow", () => {
+    expect(requireNpmPublishAfterPackaging(PATH, { jobs: {} })).toEqual([]);
+  });
+
+  test("fails when the tag filter would take in engine tags", () => {
+    const document = { ...lane({ needs: ["packages"], steps: [DISPATCH] }), on: { push: { tags: ["v*"] } } };
+    expect(requireNpmPublishAfterPackaging(RELEASE_CLI, document)[0]).toContain("must trigger on `v*-cli`");
+  });
+
+  // Dropping the dependency lets a .deb reach users for a version npm never served (#728).
+  test("fails when the npm publish no longer waits for the packaging job", () => {
+    const errors = requireNpmPublishAfterPackaging(RELEASE_CLI, lane({ needs: ["plan"], steps: [DISPATCH] }));
+    expect(errors[0]).toContain("must `needs: packages`");
+  });
+
+  test("fails when nothing dispatches npm-publish.yml", () => {
+    const errors = requireNpmPublishAfterPackaging(RELEASE_CLI, lane({ needs: ["plan", "packages"], steps: [] }));
+    expect(errors[0]).toContain("must run dispatch-npm-publish.sh");
+  });
+
+  test("fails when the publish job is gone", () => {
+    const document = { on: { push: { tags: ["v*-cli"] } }, jobs: { packages: { steps: [] } } };
+    expect(requireNpmPublishAfterPackaging(RELEASE_CLI, document)[0]).toContain("expected a `publish-npm` job");
   });
 });
 

--- a/tests/unit/cli-release-plan.test.ts
+++ b/tests/unit/cli-release-plan.test.ts
@@ -61,11 +61,25 @@ describe("the CLI release lane", () => {
     expect(workflow.on.push.branches).toBeUndefined();
   });
 
-  test("the packaging job is the one holding contents: write", () => {
+  // plan holds write only so `gh release view` can see drafts; a read-only token cannot.
+  test("only the jobs that touch releases hold contents: write", () => {
     const jobs = parse(read(".github/workflows/release-cli.yml")).jobs;
 
+    expect(jobs.plan.permissions).toEqual({ contents: "write" });
     expect(jobs.packages.permissions).toEqual({ contents: "write" });
     expect(jobs["publish-npm"].permissions).toEqual({ contents: "read", actions: "write" });
+  });
+
+  // Writing the raw dispatch input to GITHUB_OUTPUT before validating it would let a tag
+  // carrying a newline append its own output keys, so the validator echoes the tag instead.
+  test("the tag reaches GITHUB_OUTPUT only from the validator", () => {
+    const plan = parse(read(".github/workflows/release-cli.yml")).jobs.plan;
+    const step = plan.steps.find((s: { id?: string }) => s.id === "plan");
+
+    expect(plan.outputs.tag).toBe("${{ steps.plan.outputs.tag }}");
+    expect(step.run).toContain("cli-release-plan.mjs");
+    expect(step.run).not.toContain("${{");
+    expect(plan.steps.some((s: { run?: string }) => /tag=.*>>.*GITHUB_OUTPUT/.test(s.run ?? ""))).toBe(false);
   });
 
   // Assets go onto a draft and the release is un-drafted afterwards: releases here are

--- a/tests/unit/cli-release-plan.test.ts
+++ b/tests/unit/cli-release-plan.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { parse } from "yaml";
+import { planCliRelease } from "../../.github/scripts/cli-release-plan.mjs";
+import { CLI_TAG_RE } from "../../.github/scripts/release-tags.mjs";
+
+// Windows CI checks the repo out with CRLF, which no assertion here is about.
+const read = (path: string) => readFileSync(path, "utf8").replace(/\r\n/g, "\n");
+
+const pkg = (version: string, engineVersion = "1.24.9") => ({
+  version,
+  keshaEngine: { version: engineVersion },
+});
+
+describe("planCliRelease", () => {
+  test("a stable marker tag releases packages for the version it names", () => {
+    expect(planCliRelease("v1.27.0-cli", pkg("1.27.0"))).toEqual({
+      version: "1.27.0",
+      packages: true,
+      engineVersion: "1.24.9",
+    });
+  });
+
+  // The .deb carries package.json#version and nothing downstream re-checks it (#727, #728).
+  test("a tag naming a version the commit does not carry is refused", () => {
+    expect(() => planCliRelease("v1.26.0-cli", pkg("1.27.0"))).toThrow(
+      "tag v1.26.0-cli names CLI 1.26.0 but package.json at that tag carries 1.27.0",
+    );
+  });
+
+  test.each(["v1.27.0-beta.1-cli", "v1.27.0-alpha.3-cli"])("%s ships no packages", (tag) => {
+    const plan = planCliRelease(tag, pkg("1.27.0"));
+
+    expect(plan.packages).toBe(false);
+    expect(plan.engineVersion).toBeUndefined();
+  });
+
+  // A prerelease marker is skipped before the drift guard, so main being ahead is not an error.
+  test("a prerelease marker is not held to package.json", () => {
+    expect(planCliRelease("v1.27.0-beta.1-cli", pkg("9.9.9")).packages).toBe(false);
+  });
+
+  test.each(["v1.27.0", "v1.27.0-alpha.1", "1.27.0-cli", "v1.27-cli", "v1.27.0; id-cli", "v1.27.0-rc.1-cli"])(
+    "%s is not a CLI marker tag",
+    (tag) => {
+      expect(() => planCliRelease(tag, pkg("1.27.0"))).toThrow("must be a CLI marker tag");
+    },
+  );
+
+  test("a package.json with no engine pin cannot name one in the notes", () => {
+    expect(() => planCliRelease("v1.27.0-cli", { version: "1.27.0" })).toThrow("no keshaEngine.version");
+  });
+});
+
+describe("CLI marker tag grammar", () => {
+  test("it accepts every CLI shape and nothing else", () => {
+    for (const tag of ["v1.27.0-cli", "v1.27.0-beta.1-cli", "v1.27.0-alpha.1-cli"]) {
+      expect(CLI_TAG_RE.test(tag)).toBe(true);
+    }
+    for (const tag of ["v1.27.0", "v1.27.0-beta.1", "v1.27.0-cli-cli", "cli"]) {
+      expect(CLI_TAG_RE.test(tag)).toBe(false);
+    }
+  });
+
+  // The lane exists to publish packages and npm together; a wider filter would run it on
+  // engine tags, which publish neither (#729).
+  test("release-cli.yml fires on CLI marker tags only", () => {
+    const workflow = parse(read(".github/workflows/release-cli.yml"));
+
+    expect(workflow.on.push.tags).toEqual(["v*-cli"]);
+    expect(workflow.on.push.branches).toBeUndefined();
+  });
+
+  test("the packaging job is the one holding contents: write", () => {
+    const jobs = parse(read(".github/workflows/release-cli.yml")).jobs;
+
+    expect(jobs.packages.permissions).toEqual({ contents: "write" });
+    expect(jobs["publish-npm"].permissions).toEqual({ contents: "read", actions: "write" });
+  });
+
+  // Assets go onto a draft and the release is un-drafted afterwards: releases here are
+  // immutable, so an asset uploaded to a published one 422s.
+  test("the packages are attached before the release goes public", () => {
+    const script = read(".github/scripts/publish-cli-release.sh");
+    const create = script.indexOf("gh release create");
+    const undraft = script.indexOf("--draft=false");
+
+    expect(script).toContain("--draft \\");
+    expect(create).toBeGreaterThan(-1);
+    expect(undraft).toBeGreaterThan(create);
+  });
+
+  // nfpm's input sits in the same directory as its output; uploading it would ship a
+  // 50 MB compiled wrapper as a release asset.
+  test("only the packages and their checksums are uploaded", () => {
+    const script = read(".github/scripts/publish-cli-release.sh");
+
+    expect(script).toContain('"$DIR"/*.deb "$DIR"/*.rpm "$DIR/SHA256SUMS"');
+  });
+});

--- a/tests/unit/cli-release-plan.test.ts
+++ b/tests/unit/cli-release-plan.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { parse } from "yaml";
 import { planCliRelease } from "../../.github/scripts/cli-release-plan.mjs";
-import { CLI_TAG_RE } from "../../.github/scripts/release-tags.mjs";
 
 // Windows CI checks the repo out with CRLF, which no assertion here is about.
 const read = (path: string) => readFileSync(path, "utf8").replace(/\r\n/g, "\n");
@@ -52,16 +51,7 @@ describe("planCliRelease", () => {
   });
 });
 
-describe("CLI marker tag grammar", () => {
-  test("it accepts every CLI shape and nothing else", () => {
-    for (const tag of ["v1.27.0-cli", "v1.27.0-beta.1-cli", "v1.27.0-alpha.1-cli"]) {
-      expect(CLI_TAG_RE.test(tag)).toBe(true);
-    }
-    for (const tag of ["v1.27.0", "v1.27.0-beta.1", "v1.27.0-cli-cli", "cli"]) {
-      expect(CLI_TAG_RE.test(tag)).toBe(false);
-    }
-  });
-
+describe("the CLI release lane", () => {
   // The lane exists to publish packages and npm together; a wider filter would run it on
   // engine tags, which publish neither (#729).
   test("release-cli.yml fires on CLI marker tags only", () => {

--- a/tests/unit/linux-packaging.test.ts
+++ b/tests/unit/linux-packaging.test.ts
@@ -2,12 +2,13 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 
 // These lived in release-manifest.mjs while the manifest promised .deb/.rpm assets. Engine
-// releases no longer attach them (#728), but linux-packages.yml still builds and smoke-installs
-// the pair on main, and its path filter means an unrelated PR never exercises it — so the
-// invariants need a home that always runs.
+// releases no longer attach them; the CLI's own `-cli` tag does (#728). linux-packages.yml
+// still builds and smoke-installs the pair on main, and its path filter means an unrelated PR
+// never exercises it — so the invariants need a home that always runs.
 const PACKAGE_SCRIPT = ".github/scripts/build-linux-packages.mjs";
 const PACKAGE_NAMES = ".github/scripts/linux-package-names.mjs";
 const NFPM_CONFIG = "packaging/nfpm.yaml";
+const COMPOSITE = ".github/actions/linux-packages/action.yml";
 
 const read = (path: string) => readFileSync(path, "utf8");
 
@@ -18,12 +19,21 @@ describe("linux packaging pipeline", () => {
     [PACKAGE_SCRIPT, "LINUX_PACKAGE_RELEASE"],
     [PACKAGE_NAMES, "LINUX_PACKAGE_RELEASE"],
     [NFPM_CONFIG, "dst: /usr/bin/kesha"],
+    [COMPOSITE, "build-linux-packages.mjs"],
+    [COMPOSITE, "verify-linux-packages.sh"],
   ])("%s carries %s", (path, token) => {
     expect(read(path)).toContain(token);
   });
 
-  test("the packages are built by linux-packages.yml, not by an engine release", () => {
-    expect(read(".github/workflows/linux-packages.yml")).toContain("build-linux-packages.mjs");
+  // One composite so the CI lane and the release lane cannot build the pair differently.
+  test.each([".github/workflows/linux-packages.yml", ".github/workflows/release-cli.yml"])(
+    "%s builds through the shared composite",
+    (workflow) => {
+      expect(read(workflow)).toContain("./.github/actions/linux-packages");
+    },
+  );
+
+  test("no engine release builds them", () => {
     expect(read(".github/workflows/build-engine.yml")).not.toContain("build-linux-packages.mjs");
   });
 });

--- a/tests/unit/release-tag-grammar.test.ts
+++ b/tests/unit/release-tag-grammar.test.ts
@@ -12,6 +12,7 @@ import { join } from "node:path";
 import { parse } from "yaml";
 import { classifyReleaseTag } from "../../.github/scripts/classify-release-tag.mjs";
 import {
+  CLI_TAG_RE,
   cliPublishTarget,
   ENGINE_TAG_ERE,
   ENGINE_TAG_RE,
@@ -51,6 +52,21 @@ describe("engine tag grammar", () => {
 
   test("the workflow ships the grammar verbatim", () => {
     expect(WORKFLOW_YAML).toContain(ENGINE_TAG_ERE);
+  });
+});
+
+// Built from the same version pattern as the engine grammar, so the two cannot drift apart.
+describe("CLI marker tag grammar", () => {
+  test("accepts every CLI shape", () => {
+    for (const tag of [...CLI_TAGS, "v1.27.0-beta.1-cli"]) {
+      expect(CLI_TAG_RE.test(tag)).toBe(true);
+    }
+  });
+
+  test("rejects engine tags and malformed shapes", () => {
+    for (const tag of [...ENGINE_TAGS, ...NOT_TAGS, "v1.27.0-cli-cli", "v1.27.0-rc.1-cli", "cli"]) {
+      expect(CLI_TAG_RE.test(tag)).toBe(false);
+    }
   });
 });
 


### PR DESCRIPTION
`.deb`/`.rpm` now ship from the CLI's own `vX.Y.Z-cli` marker release — option 1 in #728, chosen by the owner on the issue ("Publish on CLI releases"). The package *is* the CLI, so the release that names it is the release that publishes it to npm.

Closes #728

## Why this shape

The packages are named from `package.json#version`. Engine releases could never be the right home for them: `main` has carried the CLI version ahead of npm since #691, so a stable engine tag names a CLI version npm has not published. #727 deleted the assertion that used to hold tag and package version together (correctly — it made the engine answer to the CLI's version line), and #783 stopped engine releases attaching packages at all. Since then **no release carries them**; `linux-packages.yml` only builds and smoke-installs the pair as CI on `main`. apt/dnf users have had no artifact.

**The ordering invariant, and the successor to what #763 removed:** a `.deb` can only reach users for a version npm publishes *in the same run*. `release-cli.yml` builds the packages and dispatches the npm publish in one lane, `publish-npm` `needs: packages`, and `check-workflows.ts::requireNpmPublishAfterPackaging` fails the build if that dependency or the dispatch is ever dropped. Its counterpart `forbidLinuxPackaging` still keeps packaging off engine tags; its stale "until #728 picks a channel" message is updated.

## The lane

`push: tags: ["v*-cli"]` plus `workflow_dispatch` (tag input, env-routed per #291).

1. **plan** — `cli-release-plan.mjs` classifies the tag against the grammar's one home (`release-tags.mjs`, which gains `CLI_TAG_RE` built from the same version pattern as `ENGINE_TAG_ERE`). Then it verifies `package.json#version` **at the tag** equals the version the tag names, failing loudly on drift, with `validateLinuxPackageVersion` as the second gate. Finally it refuses a tag that already has a release — before anything is built, since nothing downstream can recover from it.
2. **packages** (`contents: write`) — builds and smoke-installs via the shared composite, writes `SHA256SUMS` over just the two packages, creates the release **as a draft** with them attached, then un-drafts. Releases here are immutable: an asset uploaded to a published release 422s.
3. **publish-npm** (`contents: read`, `actions: write`) — dispatches `npm-publish.yml` via the existing `dispatch-npm-publish.sh` and waits for its conclusion, then polls `npm view` until the version is served. npm Trusted Publishing accepts one entry workflow, so this lane dispatches rather than publishes.

Two non-obvious constraints drove the shape and are commented in the workflow: **un-drafting from a workflow fires no `release: published`** (a `GITHUB_TOKEN` event does not cascade), hence the explicit dispatch; and **a `GITHUB_TOKEN` tag push fires no `on.push.tags`**, hence a human pushes the tag — and the alpha lane's own `-cli` tags never reach this workflow, which is correct, alphas have no GitHub release.

## What happens to the other markers

- **Beta `-cli`** (`vX.Y.Z-beta.N-cli`): the lane exits green with a `::notice::` naming the legacy command. Betas ship no Linux packages and keep the human un-draft gate, which auto-publishing from a tag push would remove — so they stay on `gh release create`, which still fires `📦 npm Publish` on publication.
- **Alpha `-cli`**: minted and published by `release-alpha.yml`, never gets a GitHub release, and its `GITHUB_TOKEN` tag push cannot trigger this lane anyway.
- **Legacy `gh release create vX.Y.Z-cli`** still publishes npm but ships no packages, and leaves the tag unusable by this lane (tag names are one-use). Documented as "do not use"; the guard message says so if someone does.

## Deviations from the brief, and why

- **Composite action rather than a copy of the build steps.** `.github/actions/linux-packages` holds setup → nfpm → build → verify, used by both `linux-packages.yml` and `release-cli.yml`, so the CI lane and the release lane cannot build the pair differently. The inline inspect/smoke shell (11 lines across two steps) moved to `.github/scripts/verify-linux-packages.sh` under the no-inline-scripts-over-3-lines rule.
- **`linux-packages.yml` also runs on PRs** that touch the shared machinery (composite, the three packaging scripts, `packaging/**`) — a short list, not a copy of the `push` filter. `release-cli.yml` only ever runs on a tag, so without this a broken shared step would first surface on `main` after merge, or at release time. Its `main`-push CI mode is otherwise unchanged. **This paid for itself on the first run:** extracting the inline smoke step dropped the leading `./` on the `.deb` path, and `apt install dist/linux-packages/x.deb` parses `dist/linux-packages` as a `package/suite` spec rather than a file — `E: Unable to locate package dist/linux-packages`. Fixed in 993e458; without the PR trigger that lands on `main` or, worse, in a release.
- **The release-exists guard runs in `plan`, not only at `gh release create`.** Same script (`assert-release-absent.sh`) called from both, so the friendly message appears at the earliest possible point and again at the moment of truth.

## Verification

Green locally on the final commit: `bun test` (861 pass, 5 skip, 0 fail), `bunx tsc --noEmit`, `bun run check:versions`, `bun run check:specs` (12/12), `bun run check:workflows`, `bash -n` on every script. This PR touches no `src/`, `bin/` or `rust/` code at all.

CI on the head SHA: **📦 Linux Packages green** — the job that actually exercises the extracted composite and the apt fix — plus Rust Tests and Security Audit.

New unit tests, all pure: `tests/unit/cli-release-plan.test.ts` covers the stable/beta/alpha classification, the tag↔`package.json` drift refusal, malformed tags including `v1.27.0; id-cli`, the per-job permission split, draft-before-un-draft ordering, and that only the packages are uploaded (nfpm's input — a ~50 MB compiled wrapper — sits in the same directory as its output). `tests/unit/check-workflows.test.ts` gains coverage of the new lane check. Repo-file reads normalise CRLF for Windows CI.

The guard was also exercised against the live API: `TAG=v1.27.0-cli` (a real release) exits 1 with the actionable message, `TAG=v9.9.9-cli` exits 0.

## What only the first real run can prove

The workflow cannot be run end to end from a laptop. Unverified until then:

- the composite action resolving and building inside `release-cli.yml`'s tag checkout (the PR run of `linux-packages.yml` proves the composite itself, but from a branch checkout);
- `gh release create --draft` + `--draft=false` on a real marker tag, and the asset set that lands on it;
- the dispatch-and-wait handoff to `npm-publish.yml` and the `npm view` poll.

**Plan:** the next CLI release exercises the whole lane. Before that, `workflow_dispatch` with an existing `-cli` tag (`v1.27.0-cli`) is a real, cheap test of the guard path — it should fail in `plan` with the "already exists" message having built nothing. If the npm half fails after the release is public, recovery is `gh workflow run npm-publish.yml --ref <tag> -f tag=<tag>`; it is idempotent, an already-published version exits 0 without republishing. The workflow prints exactly that on failure.

## Docs

`release-mechanics` skill: the CLI-only patch flow becomes "push the tag", with the legacy path, the beta carve-out and the recovery command spelled out; the engine-release step 8 sentence that said "#728 owns where they should be published" now states the decision. `docs/linux-packages.md` loses the "not currently published" banner and gains a download snippet that resolves the newest `-cli` tag — asking for `latest` would hit an engine release with no packages. `docs/release-manifest.md` and the README line updated. New requirement in `openspec/specs/installation/spec.md` covering the invariant and the four scenarios (stable, drift, prerelease, engine tag).
