### PR TITLE
test(models): aim the tests at what mutation testing said survives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ skills-lock.json
 .stryker-tmp/
 reports/
 mutants.out/
+mutants.out.old/

--- a/Makefile
+++ b/Makefile
@@ -33,12 +33,16 @@ integration: ## Run integration tests
 rust-test: ## Run Rust tests via nextest (matches CI — rust-test.yml)
 	cd rust && cargo nextest run --features tts
 
+# The widened set measures the ANE + diarize surfaces; `system_kokoro` cfg-excludes the ONNX-Kokoro
+# ones, so those need a second pass with FEATURES=tts. No target measures both — they are exclusive.
+FEATURES ?= tts,system_kokoro,system_diarize
+
 # `--in-place` is not optional: models.rs include_str!s a file above the crate, so the copy build fails.
-mutants-rust: ## Mutation-test one engine file, e.g. make mutants-rust FILE=src/errors.rs
-	@test -n "$(FILE)" || { echo "usage: make mutants-rust FILE=src/<file>.rs" >&2; exit 2; }
+mutants-rust: ## Mutation-test one engine file, e.g. make mutants-rust FILE=src/errors.rs [FEATURES=tts]
+	@test -n "$(FILE)" || { echo "usage: make mutants-rust FILE=src/<file>.rs [FEATURES=<set>]" >&2; exit 2; }
 	@command -v cargo-mutants >/dev/null || { echo "install it: cargo install --locked cargo-mutants" >&2; exit 2; }
 	@git diff --quiet -- rust || { echo "rust/ has uncommitted changes; --in-place mutates the tree" >&2; exit 2; }
-	cd rust && cargo mutants --in-place -f $(FILE)
+	cd rust && cargo mutants --in-place -f $(FILE) --features $(FEATURES)
 
 lint: ## Type-check with tsc
 	bunx tsc --noEmit

--- a/rust/.cargo/mutants.toml
+++ b/rust/.cargo/mutants.toml
@@ -1,5 +1,5 @@
 # Mutation testing for the engine. Run it through `make mutants-rust FILE=src/errors.rs`, which
-# supplies the two flags this repo needs — see the Makefile target for why they are not optional.
+# supplies the flags this repo needs — see the Makefile target for why they are not optional.
+# The feature set lives there too: a cfg'd-out fn compiles away, so its mutants all read as
+# missed even when a good test exists (#793), and no single feature set covers the whole file.
 test_tool = "nextest"
-# A cfg'd-out fn compiles away, so its mutants all read as missed even when tested (#793). No coreml: it excludes onnx.
-additional_cargo_args = ["--features", "tts,system_kokoro,system_diarize"]

--- a/rust/.cargo/mutants.toml
+++ b/rust/.cargo/mutants.toml
@@ -1,4 +1,5 @@
 # Mutation testing for the engine. Run it through `make mutants-rust FILE=src/errors.rs`, which
 # supplies the two flags this repo needs — see the Makefile target for why they are not optional.
 test_tool = "nextest"
-additional_cargo_args = ["--features", "tts"]
+# A cfg'd-out fn compiles away, so its mutants all read as missed even when tested (#793). No coreml: it excludes onnx.
+additional_cargo_args = ["--features", "tts,system_kokoro,system_diarize"]

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -1879,9 +1879,10 @@ fn parse_retry_after(raw: &str) -> Option<Duration> {
 }
 
 /// Exponential backoff with ±25% jitter, or the server's own `Retry-After`
-/// where it gave one. Jitter matters more than usual here: four rayon workers
-/// hit the same host together, so an unjittered schedule retries them in
-/// lockstep and re-triggers the rate limit that caused the backoff.
+/// where it gave one. Four rayon workers hit the same host together, so `jitter`
+/// must be drawn independently per call — anything they can all read at the same
+/// instant, a clock included, retries them in lockstep and re-triggers the rate
+/// limit that caused the backoff (#724).
 fn backoff_delay(attempt: u32, retry_after: Option<Duration>, jitter: f64) -> Duration {
     if let Some(after) = retry_after {
         return after.clamp(RETRY_BASE_DELAY, RETRY_AFTER_MAX);
@@ -1892,16 +1893,15 @@ fn backoff_delay(attempt: u32, retry_after: Option<Duration>, jitter: f64) -> Du
         .mul_f64(0.75 + 0.5 * jitter.clamp(0.0, 1.0))
 }
 
-/// macOS clocks tick in microseconds, so the low 1000 ns were always zero there and every worker drew the same jitter (#724).
+/// A fresh fraction in `[0, 1)` per call, independent across calls and threads.
+/// `RandomState` re-keys on every construction, so workers that back off within
+/// the same microsecond still spread; a clock read cannot promise that (#724).
 fn jitter_fraction() -> f64 {
-    let nanos = now_since_epoch().map(|d| d.subsec_nanos()).unwrap_or(0);
-    f64::from(nanos) / 1_000_000_000.0
-}
-
-fn now_since_epoch() -> Option<Duration> {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .ok()
+    use std::hash::{BuildHasher, Hasher};
+    let bits = std::collections::hash_map::RandomState::new()
+        .build_hasher()
+        .finish();
+    (bits >> 11) as f64 / (1u64 << 53) as f64
 }
 
 /// Below this a download finishes fast enough that a bar is noise, not feedback.
@@ -2558,17 +2558,41 @@ mod retry_tests {
         }
     }
 
