### PR TITLE
fix(transcribe): land the --itn review round — path-parity, output-level contract, self-gating

### DIFF
--- a/openspec/changes/transcribe-itn-flag/design.md
+++ b/openspec/changes/transcribe-itn-flag/design.md
@@ -48,6 +48,13 @@ VAD and chunked paths already produce, so `text` and `segments` cannot drift. On
 path with `--json` there is exactly one Segment whose text is the transcript, so the rebuild is
 an identity. With no Segments at all (the text-only path) the transcript is normalized directly.
 
+"The text-only path has no Segments" is not free, though: the VAD path returns its speech spans
+whether or not the caller asked for Segments, where plain returns none and chunked clears them.
+Left alone, `--itn` without `--timestamps` would normalize per span on long audio only, and a
+number phrase VAD split across two spans normalizes to `"20 1"` rather than `"21"`. So the pass
+runs behind one shared tail that drops Segments whenever they weren't requested, making
+`with_segments: false` mean the same thing on all three paths.
+
 Ordering: ITN runs last in `transcribe_with_options`, after the Diarization merge. Diarization
 assigns Speaker labels from time spans and never reads Segment text, so the two are
 order-independent; running ITN last keeps it a single post-processing tail with one call site.

--- a/openspec/changes/transcribe-itn-flag/specs/transcription/spec.md
+++ b/openspec/changes/transcribe-itn-flag/specs/transcription/spec.md
@@ -55,11 +55,13 @@ The pass rewrites text inside a Segment; it never splits, merges, drops or re-ti
 
 - GIVEN the same recording
 - WHEN Ira transcribes it as plain text with the written-form pass requested
-- THEN the transcript is normalized
+- THEN the transcript is normalized as a whole
 - AND no Segments are emitted
+- AND the result does not depend on whether VAD, chunked or single-pass ASR produced it
 
 #### Scenario: a Segment contains nothing the pass recognizes
 
 - GIVEN a Segment whose text has no spoken-form number, money amount, date or time
 - WHEN the written-form pass runs over it
-- THEN the Segment's text is unchanged
+- THEN the Segment's text is content-preserving: no word is added, removed or rewritten
+- AND leading, trailing and repeated whitespace may be normalized

--- a/rust/src/transcribe/itn.rs
+++ b/rust/src/transcribe/itn.rs
@@ -146,6 +146,44 @@ mod tests {
         assert_eq!(normalize_text("   "), "");
     }
 
+    /// The pass rewrites content but re-tokenizes whitespace, so "unchanged"
+    /// is only true word-for-word — the spec says content-preserving for this
+    /// reason rather than byte-identical.
+    #[test]
+    fn text_without_numbers_keeps_its_words_but_may_lose_spacing() {
+        assert_eq!(normalize_text("  hello   world "), "hello world");
+        assert_eq!(normalize_text("no numbers here"), "no numbers here");
+    }
+
+    #[test]
+    fn the_pass_is_idempotent() {
+        for text in [
+            "there are two hundred thirty two open pull requests",
+            "it costs five dollars and fifty cents",
+            "проверь все свои конфиги",
+            "у меня двадцать три сообщения",
+            "hello мир two hundred",
+            "nothing to rewrite here",
+        ] {
+            let once = normalize_text(text);
+            assert_eq!(normalize_text(&once), once, "not idempotent for {text:?}");
+        }
+
+        let once = normalize_output(TranscriptionOutput {
+            text: "forty two tests passed".into(),
+            segments: vec![
+                segment(0.0, 1.0, "forty two"),
+                segment(1.0, 2.0, "tests passed"),
+            ],
+        });
+        let twice = normalize_output(once.clone());
+        assert_eq!(twice.text, once.text);
+        assert_eq!(
+            twice.segments.iter().map(|s| &s.text).collect::<Vec<_>>(),
+            once.segments.iter().map(|s| &s.text).collect::<Vec<_>>()
+        );
+    }
+
     #[test]
     fn text_is_kept_when_normalization_would_erase_it() {
         // Guards the one shape that would be data loss: non-blank in, blank out.

--- a/rust/src/transcribe/mod.rs
+++ b/rust/src/transcribe/mod.rs
@@ -305,6 +305,10 @@ pub fn transcribe_with_options(
         duration
     );
 
+    #[cfg_attr(
+        not(all(feature = "system_diarize", target_os = "macos")),
+        allow(unused_mut)
+    )]
     let mut output = match decision {
         VadDecision::Vad => {
             transcribe_via_vad(audio_path, &model_dir, &vad_dir, VadConfig::default())
@@ -346,13 +350,28 @@ pub fn transcribe_with_options(
         }
     }
 
-    // Last: diarization reads only segment spans, so the two are
-    // order-independent, and this keeps ITN a single post-processing tail.
+    Ok(finalize_output(output, timestamps_required, itn_required))
+}
+
+/// Post-processing tail shared by every ASR path, run after diarization —
+/// diarization reads only segment spans, so the two are order-independent.
+fn finalize_output(
+    mut output: TranscriptionOutput,
+    timestamps_required: bool,
+    itn_required: bool,
+) -> TranscriptionOutput {
+    // The VAD path returns its speech spans even when segments weren't asked
+    // for; plain and chunked already return none. Normalising here makes
+    // `with_segments: false` mean the same thing everywhere, so text-only ITN
+    // always sees the whole transcript instead of per-span text that can split
+    // a number phrase across segments (#710).
+    if !timestamps_required {
+        output.segments.clear();
+    }
     if itn_required {
         output = itn::normalize_output(output);
     }
-
-    Ok(output)
+    output
 }
 
 /// Shared by plain and chunked paths to avoid duplicate timing+logging+create_backend blocks.
