### PR TITLE
test(cli-contracts): stop install scenarios waiting on the developer's gh

### DIFF
--- a/tests/integration/cli-contracts.test.ts
+++ b/tests/integration/cli-contracts.test.ts
@@ -1,15 +1,20 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { dirname, join } from "path";
 import { engineVersion } from "../../src/package-info";
 import { waitForPidExit, waitForPidFile } from "../helpers/process";
 import {
+  DEFAULT_TIMEOUT_MS,
   installFakeDiarizeModel,
   runCliScenario,
   type CliScenarioOptions,
   type CliScenarioResult,
 } from "./cli-scenario";
+
+// bun's 5 s per-test default sits below the harness budget, so a scenario dies by
+// opaque SIGTERM before it can report what the CLI had managed to do (#805).
+setDefaultTimeout(DEFAULT_TIMEOUT_MS * 2);
 
 const tempDirs: string[] = [];
 const DEFAULT_CWD = import.meta.dir + "/../..";

--- a/tests/integration/cli-scenario.ts
+++ b/tests/integration/cli-scenario.ts
@@ -1,11 +1,32 @@
-import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, statSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
 import { delimiter, dirname, join } from "path";
 
 const DEFAULT_CWD = import.meta.dir + "/../..";
-// macOS scans every freshly-written executable on first exec, and these scenarios
-// mint a new fake engine per test: 2-9 s observed locally, ~0.4 s once warm.
-const DEFAULT_TIMEOUT_MS = 15_000;
+// Headroom for macOS scanning the fake engine each scenario mints; measured at ~1 s
+// for a test's three stubs, well under the 2-9 s #649 attributed to it (#805).
+export const DEFAULT_TIMEOUT_MS = 15_000;
 const FORCE_KILL_GRACE_MS = 1_000;
+
+/**
+ * `kesha install` ends by asking `gh` whether the repo is already starred. Under a
+ * scenario's throwaway HOME that is an unauthenticated `gh auth status`, which blocks
+ * on the network for as long as the developer's `gh` takes — 11-25 s through a wrapper
+ * shim here — so the CLI's timing tracked an external tool rather than its own work
+ * (#805). Resolve `gh` to a stub that declines instantly; star behaviour itself is
+ * covered by tests/unit/star.test.ts, which injects its own shims.
+ */
+function stubGhOnPath(): string {
+  const binDir = join(tmpdir(), "kesha-cli-scenario-bin");
+  mkdirSync(binDir, { recursive: true });
+  const staging = join(binDir, `gh.${process.pid}`);
+  writeFileSync(staging, "#!/bin/sh\nexit 1\n");
+  chmodSync(staging, 0o755);
+  renameSync(staging, join(binDir, "gh"));
+  return binDir;
+}
+
+const STUB_BIN_DIR = stubGhOnPath();
 
 export interface CliScenarioArtifactRequest {
   name?: string;
@@ -80,7 +101,9 @@ export async function runCliScenario(
     cwd: opts.cwd ?? DEFAULT_CWD,
     env: {
       ...process.env,
-      PATH: [dirname(process.execPath), process.env.PATH].filter(Boolean).join(delimiter),
+      PATH: [STUB_BIN_DIR, dirname(process.execPath), process.env.PATH]
+        .filter(Boolean)
+        .join(delimiter),
       ...envOverrides,
     },
   });


### PR DESCRIPTION
Closes #805

## What the 5 s actually was

Bun's **per-test default timeout**, nothing in this repo. `bun test` with no flags caps every test at 5000 ms — which is the exact `[5014.03ms] … timed out after 5000ms` signature in the issue. There is no `bunfig.toml`, so the default stands.

#649 already knew about this cap and raised it, but only in the **`package.json` scripts** (`bun test --timeout 30000`). So `bun run test` / `make test` / CI were covered and plain `bun test` — the pre-push gate CLAUDE.md actually prescribes — was not. That is the whole "full-suite `bun test` only" framing: it is not about the full suite, it is about which command you type.

Confirmed empirically (bun 1.3.13): a 6 s test fails at 5000 ms under plain `bun test`, and `setDefaultTimeout` is file-scoped — a later file still gets 5000 ms.

## Why the harness budget could never help

`cli-scenario.ts`'s `DEFAULT_TIMEOUT_MS` is 15 s, i.e. **above** bun's cap. The harness could never reach its own budget: bun killed the test at 5 s first, and the resulting SIGTERM carries no information. Raising the cap so the harness wins the race is what made this diagnosable — the very first run after that change printed:

```
CliScenarioTimeoutError: CLI timed out after 15000ms: kesha install --vad
elapsedMs=16024  exitCode=137
stdout=Engine binary already installed (v1.24.9).
Installing models...
Backend installed successfully (engine v1.24.9).
```

The CLI had done **all of its work** and still had not exited. That reframed the bug from "slow" to "waiting on something".

