### PR TITLE
docs(skill): split release-engine into release-engine and release-cli

### DIFF
--- a/.claude/skills/release-cli/SKILL.md
+++ b/.claude/skills/release-cli/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: release-cli
+description: Cuts a CLI release (vX.Y.Z-cli marker tag) — the `🚀 Release (CLI)` lane builds the Linux packages, publishes the marker release, and dispatches npm publish with provenance. Covers version alignment across package.json and server.json, why the tag must be pushed by a human, and how to verify from the registry rather than through a stale global install. Refuses to auto-run; user must explicitly invoke. For an engine release use release-engine.
+disable-model-invocation: true
+---
+
+# release-cli
+
+Cuts a **CLI** release. **NEVER auto-runs** — user invokes via `/release-cli vX.Y.Z-cli`.
+
+For an engine release (bare `vX.Y.Z`, GitHub Release only) use the **`release-engine`** skill. A full ship is `/release-engine` first, then this one: the CLI release is what carries the new engine pin to users, and what ships the Linux packages.
+
+## Inputs
+
+- `$1`: target tag, e.g. `v1.27.0-cli`. The `-cli` marker routes it: `build-engine.yml` excludes it, `release-cli.yml` claims it.
+
+## What the tag sets off
+
+Pushing `vX.Y.Z-cli` runs `🚀 Release (CLI)`, which in one run:
+
+1. classifies the tag and **refuses one that already has a release**;
+2. builds and verifies the Linux `.deb`/`.rpm`;
+3. creates the marker release as a **draft** carrying those packages plus `SHA256SUMS`, then un-drafts it;
+4. dispatches `📦 npm Publish` and waits for it, then verifies the version is on npm.
+
+Steps 2–4 must happen together: the `.deb` is named from `package.json#version`, and nothing downstream re-checks that npm ever served it since #727 removed the assertion that did.
+
+**A human has to push the tag.** A `GITHUB_TOKEN` push fires no `on.push.tags` — which is exactly why the alpha lane's own `-cli` tags never reach this workflow, alphas having no GitHub release by design.
+
+**Do not `npm publish` from a laptop.** `npm-publish.yml` is the one entry workflow npm's trusted publisher accepts (#731), and it publishes with provenance from an OIDC identity. Un-drafting from a workflow raises no `release: published`, so the dispatch is explicit rather than cascading.
+
+**Cut one stable CLI release at a time.** `npm-publish.yml`'s `concurrency: queue: max` serialises runs but does not order them by version, so two stable markers in flight can finish out of order and leave `latest` on the older one.
+
+## Pre-flight
+
+```bash
+# 1. Root checkout clean, on main, up to date. Edit in a worktree, never here.
+git fetch origin main && git status -sb | head -3
+
+# 2. Version fields agree, and the pinned engine is a published, non-draft release
+bun run check:versions
+node -p "require('./package.json').version"
+python3 -c "import json;d=json.load(open('server.json'));print(d['version'], d['packages'][0]['version'])"
+gh release view "v$(node -p "require('./package.json').keshaEngine.version")" --json isDraft,isPrerelease
+
+# 3. CI green on main
+gh run list --workflow ci.yml --branch main --limit 1
+
+# 4. Local sanity
+bunx tsc --noEmit && bun test
+```
+
+Two things sink a run if they are wrong:
+
+- **`package.json#version` at the tag must be exactly the version the tag names.** The lane refuses otherwise, because the packages carry that field.
+- **The engine pin must name a published release.** Shipping a CLI whose pin 404s means `kesha install` fails for every new user.
+
+If anything fails, STOP.
+
+## Procedure
+
+### Step 1 — Align the versions (often already done)
+
+Three fields must equal the target version: `package.json#version`, `server.json#version`, `server.json#packages[0].version`. Leave `keshaEngine.version` and `rust/Cargo.toml` alone — that is the engine line.
+
+Since #691 `main` carries the next unreleased CLI version, so these are frequently **already** at the target and there is nothing to bump. Then skip to step 3: no diff, no PR.
+
+`server.json` is the MCP registry manifest, and `check:versions` rule 4 requires the match — its version tells registries which npm release to resolve.
+
+### Step 2 — Merge through a PR (only if step 1 changed something)
+
+Branch `release/X.Y.Z`; `integration-tests-full` skips on `release/*`.
+
+### Step 3 — Write the notes, then push the tag
+
+The lane creates the release itself, so the notes go on afterwards **while it is still a draft** — or, more simply, be ready to add them the moment the release appears. `gh release edit --notes` silently drops content on an already-published release.
+
+```bash
+git tag vX.Y.Z-cli
+git push origin vX.Y.Z-cli
+```
+
+Notes should say where the engine pin landed. "Engine unchanged" is only true when it is; if the pin moved, that movement is the headline, because it is how the new engine reaches users. User-facing upgrade text says **bun**, never npm: `bun add -g @drakulavich/kesha-voice-kit@latest`.
+
+### Step 4 — Watch the lane
+
+```bash
+gh run list --workflow release-cli.yml --limit 1
+gh run list --workflow npm-publish.yml --limit 1
+npm dist-tag ls @drakulavich/kesha-voice-kit
+```
+
+`npm-dist-tag.mjs` derives the tag from the SemVer prerelease identifier: stable → `latest`, `-beta.N` → `beta`, `-alpha.N` → `alpha`. A prerelease never lands on `latest`.
+
+If the run dies between `create --draft` and `--draft=false` it leaves a draft that blocks a re-run; the failing run prints the recovery, and `gh release view vX.Y.Z-cli` tells you the state directly. The full recovery table lives in **`release-mechanics`**.
+
+### Step 5 — Verify from the registry, not from the repo
+
+```bash
+npm view @drakulavich/kesha-voice-kit@X.Y.Z --json | jq '.dist.attestations.provenance.predicateType'
+npm pack @drakulavich/kesha-voice-kit@X.Y.Z && tar -xzOf *.tgz package/package.json | jq '.version, .keshaEngine.version'
+```
+
+Then install it somewhere isolated and run it — a fresh directory with `KESHA_ENGINE_BIN` pointing inside it, never the global install:
+
+```bash
+bun add @drakulavich/kesha-voice-kit@X.Y.Z
+export KESHA_ENGINE_BIN="$PWD/eng/kesha-engine"
+./node_modules/.bin/kesha --version         # X.Y.Z
+./node_modules/.bin/kesha install           # must fetch the pinned engine
+./node_modules/.bin/kesha <fixture>.ogg
+```
+
+**`make smoke-test` can false-green here.** It runs whatever `kesha` resolves to, and a previously `bun add -g`'d install outranks `bun link`; if its output prints an older version, it tested an older CLI and proves nothing about this release.
+
+## Hard rules
+
+- NEVER `npm publish` from a laptop — GHA owns it, with provenance.
+- NEVER let a bot push the marker tag; a token push triggers nothing.
+- NEVER reuse a tag name; GitHub reserves them permanently.
+- NEVER write release notes after the release is published.
+- NEVER ship a CLI whose `keshaEngine.version` has no published release.
+- User-facing install/upgrade text says bun, never npm.
+
+## Output
+
+```
+🎉 Released X.Y.Z
+- GitHub: https://github.com/drakulavich/kesha-voice-kit/releases/tag/vX.Y.Z-cli
+- npm:    https://www.npmjs.com/package/@drakulavich/kesha-voice-kit/v/X.Y.Z
+- dist-tag: latest        Provenance: yes
+- Linux packages: .deb + .rpm on the marker release
+- Engine pin: A.B.C (verified published)
+
+Verified from the registry: version ✓ pin ✓ install ✓ transcribe ✓
+```
+
+## On failure
+
+Report the last successful stage of the lane and what `gh release view vX.Y.Z-cli` shows. A draft left behind blocks a re-run and must be resolved before retrying. If npm already has the version, it is spent: fix forward under the next patch rather than unpublishing by reflex.