@@ -1435,6 +1454,69 @@ mod tests {
         assert!(!o.with_segments);
         assert!(!o.with_speakers);
         assert!(!o.itn, "the ITN pass must never be on by default (#710)");
+    }
+
+    /// The VAD path returns its speech spans whether or not segments were
+    /// requested, while plain returns none and chunked clears them. Text-only
+    /// ITN must not depend on which path ran: normalizing per span rewrites a
+    /// number phrase VAD split in two as "20 1" instead of "21" (#710).
+    #[test]
+    fn text_only_itn_is_whole_transcript_on_every_path() {
+        let vad_shaped = TranscriptionOutput {
+            text: "twenty one".into(),
+            segments: vec![
+                TranscriptionSegment {
+                    start: 0.0,
+                    end: 1.0,
+                    text: "twenty".into(),
+                    speaker: None,
+                },
+                TranscriptionSegment {
+                    start: 1.0,
+                    end: 2.0,
+                    text: "one".into(),
+                    speaker: None,
+                },
+            ],
+        };
+        let plain_shaped = TranscriptionOutput {
+            text: "twenty one".into(),
+            segments: vec![],
+        };
+
+        let from_vad = finalize_output(vad_shaped, false, true);
+        let from_plain = finalize_output(plain_shaped, false, true);
+
+        assert_eq!(from_vad.text, from_plain.text);
+        assert_eq!(from_vad.text, "21");
+        assert!(
+            from_vad.segments.is_empty(),
+            "with_segments=false must emit no segments regardless of path"
+        );
+    }
+
+    /// The counterpart to the parity test: requesting segments keeps the
+    /// per-segment contract, so `--json --timestamps` still round-trips.
+    #[test]
+    fn requested_segments_keep_per_segment_itn() {
+        let out = finalize_output(
+            TranscriptionOutput {
+                text: "forty two".into(),
+                segments: vec![TranscriptionSegment {
+                    start: 0.0,
+                    end: 1.0,
+                    text: "forty two".into(),
+                    speaker: Some(3),
+                }],
+            },
+            true,
+            true,
+        );
+
+        assert_eq!(out.segments.len(), 1);
+        assert_eq!(out.segments[0].text, "42");
+        assert_eq!(out.segments[0].speaker, Some(3));
+        assert_eq!(out.text, "42");
     }
 
     #[test]