-    /// A constant jitter puts the four download workers back in lockstep, which is
-    /// what re-triggers the rate limit the backoff exists to escape (#724).
+    /// The workers that matter draw at the same instant, so sequential variance is
+    /// not the contract — independence across threads is (#724).
     #[test]
-    fn jitter_fraction_is_a_varying_unit_fraction() {
-        let samples: Vec<f64> = (0..1_000).map(|_| jitter_fraction()).collect();
+    fn jitter_fraction_is_independent_across_simultaneous_workers() {
+        const THREADS: usize = 4;
+        const DRAWS: usize = 8;
+
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(THREADS));
+        let workers: Vec<_> = (0..THREADS)
+            .map(|_| {
+                let barrier = std::sync::Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    (0..DRAWS).map(|_| jitter_fraction()).collect::<Vec<f64>>()
+                })
+            })
+            .collect();
+        let samples: Vec<f64> = workers
+            .into_iter()
+            .flat_map(|w| w.join().expect("jitter worker panicked"))
+            .collect();
+
         for j in &samples {
             assert!((0.0..1.0).contains(j), "jitter {j} escaped [0, 1)");
         }
         let distinct: std::collections::HashSet<u64> =
             samples.iter().map(|j| j.to_bits()).collect();
-        assert!(distinct.len() > 1, "jitter never varied across 1000 draws");
+        assert_eq!(
+            distinct.len(),
+            THREADS * DRAWS,
+            "64-bit draws must not repeat; a shared clock is what makes them collide"
+        );
+        let spread = samples.iter().cloned().fold(f64::MIN, f64::max)
+            - samples.iter().cloned().fold(f64::MAX, f64::min);
+        assert!(spread > 0.001, "jitter spread {spread} is not usable");
     }
 
     #[test]
@@ -2640,7 +2664,10 @@ mod retry_tests {
             let dir = std::env::temp_dir().join(format!(
                 "kesha-retry-{name}-{}-{}",
                 std::process::id(),
-                now_since_epoch().map(|d| d.as_nanos()).unwrap_or(0)
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_nanos())
+                    .unwrap_or(0)
             ));
             fs::create_dir_all(&dir).expect("create temp cache");
             Self(dir)

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -1196,6 +1196,61 @@ mod diarize_sidecar_tests {
         assert_eq!(cleanup_diarize_compiled_sidecars(&missing)?, 0);
         Ok(())
     }