## The actual cause: the CLI waits on the developer's `gh`

`kesha install` ends in `maybeAskForStar` (`src/star.ts`), which spawns `gh auth status` synchronously to decide whether to nag about starring the repo. A scenario sets `HOME` to a throwaway temp dir, so that call is unauthenticated and goes to the network.

Timestamping each stdout chunk of the CLI under the test's exact env:

```
[+479ms]   "Engine binary already installed (v1.24.9)."
[+3004ms]  "Installing models..."
[+3037ms]  "Backend installed successfully (engine v1.24.9)."
[+14168ms] "\nIf you enjoy Kesha Voice Kit, consider starring the repo: ..."
[+14173ms] stdout closed; exit=0
```

The install finishes at **3.0 s**; the remaining **11 s** is entirely the star prompt. Measured directly, `gh auth status` with a clean `HOME` takes **11.7 s / 20.6 s** on this machine at ~2 % CPU — `/opt/homebrew/bin/gh` here is a shell wrapper (ghx) that does its own network work. Repeated cold CLI runs came in at 12.7 / 26.2 / 16.2 s, straddling both the 5 s cap and the 15 s harness budget, which is exactly the intermittency reported.

So the test's runtime tracked an external tool's latency, not the code under test. It is not isolated and not deterministic — it fails or passes according to which `gh` is on `PATH` and how the network feels. CI stays green because its `gh` situation differs.

### The pre-warm hypothesis is disproven

Issue option (b) assumed the macOS first-exec scan of the freshly minted stubs. Pre-executing all three stubs before the timed run **changed nothing** (13.5 / 18.1 / 32.4 s), and the pre-warm itself cost only **~1.0 s for three binaries** — an order of magnitude below the "2–9 s per cold binary" #649 attributed it to. #649 very likely misattributed this same `gh` wait: its reported symptom (work complete, then SIGKILL) is identical to what is above. I corrected that comment rather than leave a misleading number next to the constant.

## The fix

1. **`cli-scenario.ts`** — scenarios resolve `gh` to a stub that exits 1 instantly, prepended to the CLI's `PATH`. `Bun.which` is used in exactly one place in `src/` (`star.ts`), so the blast radius is precisely this prompt; the stub still exercises the found-but-unauthenticated branch and prints the same basic nudge. Star behaviour keeps its 19 unit tests in `tests/unit/star.test.ts`, which inject their own shims. The stub lives in one fixed dir written via staging + `rename` so concurrent test processes cannot exec a half-written file, and repeated runs reuse it instead of accumulating temp dirs.

2. **`cli-contracts.test.ts`** — `setDefaultTimeout(DEFAULT_TIMEOUT_MS * 2)` lifts bun's cap above the harness budget, so a scenario timeout reports what the CLI managed to do instead of an opaque SIGTERM, whichever command you typed. This is issue option (a); on its own it did **not** fix the flake (see below), but it is what surfaced the cause and it keeps the next one legible. 30 s also matches what the `package.json` scripts already pass, so both invocation paths now agree.

## Verification

Full `bun test` (plain, no `--timeout`), on this machine.

| Arm | Runs | Failures of this test | 5000 ms timeouts | pass / fail | wall |
| --- | --- | --- | --- | --- | --- |
| Baseline (pristine `origin/main` @ a3acb6c) | 2 | **2 / 2** | 1 per run | 955 / 24 | 100.2 s, 99.4 s |
| Option (a) only — cap lifted, `gh` still live | 1 | **1 / 1** (at 16032 ms, the 15 s harness budget) | 0 | 955 / 24 | 112.9 s |
| Fix (both changes) | 4 | **0 / 4** | 0 | 956 / 23 | 95.2 / 91.2 / 94.6 / 89.9 s |

Failure name-set delta against the baseline, per fix run: `fixed=1, new=0` — the 23 remaining are the known #796 stub e2e set, untouched. The pass count rises 955 → 956 because this test now passes rather than being skipped or dropped.

Per-test duration went **12–32 s → 3.15 s** (junit reporter), and the whole `cli-contracts` file now runs in 19.8 s with 21/21 passing.

**Sabotage check** — inverted the logged `vad` field in `src/cli/install.ts` and re-ran against the final code: the test failed in 2928 ms on a clean assertion diff (`vad: true` expected, `false` received), not a timeout. Reverted; the diff is test-only.

Gates: `bunx tsc --noEmit` clean. No Rust involved.

## Note for a follow-up

Not fixed here, because it is product behaviour and outside this issue: `maybeAskForStar` runs `gh` through `Bun.spawnSync` with **no timeout**, so a real user with a slow or unauthenticated `gh` sees a successful `kesha install` appear to hang for 10–20 s after it has already printed "Backend installed successfully". Worth capping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBTpJjqyYFW6W8LHJ2nwy
