### PR TITLE
test(engine-install): cover the install decisions mutation testing found bare

### DIFF
--- a/src/engine-install.ts
+++ b/src/engine-install.ts
@@ -1,6 +1,6 @@
-import { dirname, join } from "path";
+import { dirname, join, resolve, sep } from "path";
 import { errorMessage } from "./error-utils";
-import { tmpdir } from "os";
+import { homedir, tmpdir } from "os";
 import { existsSync, mkdirSync, chmodSync, accessSync, constants, rmSync } from "fs";
 import {
   getEngineBinPath,
@@ -560,6 +560,27 @@ function runEngineModelInstall(
   }
 }
 
+/**
+ * Refuses a test-run install that resolves to the developer's real engine cache (#796).
+ *
+ * Redirecting `KESHA_ENGINE_BIN`/`KESHA_CACHE_DIR` is opt-in per test, so a suite that forgets
+ * it overwrites a real multi-GB install with a stub — and does it silently. Bun sets
+ * `NODE_ENV=test` only under `bun test`, so this fires exactly there and nowhere else; it is
+ * checked against `homedir()` rather than `keshaCacheDir()` so an isolated cache never trips it.
+ */
+export function assertNotRealCacheUnderTest(binPath: string): void {
+  if (process.env.NODE_ENV !== "test") return;
+  const realCache = resolve(join(homedir(), ".cache", "kesha"));
+  if (!resolve(binPath).startsWith(realCache + sep)) return;
+  throw new Error(
+    `Refusing to install the engine into ${binPath} during a test run: that is the real ` +
+      "per-user cache, and writing there destroys the developer's install (#796).\n" +
+      "  Fix: call isolateEngineCache() from tests/helpers/fake-engine.ts in beforeEach, or set " +
+      "KESHA_ENGINE_BIN to a temp path.\n" +
+      "  If this is not a test run, unset NODE_ENV — Bun sets NODE_ENV=test under `bun test`.",
+  );
+}
+
 export interface EngineInstallRequest extends InstallOptions {
   noCache?: boolean;
   backend?: string;
@@ -577,6 +598,7 @@ export interface EngineInstallRequest extends InstallOptions {
 export async function installEngine(request: EngineInstallRequest = {}): Promise<string> {
   const { noCache = false, backend, version = engineVersion, ...options } = request;
   const binPath = getEngineBinPath();
+  assertNotRealCacheUnderTest(binPath);
   const installedVersion = readInstalledEngineVersion(binPath);
   const engineDir = dirname(binPath);
 

--- a/tests/helpers/fake-engine.ts
+++ b/tests/helpers/fake-engine.ts
@@ -1,4 +1,5 @@
-import { chmodSync, mkdirSync, writeFileSync } from "fs";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
 import { join } from "path";
 
 const ENGINE_ENV = ["KESHA_ENGINE_BIN", "KESHA_CACHE_DIR", "HOME", "KESHA_MODEL_MIRROR"] as const;
@@ -11,6 +12,25 @@ export function saveEngineEnv(): () => void {
       if (value === undefined) delete process.env[key];
       else process.env[key] = value;
     }
+  };
+}
+
+/**
+ * Redirects the whole engine cache into a throwaway dir for one test, and returns the undo.
+ *
+ * #796: pointing `KESHA_ENGINE_BIN` at a temp path is opt-in per test, so a test that reaches
+ * `installEngine` before staging one falls back to `~/.cache/kesha` and overwrites the
+ * developer's real engine. Overriding `KESHA_CACHE_DIR` makes that fallback harmless instead
+ * of relying on every test to remember.
+ */
+export function isolateEngineCache(): () => void {
+  const restore = saveEngineEnv();
+  const dir = mkdtempSync(join(tmpdir(), "kesha-cache-isolated-"));
+  process.env.KESHA_CACHE_DIR = dir;
+  delete process.env.KESHA_ENGINE_BIN;
+  return () => {
+    restore();
+    rmSync(dir, { recursive: true, force: true });
   };
 }
 

--- a/tests/unit/engine-install-decisions.test.ts
+++ b/tests/unit/engine-install-decisions.test.ts
@@ -1,0 +1,334 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "fs";
+import { dirname, join } from "path";
+import { tmpdir } from "os";
+import { getEngineBinaryName, installEngine, SIDECARS } from "../../src/engine-install";
+import { isDarwinArm64 } from "../../src/fluid-kokoro-cache";
+import { engineVersion } from "../../src/package-info";
+import { isolateEngineCache } from "../helpers/fake-engine";
+
+const DIARIZE_CAPS = {
+  protocolVersion: 3,
+  backend: "coreml",
+  features: ["tts", "transcribe.diarize"],
+};
+const PLAIN_CAPS = { protocolVersion: 3, backend: "onnx", features: ["tts"] };
+
+interface EngineStub {
+  caps?: Record<string, unknown> | null;
+  installExit?: number;
+  sayExit?: number;
+}
+
+/**
+ * A shell stub answering the three things `installEngine` asks of a real engine:
+ * `--capabilities-json`, `install`, and `say` (the Kokoro warmup). Each invocation appends
+ * its argv to `argvLog`, so a test can state what the engine was asked to do.
+ *
+ * The log path is baked into the script rather than read from the environment: Bun.spawn
+ * snapshots the environment at process start, so a `process.env` key set inside a test never
+ * reaches the child.
+ */
+function engineScript({ caps = PLAIN_CAPS, installExit = 0, sayExit = 0 }: EngineStub = {}): string {
+  const capsCase = caps
+    ? `  --capabilities-json) printf '%s\\n' '${JSON.stringify(caps)}'; exit 0 ;;\n`
+    : `  --capabilities-json) exit 2 ;;\n`;
+  return (
+    `#!/bin/sh\n` +
+    `echo "$*" >> '${argvLog}'\n` +
+    `case "$1" in\n` +
+    capsCase +
+    `  install) exit ${installExit} ;;\n` +
+    `  say) exit ${sayExit} ;;\n` +
+    `esac\n` +
+    `exit 0\n`
+  );
+}
+
+const savedFetch = globalThis.fetch;
+const tempDirs: string[] = [];
+let releaseCacheIsolation: () => void = () => {};
+let argvLog = "";
+
+const posixTest = process.platform === "win32" ? test.skip : test;
+/** The Kokoro warmup and the sidecars only ever run on darwin-arm64. */
+const darwinArmTest = isDarwinArm64() ? test : test.skip;
+
+beforeEach(() => {
+  releaseCacheIsolation = isolateEngineCache();
+  const dir = mkdtempSync(join(tmpdir(), "kesha-argv-log-"));
+  tempDirs.push(dir);
+  argvLog = join(dir, "argv.log");
+});
+
+afterEach(() => {
+  globalThis.fetch = savedFetch;
+  releaseCacheIsolation();
+  for (const dir of tempDirs.splice(0)) {
+    try {
+      chmodSync(join(dir, "bin"), 0o755);
+    } catch {
+      // only the read-only case created that directory
+    }
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+/** Every argv the engine stub was invoked with, in order. */
+function engineInvocations(): string[] {
+  if (!existsSync(argvLog)) return [];
+  return readFileSync(argvLog, "utf8").split("\n").filter(Boolean);
+}
+
+/** Stages a cache-valid install: right version, runnable engine, healthy sidecars. */
+function stageInstalledEngine(prefix: string, stub: EngineStub = {}): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  const binPath = join(dir, "bin", "kesha-engine");
+  mkdirSync(join(dir, "bin"), { recursive: true });
+  writeFileSync(binPath, engineScript(stub));
+  chmodSync(binPath, 0o755);
+  writeFileSync(`${binPath}.version`, `${engineVersion}\n`);
+  // A sidecar that cannot run is re-downloaded on every cache hit (#770), which would
+  // drag an unrelated fetch into these tests.
+  for (const spec of SIDECARS) {
+    const path = join(dir, "bin", spec.fileBasename);
+    writeFileSync(path, "#!/bin/sh\nexit 0\n");
+    chmodSync(path, 0o755);
+  }
+  process.env.KESHA_ENGINE_BIN = binPath;
+  return binPath;
+}
+
+/** Points KESHA_ENGINE_BIN at an empty dir so the install has to download. */
+function stageEmptyEngineDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  const binPath = join(dir, "bin", "kesha-engine");
+  mkdirSync(join(dir, "bin"), { recursive: true });
+  process.env.KESHA_ENGINE_BIN = binPath;
+  return binPath;
+}
+
+/** Serves a working engine for every release asset, recording the URLs asked for. */
+function stubRelease(stub: EngineStub = {}): string[] {
+  const urls: string[] = [];
+  const body = engineScript(stub);
+  globalThis.fetch = (async (input: Request | URL | string) => {
+    urls.push(String(input instanceof Request ? input.url : input));
+    return new Response(body, {
+      status: 200,
+      headers: { "content-length": String(Buffer.byteLength(body)) },
+    });
+  }) as typeof fetch;
+  return urls;
+}
+
+function engineDownloads(urls: string[]): string[] {
+  const binaryName = getEngineBinaryName();
+  return urls.filter((u) => u.endsWith(binaryName));
+}
+
+// The developer's real ~/.cache/kesha was overwritten with a test stub because pointing
+// KESHA_ENGINE_BIN at a temp path is opt-in per test, and the fallback is the real cache.
+describe("an install only ever writes where it was pointed (#796)", () => {
+  posixTest("with no KESHA_ENGINE_BIN it installs under KESHA_CACHE_DIR", async () => {
+    delete process.env.KESHA_ENGINE_BIN;
+    const cacheDir = process.env.KESHA_CACHE_DIR!;
+    // Also the cold-install case: nothing under the cache dir exists yet, so the install
+    // has to create the engine dir rather than refuse it as unwritable.
+    expect(existsSync(join(cacheDir, "engine"))).toBe(false);
+    stubRelease();
+
+    await installEngine();
+
+    expect(readFileSync(join(cacheDir, "engine", "bin", "kesha-engine"), "utf8")).toContain(
+      "#!/bin/sh",
+    );
+  }, 30_000);
+});
+
+describe("capabilities gate the flags forwarded to the engine (#772)", () => {
+  posixTest("a backend the installed engine does not provide fails by name", async () => {
+    stageInstalledEngine("kesha-caps-backend-mismatch-");
+    stubRelease();
+
+    await expect(installEngine({ backend: "coreml" })).rejects.toThrow(/coreml.*onnx|onnx.*coreml/s);
+    expect(engineInvocations().some((a) => a.startsWith("install"))).toBe(false);
+  }, 30_000);
+
+  posixTest("the backend the engine reports is accepted", async () => {
+    stageInstalledEngine("kesha-caps-backend-match-");
+    stubRelease();
+
+    await installEngine({ backend: "onnx" });
+
+    expect(engineInvocations().some((a) => a.startsWith("install"))).toBe(true);
+  }, 30_000);
+
+  posixTest("--diarize on an engine built without it names the missing feature", async () => {
+    stageInstalledEngine("kesha-caps-no-diarize-");
+    stubRelease();
+
+    await expect(installEngine({ diarize: true })).rejects.toThrow(/system_diarize/);
+    expect(engineInvocations().some((a) => a.startsWith("install"))).toBe(false);
+  }, 30_000);
+
+  // A pre-capabilities engine cannot be asked, and forwarding --diarize blind would surface
+  // as clap's generic "unexpected argument".
+  posixTest("--diarize is refused when the engine cannot describe itself", async () => {
+    stageInstalledEngine("kesha-caps-silent-", { caps: null });
+    stubRelease();
+
+    await expect(installEngine({ diarize: true })).rejects.toThrow(/system_diarize/);
+    expect(engineInvocations().some((a) => a.startsWith("install"))).toBe(false);
+  }, 30_000);
+
+  posixTest("--diarize reaches the engine, and pulls --vad with it (#768)", async () => {
+    stageInstalledEngine("kesha-caps-diarize-", { caps: DIARIZE_CAPS });
+    stubRelease();
+
+    await installEngine({ diarize: true });
+
+    const install = engineInvocations().find((a) => a.startsWith("install"));
+    expect(install).toContain("--diarize");
+    expect(install).toContain("--vad");
+  }, 30_000);
+});
+
+describe("a failing model install is not reported as success", () => {
+  posixTest("the engine's exit code reaches the caller", async () => {
+    stageInstalledEngine("kesha-model-install-fails-", { installExit: 42 });
+    stubRelease();
+
+    await expect(installEngine()).rejects.toThrow(/42/);
+  }, 30_000);
+});
+
+describe("cache validity (#775)", () => {
+  posixTest("--no-cache re-downloads an engine the marker vouches for", async () => {
+    stageInstalledEngine("kesha-nocache-writable-");
+    const urls = stubRelease();
+
+    await installEngine({ noCache: true });
+
+    expect(engineDownloads(urls)).toHaveLength(1);
+  }, 30_000);
+
+  posixTest("without --no-cache the same install downloads nothing", async () => {
+    stageInstalledEngine("kesha-nocache-off-");
+    const urls = stubRelease();
+
+    await installEngine();
+
+    expect(engineDownloads(urls)).toHaveLength(0);
+  }, 30_000);
+
+  // On a read-only engine dir --no-cache cannot re-download, and turning that into a hard
+  // error would break the Nix-store install, which is read-only by construction.
+  posixTest("--no-cache on a read-only engine dir keeps the cached binary", async () => {
+    if (process.getuid?.() === 0) return; // root writes through the mode bits
+    const binPath = stageInstalledEngine("kesha-nocache-readonly-");
+    chmodSync(dirname(binPath), 0o555);
+    const urls = stubRelease();
+
+    await installEngine({ noCache: true });
+
+    expect(engineDownloads(urls)).toHaveLength(0);
+    // The flag is still forwarded: only the engine binary is uncacheable here, not the models.
+    expect(engineInvocations().find((a) => a.startsWith("install"))).toContain("--no-cache");
+  }, 30_000);
+});
+
+describe("a download that never starts", () => {
+  posixTest("a fetch that throws blames the network and keeps the old binary", async () => {
+    const binPath = stageEmptyEngineDir("kesha-fetch-throws-");
+    writeFileSync(binPath, "previous engine");
+    writeFileSync(`${binPath}.version`, "1.0.0\n");
+    globalThis.fetch = (async (_input: Request | URL | string): Promise<Response> => {
+      throw new Error("getaddrinfo ENOTFOUND github.com");
+    }) as typeof fetch;
+
+    await expect(installEngine()).rejects.toThrow(/network connection/);
+
+    expect(readFileSync(binPath, "utf8")).toBe("previous engine");
+  }, 30_000);
+});
+
+describe("Kokoro warmup follows the languages asked for", () => {
+  darwinArmTest("a Russian-only install warms nothing — ru routes through Vosk", async () => {
+    stageInstalledEngine("kesha-warm-ru-");
+    stubRelease();
+
+    await installEngine({ ttsLangs: ["ru"] });
+
+    expect(engineInvocations().some((a) => a.startsWith("say"))).toBe(false);
+  }, 60_000);
+
+  darwinArmTest("an English install warms the Kokoro cache", async () => {
+    stageInstalledEngine("kesha-warm-en-");
+    stubRelease();
+
+    await installEngine({ ttsLangs: ["en"] });
+
+    expect(engineInvocations().some((a) => a.startsWith("say"))).toBe(true);
+  }, 60_000);
+
+  // The warmup is an optimisation; a failing one must not cost the user their install.
+  darwinArmTest("a warmup that fails leaves the install successful", async () => {
+    stageInstalledEngine("kesha-warm-fails-", { sayExit: 3 });
+    stubRelease();
+
+    await installEngine({ ttsLangs: ["en"] });
+
+    expect(engineInvocations().some((a) => a.startsWith("say"))).toBe(true);
+  }, 60_000);
+});
+
+describe("sidecar failures cannot fail the engine install", () => {
+  darwinArmTest("a sidecar that 404s still leaves a working engine", async () => {
+    const binPath = stageEmptyEngineDir("kesha-sidecar-404-");
+    const body = engineScript();
+    const binaryName = getEngineBinaryName();
+    globalThis.fetch = (async (input: Request | URL | string) => {
+      const url = String(input instanceof Request ? input.url : input);
+      return url.endsWith(binaryName)
+        ? new Response(body, {
+            status: 200,
+            headers: { "content-length": String(Buffer.byteLength(body)) },
+          })
+        : new Response("Not Found", { status: 404 });
+    }) as typeof fetch;
+
+    await installEngine();
+
+    expect(existsSync(binPath)).toBe(true);
+    expect(existsSync(join(dirname(binPath), SIDECARS[0]!.fileBasename))).toBe(false);
+  }, 60_000);
+
+  darwinArmTest("a sidecar whose fetch throws still leaves a working engine", async () => {
+    const binPath = stageEmptyEngineDir("kesha-sidecar-throws-");
+    const body = engineScript();
+    const binaryName = getEngineBinaryName();
+    globalThis.fetch = (async (input: Request | URL | string) => {
+      const url = String(input instanceof Request ? input.url : input);
+      if (!url.endsWith(binaryName)) throw new Error("socket hang up");
+      return new Response(body, {
+        status: 200,
+        headers: { "content-length": String(Buffer.byteLength(body)) },
+      });
+    }) as typeof fetch;
+
+    await installEngine();
+
+    expect(existsSync(binPath)).toBe(true);
+  }, 60_000);
+});

--- a/tests/unit/engine-install-decisions.test.ts
+++ b/tests/unit/engine-install-decisions.test.ts
@@ -6,11 +6,17 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "fs";
 import { dirname, join } from "path";
-import { tmpdir } from "os";
-import { getEngineBinaryName, installEngine, SIDECARS } from "../../src/engine-install";
+import { homedir, tmpdir } from "os";
+import {
+  assertNotRealCacheUnderTest,
+  getEngineBinaryName,
+  installEngine,
+  SIDECARS,
+} from "../../src/engine-install";
 import { isDarwinArm64 } from "../../src/fluid-kokoro-cache";
 import { engineVersion } from "../../src/package-info";
 import { isolateEngineCache } from "../helpers/fake-engine";
@@ -28,6 +34,11 @@ interface EngineStub {
   sayExit?: number;
 }
 
+/** POSIX single-quote escape, so a quote in the JSON or the path cannot end the sh literal. */
+function shQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
 /**
  * A shell stub answering the three things `installEngine` asks of a real engine:
  * `--capabilities-json`, `install`, and `say` (the Kokoro warmup). Each invocation appends
@@ -39,11 +50,11 @@ interface EngineStub {
  */
 function engineScript({ caps = PLAIN_CAPS, installExit = 0, sayExit = 0 }: EngineStub = {}): string {
   const capsCase = caps
-    ? `  --capabilities-json) printf '%s\\n' '${JSON.stringify(caps)}'; exit 0 ;;\n`
+    ? `  --capabilities-json) printf '%s\\n' ${shQuote(JSON.stringify(caps))}; exit 0 ;;\n`
     : `  --capabilities-json) exit 2 ;;\n`;
   return (
     `#!/bin/sh\n` +
-    `echo "$*" >> '${argvLog}'\n` +
+    `echo "$*" >> ${shQuote(argvLog)}\n` +
     `case "$1" in\n` +
     capsCase +
     `  install) exit ${installExit} ;;\n` +
@@ -137,6 +148,14 @@ function engineDownloads(urls: string[]): string[] {
   return urls.filter((u) => u.endsWith(binaryName));
 }
 
+/** Read-only view of the developer's real engine, to prove a test run never touched it (#796). */
+function realEngineSnapshot(): { exists: boolean; size?: number; mtimeMs?: number } {
+  const real = join(homedir(), ".cache", "kesha", "engine", "bin", "kesha-engine");
+  if (!existsSync(real)) return { exists: false };
+  const s = statSync(real);
+  return { exists: true, size: s.size, mtimeMs: s.mtimeMs };
+}
+
 // The developer's real ~/.cache/kesha was overwritten with a test stub because pointing
 // KESHA_ENGINE_BIN at a temp path is opt-in per test, and the fallback is the real cache.
 describe("an install only ever writes where it was pointed (#796)", () => {
@@ -154,42 +173,81 @@ describe("an install only ever writes where it was pointed (#796)", () => {
       "#!/bin/sh",
     );
   }, 30_000);
+
+  // The adversarial half: isolation is opt-in, so prove that forgetting it fails loudly
+  // rather than reaching ~/.cache/kesha. This is the automated proof the hole is closed.
+  posixTest("a test that forgets to isolate is refused, not silently served", async () => {
+    delete process.env.KESHA_ENGINE_BIN;
+    delete process.env.KESHA_CACHE_DIR;
+    const before = realEngineSnapshot();
+    stubRelease();
+
+    await expect(installEngine()).rejects.toThrow(/real\s+per-user cache/);
+
+    expect(realEngineSnapshot()).toEqual(before);
+  }, 30_000);
+
+  posixTest("the guard leaves a redirected cache alone", () => {
+    expect(() =>
+      assertNotRealCacheUnderTest(join(process.env.KESHA_CACHE_DIR!, "engine", "bin", "kesha-engine")),
+    ).not.toThrow();
+  });
+
+  // The guard must not cost a real user their install: outside `bun test` it is inert, even
+  // for the very path it refuses under one.
+  posixTest("outside a test run the real cache is allowed", () => {
+    const realBin = join(homedir(), ".cache", "kesha", "engine", "bin", "kesha-engine");
+    expect(() => assertNotRealCacheUnderTest(realBin)).toThrow(/real\s+per-user cache/);
+
+    const saved = process.env.NODE_ENV;
+    delete process.env.NODE_ENV;
+    try {
+      expect(() => assertNotRealCacheUnderTest(realBin)).not.toThrow();
+    } finally {
+      if (saved === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = saved;
+    }
+  });
 });
 
 describe("capabilities gate the flags forwarded to the engine (#772)", () => {
   posixTest("a backend the installed engine does not provide fails by name", async () => {
-    stageInstalledEngine("kesha-caps-backend-mismatch-");
+    const binPath = stageInstalledEngine("kesha-caps-backend-mismatch-");
+    const before = readFileSync(binPath, "utf8");
     stubRelease();
 
     await expect(installEngine({ backend: "coreml" })).rejects.toThrow(/coreml.*onnx|onnx.*coreml/s);
-    expect(engineInvocations().some((a) => a.startsWith("install"))).toBe(false);
+
+    expect(readFileSync(binPath, "utf8")).toBe(before);
   }, 30_000);
 
   posixTest("the backend the engine reports is accepted", async () => {
-    stageInstalledEngine("kesha-caps-backend-match-");
+    const binPath = stageInstalledEngine("kesha-caps-backend-match-");
     stubRelease();
 
-    await installEngine({ backend: "onnx" });
-
-    expect(engineInvocations().some((a) => a.startsWith("install"))).toBe(true);
+    expect(await installEngine({ backend: "onnx" })).toBe(binPath);
   }, 30_000);
 
   posixTest("--diarize on an engine built without it names the missing feature", async () => {
-    stageInstalledEngine("kesha-caps-no-diarize-");
+    const binPath = stageInstalledEngine("kesha-caps-no-diarize-");
+    const before = readFileSync(binPath, "utf8");
     stubRelease();
 
     await expect(installEngine({ diarize: true })).rejects.toThrow(/system_diarize/);
-    expect(engineInvocations().some((a) => a.startsWith("install"))).toBe(false);
+
+    expect(readFileSync(binPath, "utf8")).toBe(before);
   }, 30_000);
 
   // A pre-capabilities engine cannot be asked, and forwarding --diarize blind would surface
   // as clap's generic "unexpected argument".
   posixTest("--diarize is refused when the engine cannot describe itself", async () => {
-    stageInstalledEngine("kesha-caps-silent-", { caps: null });
+    const binPath = stageInstalledEngine("kesha-caps-silent-", { caps: null });
+    const before = readFileSync(binPath, "utf8");
     stubRelease();
 
     await expect(installEngine({ diarize: true })).rejects.toThrow(/system_diarize/);
-    expect(engineInvocations().some((a) => a.startsWith("install"))).toBe(false);
+
+    expect(readFileSync(binPath, "utf8")).toBe(before);
   }, 30_000);
 
   posixTest("--diarize reaches the engine, and pulls --vad with it (#768)", async () => {
@@ -257,7 +315,8 @@ describe("a download that never starts", () => {
       throw new Error("getaddrinfo ENOTFOUND github.com");
     }) as typeof fetch;
 
-    await expect(installEngine()).rejects.toThrow(/network connection/);
+    // The cause has to survive: "download failed" without the DNS failure is not actionable.
+    await expect(installEngine()).rejects.toThrow(/ENOTFOUND/);
 
     expect(readFileSync(binPath, "utf8")).toBe("previous engine");
   }, 30_000);

--- a/tests/unit/engine-repair.test.ts
+++ b/tests/unit/engine-repair.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
 import { tmpdir } from "os";
@@ -8,6 +8,7 @@ import { probeExecutable } from "../../src/engine-health";
 import { getEngineCapabilities } from "../../src/engine";
 import { isDarwinArm64 } from "../../src/fluid-kokoro-cache";
 import { engineVersion } from "../../src/package-info";
+import { isolateEngineCache } from "../helpers/fake-engine";
 
 // #770: an interrupted `kesha install` left a truncated binary that the kernel refuses to
 // load, while the `.version` marker still vouched for it. Every repair path then failed.
@@ -16,18 +17,21 @@ const WORKING_ENGINE = "#!/bin/sh\nexit 0\n";
 /** Mode 0o755 but not a loadable image: `posix_spawn` fails with ENOEXEC, as on a truncated Mach-O. */
 const CORRUPT_ENGINE = "\x7fELF\x00\x01\x02truncated";
 
-const savedEnv = { KESHA_ENGINE_BIN: process.env.KESHA_ENGINE_BIN };
 const savedFetch = globalThis.fetch;
 const tempDirs: string[] = [];
+let releaseCacheIsolation: () => void = () => {};
 
 const posixTest = process.platform === "win32" ? test.skip : test;
 /** Sidecars are only ever fetched on darwin-arm64, so only there can their repair be observed. */
 const sidecarTest = isDarwinArm64() ? test : test.skip;
 
+beforeEach(() => {
+  releaseCacheIsolation = isolateEngineCache();
+});
+
 afterEach(() => {
   globalThis.fetch = savedFetch;
-  if (savedEnv.KESHA_ENGINE_BIN === undefined) delete process.env.KESHA_ENGINE_BIN;
-  else process.env.KESHA_ENGINE_BIN = savedEnv.KESHA_ENGINE_BIN;
+  releaseCacheIsolation();
   for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
 });
 

--- a/tests/unit/engine-version-override.test.ts
+++ b/tests/unit/engine-version-override.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { accessSync, chmodSync, constants, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
@@ -11,21 +11,25 @@ import {
 } from "../../src/engine-install";
 import { resolveEngineVersionFlag } from "../../src/cli/install";
 import { engineVersion } from "../../src/package-info";
+import { isolateEngineCache } from "../helpers/fake-engine";
 
 const OVERRIDE = "9.9.9-alpha.1";
 const FAKE_ENGINE = "#!/bin/sh\nexit 0\n";
 
-const savedEnv = { KESHA_ENGINE_BIN: process.env.KESHA_ENGINE_BIN };
 const savedFetch = globalThis.fetch;
 const tempDirs: string[] = [];
+let releaseCacheIsolation: () => void = () => {};
 
 // The fake engine is a shell script, which Windows cannot spawn.
 const posixTest = process.platform === "win32" ? test.skip : test;
 
+beforeEach(() => {
+  releaseCacheIsolation = isolateEngineCache();
+});
+
 afterEach(() => {
   globalThis.fetch = savedFetch;
-  if (savedEnv.KESHA_ENGINE_BIN === undefined) delete process.env.KESHA_ENGINE_BIN;
-  else process.env.KESHA_ENGINE_BIN = savedEnv.KESHA_ENGINE_BIN;
+  releaseCacheIsolation();
   for (const dir of tempDirs.splice(0)) {
     try {
       chmodSync(join(dir, "bin"), 0o755);


### PR DESCRIPTION
Stage 1 of #794: close the mutation-testing gaps in `src/engine-install.ts`, the worst-scoring module in the repo and the one that downloads the engine, verifies it, repairs sidecars and decides what to reinstall.

`Refs #794`

## Stryker: before / after

Both runs mutate `src/engine-install.ts` with `bun.testFiles` paired to every importer, via `./node_modules/.bin/stryker` (not `bunx`). The "after" pairing adds the new file.

| | before | after |
| --- | ---: | ---: |
| **Mutation score** | **32.52%** | **64.81%** |
| Killed | 133 | 167 |
| Timeout | 1 | 100 |
| Survived | 148 | 92 |
| No coverage | 130 | 53 |
| Errors | 4 | 4 |

**Read the after-score as ~62%, not 64.81%.** Stryker counts Timeout as detected, and 12 of those 100 timeouts are an artifact, not a kill: they are *static* mutants (module-level `GITHUB_REPO`, the `SIDECARS` display strings, `RETIRED_SIDECAR_FILENAMES`), which Stryker cannot attribute per-test and instead re-runs the whole paired suite for. The new file takes ~16 s, which pushes those over the budget — `WARN MutantTestPlanner Detected 6 static mutants … estimated to take 100% of the time`. Scored with all 12 treated as survivors it is **61.89%**. The other 88 timeouts are ordinary in-function mutants; spot-checking lines 345 and 626–627 (survivors at baseline) gives 6 killed / 7 timeout / 0 survived, so those are real detections. Reproduced identically at `concurrency: 1` and `2`.

The unambiguous number is **no-coverage: 130 → 53**. That was the module's "surface never reached" half, and it is mostly gone.

Line coverage of `src/engine-install.ts` went **69.32% → 91.29%** (darwin, local). I did **not** raise the 15% floor: the Kokoro-warmup and sidecar tests are darwin-arm64-only and skip on `ts-coverage`'s `ubuntu-latest` runner, so the CI number is lower than the local one and I have no ubuntu measurement to set a safe floor from.

## The #796 isolation hole — found and fixed

**This is the most valuable part of the diff.** Staging an engine path was opt-in *per test*: `stageEngine()` / `stageEngineDir()` set `KESHA_ENGINE_BIN` inside each test body, and `getEngineBinPath()` falls back to `~/.cache/kesha` when it is unset. Nothing forced the override, so any test reaching `installEngine` before staging one — or a new test that simply forgets — writes a fake engine over the developer's real install. That is exactly the 17-byte `#!/bin/sh\nexit 0\n` stub found in #796, which is byte-for-byte the `WORKING_ENGINE` / `FAKE_ENGINE` constant these suites download.

Two layers, because review was right that the first one alone is still opt-in:

**1. Test-side redirect.** `isolateEngineCache()` (in `tests/helpers/fake-engine.ts`) points `KESHA_CACHE_DIR` at a throwaway dir in `beforeEach`, so the *fallback* is harmless. Wired into both suites that call `installEngine`.

**2. Production guard — the load-bearing half.** `assertNotRealCacheUnderTest()` refuses at the `installEngine` entry when `NODE_ENV === "test"` **and** the resolved binary sits under `~/.cache/kesha`. Bun sets `NODE_ENV=test` only under `bun test` (verified empirically: plain `bun run` leaves it undefined), so it fires exactly there and nowhere else, and it compares against `homedir()` rather than `keshaCacheDir()` so a redirected cache never trips it. This is what makes the class closed rather than the instance: a future test that forgets isolation now fails loudly instead of clobbering silently, including under an in-process `--concurrent` runner where env-restore would race.

The regression test has an adversarial half: it deliberately drops both overrides and asserts the install is refused and the real engine is byte-identical afterwards. A second test pins that the guard is inert with `NODE_ENV` unset, so it cannot cost a real user their install.

**Residual contract.** Isolation is safe under the sequential and process-parallel runners this repo uses. Under a hypothetical in-process `--concurrent` runner, `beforeEach`/`afterEach` env restore would race between tests — the guard is what catches that case, loudly, rather than the redirect.

To be explicit about what I could not show: the current suite does **not** reproduce #796 on its own — `~/.cache/kesha/engine/bin` stayed untouched across four full `bun test` runs and ~1100 Stryker mutant runs. So this closes the structural hole rather than a demonstrated live bug.

One incident worth recording, since it validates both the guard and the detector: while proving the guard was load-bearing I inverted its path condition locally, which let the adversarial test through to the real cache. The only effect was `codesign --force --sign -` idempotently re-signing two already-adhoc sidecars — byte-for-byte identical content, new inode and mtime. The inode+mtime detector caught it; a content hash would not have.

## What is now pinned, by cluster

- **Capabilities gate (#772)** — was 100% no-coverage. `--backend` mismatch fails naming both backends; `--diarize` is refused both when the engine lacks `system_diarize` *and* when it cannot describe itself at all; neither reaches the engine's `install`. When the feature is present, `--diarize` arrives with `--vad` (#768).
- **Model-install failure** — a non-zero `kesha-engine install` propagates with its exit code instead of being reported as success.
- **Cache validity (#775)** — `--no-cache` re-downloads a marker-valid engine; without it nothing downloads; on a read-only engine dir the binary is kept and the flag is still forwarded to the model install.
- **Network failure** — a `fetch` that throws blames the network and leaves the previous binary intact.
- **Kokoro warmup** — a Russian-only install warms nothing (`ru` routes through Vosk); an English one warms; a warmup that exits non-zero does not cost the user the install. `warmDarwinKokoro` was ~50 no-coverage mutants.
- **Sidecar isolation** — a sidecar that 404s or whose fetch throws still leaves a working engine.
- **Cold install** — a non-existent engine dir is created rather than refused as unwritable.
- **The guard itself** — refuses a real-cache target under test, allows a redirected one, and is inert outside a test run. Verified load-bearing by inverting its path condition, which fails all 19 tests in the file.

## Review fixes in the second commit

- **grok P2 / production guard** — above.
- **grok P2 / adversarial regression test** — above.
- **Greptile inline / shell escaping** — the generated `sh` stub now routes the serialized capabilities *and* the log path through a POSIX single-quote escape, so a quote in either cannot terminate the literal.
- **grok P3 / Beck bar** — dropped the `engineInvocations().some(a => a.startsWith("install"))` call-existence spies; the rejection cases now assert "rejected **and** the binary is unchanged", and the accepting case asserts `installEngine` resolves to the installed path. Replaced the `/network connection/` prose match with `/ENOTFOUND/` — the propagated cause, which is the part that has to survive for the error to be actionable. The argv assertions that remain are contracts, not spies: `--diarize` pulling `--vad` (#768) and `--no-cache` still reaching the model install on a read-only engine dir.

## Deliberately left alive

- `trustStep` / `darwinTrustBinary` internals (~30 mutants) — killing these means asserting real `codesign`/`xattr` outcomes, which vary by machine and Gatekeeper state. Both are unexported and best-effort by design.
- `waitUntilSpawnable`'s backoff and its "still locked after Ns" message (~15) — reaching them needs a probe that reliably returns `EBUSY`/`ETXTBSY`, which cannot be produced deterministically on macOS. `windows-engine-smoke` exercises the real path.
- Log and error *prose* literals throughout — killing them means asserting stderr text, which CLAUDE.md's Beck bar rejects as structure-sensitive. Assertions here name the actionable part (the exit code, the missing feature, "network connection") and not the sentence around it.
- The 12 static mutants above — killable only by pinning exact release-asset URLs or exact log prose, same objection.

## Verification

- `bun test` — 867 pass, 7 skip, **19 fail**, all pre-existing: `e2e-engine`, `e2e-transcribe`, `e2e-lang-detection` and `mcp-e2e` fail on this machine because the installed engine is the #796 stub. Baseline on `origin/main` before any change was the same 19 plus one `cli-contracts` install-timeout flake that did not recur. Unit + integration are 0 fail.
- `bunx tsc --noEmit` — clean.
- `bun run coverage:check:ts` — passes; all four floors met.
- No `rust/` changes.
- `~/.cache/kesha/engine/bin` verified untouched (inode + size + nanosecond mtime) after every suite and Stryker run — a stronger check than a content hash, which would miss a byte-identical rewrite.

## Note for stage 2

`bun test` writes nothing to the real cache today, but a slow paired test file silently degrades Stryker's static-mutant handling into timeouts that score as kills. Worth watching when status/doctor/stats get the same treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBTpJjqyYFW6W8LHJ2nwy
