### PR TITLE
refactor(ci): de-duplicate the CLI release lane's tooling

### DIFF
--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -113,6 +113,42 @@ export function forbidLinuxPackaging(path: string, contents: string): string[] {
  * Both halves have to be real: `needs:` ordering alone is satisfied by a `packages` job that
  * builds and publishes nothing, so the job's own two steps are required as well.
  */
+const usesAction = (steps: Step[], action: string) =>
+  steps.some((step) => typeof step?.uses === "string" && step.uses === action);
+
+const runsScript = (steps: Step[], script: string) =>
+  runsMatching(steps, new RegExp(script.replace(/\./g, "\\."))).length > 0;
+
+/** `needs:` is a string when it names one job, a list when it names several. */
+function dependsOn(document: unknown, job: string, dependency: string): boolean {
+  const needs = (document as { jobs?: Record<string, { needs?: unknown }> })?.jobs?.[job]?.needs;
+  return [needs].flat().includes(dependency);
+}
+
+function requirePackagingJob(path: string, document: unknown): string[] {
+  const steps = jobSteps(document, "packages");
+  if (!steps) return [`${path}: expected a \`packages\` job with steps`];
+  if (!usesAction(steps, "./.github/actions/linux-packages")) {
+    return [`${path}: \`packages\` must build through ./.github/actions/linux-packages, the composite the CI lane shares (#728)`];
+  }
+  if (!runsScript(steps, "publish-cli-release.sh")) {
+    return [`${path}: \`packages\` must run publish-cli-release.sh — it is what attaches the packages to the release (#728)`];
+  }
+  return [];
+}
+
+function requireNpmDispatchJob(path: string, document: unknown): string[] {
+  const steps = jobSteps(document, "publish-npm");
+  if (!steps) return [`${path}: expected a \`publish-npm\` job with steps`];
+  if (!dependsOn(document, "publish-npm", "packages")) {
+    return [`${path}: \`publish-npm\` must \`needs: packages\`, so no .deb is published without the npm publish it names (#728)`];
+  }
+  if (!runsScript(steps, "dispatch-npm-publish.sh")) {
+    return [`${path}: \`publish-npm\` must run dispatch-npm-publish.sh — npm trusts one entry workflow (#731)`];
+  }
+  return [];
+}
+
 export function requireNpmPublishAfterPackaging(path: string, document: unknown): string[] {
   if (!path.endsWith("release-cli.yml")) return [];
 
@@ -121,31 +157,7 @@ export function requireNpmPublishAfterPackaging(path: string, document: unknown)
     return [`${path}: must trigger on \`v*-cli\` tag pushes (#728)`];
   }
 
-  const packaging = jobSteps(document, "packages");
-  if (!packaging) return [`${path}: expected a \`packages\` job with steps`];
-
-  const builds = packaging.some(
-    (step) => typeof step?.uses === "string" && step.uses === "./.github/actions/linux-packages",
-  );
-  if (!builds) {
-    return [`${path}: \`packages\` must build through ./.github/actions/linux-packages, the composite the CI lane shares (#728)`];
-  }
-  if (runsMatching(packaging, /publish-cli-release\.sh/).length === 0) {
-    return [`${path}: \`packages\` must run publish-cli-release.sh — it is what attaches the packages to the release (#728)`];
-  }
-
-  const steps = jobSteps(document, "publish-npm");
-  if (!steps) return [`${path}: expected a \`publish-npm\` job with steps`];
-
-  // `needs:` is a string when it names one job, a list when it names several.
-  const needs = (document as { jobs?: Record<string, { needs?: unknown }> })?.jobs?.["publish-npm"]?.needs;
-  if (![needs].flat().includes("packages")) {
-    return [`${path}: \`publish-npm\` must \`needs: packages\`, so no .deb is published without the npm publish it names (#728)`];
-  }
-  if (runsMatching(steps, /dispatch-npm-publish\.sh/).length === 0) {
-    return [`${path}: \`publish-npm\` must run dispatch-npm-publish.sh — npm trusts one entry workflow (#731)`];
-  }
-  return [];
+  return [...requirePackagingJob(path, document), ...requireNpmDispatchJob(path, document)];
 }
 
 /**
@@ -192,45 +204,43 @@ function collectTestedScripts(): string[] {
   return [...found].sort();
 }
 
+function describeUnreadable(path: string, err: unknown): string {
+  if (err instanceof YAMLParseError) {
+    // Rendered line:col so editors can jump to the offending position.
+    return `${path}:${err.linePos?.[0]?.line ?? "?"}:${err.linePos?.[0]?.col ?? "?"}: ${err.message}`;
+  }
+  return `${path}: ${err instanceof Error ? err.message : String(err)}`;
+}
+
+function checkFile(path: string, testedScripts: string[]): string[] {
+  try {
+    const contents = readFileSync(path, "utf8");
+    const document = parse(contents);
+    return [
+      ...requirePinnedActions(path, contents),
+      ...requirePreUploadSynthesisSmoke(path, document),
+      ...forbidLinuxPackaging(path, contents),
+      ...requireNpmPublishAfterPackaging(path, document),
+      ...requireTestedScriptsInCodeFilter(path, document, testedScripts),
+    ];
+  } catch (err) {
+    return [describeUnreadable(path, err)];
+  }
+}
+
 function main(): void {
   const files = dirs.flatMap((dir) => collectYamlFiles(dir)).sort();
-  const testedScripts = collectTestedScripts();
-
   if (files.length === 0) {
     console.error(`no workflow or action files found in ${dirs.join(", ")}`);
     process.exit(1);
   }
 
-  let failed = 0;
-  for (const path of files) {
-    try {
-      const contents = readFileSync(path, "utf8");
-      const document = parse(contents);
-      const errors = [
-        ...requirePinnedActions(path, contents),
-        ...requirePreUploadSynthesisSmoke(path, document),
-        ...forbidLinuxPackaging(path, contents),
-        ...requireNpmPublishAfterPackaging(path, document),
-        ...requireTestedScriptsInCodeFilter(path, document, testedScripts),
-      ];
-      if (errors.length > 0) {
-        failed += errors.length;
-        for (const error of errors) console.error(error);
-      }
-    } catch (err) {
-      failed += 1;
-      if (err instanceof YAMLParseError) {
-        // Rendered line:col so editors can jump to the offending position.
-        console.error(`${path}:${err.linePos?.[0]?.line ?? "?"}:${err.linePos?.[0]?.col ?? "?"}: ${err.message}`);
-      } else {
-        const msg = err instanceof Error ? err.message : String(err);
-        console.error(`${path}: ${msg}`);
-      }
-    }
-  }
+  const testedScripts = collectTestedScripts();
+  const errors = files.flatMap((path) => checkFile(path, testedScripts));
+  for (const error of errors) console.error(error);
 
-  if (failed > 0) {
-    console.error(`\n${failed} workflow or action check(s) failed.`);
+  if (errors.length > 0) {
+    console.error(`\n${errors.length} workflow or action check(s) failed.`);
     process.exit(1);
   }
 }

--- a/.github/scripts/cli-release-plan.mjs
+++ b/.github/scripts/cli-release-plan.mjs
@@ -7,9 +7,9 @@
  * to each other — the assertion #727 removed and #728 replaced with this lane.
  */
 import { readFileSync } from "node:fs";