--- a/rust/src/transcribe/options.rs
+++ b/rust/src/transcribe/options.rs
@@ -58,7 +58,7 @@ impl<S> TranscribeOptionsBuilder<S> {
 
 impl TranscribeOptionsBuilder<marker::NoSegments> {
     /// Start a new builder. Defaults match [`TranscribeOptions::default`]:
-    /// `VadMode::Auto`, no segments, no speakers.
+    /// `VadMode::Auto`, no segments, no speakers, `itn: false`.
     pub fn new() -> Self {
         Self {
             options: TranscribeOptions::default(),

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -296,6 +296,8 @@ export async function transcribeEngine(
   audioPath: string,
   opts: TranscribeEngineOptions = {},
 ): Promise<string> {
+  await preflightTranscribeEngineItn(opts);
+
   const args = ["transcribe", audioPath, ...vadArg(opts.vad), ...itnArg(opts.itn)];
   const { stdout, stderr, exitCode } = await runEngine(args, { signal: opts.signal });
   if (exitCode !== 0) {
@@ -331,6 +333,7 @@ export async function transcribeEngineWithSegments(
   audioPath: string,
   opts: TranscribeEngineOptions = {},
 ): Promise<TranscriptionOutput> {
+  await preflightTranscribeEngineItn(opts);
   await preflightTranscribeEngineWithSegments(opts);
 
   const args = ["transcribe", audioPath, "--json", ...vadArg(opts.vad), ...itnArg(opts.itn)];

--- a/tests/unit/engine.test.ts
+++ b/tests/unit/engine.test.ts
@@ -211,6 +211,24 @@ describe("engine", () => {
     });
   });
 
+  fakeEngineTest("the plain-text helper refuses --itn on an engine without the capability", async () => {
+    // Direct ./engine callers bypass the CLI preflight, and would otherwise get
+    // clap usage noise from the old engine instead of the upgrade hint.
+    await withEngineEnv(await argEchoEngine(["transcribe.segments"]), async () => {
+      await expect(transcribeEngine("audio.wav", { itn: true })).rejects.toThrow(
+        "--itn requires a newer kesha-engine",
+      );
+    });
+  });
+
+  fakeEngineTest("the --json helper refuses --itn on an engine without the capability", async () => {
+    await withEngineEnv(await argEchoEngine(["transcribe.segments"]), async () => {
+      await expect(
+        transcribeEngineWithSegments("audio.wav", { itn: true }),
+      ).rejects.toThrow("--itn requires a newer kesha-engine");
+    });
+  });
+
   fakeEngineTest("preflight rejects timestamp requests when the engine lacks segment support", async () => {
     await withEngineEnv(fakeEngine([]), async () => {
       await expect(preflightTranscribeEngineWithSegments()).rejects.toThrow("Timestamped segments require");


### PR DESCRIPTION
Follow-ups to #756 (--itn), which merged while its adversarial review round was still in flight. The review found 0 P1 / 3 P2 / 3 P3; this PR lands all six. Closes #710.

## P2-1 — text-only ITN diverged across the VAD, plain and chunked paths

`transcribe_via_vad` returned speech spans unconditionally, while the plain path returns no segments and the chunked path clears them. With `--itn` and no `--timestamps`/`--json`, a ≥120s file (auto-VAD) got **segment-local** ITN while the same audio chunked got whole-transcript ITN — a number phrase split across a VAD boundary normalized as `"twenty"|"one"` → `"20 1"` instead of `"21"`.

Fix: the post-ASR tail is extracted into `finalize_output`, which clears segments whenever they weren't requested — before the ITN pass — so text-only ITN is always whole-transcript. Written TDD: the parity test failed with exactly the predicted `"20 1"` before the fix. `--json`/`--timestamps` per-segment behaviour is untouched and pinned by its own test. This also brings the code in line with the spec, which already said the text-only path emits no segments.

## P2-2 — the EN "spelled-out → digits" contract was never exercised through the real path

The e2e fixture (`01-check-email.ogg`) contains no spoken numbers — and no EN fixture can: per `BENCHMARK.md`, Parakeet itself emits digits (`3 p.m.`), so switching fixtures proves nothing and new audio is an LFS/owner call. The rewrite is instead pinned at output level through the real tail (`finalize_output`, not just the pure function): `"twenty one"` → `"21"`, `"forty two"` → `"42"`, with speaker labels and timing preserved. The structural e2e stays as a second check.

## P2-3 — spec claimed "unchanged if nothing recognized"; whitespace says otherwise

`normalize_sentence` re-tokenizes: `"  hello   world "` → `"hello world"`, and Russian loses double spaces the same way (verified empirically, so "leaves Russian byte-identical" only holds for already-normalized spacing). The spec scenario now reads *content-preserving; may normalize whitespace*, with a unit test pinning the actual behaviour. Design D2 documents the VAD segment-retention correction.

## P3s

- Low-level `transcribeEngine`/`transcribeEngineWithSegments` now self-gate `--itn` via `preflightTranscribeEngineItn` (same pattern as the segments preflight), so direct callers get the upgrade hint instead of clap noise.
- Idempotency tests: `normalize_output(normalize_output(x)) == normalize_output(x)` over the full corpus incl. Russian and mixed-script, at both `normalize_text` and `normalize_output` level.
- `TranscribeOptionsBuilder::new` doc now states the `itn: false` default.

One knock-on: moving ITN out of the diarize block made `mut output` unused on non-`system_diarize` builds; the `#[cfg_attr(..., allow(unused_mut))]` the feature branch had deleted is restored (verified with `--features system_diarize` and `--features coreml` checks).

## Gates

`make rust-test` 461/461 · fmt/clippy clean · `cargo check` coreml + system_diarize · `cargo deny check` clean · `tsc --noEmit` clean · `bun test`: known #796 stub e2e failures only, plus one **pre-existing** full-suite-only timeout on main (`CLI contracts > diagnostic logs record successful install events without content`, ~5s harness timeout, reproduced on pristine b757517 — filed separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBTpJjqyYFW6W8LHJ2nwy
