### PR TITLE
test(mutation): close the assertion gaps in status, doctor and stats (#794)

### DIFF
--- a/tests/unit/doctor.test.ts
+++ b/tests/unit/doctor.test.ts
@@ -8,9 +8,11 @@ import {
   engineVersionState,
   formatDoctorReport,
   redactDiagnosticValue,
+  type DoctorReport,
 } from "../../src/doctor";
 import { createSupportBundle } from "../../src/support-bundle";
-import { engineVersion } from "../../src/package-info";
+import { engineVersion, packageName, packageVersion } from "../../src/package-info";
+import { enableStats } from "../../src/stats";
 
 const fakeCapabilities = {
   protocolVersion: 2,
@@ -71,6 +73,20 @@ describe("redactDiagnosticValue", () => {
   test("leaves malformed URL-like values unchanged", () => {
     expect(redactDiagnosticValue("KESHA_MODEL_MIRROR", "https://[broken", "/tmp/home")).toBe(
       "https://[broken",
+    );
+  });
+
+  test("a value that never mentions home is handed back byte for byte", () => {
+    expect(redactDiagnosticValue("KESHA_CACHE_DIR", "/srv/kesha/", "/tmp/home")).toBe("/srv/kesha/");
+  });
+
+  test("with no home directory known, nothing is rewritten as one", () => {
+    expect(redactDiagnosticValue("KESHA_CACHE_DIR", "/srv/kesha", "")).toBe("/srv/kesha");
+  });
+
+  posixEngineTest("a directory that only differs in case is a different directory", () => {
+    expect(redactDiagnosticValue("KESHA_CACHE_DIR", "/tmp/Home/cache", "/tmp/home")).toBe(
+      "/tmp/Home/cache",
     );
   });
 });
@@ -265,6 +281,12 @@ describe("collectDoctorReport", () => {
       expect(report.diagnosticLogs.statePath).toBe("~/logs/diagnostic-logs.json");
       expect(report.diagnosticLogs.exists).toBe(false);
       expect(report.diagnosticLogs.totalSizeBytes).toBe(0);
+      // An unreadable directory still has to report the configuration in force, or the
+      // report reads as if rotation were off.
+      expect(report.diagnosticLogs.mode).toBe("retain-on-failure");
+      expect(report.diagnosticLogs.maxBytes).toBe(10 * 1024 * 1024);
+      expect(report.diagnosticLogs.retain).toBe(5);
+      expect(report.diagnosticLogs.rotatedFiles).toEqual([]);
       expect(report.diagnosticLogs.error).toContain("~/logs");
       expect(report.diagnosticLogs.error).not.toContain(dir);
 
@@ -327,6 +349,362 @@ exit 2
     }
   });
 
+});
+
+describe("the human report states what each component is doing (#770)", () => {
+  function doctorReport(overrides: Partial<DoctorReport> = {}): DoctorReport {
+    return {
+      generatedAt: "2026-05-17T12:00:00.000Z",
+      redacted: false,
+      package: { name: "kesha", version: "9.9.9" },
+      runtime: { bunVersion: "1.9.9", platform: "testos", arch: "testarch" },
+      engine: {
+        path: "/cache/engine/bin/kesha-engine",
+        installed: true,
+        versionMarker: "1.0.0",
+        pinnedVersion: "1.0.0",
+        versionState: "matches-pin",
+        runnable: true,
+        capabilities: { protocolVersion: 3, backend: "onnx", features: ["tts", "diarize"] },
+        probeError: null,
+      },
+      cache: { path: "/cache", exists: true, totalBytes: 4096, components: [] },
+      optionalComponents: [],
+      stats: {
+        enabled: true,
+        dbPath: "/stats.sqlite",
+        runCount: 3,
+        exists: true,
+        retentionDays: 90,
+      },
+      diagnosticLogs: {
+        dir: "/logs",
+        activePath: "/logs/kesha.ndjson",
+        statePath: "/logs/diagnostic-logs.json",
+        exists: true,
+        activeSizeBytes: 2048,
+        rotatedFiles: [],
+        totalSizeBytes: 2048,
+        mode: "retain-on-failure",
+        maxBytes: 10 * 1024 * 1024,
+        retain: 5,
+      },
+      env: {},
+      ...overrides,
+    };
+  }
+
+  function engineLine(report: DoctorReport): string {
+    return formatDoctorReport(report).split("\n").find((l) => l.includes("Binary:"))!;
+  }
+
+  test("the binary is missing, installed, or corrupt — and never two of those", () => {
+    expect(engineLine(doctorReport({ engine: { ...doctorReport().engine, installed: false } }))).toContain(
+      "(missing)",
+    );
+    expect(engineLine(doctorReport())).toContain("(installed)");
+
+    const corrupt = engineLine(
+      doctorReport({ engine: { ...doctorReport().engine, runnable: false } }),
+    );
+    expect(corrupt).toContain("corrupt");
+    expect(corrupt).toContain("kesha install");
+    expect(corrupt).not.toContain("(installed)");
+  });
+
+  test("an optional component's state separates corrupt from missing", () => {
+    const output = formatDoctorReport(
+      doctorReport({
+        optionalComponents: [
+          { name: "Present", path: "/a", exists: true, sizeBytes: 1, runnable: true },
+          { name: "Broken", path: "/b", exists: true, sizeBytes: 1, runnable: false },
+          { name: "Absent", path: "/c", exists: false, sizeBytes: 0 },
+        ],
+      }),
+    );
+    expect(output).toContain("Present: installed");
+    expect(output).toContain("Broken: installed but not executable (corrupt)");
+    expect(output).toContain("Absent: missing");
+  });
+
+  test("each version state reads differently, and drift names its remedy", () => {
+    const engine = doctorReport().engine;
+    const drift = formatDoctorReport(
+      doctorReport({
+        engine: { ...engine, versionMarker: "8.8.8", versionState: "differs-from-pin" },
+      }),
+    );
+    expect(drift).toContain("installed v8.8.8 differs from the pinned v1.0.0");
+    expect(drift).toContain("kesha install");
+
+    expect(
+      formatDoctorReport(
+        doctorReport({ engine: { ...engine, versionMarker: null, versionState: "unrecorded" } }),
+      ),
+    ).toContain("Version marker: missing");
+    expect(
+      formatDoctorReport(
+        doctorReport({
+          engine: { ...engine, installed: false, versionMarker: null, versionState: "unrecorded" },
+        }),
+      ),
+    ).toContain("Version state: no engine installed");
+  });
+
+  test("capabilities carry the probe error when there are none to report", () => {
+    const engine = doctorReport().engine;
+    expect(formatDoctorReport(doctorReport())).toContain(
+      "Capabilities: onnx, protocol v3, tts, diarize",
+    );
+    expect(
+      formatDoctorReport(
+        doctorReport({ engine: { ...engine, capabilities: null, probeError: "it exploded" } }),
+      ),
+    ).toContain("Capabilities: it exploded");
+    expect(
+      formatDoctorReport(
+        doctorReport({ engine: { ...engine, capabilities: null, probeError: null } }),
+      ),
+    ).toContain("Capabilities: not available");
+  });
+
+  test("a cache row shows its size when present and `missing` when not", () => {
+    const output = formatDoctorReport(
+      doctorReport({
+        cache: {
+          path: "/cache",
+          exists: true,
+          totalBytes: 8192,
+          components: [
+            { label: "Engine", path: "/cache/engine", exists: true, sizeBytes: 4096 },
+            { label: "TTS (Vosk)", path: "/cache/models/vosk-ru", exists: false, sizeBytes: 0 },
+          ],
+        },
+      }),
+    );
+    expect(output).toContain("Cache: /cache (8.0 KB)");
+    expect(output).toContain("Engine: 4.0 KB");
+    expect(output).toContain("TTS (Vosk): missing");
+
+    expect(
+      formatDoctorReport(
+        doctorReport({ cache: { path: "/cache", exists: false, totalBytes: 0, components: [] } }),
+      ),
+    ).toContain("Cache: /cache (missing)");
+  });
+
+  test("stats report either their counters or the error that hid them", () => {
+    const healthy = formatDoctorReport(doctorReport());
+    expect(healthy).toContain("Enabled: yes");
+    expect(healthy).toContain("Runs: 3");
+    expect(healthy).toContain("Database: /stats.sqlite");
+
+    expect(
+      formatDoctorReport(
+        doctorReport({
+          stats: {
+            enabled: false,
+            dbPath: "/stats.sqlite",
+            runCount: 0,
+            exists: true,
+            retentionDays: null,
+          },
+        }),
+      ),
+    ).toContain("Enabled: no");
+
+    const broken = formatDoctorReport(doctorReport({ stats: { error: "disk on fire" } }));
+    expect(broken).toContain("Error: disk on fire");
+    expect(broken).not.toContain("Enabled:");
+  });
+
+  test("a healthy log directory reports no error line", () => {
+    expect(formatDoctorReport(doctorReport())).not.toMatch(/Diagnostic logs:[\s\S]*Error:/);
+  });
+
+  test("unset environment variables are named as unset rather than blank", () => {
+    const output = formatDoctorReport(
+      doctorReport({ env: { KESHA_CACHE_DIR: "/cache", KESHA_DEBUG: null } }),
+    );
+    expect(output).toContain("KESHA_CACHE_DIR: /cache");
+    expect(output).toContain("KESHA_DEBUG: unset");
+  });
+
+  test("the report is line-oriented and ends with a newline", () => {
+    const output = formatDoctorReport(doctorReport());
+    expect(output.split("\n")).toContain("Kesha Doctor");
+    expect(output.endsWith("\n")).toBe(true);
+  });
+});
+
+describe("collectDoctorReport probe and cache accounting", () => {
+  const savedEnv = {
+    HOME: process.env.HOME,
+    KESHA_ENGINE_BIN: process.env.KESHA_ENGINE_BIN,
+    KESHA_CACHE_DIR: process.env.KESHA_CACHE_DIR,
+    KESHA_STATS_DB: process.env.KESHA_STATS_DB,
+  };
+
+  function restoreEnv() {
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+
+  beforeEach(restoreEnv);
+  afterEach(restoreEnv);
+
+  function stage(prefix: string): { dir: string; cache: string; binDir: string } {
+    const dir = mkdtempSync(join(tmpdir(), prefix));
+    const cache = join(dir, ".cache", "kesha");
+    const binDir = join(cache, "engine", "bin");
+    mkdirSync(binDir, { recursive: true });
+    process.env.HOME = dir;
+    process.env.KESHA_ENGINE_BIN = join(binDir, "kesha-engine");
+    process.env.KESHA_CACHE_DIR = cache;
+    process.env.KESHA_STATS_DB = join(dir, "stats.sqlite");
+    return { dir, cache, binDir };
+  }
+
+  test("an absent engine is not probed, so it carries no probe error", async () => {
+    const { dir } = stage("kesha-doctor-absent-probe-");
+    try {
+      const report = await collectDoctorReport();
+      expect(report.engine.installed).toBe(false);
+      expect(report.engine.runnable).toBe(false);
+      expect(report.engine.probeError).toBeNull();
+      expect(report.engine.capabilities).toBeNull();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  posixEngineTest("an engine that runs but describes nothing says so", async () => {
+    const { dir, binDir } = stage("kesha-doctor-silent-engine-");
+    writeFakeEngine(join(binDir, "kesha-engine"), "#!/bin/sh\nexit 2\n");
+    try {
+      const report = await collectDoctorReport();
+      expect(report.engine.runnable).toBe(true);
+      expect(report.engine.capabilities).toBeNull();
+      expect(report.engine.probeError).toBe("capabilities probe returned no data");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  posixEngineTest("a CoreML engine gets the external ASR row, not the ONNX model dir", async () => {
+    const { dir, binDir } = stage("kesha-doctor-coreml-cache-");
+    writeFakeEngine(
+      join(binDir, "kesha-engine"),
+      `#!/bin/sh
+if [ "$1" = "--capabilities-json" ]; then
+  printf '%s\\n' '{"protocolVersion":3,"backend":"coreml","features":[]}'
+  exit 0
+fi
+exit 2
+`,
+    );
+    try {
+      const labels = (await collectDoctorReport()).cache.components.map((c) => c.label);
+      expect(labels).toContain("ASR (Parakeet, FluidAudio) (external)");
+      expect(labels).not.toContain("ASR (Parakeet)");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  posixEngineTest("an ONNX engine keeps the ONNX model dir and no external ASR row", async () => {
+    const { dir, binDir } = stage("kesha-doctor-onnx-cache-");
+    writeFakeEngine(
+      join(binDir, "kesha-engine"),
+      `#!/bin/sh
+if [ "$1" = "--capabilities-json" ]; then
+  printf '%s\\n' '{"protocolVersion":3,"backend":"onnx","features":[]}'
+  exit 0
+fi
+exit 2
+`,
+    );
+    try {
+      const labels = (await collectDoctorReport()).cache.components.map((c) => c.label);
+      expect(labels).toContain("ASR (Parakeet)");
+      expect(labels).not.toContain("ASR (Parakeet, FluidAudio) (external)");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  posixEngineTest("an engine inside the cache is counted once, outside it is added", async () => {
+    const { dir, cache, binDir } = stage("kesha-doctor-cache-total-");
+    writeFakeEngine(join(binDir, "kesha-engine"), "#!/bin/sh\nexit 2\n");
+    mkdirSync(join(cache, "models", "silero-vad"), { recursive: true });
+    writeFileSync(join(cache, "models", "silero-vad", "model.onnx"), "x".repeat(128));
+    const engineBytes = readFileSync(join(binDir, "kesha-engine")).length;
+    try {
+      expect((await collectDoctorReport()).cache.totalBytes).toBe(engineBytes + 128);
+
+      const outside = join(dir, "opt", "engine", "bin");
+      mkdirSync(outside, { recursive: true });
+      writeFakeEngine(join(outside, "kesha-engine"), "#!/bin/sh\nexit 2\n");
+      process.env.KESHA_ENGINE_BIN = join(outside, "kesha-engine");
+      expect((await collectDoctorReport()).cache.totalBytes).toBe(
+        engineBytes + 128 + engineBytes,
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("each optional component measures its own directory and names its install flag", async () => {
+    const { dir, cache } = stage("kesha-doctor-optional-");
+    mkdirSync(join(cache, "models", "silero-vad"), { recursive: true });
+    writeFileSync(join(cache, "models", "silero-vad", "model.onnx"), "x".repeat(128));
+    mkdirSync(join(cache, "models", "kokoro-82m"), { recursive: true });
+    writeFileSync(join(cache, "models", "kokoro-82m", "model.onnx"), "x".repeat(64));
+    try {
+      const components = (await collectDoctorReport()).optionalComponents;
+      const byName = (name: string) => components.find((c) => c.name === name)!;
+
+      expect(byName("VAD (Silero)")).toMatchObject({ exists: true, sizeBytes: 128 });
+      expect(byName("VAD (Silero)").note).toContain("kesha install --vad");
+      expect(byName("TTS (Kokoro)")).toMatchObject({ exists: true, sizeBytes: 64 });
+      expect(byName("TTS (Kokoro)").note).toContain("kesha install --tts");
+      expect(byName("TTS (Vosk RU)")).toMatchObject({ exists: false, sizeBytes: 0 });
+      expect(byName("TTS (Vosk RU)").note).toContain("kesha install --tts");
+      expect(byName("Diarization (Sortformer)")).toMatchObject({ exists: false, sizeBytes: 0 });
+      expect(byName("Diarization (Sortformer)").note).toContain("kesha install --diarize");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("the package and runtime blocks describe this install", async () => {
+    const { dir } = stage("kesha-doctor-identity-");
+    try {
+      const report = await collectDoctorReport();
+      expect(report.package).toEqual({ name: packageName, version: packageVersion });
+      expect(report.runtime).toEqual({
+        bunVersion: Bun.version,
+        platform: process.platform,
+        arch: process.arch,
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("recorded runs surface in the stats section", async () => {
+    const { dir } = stage("kesha-doctor-stats-counters-");
+    try {
+      enableStats();
+      const output = formatDoctorReport(await collectDoctorReport());
+      expect(output).toContain("Enabled: yes");
+      expect(output).toContain("Runs: 0");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("createSupportBundle", () => {

--- a/tests/unit/engine-install-decisions.test.ts
+++ b/tests/unit/engine-install-decisions.test.ts
@@ -6,7 +6,6 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
-  statSync,
   writeFileSync,
 } from "fs";
 import { dirname, join } from "path";
@@ -148,13 +147,7 @@ function engineDownloads(urls: string[]): string[] {
   return urls.filter((u) => u.endsWith(binaryName));
 }
 
-/** Read-only view of the developer's real engine, to prove a test run never touched it (#796). */
-function realEngineSnapshot(): { exists: boolean; size?: number; mtimeMs?: number } {
-  const real = join(homedir(), ".cache", "kesha", "engine", "bin", "kesha-engine");
-  if (!existsSync(real)) return { exists: false };
-  const s = statSync(real);
-  return { exists: true, size: s.size, mtimeMs: s.mtimeMs };
-}
+const realEngineBin = join(homedir(), ".cache", "kesha", "engine", "bin", "kesha-engine");
 
 // The developer's real ~/.cache/kesha was overwritten with a test stub because pointing
 // KESHA_ENGINE_BIN at a temp path is opt-in per test, and the fallback is the real cache.
@@ -175,17 +168,12 @@ describe("an install only ever writes where it was pointed (#796)", () => {
   }, 30_000);
 
   // The adversarial half: isolation is opt-in, so prove that forgetting it fails loudly
-  // rather than reaching ~/.cache/kesha. This is the automated proof the hole is closed.
-  posixTest("a test that forgets to isolate is refused, not silently served", async () => {
-    delete process.env.KESHA_ENGINE_BIN;
-    delete process.env.KESHA_CACHE_DIR;
-    const before = realEngineSnapshot();
-    stubRelease();
-
-    await expect(installEngine()).rejects.toThrow(/real\s+per-user cache/);
-
-    expect(realEngineSnapshot()).toEqual(before);
-  }, 30_000);
+  // rather than reaching ~/.cache/kesha. Asserted on the predicate, never by running an
+  // install at the real path — under mutation a disabled guard would do exactly the damage
+  // this test exists to rule out.
+  posixTest("a test that forgets to isolate is refused, not silently served", () => {
+    expect(() => assertNotRealCacheUnderTest(realEngineBin)).toThrow(/real\s+per-user cache/);
+  });
 
   posixTest("the guard leaves a redirected cache alone", () => {
     expect(() =>
@@ -196,13 +184,10 @@ describe("an install only ever writes where it was pointed (#796)", () => {
   // The guard must not cost a real user their install: outside `bun test` it is inert, even
   // for the very path it refuses under one.
   posixTest("outside a test run the real cache is allowed", () => {
-    const realBin = join(homedir(), ".cache", "kesha", "engine", "bin", "kesha-engine");
-    expect(() => assertNotRealCacheUnderTest(realBin)).toThrow(/real\s+per-user cache/);
-
     const saved = process.env.NODE_ENV;
     delete process.env.NODE_ENV;
     try {
-      expect(() => assertNotRealCacheUnderTest(realBin)).not.toThrow();
+      expect(() => assertNotRealCacheUnderTest(realEngineBin)).not.toThrow();
     } finally {
       if (saved === undefined) delete process.env.NODE_ENV;
       else process.env.NODE_ENV = saved;

--- a/tests/unit/stats.test.ts
+++ b/tests/unit/stats.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { Database } from "bun:sqlite";
-import { existsSync, mkdtempSync, rmSync } from "fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
-import { tmpdir } from "os";
+import { homedir, tmpdir } from "os";
 import {
+  artifactFromBytes,
+  artifactFromFile,
   createStatsRecorder,
   disableStats,
   enableStats,
@@ -18,6 +20,7 @@ import {
   sanitizeStatsError,
   setStatsRetentionDays,
   vacuumStats,
+  type StatsWeekSummary,
 } from "../../src/stats";
 
 describe("stats storage", () => {
@@ -111,7 +114,7 @@ describe("stats storage", () => {
           { stage: "transcribe", durationMs: 100, status: "success" },
           { stage: "lang_id_audio", durationMs: 30, status: "success" },
         ],
-        inputArtifact: { format: "wav", sizeBytes: 500_000, durationMs: 45_000 },
+        inputArtifacts: [{ format: "wav", sizeBytes: 500_000, durationMs: 45_000 }],
       },
       {
         command: "say",
@@ -131,7 +134,7 @@ describe("stats storage", () => {
           { stage: "transcribe", durationMs: 3_000, status: "failed" },
           { stage: "lang_id_text", durationMs: 100, status: "success" },
         ],
-        inputArtifact: { format: "mp3", sizeBytes: 15 * 1024 * 1024, durationMs: 15 * 60_000 },
+        inputArtifacts: [{ format: "mp3", sizeBytes: 15 * 1024 * 1024, durationMs: 15 * 60_000 }],
       },
       {
         command: "say",
@@ -180,7 +183,7 @@ describe("stats storage", () => {
       finishedAt: "2026-05-16T10:00:01.000Z",
       itemCount: 1,
       stages: [{ stage: "transcribe", durationMs: 100, status: "failed" }],
-      inputArtifact: { format: "wav", sizeBytes: 1234, durationMs: 2000 },
+      inputArtifacts: [{ format: "wav", sizeBytes: 1234, durationMs: 2000 }],
       error: new Error(`${secretPath} failed with {"text":"private words"}`),
     });
 
@@ -244,7 +247,7 @@ describe("stats storage", () => {
       finishedAt: "2020-01-01T00:00:01.000Z",
       itemCount: 1,
       stages: [{ stage: "transcribe", durationMs: 100, status: "success" }],
-      inputArtifact: { format: "wav", sizeBytes: 100, durationMs: 1000 },
+      inputArtifacts: [{ format: "wav", sizeBytes: 100, durationMs: 1000 }],
     });
     seedStatsRun({
       command: "say",
@@ -293,7 +296,777 @@ describe("stats storage", () => {
   });
 });
 
+describe("week summary aggregation", () => {
+  let dir: string;
+  const savedStatsDb = process.env.KESHA_STATS_DB;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "kesha-stats-agg-"));
+    process.env.KESHA_STATS_DB = join(dir, "stats.sqlite");
+  });
+
+  afterEach(() => {
+    if (savedStatsDb === undefined) delete process.env.KESHA_STATS_DB;
+    else process.env.KESHA_STATS_DB = savedStatsDb;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const NOW = new Date("2026-05-17T00:00:00.000Z");
+
+  test("counters, sums and buckets are computed from the week's rows", () => {
+    enableStats();
+    seedStatsRuns([
+      {
+        command: "transcribe",
+        status: "success",
+        startedAt: "2026-05-16T10:00:00.000Z",
+        finishedAt: "2026-05-16T10:00:02.000Z",
+        itemCount: 1,
+        stages: [
+          { stage: "transcribe", durationMs: 100, status: "success" },
+          { stage: "lang_id_audio", durationMs: 30, status: "success" },
+        ],
+        inputArtifacts: [
+          { format: "wav", sizeBytes: 1024 * 1024, durationMs: 60_000 },
+          { format: "wav", sizeBytes: 1000, durationMs: 400 },
+        ],
+      },
+      {
+        command: "say",
+        status: "success",
+        startedAt: "2026-05-16T11:00:00.000Z",
+        finishedAt: "2026-05-16T11:00:07.000Z",
+        itemCount: 1,
+        stages: [{ stage: "tts", durationMs: 1_500, status: "success" }],
+        inputArtifacts: [{ format: null, sizeBytes: null, durationMs: null }],
+      },
+      {
+        command: "transcribe",
+        status: "failed",
+        startedAt: "2026-05-16T12:00:00.000Z",
+        finishedAt: "2026-05-16T12:00:05.000Z",
+        itemCount: 2,
+        stages: [
+          { stage: "transcribe", durationMs: 3_000, status: "failed" },
+          { stage: "tts", durationMs: 500, status: "success" },
+        ],
+        inputArtifacts: [
+          { format: "mp3", sizeBytes: 10 * 1024 * 1024, durationMs: 600_000 },
+          { format: "mp3", sizeBytes: 100 * 1024 * 1024, durationMs: 3_600_000 },
+        ],
+      },
+    ]);
+
+    const summary = getWeekSummary(NOW);
+
+    expect(summary.runs).toBe(3);
+    expect(summary.successes).toBe(2);
+    expect(summary.failures).toBe(1);
+    expect(summary.inputFiles).toBe(5);
+    expect(summary.inputBytes).toBe(1024 * 1024 + 1000 + 10 * 1024 * 1024 + 100 * 1024 * 1024);
+    expect(summary.inputDurationMs).toBe(60_000 + 400 + 600_000 + 3_600_000);
+    expect(summary.sttTimeMs).toBe(3_100);
+    expect(summary.ttsTimeMs).toBe(2_000);
+    expect(summary.hasInputDurationData).toBe(true);
+
+    expect(summary.stageBreakdown).toEqual([
+      { stage: "transcribe", count: 2, failed: 1, totalMs: 3_100, p50Ms: 100, p95Ms: 3_000, p99Ms: 3_000 },
+      { stage: "tts", count: 2, failed: 0, totalMs: 2_000, p50Ms: 500, p95Ms: 1_500, p99Ms: 1_500 },
+      { stage: "lang_id_audio", count: 1, failed: 0, totalMs: 30, p50Ms: 30, p95Ms: 30, p99Ms: 30 },
+    ]);
+
+    // Ties break alphabetically so the order does not drift with insertion order.
+    expect(summary.inputFormats).toEqual([
+      { label: "mp3", count: 2 },
+      { label: "wav", count: 2 },
+      { label: "unknown", count: 1 },
+    ]);
+    // Exactly on a boundary belongs to the bucket above it.
+    expect(summary.inputSizeBuckets).toEqual([
+      { label: "unknown", count: 1 },
+      { label: "<1 MB", count: 1 },
+      { label: "1-10 MB", count: 1 },
+      { label: "10-100 MB", count: 1 },
+      { label: "100 MB+", count: 1 },
+    ]);
+    expect(summary.inputDurationBuckets).toEqual([
+      { label: "<1 min", count: 1 },
+      { label: "1-10 min", count: 1 },
+      { label: "10-60 min", count: 1 },
+      { label: "60 min+", count: 1 },
+    ]);
+  });
+
+  test("artifacts without a measured duration leave the duration breakdown empty", () => {
+    enableStats();
+    seedStatsRun({
+      command: "transcribe",
+      status: "success",
+      startedAt: "2026-05-16T10:00:00.000Z",
+      finishedAt: "2026-05-16T10:00:01.000Z",
+      itemCount: 1,
+      stages: [],
+      inputArtifacts: [{ format: "wav", sizeBytes: 10, durationMs: null }],
+    });
+
+    const summary = getWeekSummary(NOW);
+    expect(summary.hasInputDurationData).toBe(false);
+    expect(summary.inputDurationBuckets).toEqual([]);
+    expect(renderWeekSummary(summary)).toContain("Duration: n/a");
+  });
+
+  test("negative durations and sizes are clamped, never subtracted", () => {
+    enableStats();
+    seedStatsRun({
+      command: "transcribe",
+      status: "success",
+      startedAt: "2026-05-16T10:00:00.000Z",
+      finishedAt: "2026-05-16T10:00:01.000Z",
+      itemCount: 1,
+      stages: [
+        { stage: "transcribe", durationMs: -500, status: "success" },
+        { stage: "transcribe", durationMs: 200, status: "success" },
+      ],
+      inputArtifacts: [{ format: "wav", sizeBytes: -100, durationMs: -100 }],
+    });
+
+    const summary = getWeekSummary(NOW);
+    expect(summary.sttTimeMs).toBe(200);
+    expect(summary.stageBreakdown[0]).toMatchObject({ totalMs: 200, p50Ms: 0, p95Ms: 200 });
+    expect(summary.inputBytes).toBe(0);
+    expect(summary.inputDurationMs).toBe(0);
+  });
+
+  test("the five slowest finished runs are reported, longest first", () => {
+    enableStats();
+    seedStatsRuns([
+      ...[1, 2, 3, 4, 5, 6].map((seconds) => ({
+        command: "transcribe" as const,
+        status: "success" as const,
+        startedAt: `2026-05-16T1${seconds}:00:00.000Z`,
+        finishedAt: `2026-05-16T1${seconds}:00:0${seconds}.000Z`,
+        itemCount: seconds,
+        stages: [],
+      })),
+      {
+        command: "say",
+        status: "success",
+        startedAt: "2026-05-16T09:00:00.000Z",
+        finishedAt: null,
+        itemCount: 99,
+        stages: [{ stage: "tts", durationMs: 999_999, status: "success" }],
+      },
+    ]);
+
+    const slowest = getWeekSummary(NOW).slowestRuns;
+    expect(slowest).toHaveLength(5);
+    expect(slowest.map((run) => run.durationMs)).toEqual([6_000, 5_000, 4_000, 3_000, 2_000]);
+    // A run still in flight has no duration to compare, so it is not a candidate.
+    expect(slowest.map((run) => run.itemCount)).not.toContain(99);
+  });
+
+  test("a run's stages are listed longest first, and a clock that went backwards is zero", () => {
+    enableStats();
+    seedStatsRuns([
+      {
+        command: "transcribe",
+        status: "success",
+        startedAt: "2026-05-16T10:00:05.000Z",
+        finishedAt: "2026-05-16T10:00:00.000Z",
+        itemCount: 1,
+        stages: [
+          { stage: "lang_id_audio", durationMs: 200, status: "success" },
+          { stage: "transcribe", durationMs: 900, status: "failed" },
+          { stage: "decode", durationMs: 200, status: "success" },
+        ],
+      },
+      {
+        command: "say",
+        status: "success",
+        startedAt: "2026-05-16T11:00:00.000Z",
+        finishedAt: null,
+        itemCount: 7,
+        stages: [],
+      },
+    ]);
+
+    const summary = getWeekSummary(NOW);
+    expect(summary.slowestRuns).toHaveLength(1);
+    const run = summary.slowestRuns[0];
+    expect(run.durationMs).toBe(0);
+    expect(run.stages).toEqual([
+      { stage: "transcribe", durationMs: 900, status: "failed" },
+      { stage: "decode", durationMs: 200, status: "success" },
+      { stage: "lang_id_audio", durationMs: 200, status: "success" },
+    ]);
+  });
+
+  test("percentiles index into the sorted sample, not near it", () => {
+    enableStats();
+    seedStatsRun({
+      command: "transcribe",
+      status: "success",
+      startedAt: "2026-05-16T10:00:00.000Z",
+      finishedAt: "2026-05-16T10:00:01.000Z",
+      itemCount: 1,
+      stages: [100, 30, 60, 10, 90, 40, 80, 20, 70, 50].map((durationMs) => ({
+        stage: "transcribe",
+        durationMs,
+        status: "success" as const,
+      })),
+    });
+
+    expect(getWeekSummary(NOW).stageBreakdown[0]).toMatchObject({
+      count: 10,
+      totalMs: 550,
+      p50Ms: 50,
+      p95Ms: 100,
+      p99Ms: 100,
+    });
+  });
+
+  test("a run whose timestamps do not parse has no duration and sorts last", () => {
+    enableStats();
+    seedStatsRuns([
+      {
+        command: "transcribe",
+        status: "success",
+        startedAt: "2026-05-16T10:00:00.000Z",
+        finishedAt: "whenever",
+        itemCount: 1,
+        stages: [],
+      },
+      {
+        command: "say",
+        status: "success",
+        startedAt: "2026-05-16T11:00:00.000Z",
+        finishedAt: "2026-05-16T11:00:01.000Z",
+        itemCount: 2,
+        stages: [],
+      },
+    ]);
+
+    expect(getWeekSummary(NOW).slowestRuns.map((run) => run.durationMs)).toEqual([1_000, null]);
+  });
+
+  test("with no database at all every counter reads zero", () => {
+    const summary = getWeekSummary(NOW);
+    expect(summary).toEqual({
+      runs: 0,
+      successes: 0,
+      failures: 0,
+      inputFiles: 0,
+      inputBytes: 0,
+      inputDurationMs: 0,
+      sttTimeMs: 0,
+      ttsTimeMs: 0,
+      stageBreakdown: [],
+      inputFormats: [],
+      inputSizeBuckets: [],
+      inputDurationBuckets: [],
+      hasInputDurationData: false,
+      slowestRuns: [],
+    });
+  });
+
+  test("artifact formats are recorded as a bare lowercase extension", () => {
+    enableStats();
+    const recorder = createStatsRecorder("transcribe");
+    recorder.recordArtifact({ kind: "input_audio", format: ".OGG", sizeBytes: 10 });
+    recorder.recordArtifact({ kind: "input_audio", sizeBytes: 20 });
+    recorder.finish("success", 2);
+
+    expect(getWeekSummary().inputFormats).toEqual([
+      { label: "ogg", count: 1 },
+      { label: "unknown", count: 1 },
+    ]);
+  });
+});
+
+describe("the recorder writes what it is handed", () => {
+  let dir: string;
+  const savedStatsDb = process.env.KESHA_STATS_DB;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "kesha-stats-recorder-"));
+    process.env.KESHA_STATS_DB = join(dir, "stats.sqlite");
+  });
+
+  afterEach(() => {
+    if (savedStatsDb === undefined) delete process.env.KESHA_STATS_DB;
+    else process.env.KESHA_STATS_DB = savedStatsDb;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("optional artifact and error fields survive the round trip, and absent ones are null", () => {
+    enableStats();
+    const recorder = createStatsRecorder("transcribe");
+    recorder.recordArtifact({
+      kind: "input_audio",
+      format: "wav",
+      sizeBytes: 100,
+      durationMs: 200,
+      sampleRate: 16_000,
+      channels: 2,
+    });
+    recorder.recordArtifact({ kind: "output_audio" });
+    recorder.recordError("transcribe", new Error("boom"), "E_DECODE");
+    recorder.recordError("tts", new Error("boom"));
+    recorder.finish("failed");
+
+    const exported = JSON.parse(exportStats("json"));
+    expect(exported.artifacts[0]).toMatchObject({
+      kind: "input_audio",
+      format: "wav",
+      sizeBytes: 100,
+      durationMs: 200,
+      sampleRate: 16_000,
+      channels: 2,
+    });
+    expect(exported.artifacts[1]).toMatchObject({
+      kind: "output_audio",
+      format: null,
+      sizeBytes: null,
+      durationMs: null,
+      sampleRate: null,
+      channels: null,
+    });
+    expect(exported.errors.map((e: { errorCode: string | null }) => e.errorCode)).toEqual([
+      "E_DECODE",
+      null,
+    ]);
+    // finish() without an item count records none rather than inventing one.
+    expect(exported.runs[0].itemCount).toBe(0);
+  });
+
+  test("a disabled database still yields a recorder that writes nothing", () => {
+    enableStats();
+    disableStats();
+    const recorder = createStatsRecorder("say");
+    expect(recorder.enabled).toBe(false);
+    recorder.finish("success", 1);
+    expect(getStatsStatus().runCount).toBe(0);
+  });
+
+  test("an export from an untouched install is empty but still states the contract", () => {
+    const exported = JSON.parse(exportStats("json"));
+    expect(exported.runs).toEqual([]);
+    expect(exported.artifacts).toEqual([]);
+    expect(exported.stageTimings).toEqual([]);
+    expect(exported.errors).toEqual([]);
+    expect(exported.privacy.contentFree).toBe(true);
+    expect(exported.retentionDays).toBe(90);
+  });
+});
+
+describe("artifact inputs", () => {
+  test("a file contributes its extension and size; anything else contributes nothing", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-stats-artifact-"));
+    try {
+      const file = join(dir, "clip.WAV");
+      writeFileSync(file, "x".repeat(42));
+
+      expect(artifactFromFile(file, "input_audio")).toEqual({
+        kind: "input_audio",
+        format: ".WAV",
+        sizeBytes: 42,
+      });
+      expect(artifactFromFile(dir, "input_audio")).toBeNull();
+      expect(artifactFromFile(join(dir, "gone.wav"), "input_audio")).toBeNull();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a byte count is recorded as given", () => {
+    expect(artifactFromBytes(512, "output_audio", "wav")).toEqual({
+      kind: "output_audio",
+      format: "wav",
+      sizeBytes: 512,
+    });
+    expect(artifactFromBytes(0, "output_audio")).toEqual({
+      kind: "output_audio",
+      format: undefined,
+      sizeBytes: 0,
+    });
+  });
+});
+
+describe("the default database location", () => {
+  const savedStatsDb = process.env.KESHA_STATS_DB;
+
+  afterEach(() => {
+    if (savedStatsDb === undefined) delete process.env.KESHA_STATS_DB;
+    else process.env.KESHA_STATS_DB = savedStatsDb;
+  });
+
+  test("falls back to this platform's application data directory", () => {
+    delete process.env.KESHA_STATS_DB;
+    const path = resolveStatsDbPath();
+    expect(path.endsWith(join("kesha", "stats.sqlite"))).toBe(true);
+    if (process.platform === "darwin") {
+      expect(path).toBe(join(homedir(), "Library", "Application Support", "kesha", "stats.sqlite"));
+    } else if (process.platform !== "win32") {
+      expect(path).toBe(
+        join(process.env.XDG_DATA_HOME || join(homedir(), ".local", "share"), "kesha", "stats.sqlite"),
+      );
+    }
+  });
+});
+
+describe("renderWeekSummary", () => {
+  function weekSummary(overrides: Partial<StatsWeekSummary> = {}): StatsWeekSummary {
+    return {
+      runs: 0,
+      successes: 0,
+      failures: 0,
+      inputFiles: 0,
+      inputBytes: 0,
+      inputDurationMs: 0,
+      sttTimeMs: 0,
+      ttsTimeMs: 0,
+      stageBreakdown: [],
+      inputFormats: [],
+      inputSizeBuckets: [],
+      inputDurationBuckets: [],
+      hasInputDurationData: false,
+      slowestRuns: [],
+      ...overrides,
+    };
+  }
+
+  test("the headline counters carry their figures", () => {
+    const output = renderWeekSummary(
+      weekSummary({
+        runs: 5,
+        successes: 3,
+        failures: 2,
+        inputFiles: 4,
+        inputBytes: 2048,
+        inputDurationMs: 5_000,
+        ttsTimeMs: 1_400,
+      }),
+    );
+    expect(output).toContain("Runs: 5 (3 success, 2 failed)");
+    expect(output).toContain("Input files: 4");
+    expect(output).toContain("Input audio: 5s");
+    expect(output).toContain("Input size: 2.0 KB");
+    expect(output).toContain("TTS time: 1s");
+  });
+
+  test("the realtime factor is input audio over STT time, and n/a without both", () => {
+    expect(
+      renderWeekSummary(weekSummary({ inputDurationMs: 60_000, sttTimeMs: 20_000 })),
+    ).toContain("STT time: 20s (3.0x realtime)");
+    expect(renderWeekSummary(weekSummary({ inputDurationMs: 60_000 }))).toContain("(n/a realtime)");
+    expect(renderWeekSummary(weekSummary({ sttTimeMs: 20_000 }))).toContain("(n/a realtime)");
+  });
+
+  test("durations are broken into hours, minutes and seconds", () => {
+    const cases: Array<[number, string]> = [
+      [400, "400ms"],
+      [1_000, "1s"],
+      [65_000, "1m 5s"],
+      [3_725_000, "1h 2m 5s"],
+    ];
+    for (const [ms, expected] of cases) {
+      expect(renderWeekSummary(weekSummary({ inputDurationMs: ms }))).toContain(
+        `Input audio: ${expected}`,
+      );
+    }
+  });
+
+  test("a week with nothing in it says so section by section", () => {
+    const output = renderWeekSummary(weekSummary());
+    expect(output).toContain("no stage timings recorded");
+    expect(output).toContain("no bottlenecks recorded");
+    expect(output).toContain("no completed runs recorded");
+    expect(output).toContain("Format: n/a");
+    expect(output).toContain("Size: n/a");
+    expect(output).toContain("Duration: n/a");
+  });
+
+  test("stage rows and bottlenecks replace the empty-state lines", () => {
+    const output = renderWeekSummary(
+      weekSummary({
+        stageBreakdown: [
+          { stage: "transcribe", count: 2, failed: 1, totalMs: 4_000, p50Ms: 1_000, p95Ms: 3_000, p99Ms: 3_400 },
+          { stage: "tts", count: 1, failed: 0, totalMs: 2_000, p50Ms: 2_000, p95Ms: 2_000, p99Ms: 2_000 },
+          { stage: "lang_id", count: 4, failed: 0, totalMs: 2_000, p50Ms: 400, p95Ms: 400, p99Ms: 400 },
+          { stage: "warmup", count: 1, failed: 0, totalMs: 5, p50Ms: 5, p95Ms: 5, p99Ms: 5 },
+        ],
+        inputFormats: [{ label: "wav", count: 2 }],
+        inputSizeBuckets: [{ label: "<1 MB", count: 2 }],
+        inputDurationBuckets: [{ label: "1-10 min", count: 2 }],
+        hasInputDurationData: true,
+      }),
+    );
+    expect(output).toContain(
+      "transcribe: count 2, failed 1, total 4s, p50 1s, p95 3s, p99 3s",
+    );
+    expect(output).toContain("Total time: transcribe 4s, lang_id 2s, tts 2s");
+    expect(output).toContain("p95 latency: transcribe 3s, tts 2s, lang_id 400ms");
+    expect(output).toContain("Format: wav 2");
+    expect(output).toContain("Size: <1 MB 2");
+    expect(output).toContain("Duration: 1-10 min 2");
+    expect(output).not.toContain("no stage timings recorded");
+    expect(output).not.toContain("no bottlenecks recorded");
+    // Bottlenecks are the top three; the rest stay in the stage breakdown only.
+    expect(output).toContain("warmup: count 1");
+    expect(output).not.toContain("warmup 5ms");
+  });
+
+  test("each slow run lists its stages, or says it has none", () => {
+    const output = renderWeekSummary(
+      weekSummary({
+        slowestRuns: [
+          {
+            command: "transcribe",
+            status: "failed",
+            durationMs: 5_000,
+            itemCount: 2,
+            stages: [
+              { stage: "transcribe", durationMs: 3_000, status: "failed" },
+              { stage: "lang_id", durationMs: 100, status: "success" },
+            ],
+          },
+          { command: "say", status: "success", durationMs: null, itemCount: 1, stages: [] },
+        ],
+      }),
+    );
+    expect(output).toContain(
+      "transcribe failed, 2 item(s), 5s | transcribe 3s failed, lang_id 100ms success",
+    );
+    expect(output).toContain("say success, 1 item(s), 0ms | no stages recorded");
+    expect(output).not.toContain("no completed runs recorded");
+  });
+});
+
+describe("renderErrors", () => {
+  test("each row names when it happened, what ran, and what failed", () => {
+    const rows = renderErrors([
+      {
+        occurredAt: "2026-05-16T10:00:00.000Z",
+        command: "transcribe",
+        stage: "transcribe",
+        errorClass: "Error",
+        errorCode: "E_DECODE",
+        message: "decode failed",
+      },
+      {
+        occurredAt: "2026-05-16T11:00:00.000Z",
+        command: null,
+        stage: null,
+        errorClass: "TypeError",
+        errorCode: null,
+        message: "no run attached",
+      },
+      {
+        occurredAt: "2026-05-16T12:00:00.000Z",
+        command: "say",
+        stage: "tts",
+        errorClass: null,
+        errorCode: null,
+        message: "nothing known",
+      },
+    ]).split("\n");
+
+    // The error code wins over the class, and both falling through still leaves a label.
+    expect(rows.slice(1)).toEqual([
+      "2026-05-16T10:00:00.000Z | transcribe | transcribe | E_DECODE | decode failed",
+      "2026-05-16T11:00:00.000Z | unknown | unknown | TypeError | no run attached",
+      "2026-05-16T12:00:00.000Z | say | tts | error | nothing known",
+    ]);
+  });
+});
+
+describe("stats retention settings", () => {
+  let dir: string;
+  const saved = {
+    KESHA_STATS_DB: process.env.KESHA_STATS_DB,
+    KESHA_STATS_RETENTION_DAYS: process.env.KESHA_STATS_RETENTION_DAYS,
+  };
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "kesha-stats-retention-"));
+    process.env.KESHA_STATS_DB = join(dir, "stats.sqlite");
+    delete process.env.KESHA_STATS_RETENTION_DAYS;
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("retention accepts whole positive days or off, and nothing else", () => {
+    enableStats();
+    expect(() => setStatsRetentionDays(0)).toThrow();
+    expect(() => setStatsRetentionDays(-1)).toThrow();
+    expect(() => setStatsRetentionDays(1.5)).toThrow();
+
+    setStatsRetentionDays(1);
+    expect(getStatsStatus().retentionDays).toBe(1);
+    setStatsRetentionDays(null);
+    expect(getStatsStatus().retentionDays).toBeNull();
+  });
+
+  test("the environment override spells off three ways and falls back on nonsense", () => {
+    const cases: Array<[string, number | null]> = [
+      [" OFF ", null],
+      ["none", null],
+      ["never", null],
+      ["12", 12],
+      ["banana", 90],
+      ["0", 90],
+      ["1.5", 90],
+    ];
+    for (const [raw, expected] of cases) {
+      process.env.KESHA_STATS_RETENTION_DAYS = raw;
+      expect(getStatsStatus().retentionDays).toBe(expected as number);
+    }
+  });
+
+  test("retention off keeps runs older than any window", () => {
+    enableStats();
+    setStatsRetentionDays(null);
+    seedStatsRun({
+      command: "transcribe",
+      status: "success",
+      startedAt: "2020-01-01T00:00:00.000Z",
+      finishedAt: "2020-01-01T00:00:01.000Z",
+      itemCount: 1,
+      stages: [{ stage: "transcribe", durationMs: 100, status: "success" }],
+    });
+
+    createStatsRecorder("say").finish("success", 1);
+    const runs = JSON.parse(exportStats("json")).runs as Array<{ startedAt: string }>;
+    expect(runs.map((run) => run.startedAt)).toContain("2020-01-01T00:00:00.000Z");
+  });
+});
+
+describe("stats export contracts", () => {
+  let dir: string;
+  const savedStatsDb = process.env.KESHA_STATS_DB;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "kesha-stats-export-"));
+    process.env.KESHA_STATS_DB = join(dir, "stats.sqlite");
+  });
+
+  afterEach(() => {
+    if (savedStatsDb === undefined) delete process.env.KESHA_STATS_DB;
+    else process.env.KESHA_STATS_DB = savedStatsDb;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("the CSV header is the whole column contract, in order", () => {
+    enableStats();
+    expect(exportStats("csv").split("\n")[0]).toBe(
+      "table,id,run_id,command,kind,stage,status,started_at,finished_at,occurred_at," +
+        "duration_ms,format,size_bytes,sample_rate,channels,error_class,error_code," +
+        "sanitized_message,app_version,item_count",
+    );
+  });
+
+  test("the export states everything stats never stores", () => {
+    enableStats();
+    expect(JSON.parse(exportStats("json")).privacy).toEqual({
+      contentFree: true,
+      neverStored: [
+        "audio bytes",
+        "transcripts",
+        "input text",
+        "output text",
+        "file names",
+        "full file paths",
+        "raw stdout",
+        "raw stderr",
+        "environment variables",
+        "model files",
+      ],
+    });
+  });
+
+  test("every row carries one cell per column, blank where the table has no such field", () => {
+    enableStats();
+    seedStatsRun({
+      command: "transcribe",
+      status: "failed",
+      startedAt: "2026-05-16T10:00:00.000Z",
+      finishedAt: "2026-05-16T10:00:01.000Z",
+      itemCount: 1,
+      stages: [],
+    });
+
+    const lines = exportStats("csv").trim().split("\n");
+    const header = lines[0].split(",");
+    const runRow = lines.find((line) => line.startsWith("runs,"))!.split(",");
+
+    expect(runRow).toHaveLength(header.length);
+    expect(runRow[header.indexOf("command")]).toBe("transcribe");
+    expect(runRow[header.indexOf("status")]).toBe("failed");
+    expect(runRow[header.indexOf("item_count")]).toBe("1");
+    expect(runRow[header.indexOf("kind")]).toBe("");
+    expect(runRow[header.indexOf("size_bytes")]).toBe("");
+  });
+
+  test("a cell containing a comma or a quote is quoted rather than splitting the row", () => {
+    enableStats();
+    seedStatsRun({
+      command: "transcribe",
+      status: "failed",
+      startedAt: "2026-05-16T10:00:00.000Z",
+      finishedAt: "2026-05-16T10:00:01.000Z",
+      itemCount: 1,
+      stages: [],
+      error: new Error('one, two "three"'),
+    });
+
+    expect(exportStats("csv")).toContain('"one, two ""three"""');
+  });
+});
+
 describe("sanitizeStatsError", () => {
+  test("replaces the sensitive span rather than dropping the message", () => {
+    expect(
+      sanitizeStatsError(new Error('failed {"text":"secret"} via https://example.com/a?token=x'))
+        .message,
+    ).toBe('failed {"text":"<redacted>"} via https://example.com/a?<redacted>');
+    expect(
+      sanitizeStatsError(new Error('{"transcript":"a"} {"stdout":"b"} {"stderr":"c"}')).message,
+    ).toBe('{"transcript":"<redacted>"} {"stdout":"<redacted>"} {"stderr":"<redacted>"}');
+    expect(sanitizeStatsError(new Error("open /Users/alice/a.wav failed")).message).toBe(
+      "open <path> failed",
+    );
+    expect(sanitizeStatsError(new Error("open C:\\Users\\bob\\a.wav failed")).message).toBe(
+      "open <path> failed",
+    );
+  });
+
+  test("falls back to the class when there is no message, and reports non-errors", () => {
+    expect(sanitizeStatsError(new Error("")).message).toBe("Error");
+    expect(sanitizeStatsError("plain failure")).toEqual({
+      errorClass: "string",
+      message: "plain failure",
+    });
+  });
+
+  test("a message that is nothing but a stack frame falls back to the class", () => {
+    expect(sanitizeStatsError(new Error("    at frame (file.ts:1:1)")).message).toBe("Error");
+  });
+
+  test("truncation starts one character past the limit", () => {
+    const exact = "y".repeat(300);
+    expect(sanitizeStatsError(new Error(exact)).message).toBe(exact);
+
+    const truncated = sanitizeStatsError(new Error("y".repeat(301))).message;
+    expect(truncated).toHaveLength(300);
+    expect(truncated.endsWith("...")).toBe(true);
+  });
+
   test("removes paths, query strings, stack lines, and truncates long messages", () => {
     const long = "x".repeat(400);
     const err = new Error(`/Users/alice/audio/private.wav failed at https://example.com/a?token=secret {"text":"private transcript"}\n    at frame\n${long}`);
@@ -308,29 +1081,26 @@ describe("sanitizeStatsError", () => {
   });
 });
 
-function seedStatsRun(input: {
+interface SeededRun {
   command: "transcribe" | "say";
   status: "success" | "failed";
   startedAt: string;
-  finishedAt: string;
+  finishedAt: string | null;
   itemCount: number;
   stages: Array<{ stage: string; durationMs: number; status: "success" | "failed" }>;
-  inputArtifact?: { format: string; sizeBytes: number; durationMs: number };
+  inputArtifacts?: Array<{
+    format: string | null;
+    sizeBytes: number | null;
+    durationMs: number | null;
+  }>;
   error?: Error;
-}): void {
+}
+
+function seedStatsRun(input: SeededRun): void {
   seedStatsRuns([input]);
 }
 
-function seedStatsRuns(inputs: Array<{
-  command: "transcribe" | "say";
-  status: "success" | "failed";
-  startedAt: string;
-  finishedAt: string;
-  itemCount: number;
-  stages: Array<{ stage: string; durationMs: number; status: "success" | "failed" }>;
-  inputArtifact?: { format: string; sizeBytes: number; durationMs: number };
-  error?: Error;
-}>): void {
+function seedStatsRuns(inputs: SeededRun[]): void {
   const db = new Database(resolveStatsDbPath());
   try {
     db.exec("begin");
@@ -343,12 +1113,12 @@ function seedStatsRuns(inputs: Array<{
            returning id`,
         ).get(input.command, input.startedAt, input.finishedAt, input.status, input.itemCount) as { id: number };
 
-        if (input.inputArtifact) {
+        for (const artifact of input.inputArtifacts ?? []) {
           db.query(
             `insert into artifacts
               (run_id, kind, format, size_bytes, duration_ms, sample_rate, channels)
              values (?, 'input_audio', ?, ?, ?, null, null)`,
-          ).run(run.id, input.inputArtifact.format, input.inputArtifact.sizeBytes, input.inputArtifact.durationMs);
+          ).run(run.id, artifact.format, artifact.sizeBytes, artifact.durationMs);
         }
 
         for (const stage of input.stages) {

--- a/tests/unit/stats.test.ts
+++ b/tests/unit/stats.test.ts
@@ -23,23 +23,30 @@ import {
   type StatsWeekSummary,
 } from "../../src/stats";
 
-describe("stats storage", () => {
+/** Points the stats DB at a throwaway directory for one describe, and cleans it up after. */
+function useTempStatsDb(prefix: string): () => string {
   let dir: string;
-  const savedStatsDb = process.env.KESHA_STATS_DB;
+  const saved = process.env.KESHA_STATS_DB;
 
   beforeEach(() => {
-    dir = mkdtempSync(join(tmpdir(), "kesha-stats-test-"));
+    dir = mkdtempSync(join(tmpdir(), prefix));
     process.env.KESHA_STATS_DB = join(dir, "stats.sqlite");
   });
 
   afterEach(() => {
-    if (savedStatsDb === undefined) delete process.env.KESHA_STATS_DB;
-    else process.env.KESHA_STATS_DB = savedStatsDb;
+    if (saved === undefined) delete process.env.KESHA_STATS_DB;
+    else process.env.KESHA_STATS_DB = saved;
     rmSync(dir, { recursive: true, force: true });
   });
 
+  return () => dir;
+}
+
+describe("stats storage", () => {
+  const statsDir = useTempStatsDb("kesha-stats-test-");
+
   test("resolveStatsDbPath respects KESHA_STATS_DB", () => {
-    expect(resolveStatsDbPath()).toBe(join(dir, "stats.sqlite"));
+    expect(resolveStatsDbPath()).toBe(join(statsDir(), "stats.sqlite"));
   });
 
   test("status is disabled before the database exists", () => {
@@ -69,7 +76,7 @@ describe("stats storage", () => {
     expect(recorder.enabled).toBe(true);
     recorder.recordArtifact({ kind: "input_audio", format: ".ogg", sizeBytes: 1024 });
     await recorder.timeStage("transcribe", async () => "ok");
-    recorder.recordError("transcribe", new Error(`${dir}/secret.ogg failed?token=abc`));
+    recorder.recordError("transcribe", new Error(`${statsDir()}/secret.ogg failed?token=abc`));
     recorder.finish("failed", 1);
 
     const status = getStatsStatus();
@@ -83,7 +90,7 @@ describe("stats storage", () => {
     expect(week.inputBytes).toBe(1024);
     expect(week.sttTimeMs).toBeGreaterThanOrEqual(0);
     expect(errors).toHaveLength(1);
-    expect(errors[0].message).not.toContain(dir);
+    expect(errors[0].message).not.toContain(statsDir());
     expect(errors[0].message).not.toContain("secret.ogg");
   });
 
@@ -175,7 +182,7 @@ describe("stats storage", () => {
 
   test("exports content-free JSON and CSV", () => {
     enableStats();
-    const secretPath = `${dir}/private-recording.wav`;
+    const secretPath = `${statsDir()}/private-recording.wav`;
     seedStatsRun({
       command: "transcribe",
       status: "failed",
@@ -297,19 +304,7 @@ describe("stats storage", () => {
 });
 
 describe("week summary aggregation", () => {
-  let dir: string;
-  const savedStatsDb = process.env.KESHA_STATS_DB;
-
-  beforeEach(() => {
-    dir = mkdtempSync(join(tmpdir(), "kesha-stats-agg-"));
-    process.env.KESHA_STATS_DB = join(dir, "stats.sqlite");
-  });
-
-  afterEach(() => {
-    if (savedStatsDb === undefined) delete process.env.KESHA_STATS_DB;
-    else process.env.KESHA_STATS_DB = savedStatsDb;
-    rmSync(dir, { recursive: true, force: true });
-  });
+  useTempStatsDb("kesha-stats-agg-");
 
   const NOW = new Date("2026-05-17T00:00:00.000Z");
 
@@ -584,19 +579,7 @@ describe("week summary aggregation", () => {
 });
 
 describe("the recorder writes what it is handed", () => {
-  let dir: string;
-  const savedStatsDb = process.env.KESHA_STATS_DB;
-
-  beforeEach(() => {
-    dir = mkdtempSync(join(tmpdir(), "kesha-stats-recorder-"));
-    process.env.KESHA_STATS_DB = join(dir, "stats.sqlite");
-  });
-
-  afterEach(() => {
-    if (savedStatsDb === undefined) delete process.env.KESHA_STATS_DB;
-    else process.env.KESHA_STATS_DB = savedStatsDb;
-    rmSync(dir, { recursive: true, force: true });
-  });
+  useTempStatsDb("kesha-stats-recorder-");
 
   test("optional artifact and error fields survive the round trip, and absent ones are null", () => {
     enableStats();
@@ -948,19 +931,7 @@ describe("stats retention settings", () => {
 });
 
 describe("stats export contracts", () => {
-  let dir: string;
-  const savedStatsDb = process.env.KESHA_STATS_DB;
-
-  beforeEach(() => {
-    dir = mkdtempSync(join(tmpdir(), "kesha-stats-export-"));
-    process.env.KESHA_STATS_DB = join(dir, "stats.sqlite");
-  });
-
-  afterEach(() => {
-    if (savedStatsDb === undefined) delete process.env.KESHA_STATS_DB;
-    else process.env.KESHA_STATS_DB = savedStatsDb;
-    rmSync(dir, { recursive: true, force: true });
-  });
+  useTempStatsDb("kesha-stats-export-");
 
   test("the CSV header is the whole column contract, in order", () => {
     enableStats();

--- a/tests/unit/status.test.ts
+++ b/tests/unit/status.test.ts
@@ -1,8 +1,16 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import { formatStatusLine, activeModelMirror, collectStatus, renderStatus } from "../../src/status";
+import {
+  formatStatusLine,
+  activeModelMirror,
+  collectStatus,
+  renderStatus,
+  type StatusDiskUsage,
+  type StatusReport,
+} from "../../src/status";
+import { humanBytes } from "../../src/format";
 import { starSeenPath } from "../../src/star";
 import { saveEngineEnv, writeFakeEngine } from "../helpers/fake-engine";
 
@@ -368,6 +376,310 @@ describe("collectStatus --json payload (#647)", () => {
   });
 });
 
+describe("renderStatus turns a report into the states a user acts on", () => {
+  function report(overrides: Partial<StatusReport> = {}): StatusReport {
+    return {
+      cliVersion: "9.9.9",
+      engine: { installed: true, path: "/cache/engine/bin/kesha-engine", capabilities: null },
+      voices: [],
+      runtime: { bun: "1.9.9", platform: "testos", arch: "testarch" },
+      modelMirror: null,
+      hint: null,
+      disk: null,
+      ...overrides,
+    };
+  }
+
+  function render(r: StatusReport): string {
+    const originalLog = console.log;
+    const lines: string[] = [];
+    console.log = (msg: string) => {
+      lines.push(msg);
+    };
+    try {
+      renderStatus(r);
+    } finally {
+      console.log = originalLog;
+    }
+    return lines.join("\n").replace(/\u001b\[\d+m/g, "");
+  }
+
+  test("an engine that cannot describe itself is a failed probe, not a missing one", () => {
+    const output = render(report({ engine: { installed: true, path: "/bin/e", capabilities: null } }));
+    expect(output).toContain("✗ Capabilities: probe failed");
+    expect(output).not.toContain("Backend");
+  });
+
+  test("a described engine reports its backend, protocol and features", () => {
+    const output = render(
+      report({
+        engine: {
+          installed: true,
+          path: "/bin/e",
+          capabilities: { protocolVersion: 4, backend: "onnx", features: ["tts", "diarize"] },
+        },
+      }),
+    );
+    expect(output).toContain("✓ Backend: onnx");
+    expect(output).toContain("✓ Protocol: v4");
+    expect(output).toContain("✓ Features: tts, diarize");
+    expect(output).not.toContain("probe failed");
+  });
+
+  test("nothing engine-shaped is reported when the engine is absent", () => {
+    const output = render(
+      report({
+        engine: {
+          installed: false,
+          path: "/bin/e",
+          capabilities: { protocolVersion: 4, backend: "onnx", features: ["tts"] },
+        },
+        voices: ["en-am_michael"],
+        disk: diskUsage(),
+      }),
+    );
+    expect(output).toContain("✗ Binary: not installed");
+    expect(output).not.toContain("Backend");
+    expect(output).not.toContain("TTS voices");
+    expect(output).not.toContain("Disk usage");
+  });
+
+  test("runtime and platform are reported as present, never as not installed", () => {
+    const output = render(report());
+    expect(output).toContain("Runtime: Bun 1.9.9");
+    expect(output).toContain("Platform: testos testarch");
+    expect(output).not.toContain("Runtime: not installed");
+    expect(output).not.toContain("Platform: not installed");
+  });
+
+  test("the mirror line appears only when a mirror is configured", () => {
+    expect(render(report({ modelMirror: "https://mirror.example.com" }))).toContain(
+      "Mirror: https://mirror.example.com",
+    );
+    expect(render(report())).not.toContain("Mirror");
+  });
+
+  test("the voices section is dropped rather than shown empty", () => {
+    expect(render(report({ voices: [] }))).not.toContain("TTS voices");
+    const listed = render(report({ voices: ["en-am_michael", "ru-vosk-m02"] }));
+    expect(listed).toContain("TTS voices:");
+    expect(listed).toContain("en-am_michael");
+    expect(listed).toContain("ru-vosk-m02");
+  });
+
+  function diskUsage(overrides: Partial<StatusDiskUsage> = {}): StatusDiskUsage {
+    return {
+      cachePath: "/cache",
+      components: [
+        { label: "Engine", sizeBytes: 4_000 },
+        { label: "TTS (Kokoro)", sizeBytes: 6_000 },
+      ],
+      componentTotalBytes: 10_000,
+      totalBytes: 10_000,
+      fluidKokoro: null,
+      fluidAsr: null,
+      ...overrides,
+    };
+  }
+
+  test("each component is listed with its own size", () => {
+    const output = render(report({ disk: diskUsage() }));
+    expect(output).toContain(`Engine:`);
+    expect(output).toContain(humanBytes(4_000));
+    expect(output).toContain(`TTS (Kokoro):`);
+    expect(output).toContain(humanBytes(6_000));
+  });
+
+  test("cache bytes outside the listed components are called out, and only then", () => {
+    const surplus = render(report({ disk: diskUsage({ totalBytes: 25_000 }) }));
+    expect(surplus).toContain(humanBytes(25_000));
+    expect(surplus).toContain(`includes ${humanBytes(15_000)} of other cache files`);
+
+    const exact = render(report({ disk: diskUsage() }));
+    expect(exact).not.toContain("other cache files");
+  });
+
+  test("external caches are reported apart from the Kesha total", () => {
+    const output = render(
+      report({
+        disk: diskUsage({ fluidAsr: { path: "/fluid/asr", sizeBytes: 2_000_000 } }),
+      }),
+    );
+    expect(output).toContain("External caches (not included in Kesha total):");
+    expect(output).toContain(`FluidAudio ASR:    ${humanBytes(2_000_000)} (/fluid/asr)`);
+    expect(output).not.toContain("FluidAudio Kokoro:");
+
+    expect(render(report({ disk: diskUsage() }))).not.toContain("External caches");
+  });
+
+  test("a cache with nothing in it prints no disk section", () => {
+    expect(render(report({ disk: diskUsage({ components: [] }) }))).not.toContain("Disk usage");
+  });
+
+  test("the reset hint names the directory to remove", () => {
+    const output = render(report({ disk: diskUsage({ cachePath: "/somewhere/kesha" }) }));
+    expect(output).toContain("rm -rf /somewhere/kesha");
+  });
+});
+
+describe("collectStatus disk accounting (#647)", () => {
+  const restoreEnv = saveEngineEnv();
+
+  beforeEach(restoreEnv);
+  afterEach(restoreEnv);
+
+  posixEngineTest("empty component directories are dropped and the rest are summed", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-status-disk-sum-"));
+    const cache = join(dir, ".cache", "kesha");
+    const binPath = writeFakeEngine(join(cache, "engine", "bin"));
+    mkdirSync(join(cache, "engine", "lib"), { recursive: true });
+    writeFileSync(join(cache, "engine", "lib", "sidecar.dylib"), "x".repeat(32));
+    mkdirSync(join(cache, "models", "kokoro-82m"), { recursive: true });
+    writeFileSync(join(cache, "models", "kokoro-82m", "voice.bin"), "x".repeat(64));
+    mkdirSync(join(cache, "models", "vosk-ru"), { recursive: true });
+
+    process.env.KESHA_ENGINE_BIN = binPath;
+    process.env.KESHA_CACHE_DIR = cache;
+    process.env.HOME = dir;
+    try {
+      const disk = (await collectStatus({ disk: true })).disk!;
+      // The Engine row covers the whole engine root, not just the bin/ dir the binary sits in.
+      const engineBytes = statSync(binPath).size + 32;
+
+      expect(disk.components.map((c) => c.label)).toEqual(["Engine", "TTS (Kokoro)"]);
+      expect(disk.components[0].sizeBytes).toBe(engineBytes);
+      expect(disk.componentTotalBytes).toBe(engineBytes + 64);
+      // The engine lives under the cache, so its bytes are counted once, not twice.
+      expect(disk.totalBytes).toBe(engineBytes + 64);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  posixEngineTest("an engine installed outside the cache is added to the total", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-status-disk-outside-"));
+    const cache = join(dir, ".cache", "kesha");
+    const binPath = writeFakeEngine(join(dir, "opt", "engine", "bin"));
+    mkdirSync(join(cache, "models", "kokoro-82m"), { recursive: true });
+    writeFileSync(join(cache, "models", "kokoro-82m", "voice.bin"), "x".repeat(64));
+
+    process.env.KESHA_ENGINE_BIN = binPath;
+    process.env.KESHA_CACHE_DIR = cache;
+    process.env.HOME = dir;
+    try {
+      const disk = (await collectStatus({ disk: true })).disk!;
+      expect(disk.totalBytes).toBe(64 + statSync(binPath).size);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("collectStatus voice inventory", () => {
+  const restoreEnv = saveEngineEnv();
+
+  beforeEach(restoreEnv);
+  afterEach(restoreEnv);
+
+  posixEngineTest("a half-downloaded Vosk model advertises no Russian voices", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-status-vosk-partial-"));
+    const cache = join(dir, ".cache", "kesha");
+    const binPath = writeFakeEngine(join(cache, "engine", "bin"));
+    const vosk = join(cache, "models", "vosk-ru");
+    mkdirSync(join(vosk, "bert"), { recursive: true });
+
+    process.env.KESHA_ENGINE_BIN = binPath;
+    process.env.KESHA_CACHE_DIR = cache;
+    process.env.HOME = dir;
+    try {
+      writeFileSync(join(vosk, "bert", "model.onnx"), "bert");
+      expect((await collectStatus()).voices).toEqual([]);
+
+      rmSync(join(vosk, "bert", "model.onnx"));
+      writeFileSync(join(vosk, "model.onnx"), "model");
+      expect((await collectStatus()).voices).toEqual([]);
+
+      writeFileSync(join(vosk, "bert", "model.onnx"), "bert");
+      expect((await collectStatus()).voices).toEqual([
+        "ru-vosk-f01",
+        "ru-vosk-f02",
+        "ru-vosk-f03",
+        "ru-vosk-m01",
+        "ru-vosk-m02",
+      ]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  posixEngineTest("voices are listed in sorted order across engines", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-status-voice-order-"));
+    const cache = join(dir, ".cache", "kesha");
+    const binPath = writeFakeEngine(join(cache, "engine", "bin"));
+    mkdirSync(join(cache, "models", "kokoro-82m", "voices"), { recursive: true });
+    for (const name of ["zf_xiaobei.bin", "am_michael.bin", "bf_emma.bin"]) {
+      writeFileSync(join(cache, "models", "kokoro-82m", "voices", name), "voice");
+    }
+    mkdirSync(join(cache, "models", "vosk-ru", "bert"), { recursive: true });
+    writeFileSync(join(cache, "models", "vosk-ru", "model.onnx"), "model");
+    writeFileSync(join(cache, "models", "vosk-ru", "bert", "model.onnx"), "bert");
+
+    process.env.KESHA_ENGINE_BIN = binPath;
+    process.env.KESHA_CACHE_DIR = cache;
+    process.env.HOME = dir;
+    try {
+      expect((await collectStatus()).voices).toEqual([
+        "en-am_michael",
+        "en-bf_emma",
+        "en-zf_xiaobei",
+        "ru-vosk-f01",
+        "ru-vosk-f02",
+        "ru-vosk-f03",
+        "ru-vosk-m01",
+        "ru-vosk-m02",
+      ]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("the runtime block describes the running process", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-status-runtime-"));
+    process.env.KESHA_ENGINE_BIN = join(dir, "nope", "kesha-engine");
+    process.env.KESHA_CACHE_DIR = join(dir, ".cache", "kesha");
+    process.env.HOME = dir;
+    try {
+      expect((await collectStatus()).runtime).toEqual({
+        bun: Bun.version,
+        platform: process.platform,
+        arch: process.arch,
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  posixEngineTest("an engine the OS refuses to run reports capabilities as null", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-status-unrunnable-"));
+    const binDir = join(dir, ".cache", "kesha", "engine", "bin");
+    mkdirSync(binDir, { recursive: true });
+    const binPath = join(binDir, "kesha-engine");
+    writeFileSync(binPath, "#!/bin/sh\nexit 0\n");
+    chmodSync(binPath, 0o644);
+
+    process.env.KESHA_ENGINE_BIN = binPath;
+    process.env.KESHA_CACHE_DIR = join(dir, ".cache", "kesha");
+    process.env.HOME = dir;
+    try {
+      const report = await collectStatus();
+      expect(report.engine.installed).toBe(true);
+      expect(JSON.parse(JSON.stringify(report)).engine).toHaveProperty("capabilities", null);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("kesha status --json stdout discipline (#647)", () => {
   test("stdout is exactly one JSON object and the hint stays off stderr", async () => {
     const dir = mkdtempSync(join(tmpdir(), "kesha-status-json-cli-"));
@@ -418,11 +730,16 @@ describe("human status output is a load-bearing contract (#647)", () => {
       },
     });
     try {
-      const stdout = await new Response(proc.stdout).text();
+      const [stdout, stderr] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+      ]);
       await proc.exited;
       const binaryLine = stdout.split("\n").find((l) => l.includes("Binary:"));
       expect(binaryLine).toBeDefined();
       expect(binaryLine!).toContain("not installed");
+      // The human path has no payload to carry the hint, so it has to reach stderr.
+      expect(stderr).toContain("kesha install");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
Stage 2 of #794, closing the mutation-testing gaps in the three reporting modules. Stage 1 (#799) covered `engine-install.ts`; this one covers `status.ts`, `doctor.ts` and `stats.ts`.

All three showed the same shape the issue predicted — far more **survived** mutants than **no-coverage** ones, i.e. the tests walked the code and never checked what it produced. The fix is assertions inside the existing flows, not new entry points.

## Mutation score, per module

Each module measured on its own with `mutate` set to that file and `bun.testFiles` set to every test importing it (`status.test.ts`; `doctor.test.ts`; `stats.test.ts` + `stats-action.test.ts` + `command-session.test.ts`).

| Module | Score | Killed | Survived | No coverage | Timeout |
| --- | ---: | ---: | ---: | ---: | ---: |
| `src/status.ts` before | 55.61% | 104 | 74 | 9 | 0 |
| `src/status.ts` after | **83.96%** | 157 | 24 | 6 | 0 |
| `src/doctor.ts` before | 64.27% | 232 | 120 | 9 | 0 |
| `src/doctor.ts` after | **81.99%** | 296 | 57 | 8 | 0 |
| `src/stats.ts` before | 53.32% | 425 | 278 | 94 | 0 |
| `src/stats.ts` after | **86.20%** | 687 | 70 | 40 | 0 |

**No timeout adjustment applies here** — every one of the six runs reported 0 timeouts, so unlike stage 1 there are no STATIC-mutant artifacts miscounted as kills. The numbers above are as reported.

## What the new assertions are about

**`status.ts`** — `renderStatus` takes a plain `StatusReport`, so the render decisions are driven from synthesized reports rather than staged filesystems: an installed engine that cannot describe itself renders as a failed probe (not as absent), an absent engine prints no capabilities/voices/disk sections, the mirror line appears only when configured, cache surplus over the listed components is called out only when there is some, external caches are reported apart from the Kesha total, and the reset hint names the directory to delete. Disk accounting and the voice inventory still use a staged cache, now asserting exact byte totals — an engine inside the cache is counted once, outside it is added — and that a Vosk model missing either half advertises no Russian voices.

**`doctor.ts`** — `formatDoctorReport` is likewise pure, so the states users act on are table-driven: missing/installed/corrupt for the binary and for every optional component, the three version states with drift naming `kesha install` as the remedy, capabilities falling back to the probe error and then to `not available`, cache rows sized or `missing`, stats counters vs the error that hid them, unset env vars named `unset`. At collection level: an absent engine is never probed (so it carries no probe error), an engine that runs but returns nothing reports `capabilities probe returned no data`, a CoreML engine gets the external FluidAudio ASR row instead of the ONNX model dir (#684), and each optional component measures its own directory and names the flag that installs it.

**`stats.ts`** — the arithmetic, per the issue's steer. Seeded runs with figures chosen to pin the maths: counters and sums, size/duration buckets sitting exactly on their boundaries (1 MB, 10 MB, 100 MB; 60 s, 10 min, 60 min) so an off-by-one comparison moves them, percentiles indexed into a ten-sample stage, negative durations clamped rather than subtracted, the five slowest finished runs with unfinished and unparsable-timestamp runs excluded, stages ordered longest first with alphabetical tie-breaks. `renderWeekSummary` is exercised as the pure function it is (realtime factor, hour/minute/second decomposition, empty-state lines and the rows that replace them); `renderErrors` had **no** coverage and now has its row format and `unknown`/`error` fallbacks. Plus the CSV column contract and cell quoting, the privacy contract's full list, retention parsing and its env override, `artifactFromFile`/`artifactFromBytes`, the default DB location, and `sanitizeStatsError`'s replacements and truncation boundary.

`seedStatsRun(s)` grew `inputArtifacts` (was a single `inputArtifact`) and a nullable `finishedAt`, so one helper serves both the existing cases and runs still in flight — no second seeding helper.

## Left alive deliberately

Per the Beck bar in the issue, these are triaged rather than chased:

- **Section headers, blank-line separators and prose notes** (most of the remaining `StringLiteral` mutants in all three modules): `"Engine:"`, `log.info("")`, `"Kesha Stats - last 7 days"`, `"Optional components:"`, the component `note` prose. Killing them means pinning sentences.
- **Column-alignment arithmetic** in `status.ts`'s disk table (`labelWidth`, `" ".repeat(...)`): cosmetic padding, not a figure anyone acts on.
- **The install-hint warn branch** (`status.ts:133`): the hint reaching stderr on the human path *is* asserted, but through the spawned CLI (`kesha status` with no engine), which Stryker's in-process mutant switch does not reach. Killing the mutant itself needs a `process.stderr.write` spy, which the issue rules out.
- **Platform-gated branches**: the FluidAudio Kokoro/ASR external caches (darwin-arm64, and CoreML for ASR), `redactHomePaths`'s `win32` case-folding, `resolveStatsDbPath`'s other-platform arms. Each is unreachable from the platform CI runs on for the others.
- **Equivalent mutants**, where the mutation cannot change output for any reachable input: `redactHomePaths`'s `startsWith` fast path (the regex fallback below it produces the same string), `voices.sort()` (every id is `en-*` or `ru-*`, appended in that order), `/\.bin$/` vs `/\.bin/` for voice filenames, `percentile`'s empty-array guard (only ever called with a non-empty sample), `["--version"]` as the probe argv (the health bar is "it ran", not what it printed).
- **Regex-detail mutants in `sanitizeStatsError`**: the substitutions are pinned by exact expected output (`<path>`, `<redacted>`); the individual character classes inside each pattern are not, and adversarial inputs for them would be testing the regex engine.
- **Defensive fallbacks with no reachable trigger**: `?? "unknown"` after `errorMessage()`, the schema-migration version guards (one version exists), the `catch` in `collectEngine` (the probe returns null rather than throwing).

## Verification

- `bun test tests/unit` — 798 pass, 2 skip, **0 fail**
- `bunx tsc --noEmit` — clean
- `bun run coverage:check:ts` — passes; total TS line coverage **80.96%**, all risk-based floors met (`src/engine.ts` 87.07%, `src/cli/say.ts` 51.75%, `src/cli/main.ts` 39.48%, `src/engine-install.ts` 91.48%)
- Full `bun test` — 940 pass, 19 fail, all of them `e2e-engine` / `e2e-transcribe` / `e2e-lang-detection` / `mcp-e2e` cases that need a working local engine. **Pre-existing on this machine, not caused by this branch**: with the changes stashed, `tests/integration/e2e-engine.test.ts` alone already fails 18. No unit or non-e2e integration test fails.
- No `rust/` changes.

Closes #794