-import { pathToFileURL } from "node:url";
 import { validateLinuxPackageVersion } from "./linux-package-names.mjs";
 import { CLI_MARKER, CLI_TAG_RE, cliPublishTarget } from "./release-tags.mjs";
+import { runTagScript } from "./tag-script.mjs";
 import { isStableVersion } from "../../src/semver.mjs";
 
 export function planCliRelease(tag, pkg) {
@@ -39,24 +39,24 @@ export function planCliRelease(tag, pkg) {
   return { version, packages: true, engineVersion };
 }
 
-if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
-  const tag = process.argv[2];
-  if (!tag) {
-    console.error("usage: node .github/scripts/cli-release-plan.mjs <tag>");
-    process.exit(2);
-  }
-
+runTagScript(import.meta.url, {
+  usage: "usage: node .github/scripts/cli-release-plan.mjs <tag>",
   // The tag is echoed back rather than written by the workflow: it reaches GITHUB_OUTPUT only
   // once the grammar has accepted it, so a dispatch input carrying a newline cannot append keys.
-  const plan = planCliRelease(tag, JSON.parse(readFileSync("package.json", "utf8")));
-  if (!plan.packages) {
-    console.error(
-      `::notice::${tag} is a prerelease marker — beta and alpha CLI markers ship no Linux ` +
-        `packages and no GitHub release from this lane. Publish it the legacy way: ` +
-        `gh release create ${tag} --title "${plan.version} (CLI-only)" --notes "…".`,
-    );
-  }
-  process.stdout.write(
-    `tag=${tag}\nversion=${plan.version}\npackages=${plan.packages}\nengine_version=${plan.engineVersion ?? ""}\n`,
-  );
-}
+  run: (tag) => {
+    const plan = planCliRelease(tag, JSON.parse(readFileSync("package.json", "utf8")));
+    if (!plan.packages) {
+      console.error(
+        `::notice::${tag} is a prerelease marker — beta and alpha CLI markers ship no Linux ` +
+          `packages and no GitHub release from this lane. Publish it the legacy way: ` +
+          `gh release create ${tag} --title "${plan.version} (CLI-only)" --notes "…".`,
+      );
+    }
+    return {
+      tag,
+      version: plan.version,
+      packages: plan.packages,
+      engine_version: plan.engineVersion ?? "",
+    };
+  },
+});

