### PR TITLE
fix(release): refuse an alpha base the channel has already released

### DIFF
--- a/.github/scripts/derive-alpha-version.ts
+++ b/.github/scripts/derive-alpha-version.ts
@@ -7,7 +7,7 @@
  * `version=`/`tag=` lines suitable for `$GITHUB_OUTPUT`.
  */
 import { readFileSync } from "node:fs";
-import { CLI_MARKER, publishedVersionRe } from "./release-tags.mjs";
+import { CLI_MARKER, publishedVersionRe, stableVersionRe } from "./release-tags.mjs";
 import { cmp, parseSemver } from "../../src/semver.mjs";
 
 export type Channel = "cli" | "engine";
@@ -53,6 +53,36 @@ export function previousTag(channel: Channel, tags: string[]): string | undefine
     if (!best || cmp(version, best.version) > 0) best = { tag: raw.trim(), version };
   }
   return best?.tag;
+}
+
+/**
+ * A prerelease sorts below its own stable version, so an alpha of an already-released base is
+ * older than what the channel already serves — npm showed `@alpha` 1.27.0-alpha.2 behind
+ * `@latest` 1.27.0 (#802). The refusal reads the same tags the sequence is counted from.
+ */
+export function assertBaseLeadsPublished(channel: Channel, base: string, tags: string[]): void {
+  const shape = stableVersionRe(MARKER[channel]);
+
+  let highest: { raw: string; version: ReturnType<typeof parseSemver> } | undefined;
+  for (const tag of tags) {
+    const match = shape.exec(tag.trim());
+    if (!match) continue;
+    const version = parseSemver(match[1], "published stable");
+    if (!highest || cmp(version, highest.version) > 0) highest = { raw: match[1], version };
+  }
+  if (!highest) return;
+  if (cmp(parseSemver(base, "alpha base"), highest.version) > 0) return;
+
+  const remedy =
+    channel === "cli"
+      ? "bump package.json#version on main to the next unreleased version — the release-cli " +
+        "skill's 'Re-lead the base version on main' step"
+      : "name an engine base above it";
+  throw new Error(
+    `${channel} alpha base ${base} does not lead the highest published stable ${highest.raw}: ` +
+      `${base}-alpha.N sorts below ${highest.raw}, so the alpha channel would serve a version older ` +
+      `than the released one. Fix: ${remedy}.`,
+  );
 }
 
 /**
@@ -104,6 +134,8 @@ export function deriveAlpha(
   if (base.includes("-")) {
     throw new Error(`alpha base must be a stable version, got ${base} — alphas derive from it`);
   }
+
+  assertBaseLeadsPublished(channel, base, tags);
 
   const sequence = nextSequence(channel, base, tags);
   const version = `${base}-alpha.${sequence}`;

--- a/.github/scripts/release-tags.d.mts
+++ b/.github/scripts/release-tags.d.mts
@@ -8,6 +8,7 @@ export function isStableTag(tag: string): boolean;
 export function isEngineAlphaTag(tag: string): boolean;
 export const CLI_MARKER: string;
 export function publishedVersionRe(marker: string): RegExp;
+export function stableVersionRe(marker: string): RegExp;
 export function cliPublishTarget(tag: string): {
   version: string;
   engineOnly: boolean;

--- a/.github/scripts/release-tags.mjs
+++ b/.github/scripts/release-tags.mjs
@@ -36,6 +36,11 @@ export function publishedVersionRe(marker) {
   return new RegExp(`^v([0-9]+\\.[0-9]+\\.[0-9]+(?:-(?:alpha|beta)\\.[0-9]+)?)${marker}$`);
 }
 
+/** A channel's released stables only — the floor an alpha base has to lead (#802). */
+export function stableVersionRe(marker) {
+  return new RegExp(`^v([0-9]+\\.[0-9]+\\.[0-9]+)${marker}$`);
+}
+
 /**
  * What the CLI publish path should do with a release tag.
  *

--- a/tests/unit/derive-alpha-version.test.ts
+++ b/tests/unit/derive-alpha-version.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   alphaTag,
+  assertBaseLeadsPublished,
   assertPassesVersionGate,
   deriveAlpha,
   nextSequence,
@@ -70,6 +71,57 @@ describe("assertPassesVersionGate", () => {
   });
 });
 
+describe("assertBaseLeadsPublished", () => {
+  test("accepts a base above every published stable on the channel", () => {
+    const tags = ["v1.27.0-cli", "v1.26.0-cli", "v1.24.7"];
+
+    expect(() => assertBaseLeadsPublished("cli", "1.28.0", tags)).not.toThrow();
+  });
+
+  // The #802 inversion: 1.27.0-alpha.N sorts below the released 1.27.0, so npm's @alpha
+  // would serve something older than @latest.
+  test("refuses a base equal to the highest published stable", () => {
+    expect(() => assertBaseLeadsPublished("cli", "1.27.0", ["v1.27.0-cli"])).toThrow(
+      /1\.27\.0.*does not lead.*1\.27\.0/s,
+    );
+  });
+
+  test("refuses a base below the highest published stable", () => {
+    const tags = ["v1.26.0-cli", "v1.27.0-cli"];
+
+    expect(() => assertBaseLeadsPublished("cli", "1.26.5", tags)).toThrow(/does not lead/);
+  });
+
+  test("names the remedy so the refusal is actionable", () => {
+    expect(() => assertBaseLeadsPublished("cli", "1.27.0", ["v1.27.0-cli"])).toThrow(
+      /package\.json#version/,
+    );
+    expect(() => assertBaseLeadsPublished("engine", "1.24.7", ["v1.24.7"])).toThrow(
+      /engine base above it/,
+    );
+  });
+
+  // A first release must not be bricked: nothing published means nothing to lead.
+  test("proceeds when the channel has published no stable yet", () => {
+    expect(() => assertBaseLeadsPublished("cli", "0.1.0", ["v1.24.7"])).not.toThrow();
+  });
+
+  test("proceeds against a prerelease-only history", () => {
+    const tags = ["v1.27.0-alpha.2-cli", "v1.27.0-beta.1-cli"];
+
+    expect(() => assertBaseLeadsPublished("cli", "1.27.0", tags)).not.toThrow();
+  });
+
+  test("ignores the other channel's stables", () => {
+    expect(() => assertBaseLeadsPublished("cli", "1.25.0", ["v1.30.0"])).not.toThrow();
+    expect(() => assertBaseLeadsPublished("engine", "1.25.0", ["v1.30.0-cli"])).not.toThrow();
+  });
+
+  test("compares by SemVer, not lexically", () => {
+    expect(() => assertBaseLeadsPublished("cli", "1.9.0", ["v1.10.0-cli"])).toThrow(/does not lead/);
+  });
+});
+
 describe("deriveAlpha", () => {
   test("the CLI base comes from the next unreleased version on main", () => {
     expect(deriveAlpha("cli", PKG, SOME_TAGS)).toEqual({
@@ -95,6 +147,21 @@ describe("deriveAlpha", () => {
     for (const base of ["1.24.7", "1.24.6"]) {
       expect(() => deriveAlpha("engine", PKG, SOME_TAGS, base)).toThrow(/must be above/);
     }
+  });
+
+  // #802: main's base lapsed to the version v1.27.0-cli had already released.
+  test("refuses a CLI base the channel has already released", () => {
+    const tags = ["v1.24.7", "v1.27.0-cli", "v1.27.0-alpha.2-cli"];
+
+    expect(() => deriveAlpha("cli", PKG, tags)).toThrow(/does not lead/);
+  });
+
+  test("refuses an engine target a bare tag has already released", () => {
+    const pkg = { version: "1.30.0", keshaEngine: { version: "1.24.7" } };
+
+    expect(() => deriveAlpha("engine", pkg, ["v1.24.9", "v1.26.0-cli"], "1.24.8")).toThrow(
+      /does not lead/,
+    );
   });
 
   test("refuses a base that is already a prerelease", () => {

--- a/tests/unit/release-tag-grammar.test.ts
+++ b/tests/unit/release-tag-grammar.test.ts
@@ -9,6 +9,7 @@ import {
   ENGINE_TAG_ERE,
   ENGINE_TAG_RE,
   isEngineAlphaTag,
+  stableVersionRe,
 } from "../../.github/scripts/release-tags.mjs";
 import { parseRepoYaml, readRepoFile, REPO_ROOT } from "../helpers/repo";
 
@@ -61,6 +62,57 @@ describe("CLI marker tag grammar", () => {
     for (const tag of [...ENGINE_TAGS, ...NOT_TAGS, "v1.27.0-cli-cli", "v1.27.0-rc.1-cli", "cli"]) {
       expect(CLI_TAG_RE.test(tag)).toBe(false);
     }
+  });
+});
+
+// The floor the alpha derivation refuses to mint below, so a prerelease slipping through here
+// would let an alpha of an already-released base pass the guard (#802).
+describe("published stable shape", () => {
+  const CLI_STABLE = stableVersionRe("-cli");
+  const ENGINE_STABLE = stableVersionRe("");
+  const PRERELEASES = ["v1.27.0-alpha.2-cli", "v1.27.0-beta.1-cli", "v1.27.0-alpha.2", "v1.24.8-beta.1"];
+  const LOOKALIKES = [
+    "V1.27.0-cli",
+    "1.27.0-cli",
+    "v1.27.0-cli-cli",
+    "v1.27.0cli",
+    "v1.27.0-CLI",
+    "v1.27.0.1-cli",
+    "v1.27.0+build-cli",
+    "V1.24.8",
+    "1.24.8",
+    "v1.24.8.1",
+    "v1.24.8+build",
+  ];
+
+  test("accepts exactly its own channel's stable tag", () => {
+    expect(CLI_STABLE.test("v1.27.0-cli")).toBe(true);
+    expect(ENGINE_STABLE.test("v1.24.8")).toBe(true);
+  });
+
+  // The guard compares the captured version, not the tag, so the marker must not leak into it.
+  test("captures the bare version", () => {
+    expect(CLI_STABLE.exec("v1.27.0-cli")?.[1]).toBe("1.27.0");
+    expect(ENGINE_STABLE.exec("v1.24.8")?.[1]).toBe("1.24.8");
+  });
+
+  test("rejects every prerelease", () => {
+    for (const tag of PRERELEASES) {
+      expect(CLI_STABLE.test(tag)).toBe(false);
+      expect(ENGINE_STABLE.test(tag)).toBe(false);
+    }
+  });
+
+  test("rejects malformed and marker-lookalike shapes", () => {
+    for (const tag of [...LOOKALIKES, ...NOT_TAGS, "cli", ""]) {
+      expect(CLI_STABLE.test(tag)).toBe(false);
+      expect(ENGINE_STABLE.test(tag)).toBe(false);
+    }
+  });
+
+  test("neither channel matches the other's stable tag", () => {
+    expect(CLI_STABLE.test("v1.24.8")).toBe(false);
+    expect(ENGINE_STABLE.test("v1.27.0-cli")).toBe(false);
   });
 });
 


### PR DESCRIPTION
Closes #802 — the **M** part. The two **S** fixes landed in #803 (main bumped to 1.28.0, `release-cli` gained the "Re-lead the base version on `main`" step); this is what makes the failure structural rather than procedural.

## The guard

`deriveAlpha` now calls `assertBaseLeadsPublished(channel, base, tags)` before counting a sequence. The base must sort strictly **above** the highest stable tag on its own channel; equal or below throws. No new plumbing — the highest published stable comes from the same tag list the sequence is already counted from, and the stable-only shape joins the rest of the tag grammar in `release-tags.mjs` as `stableVersionRe(marker)`.

The refusal names both versions and the remedy:

```
cli alpha base 1.27.0 does not lead the highest published stable 1.27.0:
1.27.0-alpha.N sorts below 1.27.0, so the alpha channel would serve a version
older than the released one. Fix: bump package.json#version on main to the next
unreleased version — the release-cli skill's 'Re-lead the base version on main' step.
```

Verified against the real tag list: today's main (base `1.28.0`) still derives `1.28.0-alpha.1` / `v1.28.0-alpha.1-cli`, and replaying the pre-#803 base `1.27.0` produces exactly the refusal above.

## Both channels, deliberately

The engine lane shares the code path and gets the same guard. Its existing check compares the requested target against `package.json#keshaEngine.version` — the **pin**, not what is released. If an engine tag ships above a stale pin, that check passes and the tag-based one catches it. Prerelease tags are not a floor for either channel: an alpha of a base that already has alphas or a beta is exactly what the sequence exists for.

## Test cases

`tests/unit/derive-alpha-version.test.ts`, red before the guard:

| case | expected |
| --- | --- |
| base == highest published stable | refuse (the #802 numbers) |
| base < highest published stable | refuse |
| base > highest published stable | proceed |
| channel has no stable tag yet | proceed (a first release must not brick) |
| prerelease-only history | proceed |

Plus: the message names `package.json#version` for CLI and the engine base for engine; the other channel's stables are ignored; comparison is SemVer, not lexical (`1.9.0` vs `1.10.0-cli`); and two `deriveAlpha`-level cases covering each lane end to end.

## Verification

- `bunx tsc --noEmit` → clean
- `bun test tests/unit/derive-alpha-version.test.ts tests/unit/release-tag-grammar.test.ts tests/integration/alpha-tag.test.ts` → 76 pass, 0 fail
- `bun test` → 969 pass, 23 fail — all 23 are the pre-existing engine-e2e set on a machine without a real engine, none in the release scripts

No workflow changes, so no `${{ }}`-in-`run:` surface touched.

## Grammar coverage

`stableVersionRe` joins the tag grammar, so `tests/unit/release-tag-grammar.test.ts` — the grammar's paired suite — owns it directly rather than only through the derivation's tests. Five cases, both channels in each: accepts exactly its own channel's stable tag; captures the bare version with the marker excluded (the guard compares the capture, not the tag); rejects every prerelease; rejects malformed and marker-lookalike shapes (`V1.27.0-cli`, `1.27.0-cli`, `v1.27.0-cli-cli`, `v1.27.0cli`, `v1.27.0-CLI`, `v1.27.0.1-cli`, `v1.27.0+build-cli`, four-part and build-metadata engine shapes); and cross-channel exclusion in both directions. Every shape already rejected correctly, so that commit changes no production code.

## Known limits (reviewed, not fixed here)

- **Leading zeros.** `v01.27.0-cli` matches the shape and then throws out of `parseSemver`. That is the existing `publishedVersionRe` / `ENGINE_TAG_ERE` behaviour — the family is loose there because bash `=~` consumes the same text — and it fails closed rather than silently understating the floor.
- **Truncated tag fetch.** A partial tag list could understate the highest published stable and let a bad base through. The `decide` job checks out with `fetch-depth: 0` and `fetch-tags: true`, and an *empty* list is already refused outright by `nextSequence`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBTpJjqyYFW6W8LHJ2nwy
