### PR TITLE
fix(install): stop the star nudge holding the CLI open on a slow gh

### DIFF
--- a/src/star.ts
+++ b/src/star.ts
@@ -1,6 +1,10 @@
 import { existsSync, readFileSync, writeFileSync } from "fs";
 import { tryParseSemver } from "./semver.mjs";
 
+// Clears a healthy `gh auth status` (0.77-1.21 s measured) but not a wedged one, which
+// blocked install 11-25 s; Bun kills at the budget and reports exitCode null (#810).
+const GH_PROBE_TIMEOUT_MS = 2_000;
+
 /**
  * Version-bump gate for the "star the repo" prompt in `kesha install`.
  *
@@ -68,7 +72,11 @@ export async function maybeAskForStar(
   const spawn =
     shims?.spawn ??
     ((cmd: string[]) =>
-      Bun.spawnSync(cmd, { stdout: "ignore", stderr: "ignore" }));
+      Bun.spawnSync(cmd, {
+        stdout: "ignore",
+        stderr: "ignore",
+        timeout: GH_PROBE_TIMEOUT_MS,
+      }));
   if (!currentVersion) return;
   const seen = readStarSeen(binPath);
   if (!shouldShowStarPrompt(currentVersion, seen)) {

--- a/tests/integration/cli-contracts.test.ts
+++ b/tests/integration/cli-contracts.test.ts
@@ -1,7 +1,16 @@
 import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "fs";
 import { tmpdir } from "os";
-import { dirname, join } from "path";
+import { delimiter, dirname, join } from "path";
 import { engineVersion } from "../../src/package-info";
 import { waitForPidExit, waitForPidFile } from "../helpers/process";
 import {
@@ -118,6 +127,17 @@ process.exit(2);
   );
   chmodSync(enginePath, 0o755);
   return enginePath;
+}
+
+/** A `gh` that never answers, shadowing the scenario's fast stub via a PATH override. */
+function createWedgedGh(dir: string): string {
+  const binDir = join(dir, "wedged-bin");
+  mkdirSync(binDir, { recursive: true });
+  const staging = join(binDir, "gh.staging");
+  writeFileSync(staging, "#!/bin/sh\nexec sleep 30\n");
+  chmodSync(staging, 0o755);
+  renameSync(staging, join(binDir, "gh"));
+  return binDir;
 }
 
 function markFakeEngineInstalled(enginePath: string): void {
@@ -677,6 +697,27 @@ describe("CLI contracts", () => {
       status: "success",
     });
     expect(typeof events[1].durationMs).toBe("number");
+  });
+
+  test("install finishes even when gh on PATH never answers (#810)", async () => {
+    const dir = makeTempDir("kesha-cli-contract-wedged-gh-");
+    const enginePath = createFakeEngine(dir);
+    markFakeEngineInstalled(enginePath);
+    const env: Record<string, string> = {
+      ...isolatedEnv(dir),
+      KESHA_ENGINE_BIN: enginePath,
+      PATH: [createWedgedGh(dir), dirname(process.execPath), process.env.PATH]
+        .filter(Boolean)
+        .join(delimiter),
+    };
+
+    // The star probe is the last thing install does, so completing at all — inside
+    // the harness budget, against a `gh` that sleeps far past it — is the contract.
+    const run = await runCli(["install"], { env });
+    expectContract(run, {
+      exitCode: 0,
+      stdoutContains: ["Backend installed successfully"],
+    });
   });
 
   test("diagnostic logs record failed install events without content", async () => {

--- a/tests/unit/star.test.ts
+++ b/tests/unit/star.test.ts
@@ -111,7 +111,7 @@ describe("maybeAskForStar — orchestration", () => {
   // exitCode for each so we can simulate every branch deterministically
   // without spawning a real subprocess (Bun.which caches PATH at process
   // start, so PATH manipulation in-test does not work).
-  function shimsWithGh(opts: { authExit: number; apiExit: number }) {
+  function shimsWithGh(opts: { authExit: number | null; apiExit: number | null }) {
     return {
       which: () => "/fake/gh",
       spawn: (cmd: string[]) => ({
@@ -156,6 +156,24 @@ describe("maybeAskForStar — orchestration", () => {
     await maybeAskForStar(binPath, "1.2.0", log, shimsWithGh({ authExit: 1, apiExit: 0 }));
     expect(hasStarMarker(binPath)).toBe(true);
     expect(lines.join("\n")).toContain("consider starring the repo");
+  });
+
+  // Bun reports a spawnSync timeout as exitCode null, so these two cover the
+  // budget expiring on either probe (#810).
+  test("auth probe times out → marker written + basic prompt printed", async () => {
+    const binPath = mkTmpBinPath();
+    const { log, lines } = captureLog();
+    await maybeAskForStar(binPath, "1.2.0", log, shimsWithGh({ authExit: null, apiExit: 0 }));
+    expect(hasStarMarker(binPath)).toBe(true);
+    expect(lines.join("\n")).toContain("consider starring the repo");
+  });
+
+  test("star probe times out → rich prompt rather than a silent already-starred", async () => {
+    const binPath = mkTmpBinPath();
+    const { log, lines } = captureLog();
+    await maybeAskForStar(binPath, "1.2.0", log, shimsWithGh({ authExit: 0, apiExit: null }));
+    expect(hasStarMarker(binPath)).toBe(true);
+    expect(lines.join("\n")).toContain("⭐ If you enjoy Kesha Voice Kit");
   });
 
   test("gh authenticated + already starred → marker consumed, no prompt", async () => {


### PR DESCRIPTION
Closes #810

Product half of #805; PR #809 fixed the test-side symptom, this fixes the CLI.

## What Bun's `spawnSync` timeout actually does

Measured on bun 1.3.13 rather than taken from docs, because the exact shape decides whether any new branch is needed:

| | result |
| --- | --- |
| 5 s child, `timeout: 500` | returns at **503 ms** |
| child killed with | **SIGTERM** (`signalCode: "SIGTERM"`) |
| `exitCode` on expiry | **`null`** — not a number, not 124 |
| also set | `success: false`, `exitedDueToTimeout: true` |
| fast children (`exit 3` / `exit 0`) | unaffected, returned in ~9 ms with exitCode 3 / 0 |

`exitCode === null` is the load-bearing detail: `star.ts` already gates both probes on `exitCode !== 0`, so a timeout falls into the existing "gh could not answer" path. The fix needs no new branch — just the budget.

## Why 2 s and not the ~500 ms the issue proposed

The issue attributed 11–25 s to `gh`. That was measured through `/opt/homebrew/bin/gh`, which on this machine is a **shell wrapper** (`exec ghx "$@"`), not the real binary. Timing the real one underneath:

| `gh auth status` | time |
| --- | --- |
| real binary, authenticated | **0.77 / 1.21 / 0.77 s** |
| real binary, clean HOME (unauthenticated) | **0.06 / 0.04 s** |
| through the ghx wrapper, clean HOME | 11.7 s / 20.6 s |

So an unauthenticated `gh` is fast — it reads config and gives up without a network call. The pathological latency was always the wrapper, and the authenticated path costs ~1 s because it validates the token over the network.

That makes 500 ms the wrong number: it would expire on **every healthy authenticated machine**, so the auth probe would never succeed, the `gh api` star check would never run, and the "already starred → stay quiet" courtesy would never fire. The feature would be dead code that still looks alive — effectively issue option 3 (drop the probe) implemented by accident. 2 s clears the measured healthy cost with margin while still cutting the pathological case by an order of magnitude.

Worst case is one budget per probe. A wedged `gh` expires on the auth probe and returns immediately (2 s total); reaching the second probe requires the first to have answered fast, so 4 s needs a `gh` that is healthy then wedges mid-run.

Both are one constant (`GH_PROBE_TIMEOUT_MS`) if you want a different trade.

## One deliberate deviation, worth a look

The issue says "on expiry, skip the nudge silently". This prints the basic nudge instead, because `writeStarSeen` runs **before** the probes: by the time the budget expires the version slot is already consumed, so staying silent burns the user's one prompt for that major/minor bump. `star.ts` states that invariant in place — *"Marker recorded — every return below must print, except 'already starred'"* — and printing costs nothing once we have stopped waiting. The "never worth waiting for" rationale is satisfied by the budget, not by the silence. Easy to flip if you disagree.

## Tests

**Regression test** (`cli-contracts`, integration): points `PATH` at a `gh` that sleeps 30 s, shadowing the fast stub #809 installed, and asserts install completes with its success line. The bound is the harness's own 15 s budget rather than a hand-tuned millisecond figure — deliberately, since a wall-clock threshold in this very file is what made #805 fragile.

- against `main`: **fails** at 16043 ms, `exitCode=137`, `timedOut=true`, with `stdout` already reading `Backend installed successfully (engine v1.24.9).` — the user-visible bug reproduced exactly
- with the fix: **passes in 5.17 s** (3.89 s when the budget was still 500 ms)

**Unit tests** (`star.test.ts`, +2): cover the expiry on either probe through the same injected-shim seam the file already uses — the shim's `exitCode` type widened to `number | null`, no env tricks, no real subprocess. Sabotage-checked: rewriting the guard as `exitCode === 1` makes the auth-timeout test fail and the other 20 pass, so it bites the branch it claims to.

## Verification

Full plain `bun test`, delta against a fresh `origin/main` worktree @ 70f2af2:

| Arm | pass / fail | wall |
| --- | --- | --- |
| Baseline `origin/main` | 956 / 23 | 96.1 s |
| Fix (shipped 2 s budget) | **959 / 23** | 98.8 s |

Failure name-set delta: **nothing only-in-base, nothing only-in-fix** — the 23 are the known #796 stub e2e set, unchanged. +3 passing tests are exactly the ones added. `bunx tsc --noEmit` clean. No Rust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBTpJjqyYFW6W8LHJ2nwy