--- a/.claude/skills/release-cli/SKILL.md
+++ b/.claude/skills/release-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release-cli
-description: Cuts a CLI release (vX.Y.Z-cli marker tag) — the `🚀 Release (CLI)` lane builds the Linux packages, publishes the marker release, and dispatches npm publish with provenance. Covers version alignment across package.json and server.json, why the tag must be pushed by a human, and how to verify from the registry rather than through a stale global install. Refuses to auto-run; user must explicitly invoke. For an engine release use release-engine.
+description: Cuts a STABLE CLI release (vX.Y.Z-cli marker tag; not for beta or alpha markers, which this lane silently skips while burning the tag) — the `🚀 Release (CLI)` lane builds the Linux packages, publishes the marker release, and dispatches npm publish with provenance. Covers version alignment across package.json and server.json, why the tag must be pushed by a human, and how to verify from the registry rather than through a stale global install. Refuses to auto-run; user must explicitly invoke. For an engine release use release-engine.
 disable-model-invocation: true
 ---
 
@@ -13,6 +13,8 @@ For an engine release (bare `vX.Y.Z`, GitHub Release only) use the **`release-en
 ## Inputs
 
 - `$1`: target tag, e.g. `v1.27.0-cli`. The `-cli` marker routes it: `build-engine.yml` excludes it, `release-cli.yml` claims it.
+
+**Stable versions only.** `cli-release-plan.mjs` returns `packages: false` for anything with a prerelease identifier, which skips the packages job and — because `publish-npm` needs it — the npm dispatch too. A `v1.28.0-beta.1-cli` tag therefore does nothing at all while permanently consuming the name. Betas go through the legacy hand-cut path in `release-mechanics`; alphas have their own lane and no GitHub release.
 
 ## What the tag sets off
 
@@ -41,7 +43,7 @@ git fetch origin main && git status -sb | head -3
 bun run check:versions
 node -p "require('./package.json').version"
 python3 -c "import json;d=json.load(open('server.json'));print(d['version'], d['packages'][0]['version'])"
-gh release view "v$(node -p "require('./package.json').keshaEngine.version")" --json isDraft,isPrerelease
+gh release view "v$(node -p "require('./package.json').keshaEngine.version")" --json isDraft --jq 'if .isDraft then error("engine pin is still a draft") else "pin published" end'
 
 # 3. CI green on main
 gh run list --workflow ci.yml --branch main --limit 1
@@ -71,16 +73,24 @@ Since #691 `main` carries the next unreleased CLI version, so these are frequent
 
 Branch `release/X.Y.Z`; `integration-tests-full` skips on `release/*`.
 
-### Step 3 — Write the notes, then push the tag
-
-The lane creates the release itself, so the notes go on afterwards **while it is still a draft** — or, more simply, be ready to add them the moment the release appears. `gh release edit --notes` silently drops content on an already-published release.
+### Step 3 — Push the tag
 
 ```bash
 git tag vX.Y.Z-cli
 git push origin vX.Y.Z-cli
 ```
 
-Notes should say where the engine pin landed. "Engine unchanged" is only true when it is; if the pin moved, that movement is the headline, because it is how the new engine reaches users. User-facing upgrade text says **bun**, never npm: `bun add -g @drakulavich/kesha-voice-kit@latest`.
+**The lane writes the release body itself, and there is no draft window to slip notes into.** `publish-cli-release.sh` runs `gh release create --draft … --notes "v$VERSION (CLI-only). Engine: v$ENGINE_VERSION (unchanged)."` and un-drafts it in the next line of the same script.
+
+That body is hardcoded, so it says **"(unchanged)" even when this release is the one carrying a new engine pin** — the case that most deserves a headline. When the pin moved, replace the body after the fact; `gh release edit --notes` is silently dropped on a published release, so it takes the API:
+
+```bash
+RELEASE_ID=$(gh api repos/drakulavich/kesha-voice-kit/releases/tags/vX.Y.Z-cli --jq .id)
+jq -Rs '{body: .}' < notes.md > body.json
+gh api -X PATCH "repos/drakulavich/kesha-voice-kit/releases/$RELEASE_ID" --input body.json
+```
+
+User-facing upgrade text says **bun**, never npm: `bun add -g @drakulavich/kesha-voice-kit@latest`.
 
 ### Step 4 — Watch the lane
 
@@ -104,11 +114,12 @@ npm pack @drakulavich/kesha-voice-kit@X.Y.Z && tar -xzOf *.tgz package/package.j
 Then install it somewhere isolated and run it — a fresh directory with `KESHA_ENGINE_BIN` pointing inside it, never the global install:
 
 ```bash
+V=$(mktemp -d) && cd "$V"          # never in the repo: bun add here rewrites package.json
 bun add @drakulavich/kesha-voice-kit@X.Y.Z
-export KESHA_ENGINE_BIN="$PWD/eng/kesha-engine"
+export KESHA_ENGINE_BIN="$V/eng/kesha-engine"
 ./node_modules/.bin/kesha --version         # X.Y.Z
 ./node_modules/.bin/kesha install           # must fetch the pinned engine
-./node_modules/.bin/kesha <fixture>.ogg
+./node_modules/.bin/kesha <repo>/tests/fixtures/benchmark/09-ustanovi-poka-klod-kod.ogg
 ```
 
 **`make smoke-test` can false-green here.** It runs whatever `kesha` resolves to, and a previously `bun add -g`'d install outranks `bun link`; if its output prints an older version, it tested an older CLI and proves nothing about this release.
@@ -116,6 +127,8 @@ export KESHA_ENGINE_BIN="$PWD/eng/kesha-engine"
 ## Hard rules
 
 - NEVER `npm publish` from a laptop — GHA owns it, with provenance.
+- NEVER push a `-beta.N-cli` or alpha marker through this lane; it no-ops and burns the tag.
+- NEVER hand-cut `gh release create vX.Y.Z-cli`. The release would carry no packages, and `assert-release-absent.sh` then blocks the lane on that tag forever.
 - NEVER let a bot push the marker tag; a token push triggers nothing.
 - NEVER reuse a tag name; GitHub reserves them permanently.
 - NEVER write release notes after the release is published.

--- a/.claude/skills/release-engine/SKILL.md
+++ b/.claude/skills/release-engine/SKILL.md
@@ -1,215 +1,143 @@
 ---
 name: release-engine
-description: Cuts a kesha-engine release per CLAUDE.md rules — pre-flight audits, version bump, tag, release-notes BEFORE publish, smoke-test AFTER publish, then npm publish. Refuses to auto-run; user must explicitly invoke. Knows the gh-cli release-notes trap and the draft-URL 404 trap.
+description: Cuts a kesha-engine release (bare vX.Y.Z tag) per CLAUDE.md rules — pre-flight audits, engine-only version bump, annotated tag carrying the notes, draft validation with authenticated download, publish, then verify. Refuses to auto-run; user must explicitly invoke. Knows the workflow-frozen-at-the-tag trap, the gh-cli release-notes trap, and the draft-URL 404 trap. For a CLI release use release-cli.
 disable-model-invocation: true
 ---
 
 # release-engine
 
-Cuts a kesha-engine release. **NEVER auto-runs** — user invokes via `/release-engine vX.Y.Z` (or `/release-engine vX.Y.Z-cli` for CLI-only).
+Cuts a **kesha-engine** release. **NEVER auto-runs** — user invokes via `/release-engine vX.Y.Z`.
+
+For a CLI release (`vX.Y.Z-cli`, npm) use the **`release-cli`** skill instead. The two are independent version lines; a full ship is usually `/release-engine` then `/release-cli`.
 
 ## Inputs
 
-- `$1`: target tag, e.g. `v1.4.4` (engine release) or `v1.4.4-cli` (CLI-only marker release).
+- `$1`: target tag, e.g. `v1.24.9`. Bare — no `-cli` suffix. `-beta.N` / `-alpha.N` are prerelease shapes; alphas are dispatched, not tagged by hand (see `release-mechanics`).
 - Optional: `--draft` to stop before publishing.
 
-## Two release modes
+## THE TRAP THAT COSTS A TAG
 
-### Mode A: CLI-only (suffix `-cli`)
+**The workflow GitHub runs for a tag is the one stored *at that tag*.** A fix merged to `main` afterwards cannot rescue it, and re-running the failed job re-runs the broken definition. If the release job fails for a reason living in the workflow itself, that tag is dead — tag names are one-use, so you bump the patch and cut a new one. (v1.24.8 was lost exactly this way.)
 
-For docs/TS/plugin tweaks where the engine binary is unchanged.
-
-1. Bump `package.json#version`, plus `server.json#version` and `server.json#packages[0].version` to the same value. Leave `package.json#keshaEngine.version` and `rust/Cargo.toml` untouched.
-2. PR through CI (integration tests reuse the existing engine binary at the pinned `keshaEngine.version`).
-3. Merge.
-4. `gh release create $TAG --title "$VERSION (CLI-only)" --notes "Engine: v<keshaEngine.version> (unchanged)."`
-5. `npm publish --access public`
-
-The `-cli` suffix is excluded from `build-engine.yml`'s tag filter — no Rust rebuild.
-
-### Mode B: Engine release (no suffix, e.g. `v1.4.4`)
-
-Anything under `rust/`, or bumping `keshaEngine.version`.
-
-## Pre-flight checklist (run BEFORE bumping versions)
+Corollary: when the workflow on `main` is already fixed but a tag is not, release via `workflow_dispatch --ref main`, which runs main's definition:
 
 ```bash
-# 1. Working tree clean, on main, up to date
-git status
-git fetch origin && git status -sb | head -3
+gh workflow run "🔨 Build Engine" -R drakulavich/kesha-voice-kit \
+  -f tag=vX.Y.Z -f ref=main -f notes="$(cat notes.md)"
+```
 
-# 2. Feature matrix audit — every default cargo feature MUST appear in every build-engine.yml matrix row.
-#    v1.1.0 shipped without TTS because the matrix drifted; v1.1.3 fixed it.
-diff <(grep 'features = ' .github/workflows/build-engine.yml) <(grep '^default' rust/Cargo.toml)
+## Pre-flight (run BEFORE bumping versions)
+
+```bash
+# 1. Root checkout clean, on main, up to date. Edit in a worktree, never here.
+git fetch origin main && git status -sb | head -3
+
+# 2. Every additive cargo default in every matrix row — v1.1.0 shipped without TTS when this drifted.
+grep -E '^\s+features:' .github/workflows/build-engine.yml
+grep '^default =' rust/Cargo.toml
 
 # 3. CI green on main
 gh run list --workflow ci.yml --branch main --limit 1
 gh run list --workflow rust-test.yml --branch main --limit 1
 
-# 4. Local sanity
-cd rust && cargo fmt --check && cargo clippy --all-targets -- -D warnings
-cargo test --release
-cd .. && bun test && bunx tsc --noEmit
+# 4. Local sanity — nextest, not `cargo test` (CLAUDE.md)
+cargo fmt --check --manifest-path rust/Cargo.toml
+cargo clippy --manifest-path rust/Cargo.toml --all-targets -- -D warnings
+cargo check --manifest-path rust/Cargo.toml --features coreml --no-default-features
+make rust-test
+bunx tsc --noEmit && bun test && bun run check:versions
 ```
 
-If anything fails, STOP. Do not bump versions.
+If anything fails, STOP. Do not bump versions. A `bun test` failure that does not reproduce on a second run is the documented timing flake — confirm against CI on the same SHA rather than chasing it.
 
-## Engine release procedure
+## Procedure
 
-### Step 1: Version bump — engine fields ONLY
+### Step 1 — Version bump, engine fields ONLY
 
-Bump these THREE in the same commit:
+In a worktree (`git worktree add .worktrees/release-X.Y.Z -b release/X.Y.Z origin/main`), bump three fields in one commit:
 
-- `rust/Cargo.toml` — `version = "X.Y.Z"`
-- `rust/Cargo.lock` — refresh via `cd rust && cargo check`
+- `rust/Cargo.toml` — use `node .github/scripts/set-cargo-version.mjs X.Y.Z`, which rewrites only the `[package]` version. **It resolves paths from the current directory** — run it from inside the worktree or it edits the root checkout.
+- `rust/Cargo.lock` — refresh with `cd rust && cargo check`
 - `package.json#keshaEngine.version` — **not** `package.json#version`
 
-Since #691 `main` carries the next unreleased CLI version; dragging it down to the
-engine's number would publish that as npm `latest` and downgrade every user (#729). An
-engine tag publishes no npm package at all now — users get the new engine when a
-`-cli` release ships the bumped pin (Mode A, after this one).
+`main` carries the next *unreleased* CLI version since #691; dragging it down would publish that as npm `latest` and downgrade every user (#729). An engine tag publishes no npm package — users get the engine when a `-cli` release ships the bumped pin.
 
-**Raise, never lower.** If the new engine version would overtake `package.json#version`,
-raise the CLI line to match in the same commit — `check:versions` rule 2 requires
-`cli >= engine` and will reject the release commit otherwise. Raising is safe because the
-result still leads the published `latest`; only lowering downgrades users.
+**Raise, never lower.** If the engine version would overtake `package.json#version`, raise the CLI line to match in the same commit: `check:versions` rule 2 requires `cli >= engine`.
 
-```bash
-cd rust && cargo check
-cd ..
-git diff rust/Cargo.toml rust/Cargo.lock package.json  # eyeball
-git add rust/Cargo.toml rust/Cargo.lock package.json
-git commit -m "chore(release): vX.Y.Z"
-```
+### Step 2 — Merge through a PR on `release/X.Y.Z`
 
-### Step 2: Merge through PR (branch `release/X.Y.Z` is fine — `integration-tests` job is filtered to skip on `release/*` since the engine tag doesn't exist yet)
+The branch name matters twice: `integration-tests-full` skips on `release/*` (it downloads the *published* engine, whose tag does not exist yet), and `check-engine-targets` skips its 404 check there — that is the documented window between the release merge and its tag.
+
+That window must stay short. While it is open, `check-engine-targets` fails **every other PR** in the repo, because `main` pins an engine with no release.
+
+### Step 3 — Tag with the notes inside it
+
+Write the notes first, then create an **annotated** tag whose message is the notes. `build-engine.yml` reads `git tag -l --format='%(contents)'` into the draft body, so this sidesteps the published-release notes trap entirely.
 
 ```bash
-git push -u origin release/X.Y.Z
-gh pr create --fill --base main
-# wait for green
-gh pr merge --squash --delete-branch
+git tag -a vX.Y.Z --cleanup=verbatim -F notes.md
+git push origin refs/tags/vX.Y.Z
 ```
 
-### Step 3: Tag + push (triggers build-engine.yml)
+`--cleanup=verbatim` keeps the `#` heading lines a release body needs. Do **not** run `.github/scripts/push-annotated-tag.sh` locally — it sets `user.name`/`user.email` to github-actions[bot] in the repo config, which is right in CI and wrong on a laptop.
+
+The build produces 3 platform binaries, smoke-tests each with `--capabilities-json`, and creates a **draft** release with SBOM, manifest, `SHA256SUMS` and Sigstore bundles. Engine tags do **not** attach Linux `.deb`/`.rpm` — those ship on the `-cli` marker release now (#728).
+
+Expect `Darwin synthesis smoke (advisory)` to fail — it is `continue-on-error` and tracked as #742 / #678.
+
+### Step 4 — Validate the draft before publishing
+
+Draft asset URLs return **404 to unauthenticated clients**, so `curl` and `make smoke-test` can false-green through a stale global install. Download with `gh`:
 
 ```bash
-git checkout main && git pull
-git tag vX.Y.Z
-git push origin vX.Y.Z
+gh release download vX.Y.Z -p 'kesha-engine-darwin-arm64' -p 'SHA256SUMS' -p 'kesha-release-manifest.json'
+chmod +x kesha-engine-darwin-arm64
+./kesha-engine-darwin-arm64 --version          # must equal X.Y.Z
+shasum -a 256 -c SHA256SUMS --ignore-missing
+./kesha-engine-darwin-arm64 --capabilities-json | jq '.backend, (.features|length)'
 ```
 
-`build-engine.yml` builds 3 platform binaries, smoke-tests each with `--capabilities-json`, creates a **DRAFT** release with EMPTY body.
+Compare the feature list against the previous release. A silently missing feature is the v1.1.0 failure mode, and the count is the cheapest way to catch it.
 
-### Step 4: WRITE RELEASE NOTES — BEFORE PUBLISHING
-
-⚠️ **CRITICAL:** `gh release edit --notes` silently drops content on PUBLISHED releases (gh CLI quirk, not GitHub limitation). Author the notes WHILE the release is still a draft.
-
-Template (modeled on v1.1.3):
-
-```markdown
-## Highlights
-- <new feature 1>
-- <new feature 2>
-
-## Platform support
-- macOS arm64 (CoreML)
-- macOS arm64 / x64 (ONNX)
-- Linux x64 (ONNX)
-- Windows x64 (ONNX)
-
-## Breaking changes
-- <if any; otherwise omit>
-
-## Shipped PRs
-- #N — title
-- ...
-
-## Follow-up issues
-- #N — title
-- ...
-
-## Upgrade
-```bash
-bun install -g @drakulavich/kesha-voice-kit@X.Y.Z
-kesha install
-```
-```
-
-Apply:
-
-```bash
-gh release edit vX.Y.Z --notes "$(cat <<'EOF'
-<your notes>
-EOF
-)"
-```
-
-**If you forgot and already published:** the only escape hatch is a direct API PATCH (gh's `--notes` is silently ignored on published releases due to `immutable: true` on tag/assets, NOT body — but gh treats it as immutable anyway).
-
-```bash
-RELEASE_ID=$(gh api repos/drakulavich/kesha-voice-kit/releases/tags/vX.Y.Z --jq '.id')
-jq -Rs '{body: .}' < notes.md > body.json
-gh api -X PATCH "repos/drakulavich/kesha-voice-kit/releases/$RELEASE_ID" --input body.json
-```
-
-### Step 5: Publish the draft
+### Step 5 — Publish
 
 ```bash
 gh release edit vX.Y.Z --draft=false
 ```
 
-⚠️ Draft release asset URLs return **HTTP 404** to unauthenticated clients. `make smoke-test` and `kesha install` will fail against a draft. Smoke-test must run AFTER publish.
+Un-drafting a **bare** engine tag publishes nothing to npm: `cliPublishTarget` marks it `engineOnly`. The blast radius is the GitHub release alone.
 
-### Step 6: Smoke test
+### Step 6 — Verify against the published release
 
-```bash
-make smoke-test
-```
-
-Verifies each platform binary downloads + executes correctly.
-
-If smoke fails: **DO NOT** publish to npm. Investigate. The release can be re-drafted with `gh release edit vX.Y.Z --draft=true`, fixed via re-tag of a NEW version (tags are immutable — never reuse vX.Y.Z), and re-published.
-
-### Step 7: npm publish
+**`make smoke-test` is not sufficient on its own.** It runs whatever `kesha` resolves to, and a previously `bun add -g`'d install outranks `bun link` — a run that prints an old version tested an old CLI. Verify the real artifact in an isolated path:
 
 ```bash
-npm publish --access public
+export KESHA_ENGINE_BIN="$SCRATCH/engine/kesha-engine"
+bun run bin/kesha.js install          # must report the new engine version
+bun run bin/kesha.js tests/fixtures/benchmark/09-*.ogg
 ```
 
-### Step 8: Verify install end-to-end
+Then hand off to **`/release-cli`** so the pin reaches users.
 
-```bash
-npx -y @drakulavich/kesha-voice-kit@X.Y.Z --version
-npx -y @drakulavich/kesha-voice-kit@X.Y.Z install
-npx -y @drakulavich/kesha-voice-kit@X.Y.Z <fixture.ogg>
-```
+## Hard rules
 
-## Hard rules (from CLAUDE.md)
-
-- NEVER reuse a tag name. Bump patch instead of "tagging just to test" — use `gh workflow run "🔨 Build Engine" --ref main` for test builds.
-- NEVER skip pre-commit hooks (`--no-verify`).
-- NEVER force-push to main.
-- NEVER `npm publish` if smoke-test failed.
-- NEVER write release notes AFTER publishing — gh silently drops them.
-- ALWAYS verify the build-engine.yml feature matrix matches `rust/Cargo.toml` `default = [...]` before tagging.
+- NEVER reuse a tag name. Broken release → bump patch, new tag. For test builds use `gh workflow run "🔨 Build Engine" --ref main` with no tag.
+- NEVER skip pre-commit hooks (`--no-verify`) or force-push to `main`.
+- NEVER write release notes after publishing — `gh release edit --notes` silently drops them.
+- ALWAYS check the feature matrix against cargo's defaults before tagging.
+- ALWAYS leave the root checkout on `main`; edit in a worktree.
 
 ## Output
-
-At the end, print:
 
 ```
 🎉 Released vX.Y.Z
 - GitHub: https://github.com/drakulavich/kesha-voice-kit/releases/tag/vX.Y.Z
-- npm:    https://www.npmjs.com/package/@drakulavich/kesha-voice-kit/v/X.Y.Z
-- npm tag: latest
+- Assets: <n> (engine ×3, sidecars ×2, SBOM, manifest, SHA256SUMS, Sigstore bundles)
+- Engine reports: X.Y.Z   Checksums: OK   Features: <n> (unchanged vs previous)
 
-Smoke: <macos-coreml ✓ | linux-onnx ✓ | windows-onnx ✓>
+Next: /release-cli vA.B.C-cli to ship the pin to npm.
 ```
 
 ## On failure
 
-If any step fails partway through, report:
-- Last successful step
-- The failing command + output
-- Recovery hint (most common: re-run smoke after `gh release edit --draft=false`)
+Report the last successful step, the failing command and its output, and whether the tag is still usable. If the failure lives in the workflow stored at the tag, say so plainly: that tag cannot be rescued and the fix ships under the next patch number.

--- a/.claude/skills/release-engine/SKILL.md
+++ b/.claude/skills/release-engine/SKILL.md
@@ -13,7 +13,6 @@ For a CLI release (`vX.Y.Z-cli`, npm) use the **`release-cli`** skill instead. T
 ## Inputs
 
 - `$1`: target tag, e.g. `v1.24.9`. Bare — no `-cli` suffix. `-beta.N` / `-alpha.N` are prerelease shapes; alphas are dispatched, not tagged by hand (see `release-mechanics`).
-- Optional: `--draft` to stop before publishing.
 
 ## THE TRAP THAT COSTS A TAG
 
@@ -68,7 +67,7 @@ In a worktree (`git worktree add .worktrees/release-X.Y.Z -b release/X.Y.Z origi
 
 The branch name matters twice: `integration-tests-full` skips on `release/*` (it downloads the *published* engine, whose tag does not exist yet), and `check-engine-targets` skips its 404 check there — that is the documented window between the release merge and its tag.
 
-That window must stay short. While it is open, `check-engine-targets` fails **every other PR** in the repo, because `main` pins an engine with no release.
+That window must stay short. While it is open, `main` pins an engine with no release, so `check-engine-targets` fails any PR that reaches `workflow-lint` — anything touching workflow-shaped paths, plus the scheduled run.
 
 ### Step 3 — Tag with the notes inside it
 
@@ -97,7 +96,19 @@ shasum -a 256 -c SHA256SUMS --ignore-missing
 ./kesha-engine-darwin-arm64 --capabilities-json | jq '.backend, (.features|length)'
 ```
 
-Compare the feature list against the previous release. A silently missing feature is the v1.1.0 failure mode, and the count is the cheapest way to catch it.
+Compare the feature list against the previous release: a silently missing feature is the v1.1.0 failure mode, and the count is the cheapest way to catch it.
+
+**A capabilities probe is not enough.** v1.5.0 reported itself healthy and could not synthesise. Actually exercise the binary before un-drafting — transcribe a fixture and synthesise a line — and verify a signature while you are there:
+
+```bash
+export KESHA_ENGINE_BIN="$PWD/kesha-engine-darwin-arm64"
+bun run bin/kesha.js tests/fixtures/benchmark-en/01-check-email.ogg
+bun run bin/kesha.js say "release check" --out /tmp/check.wav
+cosign verify-blob --bundle kesha-engine-darwin-arm64.sigstore.json \
+  --certificate-identity "https://github.com/drakulavich/kesha-voice-kit/.github/workflows/build-engine.yml@refs/tags/vX.Y.Z" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  kesha-engine-darwin-arm64
+```
 
 ### Step 5 — Publish
 
@@ -105,17 +116,19 @@ Compare the feature list against the previous release. A silently missing featur
 gh release edit vX.Y.Z --draft=false
 ```
 
-Un-drafting a **bare** engine tag publishes nothing to npm: `cliPublishTarget` marks it `engineOnly`. The blast radius is the GitHub release alone.
+Un-drafting a **bare** engine tag publishes nothing to npm — `npm-publish.yml` skips its publish job on `engine_only` (#729). It does fire `release: published`, which starts **`🍺 Homebrew Tap`** for stable tags, so the blast radius is the GitHub release plus the tap.
 
 ### Step 6 — Verify against the published release
 
 **`make smoke-test` is not sufficient on its own.** It runs whatever `kesha` resolves to, and a previously `bun add -g`'d install outranks `bun link` — a run that prints an old version tested an old CLI. Verify the real artifact in an isolated path:
 
 ```bash
-export KESHA_ENGINE_BIN="$SCRATCH/engine/kesha-engine"
+SMOKE=$(mktemp -d) && export KESHA_ENGINE_BIN="$SMOKE/kesha-engine"
 bun run bin/kesha.js install          # must report the new engine version
-bun run bin/kesha.js tests/fixtures/benchmark/09-*.ogg
+bun run bin/kesha.js tests/fixtures/benchmark/09-ustanovi-poka-klod-kod.ogg
 ```
+
+This re-downloads from the published release rather than re-using the draft binary from step 4 — which is the point: it exercises what a user gets.
 
 Then hand off to **`/release-cli`** so the pin reaches users.
 

--- a/.claude/skills/release-mechanics/SKILL.md
+++ b/.claude/skills/release-mechanics/SKILL.md
@@ -47,8 +47,8 @@ Two things do *not* go through this lane. A **beta marker** (`vX.Y.Z-beta.N-cli`
 
 1. Bump `rust/Cargo.toml`, `rust/Cargo.lock` (`cargo check`), `package.json#keshaEngine.version` — leave `package.json#version` alone, it carries the next unreleased CLI (#691). An engine tag publishes nothing to npm; the bumped pin reaches users with the next `-cli` release (#729). If the engine would overtake the CLI line, raise it to match — rule 2 (`cli >= engine`) rejects the commit otherwise — but never lower it.
 2. Merge to main.
-3. Tag/push: `git tag vX.Y.Z && git push origin vX.Y.Z` → `build-engine.yml`.
-4. Write release notes before publishing. Draft releases start with an empty body:
+3. Tag/push **annotated, with the notes as the message**: `git tag -a vX.Y.Z --cleanup=verbatim -F notes.md && git push origin refs/tags/vX.Y.Z` → `build-engine.yml`, whose release job reads `git tag -l --format='%(contents)'` into the draft body. A lightweight tag leaves the body empty.
+4. If the tag was lightweight, write the notes before publishing:
 
    ```bash
    gh release edit vX.Y.Z --notes "$(cat <<'EOF'
@@ -79,7 +79,7 @@ Two things do *not* go through this lane. A **beta marker** (`vX.Y.Z-beta.N-cli`
    ```
 
 6. Treat `make smoke-test` as a local sanity check only; it can run the old globally installed CLI/engine. The release gate is draft-asset validation.
-7. Publish: `gh release edit vX.Y.Z --draft=false`. This fires `📦 npm Publish`; verify `npm view @drakulavich/kesha-voice-kit version` within ~60s. Manual fallback: `npm publish --access public` from the maintainer laptop.
+7. Publish: `gh release edit vX.Y.Z --draft=false`. A bare engine tag reaches **no npm package** — `npm-publish.yml` skips its publish job on `engine_only` (#729) — but it does fire `🍺 Homebrew Tap`. The CLI arrives with its own `-cli` marker; see the `release-cli` skill.
 8. Stable `vX.Y.Z` engine releases also update `drakulavich/homebrew-tap` via `🍺 Homebrew Tap` using `HOMEBREW_TAP_TOKEN` scoped only to the tap repo. CLI-only marker releases skip Homebrew. **Engine releases no longer attach Linux `.deb`/`.rpm`**: those packages carry `package.json#version`, which `main` holds ahead of npm since #691, so naming them on an engine tag meant naming a CLI version npm had not published. The gate that checked this (`assert-npm-published.mjs`) made stable engine tags unreleasable and is gone. They ship from the stable `-cli` marker instead (#728) — the package *is* the CLI — which is the one release that publishes the same version to npm in the same run; `linux-packages.yml` keeps building and smoke-installing the pair on `main` as CI. `check-workflows.ts` holds both halves: `forbidLinuxPackaging` keeps them off engine tags, `requireNpmPublishAfterPackaging` keeps the `-cli` lane's npm publish downstream of the packaging job.
 
 **Prerelease channels.** The validators accept two shapes beside stable — `vX.Y.Z-beta.N` and `vX.Y.Z-alpha.N` (a CLI release on either channel adds the `-cli` marker) — and the grammar has one home, `release-tags.mjs`. Neither channel can reach `latest`: `npm-dist-tag.mjs` derives the dist-tag from the SemVer prerelease identifier, returns `latest` only for a version that has none, and *refuses* one whose identifier decodes to `latest` (`1.27.0-latest.1`) rather than handing a prerelease to everyone who never asked for a channel.
@@ -159,7 +159,7 @@ Post-#291 happy path: publishing a GitHub release runs `.github/workflows/npm-pu
 - Guards: tag must match `package.json#version` after stripping leading `v` and trailing `-cli`; already-published versions skip publish and exit 0. An alpha version is minted at publish time, so it is injected into `package.json` instead of verified against it.
 - Dist-tags: resolved by `npm-dist-tag.mjs` from the prerelease identifier — stable → `latest`, `-beta.N` → `beta`, `-alpha.N` → `alpha`, and a prerelease never lands on `latest`.
 - Injection rule: route `inputs.tag` / `github.event.release.tag_name` through `env:`, never directly into `run:` while the job holds `id-token: write`.
-- Required secret: `NPM_TOKEN` (granular publish-only token for `@drakulavich/kesha-voice-kit`), set with `gh secret set NPM_TOKEN -R drakulavich/kesha-voice-kit`. If missing, the release remains published but the publish step fails; fallback is `npm publish --access public` from a laptop.
+- Required secret: `NPM_TOKEN` (granular publish-only token for `@drakulavich/kesha-voice-kit`), set with `gh secret set NPM_TOKEN -R drakulavich/kesha-voice-kit`. If missing, the release remains published but the publish step fails; fix the secret and re-run rather than publishing from a laptop, which would ship without provenance and outside the workflow npm's trusted publisher accepts.
 - Release implication: un-draft is the commit-to-publish point. Validate draft assets via authenticated `gh release download` before un-drafting; npm publish is effectively permanent (72 h unpublish window, noisy provenance). If validation fails before publish: delete release + tag, bump patch, retry.
 
 ## TAG NAMES ARE ONE-USE

--- a/.claude/skills/release-mechanics/SKILL.md
+++ b/.claude/skills/release-mechanics/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release-mechanics
-description: Use when touching anything release-shaped — version bumps, tags, draft releases, npm publish and provenance, the build-engine feature matrix, release/* PRs, bun link, or CI jobs that download a published engine. Explains why CLI and engine version independently, why tag names are one-use, why draft assets 404 for anonymous clients, and how Greptile re-review and auto-merge behave. To actually cut a release use the release-engine skill instead; this one is the reference behind it.
+description: Use when touching anything release-shaped — version bumps, tags, draft releases, npm publish and provenance, the build-engine feature matrix, release/* PRs, bun link, or CI jobs that download a published engine. Explains why CLI and engine version independently, why tag names are one-use, why draft assets 404 for anonymous clients, and how Greptile re-review and auto-merge behave. To actually cut a release use the release-engine skill (engine) or release-cli skill (npm) instead; this one is the reference behind both.
 ---
 
 # Release mechanics

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,7 +136,7 @@ Three invariants worth knowing before you touch a release:
 - **Un-drafting fires npm publish and is effectively permanent.** Validate the draft binary first with authenticated `gh release download` (draft asset URLs 404 for anonymous clients, so `curl` / `make smoke-test` can false-green through an old global shim) and exercise it end-to-end.
 - **`integration-tests-full` skips on `release/*`** via `!startsWith(github.head_ref, 'release/')` — that is the job which downloads the *published* engine, whose tag doesn't exist yet on a release PR. The lighter `integration-tests` job carries no such guard and is safe there. Don't remove the filter; reuse it for new engine-downloading jobs.
 
-Full procedure, `bun link` gotchas, and re-review mechanics: the **`release-mechanics`** skill (loads on demand). To cut a release, invoke **`release-engine`**.
+Full procedure, `bun link` gotchas, and re-review mechanics: the **`release-mechanics`** skill (loads on demand). To cut one, invoke **`release-engine`** (engine, bare `vX.Y.Z`) or **`release-cli`** (CLI to npm, `vX.Y.Z-cli`); a full ship is the engine first, then the CLI that carries its pin.
 
 ## Build Commands
 
@@ -184,7 +184,7 @@ Engine internals, ONNX I/O shapes, G2P split, SSML, `KESHA_*` env vars: the **`t
 
 ## Deeper references
 
-Topic knowledge lives in on-demand **skills** under `.claude/skills/` rather than here, so it costs nothing until it's relevant: `tts-internals`, `release-mechanics`, `release-engine` (cuts a release, explicit invoke only), `verify-pin-bump` (model SHA-256 mismatches).
+Topic knowledge lives in on-demand **skills** under `.claude/skills/` rather than here, so it costs nothing until it's relevant: `tts-internals`, `release-mechanics`, `release-engine` and `release-cli` (cut a release, explicit invoke only), `verify-pin-bump` (model SHA-256 mismatches).
 
 Still plain runbooks: [rust-gotchas](docs/runbooks/rust-gotchas.md) · [openclaw-plugin](docs/runbooks/openclaw-plugin.md).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,12 +128,12 @@ This repo has seen attempts (often in Russian) to make the agent read `~/.ssh/id
 
 ## Releases
 
-CLI (`package.json#version`) and engine (`package.json#keshaEngine.version` + `rust/Cargo.toml`) are versioned independently; `bun run check:versions` is the drift gate. Publishing a GitHub release triggers `npm-publish.yml` → `npm publish --provenance` in GHA; don't publish from a laptop.
+CLI (`package.json#version`) and engine (`package.json#keshaEngine.version` + `rust/Cargo.toml`) are versioned independently; `bun run check:versions` is the drift gate. Only a `-cli` marker tag reaches npm, through `npm-publish.yml` → `npm publish --provenance` in GHA; a bare engine tag skips that job on `engine_only` (#729). Don't publish from a laptop.
 
 Three invariants worth knowing before you touch a release:
 
 - **Tag names are one-use.** GitHub reserves them permanently — a broken release means a new patch tag, never a "test" tag.
-- **Un-drafting fires npm publish and is effectively permanent.** Validate the draft binary first with authenticated `gh release download` (draft asset URLs 404 for anonymous clients, so `curl` / `make smoke-test` can false-green through an old global shim) and exercise it end-to-end.
+- **Publishing is effectively permanent, and un-drafting an engine tag still fires `🍺 Homebrew Tap`.** It does not reach npm — only `-cli` does. Validate the draft binary first with authenticated `gh release download` (draft asset URLs 404 for anonymous clients, so `curl` / `make smoke-test` can false-green through an old global shim) and exercise it end-to-end.
 - **`integration-tests-full` skips on `release/*`** via `!startsWith(github.head_ref, 'release/')` — that is the job which downloads the *published* engine, whose tag doesn't exist yet on a release PR. The lighter `integration-tests` job carries no such guard and is safe there. Don't remove the filter; reuse it for new engine-downloading jobs.
 
 Full procedure, `bun link` gotchas, and re-review mechanics: the **`release-mechanics`** skill (loads on demand). To cut one, invoke **`release-engine`** (engine, bare `vX.Y.Z`) or **`release-cli`** (CLI to npm, `vX.Y.Z-cli`); a full ship is the engine first, then the CLI that carries its pin.


### PR DESCRIPTION
`/release-engine` and `/release-cli` are now separate skills.

## Why split

One skill covering both lanes meant every invocation carried the other lane's procedure, and "Mode A / Mode B" made the reader pick before doing anything. They are separate tags, separate artifacts, separate failure modes. Each skill now names the other for the hand-off: a full ship is `/release-engine` then `/release-cli`, because the CLI release is what carries the new engine pin to users.

## Both rewritten against what today actually took

Cutting v1.24.9 and 1.27.0 turned up instructions that were wrong, missing, or actively expensive:

- **The workflow GitHub runs for a tag is the one stored *at that tag*.** A fix merged to `main` afterwards cannot rescue it, and re-running the failed job re-runs the broken definition. That is what cost `v1.24.8`. It now leads the engine skill, together with the `workflow_dispatch --ref main` way out.
- **Pre-flight said `cargo test --release`**, which CLAUDE.md forbids for the suite — it is `make rust-test` (nextest). Added the `--features coreml --no-default-features` check too.
- **Release notes go inside the annotated tag.** `build-engine.yml` reads `git tag -l --format='%(contents)'` into the draft body, so the dropped-notes trap is designed around rather than warned about. Also: do not run `push-annotated-tag.sh` locally — it rewrites the repo's git identity to github-actions[bot].
- **`set-cargo-version.mjs` resolves paths from the cwd** and will happily edit the root checkout if run from there.
- **The CLI skill describes the lane that exists now.** `🚀 Release (CLI)` builds the Linux packages onto the marker release and dispatches npm publish; a human must push the tag because a `GITHUB_TOKEN` push fires no `on.push.tags`. The old `gh release create` by hand is gone, and so is `npm publish --access public` from a laptop — that would drop provenance and bypass the workflow npm's trusted publisher validates.
- **`make smoke-test` false-greens** through a globally installed CLI: it runs whatever `kesha` resolves to, and a prior `bun add -g` outranks `bun link`. Both skills now give the isolated verification instead — a scratch dir with `KESHA_ENGINE_BIN` inside it.
- Linux packages ship on the `-cli` marker release now, so the engine skill says that rather than repeating the old "stable engine releases attach them".

## Verification

`bunx tsc --noEmit`, `bun test` (865 pass, two consecutive clean runs). Docs-only otherwise; `.claude/skills/release-cli/SKILL.md` needed `git add -f`, since new `.claude/*` files are blocked by the local exclude rather than `.gitignore`.