### PR TITLE
fix(tts): synthesize past the 510-phoneme cap instead of cutting at it

### DIFF
--- a/rust/src/tts/sessions.rs
+++ b/rust/src/tts/sessions.rs
@@ -17,7 +17,13 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-use super::{charsiu::Charsiu, kokoro::Kokoro, tokenizer::Tokenizer, voices, vosk::Vosk};
+use super::{
+    charsiu::Charsiu,
+    kokoro::Kokoro,
+    tokenizer::{self, Tokenizer},
+    voices,
+    vosk::Vosk,
+};
 
 /// Cached Kokoro inference state. One ONNX session, one tokenizer, one voice
 /// cache. Cheap to clone-key (`PathBuf`); the actual session is non-Clone.
@@ -70,26 +76,34 @@ impl KokoroSession {
     /// Returns an empty `Vec` (not an error) when the IPA contains no recognisable
     /// phonemes — callers decide whether that's a hard error (one-shot) or a
     /// silent skip (SSML segments).
+    ///
+    /// IPA past Kokoro's active-token cap is split with
+    /// [`tokenizer::chunk_ipa`] and the chunks' samples concatenated, so long
+    /// input synthesizes in full instead of being cut at the cap (#715).
     pub fn infer_ipa(
         &mut self,
         ipa: &str,
         voice_path: &Path,
         speed: f32,
     ) -> anyhow::Result<Vec<f32>> {
-        let ids = self.tokenizer.encode(ipa);
-        if ids.is_empty() {
-            return Ok(Vec::new());
-        }
-        let active = ids.len();
-        let padded = Tokenizer::pad_to_context(ids);
+        let mut samples = Vec::new();
+        for chunk in tokenizer::chunk_ipa(ipa, tokenizer::KOKORO_MAX_ACTIVE) {
+            let ids = self.tokenizer.encode(&chunk);
+            if ids.is_empty() {
+                continue;
+            }
+            let active = ids.len();
+            let padded = Tokenizer::pad_to_context(ids);
 
-        // Detach style row from the &self.voices borrow before we touch
-        // &mut self.kokoro — the row is 256 floats (~1 KB), copy is free.
-        let style: Vec<f32> = {
-            let voice = self.voice(voice_path)?;
-            voices::select_style(voice, active).to_vec()
-        };
-        self.kokoro.infer(&padded, &style, speed)
+            // Detach style row from the &self.voices borrow before we touch
+            // &mut self.kokoro — the row is 256 floats (~1 KB), copy is free.
+            let style: Vec<f32> = {
+                let voice = self.voice(voice_path)?;
+                voices::select_style(voice, active).to_vec()
+            };
+            samples.extend(self.kokoro.infer(&padded, &style, speed)?);
+        }
+        Ok(samples)
     }
 }
 

--- a/rust/src/tts/tokenizer.rs
+++ b/rust/src/tts/tokenizer.rs
@@ -31,9 +31,12 @@ impl Tokenizer {
     }
 
     /// Wrap with a single leading+trailing 0 — matches `kokoro-onnx` upstream