--- a/.github/scripts/release-tags.mjs
+++ b/.github/scripts/release-tags.mjs
@@ -6,7 +6,7 @@
  * workflow to it, which is what keeps the two languages from drifting (#685).
  */
 
-import { pathToFileURL } from "node:url";
+import { runTagScript } from "./tag-script.mjs";
 
 const VERSION_ERE = "[0-9]+\\.[0-9]+\\.[0-9]+(-(beta|alpha)\\.[0-9]+)?";
 
@@ -55,14 +55,10 @@ export function cliPublishTarget(tag) {
   };
 }
 
-if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
-  const tag = process.argv[2];
-  if (!tag) {
-    console.error("usage: node .github/scripts/release-tags.mjs <tag>");
-    process.exit(2);
-  }
-  const target = cliPublishTarget(tag);
-  process.stdout.write(
-    `version=${target.version}\nengine_only=${target.engineOnly}\nderived=${target.derived}\n`,
-  );
-}
+runTagScript(import.meta.url, {
+  usage: "usage: node .github/scripts/release-tags.mjs <tag>",
+  run: (tag) => {
+    const target = cliPublishTarget(tag);
+    return { version: target.version, engine_only: target.engineOnly, derived: target.derived };
+  },
+});

--- a/.github/scripts/tag-script.d.mts
+++ b/.github/scripts/tag-script.d.mts
@@ -1,0 +1,8 @@
+// The module stays .mjs: the workflows run its callers under node, which cannot import a .ts.
+export function runTagScript(
+  moduleUrl: string,
+  options: {
+    usage: string;
+    run: (tag: string) => Record<string, string | number | boolean>;
+  },
+): void;