+
+    const DIARIZE_RUNTIME_FILES: [&str; 4] = [
+        "Manifest.json",
+        "Data/com.apple.CoreML/model.mlmodel",
+        "Data/com.apple.CoreML/weights/0-weight.bin",
+        "Data/com.apple.CoreML/weights/1-weight.bin",
+    ];
+
+    fn write_layout(dir: &Path, files: &[&str]) -> Result<()> {
+        for rel in files {
+            let path = dir.join(rel);
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            fs::write(&path, b"x")?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn diarize_layout_needs_every_runtime_file() -> Result<()> {
+        let tmp = TempDir::new("diarize-layout")?;
+        let complete = tmp.path.join("complete.mlpackage");
+        write_layout(&complete, &DIARIZE_RUNTIME_FILES)?;
+        assert!(has_diarize_layout(&complete), "complete bundle is ready");
+
+        for (i, missing) in DIARIZE_RUNTIME_FILES.iter().enumerate() {
+            let partial = tmp.path.join(format!("partial-{i}.mlpackage"));
+            let present: Vec<&str> = DIARIZE_RUNTIME_FILES
+                .iter()
+                .filter(|f| f != &missing)
+                .copied()
+                .collect();
+            write_layout(&partial, &present)?;
+            assert!(
+                !has_diarize_layout(&partial),
+                "{missing} missing must not read as ready"
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn only_compiled_sidecars_are_removable() {
+        assert!(is_compiled_mlpackage_sidecar(Path::new(
+            "/cache/Sortformer.mlpackage.mlmodelc"
+        )));
+        assert!(!is_compiled_mlpackage_sidecar(Path::new(
+            "/cache/Sortformer.mlpackage"
+        )));
+        assert!(!is_compiled_mlpackage_sidecar(Path::new(
+            "/cache/Sortformer.mlmodelc"
+        )));
+        assert!(!is_compiled_mlpackage_sidecar(Path::new("/")));
+    }
 }
 
 #[cfg(test)]
@@ -1837,9 +1892,10 @@ fn backoff_delay(attempt: u32, retry_after: Option<Duration>, jitter: f64) -> Du
         .mul_f64(0.75 + 0.5 * jitter.clamp(0.0, 1.0))
 }
 
+/// macOS clocks tick in microseconds, so the low 1000 ns were always zero there and every worker drew the same jitter (#724).
 fn jitter_fraction() -> f64 {
     let nanos = now_since_epoch().map(|d| d.subsec_nanos()).unwrap_or(0);
-    f64::from(nanos % 1_000) / 1_000.0
+    f64::from(nanos) / 1_000_000_000.0
 }
 
 fn now_since_epoch() -> Option<Duration> {
@@ -2094,7 +2150,7 @@ mod characterization_tests {
 
     #[cfg(unix)]
     #[test]
-    fn orphan_staging_sweep_removes_stale_keeps_fresh_and_finished() -> Result<()> {
+    fn orphan_staging_sweep_removes_only_what_passed_the_24h_threshold() -> Result<()> {
         let dir = std::env::temp_dir().join(format!(
             "kesha-part-gc-{}-{}",
             std::process::id(),
@@ -2104,25 +2160,53 @@ mod characterization_tests {
         ));
         fs::create_dir_all(dir.join("models"))?;
         let stale = dir.join("models/encoder.onnx.part.12345");
+        let at_threshold = dir.join("models/joint.onnx.part.4242");
         let fresh = dir.join("models/decoder.onnx.part.999");
         let finished = dir.join("models/encoder.onnx");
-        for p in [&stale, &fresh, &finished] {
+        for p in [&stale, &at_threshold, &fresh, &finished] {
             fs::write(p, b"bytes")?;
         }
-        let old =
-            std::time::SystemTime::now() - std::time::Duration::from_secs(STALE_STAGING_SECS + 60);
-        fs::File::options()
-            .write(true)
-            .open(&stale)?
-            .set_times(fs::FileTimes::new().set_modified(old))?;
+        let now = std::time::SystemTime::now();
+        for (path, age) in [
+            (&stale, STALE_STAGING_SECS + 60),
+            (&at_threshold, STALE_STAGING_SECS),
+        ] {
+            fs::File::options().write(true).open(path)?.set_times(
+                fs::FileTimes::new().set_modified(now - std::time::Duration::from_secs(age)),
+            )?;
+        }
 
         cleanup_orphan_staging(&dir);
 
         assert!(!stale.exists(), "stale staging must be swept");
+        assert!(
+            at_threshold.exists(),
+            "24h is the boundary a download must pass, not reach"
+        );
         assert!(fresh.exists(), "a live installer's fresh staging survives");
         assert!(finished.exists(), "real model files are never touched");
         let _ = fs::remove_dir_all(&dir);
         Ok(())
+    }
+
+    #[test]
+    fn is_cached_resolves_against_the_active_cache_root() {
+        let _lock = crate::util::test_env::lock();
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = crate::util::test_env::EnvGuard::set(
+            "KESHA_CACHE_DIR",
+            tmp.path().to_str().expect("utf-8 temp path"),
+        );
+
+        assert!(!is_cached(ModelKind::LangId), "empty cache is not cached");
+
+        let dir = tmp.path().join(ModelKind::LangId.subdir());
+        fs::create_dir_all(&dir).unwrap();
+        for f in LANG_ID_FILES {
+            let name = std::path::Path::new(f.rel_path).file_name().unwrap();
+            fs::write(dir.join(name), b"dummy").unwrap();
+        }
+        assert!(is_cached(ModelKind::LangId), "staged cache is cached");
     }
 
     /// `Repo.folderName` strips the `-coreml` suffix, and a `…-v3-coreml` sibling
@@ -2472,6 +2556,19 @@ mod retry_tests {
             let delay = backoff_delay(3, None, jitter).as_secs_f64();
             assert!((3.0..=5.0).contains(&delay), "{jitter} produced {delay}s");
         }
+    }
+
+    /// A constant jitter puts the four download workers back in lockstep, which is
+    /// what re-triggers the rate limit the backoff exists to escape (#724).
+    #[test]
+    fn jitter_fraction_is_a_varying_unit_fraction() {
+        let samples: Vec<f64> = (0..1_000).map(|_| jitter_fraction()).collect();
+        for j in &samples {
+            assert!((0.0..1.0).contains(j), "jitter {j} escaped [0, 1)");
+        }
+        let distinct: std::collections::HashSet<u64> =
+            samples.iter().map(|j| j.to_bits()).collect();
+        assert!(distinct.len() > 1, "jitter never varied across 1000 draws");
     }
 
     #[test]


### PR DESCRIPTION
## The mutation lane was scoring a build it never compiled

`ane_voice_lang` was called the worst spot in the file — 8 surviving mutants, "and it has none" for tests. It has one, and a good one: `ane_voice_lang_maps_prefixes_correctly` has been sitting in `characterization_tests` all along, covering all nine prefixes plus both `None` arms.

The lane could not see it. `rust/.cargo/mutants.toml` built with `--features tts`, and `ane_voice_lang` is `#[cfg(all(feature = "system_kokoro", target_os = "macos", target_arch = "aarch64"))]` — so is its test. Under `--features tts` both compile away, so the mutated build stays green and every mutant inside is reported *missed* without a single test having run. Same for `has_diarize_layout`, `is_compiled_mlpackage_sidecar` and `cleanup_diarize_compiled_sidecars` under `system_diarize`, where the existing `cleanup_diarize_sidecars_keeps_current_and_removes_stale` was already strong enough to kill all eight of its mutants.

That is the more useful half of the finding: a cfg'd-out function is not untested, it is *unmeasured*, and mutation testing reports the two identically. The 47% survival figure was inflated by functions the lane never built.

## Layer 1 — make the lane honest

The lane now builds with `tts,system_kokoro,system_diarize`. These are additive features, independent of the `coreml`/`onnx` backend split; `coreml` stays out because it is mutually exclusive with the default `onnx`. Some targets remain `target_os`/`target_arch`-gated on top of the feature, which is fine — the lane runs on maintainer macs.

**One run cannot measure everything, so the feature set is now a knob.** `system_kokoro` cfg-*excludes* the ONNX-Kokoro surfaces, so the widened set trades them away for the ANE and diarize ones — measuring one path means not measuring the other, and no single target does both. The set therefore lives in the Makefile behind a `FEATURES` override rather than in `mutants.toml`: `make mutants-rust FILE=src/models.rs` gets the widened default, `make mutants-rust FILE=src/models.rs FEATURES=tts` gets the ONNX pass. Both matrices are one command each.

The cost is wall-clock: the widened build pulls `diarize_e2e` and `kokoro_rate_e2e` into every mutant run, so the baseline goes from ~8 s to 33 s and the targeted 40-mutant run took 10 min. If that becomes painful the lever is restricting which test binaries the lane runs, not narrowing the features back down.

## Layer 2 — `jitter_fraction` was a live bug, not a coverage hole

The new test failed on its first run, and the test was right. macOS clocks tick at microsecond resolution, so `SystemTime::now().subsec_nanos()` is always a multiple of 1000 — which made `nanos % 1_000` always `0`, and `jitter_fraction()` returned **`0.0` on every call on macOS**. A 10 000-sample probe found zero values not divisible by 1000.

So the ±25% jitter added in #724 has been dead on macOS since it landed: `backoff_delay` collapsed to a constant `0.75 ×` multiplier. That is also why `replace jitter_fraction -> f64 with 0.0` survived — on macOS it was an *equivalent* mutant. The mutation run was reporting a real defect, not a missing assertion.

**Two rounds, two different bugs.** The first fix divided the whole nanosecond count, which cured the constant `0.75 ×` but *not* the lockstep, and grok's adversarial pass caught the difference. A wall-clock fraction is still something all four workers read at the same instant: workers that get 429'd within the same microsecond draw near-identical values, spreading their retries by a fraction of a millisecond. On Linux it was a regression outright — the original `nanos % 1_000` at least gave concurrent workers decorrelated low bits, and the full-subsecond fraction collapsed that.

The second fix draws from `std::collections::hash_map::RandomState`, which re-keys on every construction, mapped to `[0, 1)` via the top 53 bits. Independent per call *and* per thread, no new dependency, no unwrap that can panic. `now_since_epoch` lost its only non-test caller and went with it. `backoff_delay`'s doc comment now states the actual contract — jitter must be drawn per call, not read from anything simultaneous workers share.

## Layer 2 — the tests that were genuinely missing

- **`jitter_fraction`** — four threads released together by a `Barrier`, eight draws each. Every draw asserted inside `[0, 1)`, all 32 asserted distinct, and the max-minus-min spread asserted wide enough to be usable. Range kills the `1.0` / `-1.0` / `%` / `*` / shift mutants; the distinctness assertion kills the `0.0` constant. Sequential variance was never the contract — the workers that matter draw at the same instant, so the test has to as well.
- **`has_diarize_layout`** — tempdir truth table: complete bundle is ready, and each of the four required files removed alone makes it not ready. Kills all three `&&` → `||` mutants and both pinned constants.
- **`is_compiled_mlpackage_sidecar`** — the `.mlpackage.mlmodelc` suffix, plus a bare `.mlpackage`, a bare `.mlmodelc`, and a path with no file name.
- **`is_cached`** — resolves against `KESHA_CACHE_DIR`, asserted empty→false and staged→true. `is_cached_in` was already covered; the public wrapper that reads the active cache root was not.
- **`cleanup_orphan_staging`** — a file whose mtime sits exactly on the 24 h threshold now has to survive, pinning `>` against `>=`. Folded into the existing sweep test so it stays one decision table.
- **`ane_voice_lang`** and **`cleanup_diarize_compiled_sidecars`** — no new tests. Their existing tests kill every mutant; they only needed the lane to compile them.

## Targeted mutation evidence

`cargo mutants --in-place -f src/models.rs --re '<the seven functions>'` on this branch:

```
40 mutants tested in 10m: 40 caught
```

| function | mutants | before (#792 run) | after |
|---|---|---|---|
| `ane_voice_lang` | 11 | 8 missed | **11 caught** |
| `cleanup_diarize_compiled_sidecars` | 8 | 6 missed | **8 caught** |
| `jitter_fraction` | 5 | 4 missed | **5 caught** |
| `has_diarize_layout` | 5 | 3 missed | **5 caught** |
| `cleanup_orphan_staging` | 5 | 1 missed (`>` → `>=`) | **5 caught** |
| `is_cached` (+ `is_cached_in`) | 4 | 2 missed | **4 caught** |
| `is_compiled_mlpackage_sidecar` | 2 | 2 missed | **2 caught** |

Zero missed, zero timeouts, zero unviable. The "before" column is the per-function breakdown quoted in #793 from the full 180-mutant run in #792, not a re-run. `git status` was clean after the in-place run, so the tree was restored intact.

Re-run after the entropy change, since the new implementation generates two extra mutants for its shifts:

```
cargo mutants --in-place -f src/models.rs --features tts,system_kokoro,system_diarize --re jitter_fraction
7 mutants tested in 3m: 7 caught
```

Both `>>` → `<<` and `<<` → `>>` land outside `[0, 1)` (the second divides by zero), so the range assertion takes them; the `0.0` constant dies on the distinctness assertion.

Out of scope per the issue: `ProgressReader::draw` arithmetic, the fs-heavy functions covered by CI integration lanes, and `ErrorCode::title`.

## Verification

- `cargo nextest run --features tts,system_kokoro,system_diarize` — 464 passed, 1 skipped
- `make rust-test` (the `tts` CI lane) — 426 passed
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo clippy --features tts,system_kokoro,system_diarize --all-targets -- -D warnings` — clean
- `cargo check --features coreml --no-default-features` — clean
- `cargo fmt --check` — clean
- `bunx tsc --noEmit` — clean
- `bun test` — 872 pass, 0 fail as of the first commit. It does not pass on my machine now, for a reason outside this PR: the engine at `~/.cache/kesha/engine/bin/kesha-engine` is a 17-byte `#!/bin/sh\nexit 0\n` stub rather than a real binary, so the 20-21 `e2e-engine` / `e2e-transcribe` cases that need a working engine fail. This diff is Rust-only and touches no TypeScript. I confirmed the suite is not what corrupts it — with a sentinel written to that path, `bun test tests/unit/`, `bun test tests/integration/` and a full `bun test` all leave the sentinel intact. Repair with `kesha install`; CI is unaffected since it installs its own engine.

Closes #793
