### PR TITLE
fix(install): update ENGINE_TARGETS sizes for the v1.24.9 assets

### DIFF
--- a/src/engine-targets.ts
+++ b/src/engine-targets.ts
@@ -17,17 +17,17 @@ const ENGINE_TARGETS: Record<string, EngineTarget> = {
   "darwin-arm64": {
     assetName: "kesha-engine-darwin-arm64",
     backend: "coreml",
-    sizeBytes: 62_172_768,
+    sizeBytes: 63_780_320,
   },
   "linux-x64": {
     assetName: "kesha-engine-linux-x64",
     backend: "onnx",
-    sizeBytes: 63_188_728,
+    sizeBytes: 66_101_160,
   },
   "win32-x64": {
     assetName: "kesha-engine-windows-x64.exe",
     backend: "onnx",
-    sizeBytes: 63_447_040,
+    sizeBytes: 65_067_520,
   },
 };
 


### PR DESCRIPTION
v1.24.9 was published with binaries whose sizes no longer match `src/engine-targets.ts`, so `check:engine-targets` — and with it the `workflow-lint` job — fails on every branch cut after the release (first seen on #784's second push; the first push predated the publish and was green).

Three `sizeBytes` values updated to what the checker itself reports from the published release:

| target | was | v1.24.9 |
| --- | --- | --- |
| darwin-arm64 | 62 172 768 | 63 780 320 |
| linux-x64 | 63 188 728 | 66 101 160 |
| win32-x64 | 63 447 040 | 65 067 520 |

Verified: `bun .github/scripts/check-engine-targets.ts` passes against the live release; unit suite 671 pass; `tsc --noEmit` clean. No behavior change — the table feeds `kesha install --plan` display and the drift check.