--- a/.github/scripts/tag-script.mjs
+++ b/.github/scripts/tag-script.mjs
@@ -1,0 +1,24 @@
+/**
+ * The entry-point half of a workflow script that turns a tag into `$GITHUB_OUTPUT` lines.
+ *
+ * Only the grammar lives in release-tags.mjs; this is the argv/usage/exit-code contract the
+ * workflows depend on, shared so two scripts cannot drift on it.
+ */
+import { pathToFileURL } from "node:url";
+
+export function runTagScript(moduleUrl, { usage, run }) {
+  if (moduleUrl !== pathToFileURL(process.argv[1] ?? "").href) return;
+
+  const tag = process.argv[2];
+  if (!tag) {
+    console.error(usage);
+    process.exit(2);
+  }
+
+  const outputs = run(tag);
+  process.stdout.write(
+    Object.entries(outputs)
+      .map(([key, value]) => `${key}=${value}\n`)
+      .join(""),
+  );
+}

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -117,45 +117,28 @@ describe("requireNpmPublishAfterPackaging", () => {
     expect(requireNpmPublishAfterPackaging(PATH, { jobs: {} })).toEqual([]);
   });
 
-  test("fails when the tag filter would take in engine tags", () => {
-    const document = { ...lane({ needs: ["packages"], steps: [DISPATCH] }), on: { push: { tags: ["v*"] } } };
-    expect(requireNpmPublishAfterPackaging(RELEASE_CLI, document)[0]).toContain("must trigger on `v*-cli`");
-  });
+  const NPM = { needs: ["packages"], steps: [DISPATCH] };
+  const firstError = (document: unknown) =>
+    requireNpmPublishAfterPackaging(RELEASE_CLI, document)[0] ?? "";
 
-  // `needs: packages` on an empty packages job satisfies the ordering and ships nothing (grok).
-  test("fails when the packaging job builds nothing", () => {
-    const errors = requireNpmPublishAfterPackaging(RELEASE_CLI, withNpm([PACKAGING[1]]));
-    expect(errors[0]).toContain("must build through ./.github/actions/linux-packages");
-  });
+  const broken: [string, unknown, string][] = [
+    ["the tag filter would take in engine tags", { ...lane(NPM), on: { push: { tags: ["v*"] } } }, "must trigger on `v*-cli`"],
+    // `needs: packages` on a packages job that builds nothing satisfies the ordering and ships nothing (grok).
+    ["the packaging job builds nothing", withNpm([PACKAGING[1]]), "must build through ./.github/actions/linux-packages"],
+    ["the packaging job publishes nothing", withNpm([PACKAGING[0]]), "must run publish-cli-release.sh"],
+    ["the packaging job is gone", { on: { push: { tags: ["v*-cli"] } }, jobs: { "publish-npm": NPM } }, "expected a `packages` job"],
+    // Dropping the dependency lets a .deb reach users for a version npm never served (#728).
+    ["the npm publish no longer waits for the packaging job", lane({ ...NPM, needs: ["plan"] }), "must `needs: packages`"],
+    ["nothing dispatches npm-publish.yml", lane({ needs: ["plan", "packages"], steps: [] }), "must run dispatch-npm-publish.sh"],
+    ["the publish job is gone", { on: { push: { tags: ["v*-cli"] } }, jobs: { packages: { steps: PACKAGING } } }, "expected a `publish-npm` job"],
+  ];
 