-    /// (`tokens = [[0, *tokens, 0]]`). Truncates beyond [`KOKORO_MAX_ACTIVE`]
-    /// silently. Earlier versions padded to 512 with trailing zeros, which the
-    /// model interpreted as additional silence/noise tokens — see #207.
+    /// (`tokens = [[0, *tokens, 0]]`). Earlier versions padded to 512 with
+    /// trailing zeros, which the model interpreted as additional silence/noise
+    /// tokens — see #207.
+    ///
+    /// The clamp to [`KOKORO_MAX_ACTIVE`] is a backstop: callers split long
+    /// input with [`chunk_ipa`] first, so nothing reaches it in practice (#715).
     pub fn pad_to_context(mut ids: Vec<i64>) -> Vec<i64> {
         if ids.len() > KOKORO_MAX_ACTIVE {
             ids.truncate(KOKORO_MAX_ACTIVE);
@@ -43,6 +46,62 @@ impl Tokenizer {
         out.extend(ids);
         out.push(0);
         out
+    }
+}
+
+/// Pause punctuation that marks a natural break point, mirroring FluidAudio's
+/// `PhonemeChunker.defaultBoundaryPunctuation` so the ONNX and ANE Kokoro paths
+/// split long input at the same places.
+const BOUNDARY_PUNCTUATION: [char; 8] = [',', '.', ';', ':', '!', '?', '…', '—'];
+
+/// Split an IPA string into chunks that each fit Kokoro's active-token cap.
+///
+/// Each break is taken at the latest whitespace or pause-punctuation boundary
+/// inside the `max_len` window, so words stay intact and punctuation stays with
+/// the preceding chunk; a boundary-less run is hard-split at the cap. Chunks are
+/// whitespace-trimmed and never empty. Input that already fits is returned
+/// verbatim, so short input synthesizes byte-for-byte as it did before #715.
+///
+/// `max_len` counts characters: [`Tokenizer::encode`] drops what the vocab does
+/// not cover and so never emits more ids than input characters.
+pub fn chunk_ipa(ipa: &str, max_len: usize) -> Vec<String> {
+    assert!(max_len > 0, "chunk_ipa: max_len must be positive");
+    let chars: Vec<char> = ipa.chars().collect();
+    if chars.len() <= max_len {
+        return vec![ipa.to_string()];
+    }
+
+    let is_boundary = |c: char| c.is_whitespace() || BOUNDARY_PUNCTUATION.contains(&c);
+    let skip_whitespace = |from: usize| {
+        let mut i = from;
+        while i < chars.len() && chars[i].is_whitespace() {
+            i += 1;
+        }
+        i
+    };
+
+    let mut chunks = Vec::new();
+    let mut start = skip_whitespace(0);
+    while chars.len() - start > max_len {
+        let window_end = start + max_len;
+        let break_at = (start + 1..window_end)
+            .rev()
+            .find(|&i| is_boundary(chars[i]))
+            .map_or(window_end, |i| i + 1);
+        push_trimmed(&chars[start..break_at], &mut chunks);
+        start = skip_whitespace(break_at);
+    }
+    if start < chars.len() {
+        push_trimmed(&chars[start..], &mut chunks);
+    }
+    chunks
+}
+
+fn push_trimmed(slice: &[char], chunks: &mut Vec<String>) {
+    let text: String = slice.iter().collect();
+    let trimmed = text.trim();
+    if !trimmed.is_empty() {
+        chunks.push(trimmed.to_string());
     }
 }
 
@@ -82,6 +141,46 @@ mod tests {
     fn wraps_with_leading_and_trailing_zero() {
         let padded = Tokenizer::pad_to_context(vec![1, 2, 3]);
         assert_eq!(padded, vec![0, 1, 2, 3, 0]);
+    }
+
+    #[test]
+    fn chunk_returns_short_input_verbatim() {
+        assert_eq!(chunk_ipa(" həlˈoʊ ", 510), vec![" həlˈoʊ "]);
+        assert_eq!(chunk_ipa("", 510), vec![""]);
+    }
+
+    #[test]
+    fn chunk_breaks_at_latest_whitespace_in_window() {
+        assert_eq!(chunk_ipa("aaa bbb ccc ddd", 8), vec!["aaa bbb", "ccc ddd"]);
+    }
+
+    #[test]
+    fn chunk_keeps_punctuation_with_preceding_chunk() {
+        assert_eq!(chunk_ipa("aaaa,bbb", 6), vec!["aaaa,", "bbb"]);
+    }
+
+    #[test]
+    fn chunk_hard_splits_a_boundary_less_run() {
+        assert_eq!(chunk_ipa("aaaaaaaaa", 4), vec!["aaaa", "aaaa", "a"]);
+    }
+
+    #[test]
+    fn chunk_preserves_every_phoneme() {
+        let ipa = (0..300)
+            .map(|i| format!("wɜrd{i}"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        let chunks = chunk_ipa(&ipa, KOKORO_MAX_ACTIVE);
+        assert!(chunks.len() > 1, "expected a split, got {}", chunks.len());
+        for c in &chunks {
+            assert!(
+                c.chars().count() <= KOKORO_MAX_ACTIVE,
+                "chunk over cap: {} chars",
+                c.chars().count()
+            );
+        }
+        let joined: String = chunks.join(" ");
+        assert_eq!(joined, ipa, "chunking dropped or reordered phonemes");
     }
 
     #[test]


### PR DESCRIPTION
Closes #715
Supersedes #758.

Revival of #758, which GitHub auto-closed when its base branch `deps/issue-709` was deleted on #755's merge. A PR whose base is gone cannot be reopened, so this is the same work rebased onto current `main` and raised against `main` directly. The two stacked deps commits dropped out (they landed as #755, `a738a8b`); only the fix commit replays, and it applies without conflict — neither `rust/src/tts/sessions.rs` nor `rust/src/tts/tokenizer.rs` changed on `main` since the branch was cut. Both files are byte-identical to #758's head `7b55078`, so the audio measurements below still describe exactly this code.

## What was broken

A 130-word sentence with no internal punctuation (694 phonemes, cap 510) behaves three different ways depending on the build:

| build | before | after |
|---|---|---|
| darwin-arm64 `system_kokoro`, FluidAudio 0.14.8 | hard fail: `phonemeSequenceTooLong(694)`, `E_INTERNAL`, exit 4 | — (fixed by the 0.15.5 bump in #755) |
| darwin-arm64 `system_kokoro`, FluidAudio 0.15.5 | 42.83 s, full text | unchanged, byte-identical |
| ONNX Kokoro (Linux / Windows / non-`system_kokoro`) | **29.10 s, exit 0** — last 27% of the text silently dropped | 42.98 s, full text |

The ONNX case is the bad one. `infer_ipa` handed the whole IPA string to `pad_to_context`, which truncated to `KOKORO_MAX_ACTIVE` and reported success. Round-tripping the truncated WAV through the engine's own ASR shows both the loss and the artifact the abrupt token cut produces:

> … where the fence has been leaning for years without ever quite falling down **and the water and a little bit of a little bit of a little bit of** …

Everything after "falling down" — 35 words — never rendered, and the last few seconds are babble.

## The fix

`tokenizer::chunk_ipa` splits the resolved IPA at the latest whitespace or pause-punctuation boundary inside the cap window, keeps punctuation with the preceding chunk, and hard-splits a boundary-less run. That is a deliberate port of FluidAudio's `PhonemeChunker` (same boundary set, same window rule), so both Kokoro backends now break long input at the same places. `infer_ipa` loops the chunks and concatenates their samples; the ONNX path applies no per-utterance normalization, only `clamp_audio`, so concatenation cannot introduce a level step.

Input that already fits is returned verbatim rather than trimmed — upstream trims in its fast path too, but here that would change leading-whitespace IPA that works today, and this is a bugfix.

`pad_to_context`'s clamp stays as a backstop; its doc comment now says so.

### Why the ANE path needs no kesha code

`fluid_kokoro::synthesize` → `FluidAudio::synthesize_kokoro` → `fluidaudio_kokoro_synthesize` → `FluidAudioBridge.synthesizeKokoro` → `KokoroAneManager.synthesize(text:voice:speed:)` → `synthesizeDetailed`. That is exactly the high-level text API FluidAudio 0.15.5 wired `PhonemeChunker` into, and 0.15.5 normalizes once over the concatenated samples. The low-level `synthesizeFromPhonemes` that stays strict is not on this path.

That argument was written against the `dc931c5` pin from #755. `main` has since moved the `fluidaudio-rs` pin to `91d80ea` (#806, fork branch `feat/diarize-control`), so it was re-checked rather than assumed: `91d80ea` is `dc931c5` plus two diarize-only commits, and `Cargo.lock` still resolves the crate at 0.15.5. The 0.15.5 `PhonemeChunker` wiring this rests on is intact, and this PR touches no Cargo manifest, so there is no pin interaction either way.

## Verification

All audio runs use a 130-word / 701-char single sentence with no internal punctuation, measured on #758's head (identical tree for both changed files).

**Completeness** — engine ASR round-trip of the ONNX output recovers the full input text, no babble tail. Duration 42.98 s, matching the ANE path's 42.83 s.

**No regression on short input** — pre-change and post-change ONNX binaries produce byte-identical WAVs (`cmp` clean) for both a short sentence and `<speak>First part.<break time="500ms"/>Second part.</speak>`.

**SSML stitching** — two long segments plus a 700 ms `<break>`: ONNX 86.65 s vs 86.66 s expected, ANE 86.35 s vs 86.36 s expected. Break duration preserved, and each long segment chunks internally.

**Joins, RMS-window analysis** (50 ms windows, mean level of the 4 s of speech either side of the join):

| | join | pre | post | offset |
|---|---|---|---|---|
| ONNX | 27.95 s | −26.94 dB | −25.10 dB | **+1.84 dB** |
| ANE | 29.85 s | −23.92 dB | −22.37 dB | **+1.55 dB** |

For scale, the worst sustained 3 s/3 s level swing *within* a single un-chunked utterance is −3.60 dB (`h2`) and +2.60 dB (`h1`). Both joins sit below ordinary prosodic variation, so there is no level step attributable to chunking. A human listen is still the final word.

## Gates

Re-run on the rebased head, against current `main`:

- `make rust-test` — 424 passed, 0 skipped
- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo check --features coreml --no-default-features` — clean
- `cargo check --features system_kokoro --no-default-features` — clean (this is the gate that compiles the darwin TTS path; `tokenizer` and `sessions` are declared unconditionally in `tts/mod.rs`, so both feature sets build the changed code)
- `bunx tsc --noEmit` — clean
- `bun test` — 956 pass, 7 skip, 23 fail. All 23 are pre-existing and unrelated: a fresh `origin/main` worktree run on the same machine fails the identical 23 (`comm` delta empty in both directions), and they are the engine-dependent `e2e-engine` / `e2e-transcribe` / `e2e-lang-detection` / `mcp-e2e` cases from the #796 stub. Nothing in TTS or `cli-contracts` fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBTpJjqyYFW6W8LHJ2nwy
