### PR TITLE
chore(release): lead the base version past v1.27.0-cli

### DIFF
--- a/.claude/skills/release-cli/SKILL.md
+++ b/.claude/skills/release-cli/SKILL.md
@@ -124,6 +124,10 @@ export KESHA_ENGINE_BIN="$V/eng/kesha-engine"
 
 **`make smoke-test` can false-green here.** It runs whatever `kesha` resolves to, and a previously `bun add -g`'d install outranks `bun link`; if its output prints an older version, it tested an older CLI and proves nothing about this release.
 
+### Step 6 — Re-lead the base version on `main`
+
+`main` must carry the next *unreleased* CLI version (#691), and this release just consumed the current one. Open a follow-up PR bumping `package.json#version`, `server.json#version`, and `server.json#packages[0].version` to the next minor. Skipping this step is how #802 happened: the alpha derivation kept emitting `X.Y.Z-alpha.N` for an already-released `X.Y.Z`, so the next labelled merge would point `@alpha` at a version older than `@latest`.
+
 ## Hard rules
 
 - NEVER `npm publish` from a laptop — GHA owns it, with provenance.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "description": "Give your tools a voice — speech to text and back, 25 languages, up to ~19× faster than Whisper. On your machine.",
   "type": "module",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/drakulavich/kesha-voice-kit",
     "source": "github"
   },
-  "version": "1.27.0",
+  "version": "1.28.0",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@drakulavich/kesha-voice-kit",
-      "version": "1.27.0",
+      "version": "1.28.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
The two S-fixes from #802 (the derivation guard stays open there as the M follow-up):

1. **Base version → 1.28.0** in `package.json#version`, `server.json#version`, `server.json#packages[0].version`. `v1.27.0-cli` shipped 2026-08-08 and main's base never moved, so `derive-alpha-version.ts cli` emits `1.27.0-alpha.N` — SemVer-below the published `1.27.0`; npm already shows `alpha=1.27.0-alpha.2 < latest=1.27.0`. After this bump the next labelled merge derives `1.28.0-alpha.1`, restoring `@alpha > @latest`.
2. **`release-cli` skill gains Step 6** — the post-release "re-lead the base" instruction whose absence is how the convention lapsed silently.

Verification: `bun run check:versions` clean (rule 4 covered — both `server.json` fields move with `package.json`), `bunx tsc --noEmit` clean, `bun test tests/unit` 804 pass / 0 fail.

Refs #802, refs #685.