-  test("fails when the packaging job publishes nothing", () => {
-    const errors = requireNpmPublishAfterPackaging(RELEASE_CLI, withNpm([PACKAGING[0]]));
-    expect(errors[0]).toContain("must run publish-cli-release.sh");
-  });
-
-  test("fails when the packaging job is gone", () => {
-    const document = { on: { push: { tags: ["v*-cli"] } }, jobs: { "publish-npm": { steps: [DISPATCH] } } };
-    expect(requireNpmPublishAfterPackaging(RELEASE_CLI, document)[0]).toContain("expected a `packages` job");
-  });
-
-  // Dropping the dependency lets a .deb reach users for a version npm never served (#728).
-  test("fails when the npm publish no longer waits for the packaging job", () => {
-    const errors = requireNpmPublishAfterPackaging(RELEASE_CLI, lane({ needs: ["plan"], steps: [DISPATCH] }));
-    expect(errors[0]).toContain("must `needs: packages`");
+  test.each(broken)("fails when %s", (_name, document, expected) => {
+    expect(firstError(document)).toContain(expected);
   });
 
   test("accepts the single-job spelling of needs", () => {
-    expect(requireNpmPublishAfterPackaging(RELEASE_CLI, lane({ needs: "packages", steps: [DISPATCH] }))).toEqual([]);
-  });
-
-  test("fails when nothing dispatches npm-publish.yml", () => {
-    const errors = requireNpmPublishAfterPackaging(RELEASE_CLI, lane({ needs: ["plan", "packages"], steps: [] }));
-    expect(errors[0]).toContain("must run dispatch-npm-publish.sh");
-  });
-
-  test("fails when the publish job is gone", () => {
-    const document = { on: { push: { tags: ["v*-cli"] } }, jobs: { packages: { steps: PACKAGING } } };
-    expect(requireNpmPublishAfterPackaging(RELEASE_CLI, document)[0]).toContain("expected a `publish-npm` job");
+    expect(requireNpmPublishAfterPackaging(RELEASE_CLI, lane({ ...NPM, needs: "packages" }))).toEqual([]);
   });
 });
 


### PR DESCRIPTION
Follow-up to #784, which merged before this round could land on its branch. Pure refactor of the CLI release lane's own tooling — **no behavior change to the lane**, and no workflow YAML is touched.

Repowise scored -1.1 on #784's final head with three real findings (not the re-parse drift it had reported earlier). This addresses all three.

## 1. `cli-release-plan.mjs` cloned 13 lines of `release-tags.mjs` (23% of the file)

The clone was not the grammar — it was the *entry-point contract*: the `import.meta.url === pathToFileURL(process.argv[1])` idiom, the argv/usage/exit-2 handling, and the `key=value` writing for `>> "$GITHUB_OUTPUT"`. Two scripts restating that can drift on the exact thing the workflows depend on, and the duplication was creeping toward `release-tags.mjs`, which is single-homed grammar by design.

It moves to `.github/scripts/tag-script.mjs::runTagScript`, so each caller now describes only what it computes. Verified byte-identical output for both scripts across every path — stable tag, prerelease marker (including the `::notice::`), and the no-argument usage/exit-2 case.

## 2. `requireNpmPublishAfterPackaging` at cc 11, `main` at cc 9, plus a 9-line internal clone

The deepened checks repeated a find-job / assert-its-steps / return-a-message shape. Now there are three predicates (`usesAction`, `runsScript`, `dependsOn`) and one function per job (`requirePackagingJob`, `requireNpmDispatchJob`), so each rule reads as its list of requirements and the exported function is a trigger check plus a concat. Every helper is well under cc 10 and 50 lines; all plain functions, no classes.

`main` splits into `checkFile` (per-file, owns the try/catch) and `describeUnreadable` (formats a YAML parse error vs any other), leaving `main` as collect → check → report.

One deliberate behavior refinement: the checker now reports failures from both jobs rather than returning at the first. That is strictly more information; no existing assertion depended on getting exactly one.

## 3. The test's negative cases shared scaffolding seven times

They collapse into one `[name, document, expected]` table. **Still 35 tests at runtime — identical to the baseline**, verified by stashing this diff and re-running `origin/main`'s copy of the file. The tests that read the real `publish-cli-release.sh` off disk still read it rather than a string copy.

## Verification

- `bun test`: 864 pass. One pre-existing flake (`cli-contracts` → "Capabilities: probe failed", exit 143 under full-suite load) which passes 21/21 in isolation — the known macOS Gatekeeper first-exec issue. This PR touches no `src/`, `bin/` or `rust/`.
- `bunx tsc --noEmit`, `bun run check:workflows`, `bun run check:specs` (12/12), `bun run check:versions` — all clean.
- Checker behavior held to the baseline: the same 35 tests pass, including the three negative cases added in #784's last round (hollowed packaging job builds nothing / publishes nothing / job missing).
