### PR TITLE
fix(status): stop counting a prefix-sharing sibling as inside the cache

### DIFF
--- a/src/cache-layout.ts
+++ b/src/cache-layout.ts
@@ -1,4 +1,4 @@
-import { join } from "path";
+import { join, resolve, sep } from "path";
 
 export interface CachePathEntry {
   label: string;
@@ -11,6 +11,19 @@ export interface CachePathEntry {
  * populates the ONNX ASR dir and keeps its own bundle outside this cache, so that row is
  * dropped rather than rendered as missing; callers list it under external caches (#684).
  */
+/**
+ * Whether `child` is `parent` itself or lives under it — the one answer `status --disk` and
+ * `doctor` both need before deciding whether an engine dir is already inside the cache total.
+ * A bare `startsWith` reads the sibling `~/.cache/kesha-alt` as inside `~/.cache/kesha` and
+ * drops its size (#790); `KESHA_CACHE_DIR` and `KESHA_ENGINE_BIN` are taken verbatim, so both
+ * sides are resolved first.
+ */
+export function isInsideDir(child: string, parent: string): boolean {
+  const resolvedChild = resolve(child);
+  const resolvedParent = resolve(parent);
+  return resolvedChild === resolvedParent || resolvedChild.startsWith(`${resolvedParent}${sep}`);
+}
+
 export function cacheComponentPaths(
   cacheRoot: string,
   engineDir: string,

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -1,8 +1,8 @@
 import { existsSync } from "fs";
-import { cacheComponentPaths } from "./cache-layout";
+import { cacheComponentPaths, isInsideDir } from "./cache-layout";
 import { errorMessage } from "./error-utils";
 import { humanBytes } from "./format";
-import { dirname, join, sep } from "path";
+import { dirname, join } from "path";
 import {
   getEngineBinPath,
   getEngineCapabilities,
@@ -259,8 +259,7 @@ function collectCache(
       sizeBytes: fluidKokoro.sizeBytes,
     });
   }
-  const engineInsideCache = engineDir === cache || engineDir.startsWith(`${cache}${sep}`);
-  const engineOutsideCache = engineInsideCache ? 0 : dirSizeBytes(engineDir);
+  const engineOutsideCache = isInsideDir(engineDir, cache) ? 0 : dirSizeBytes(engineDir);
 
   return {
     path: redactPath(cache, redact),

--- a/src/status.ts
+++ b/src/status.ts
@@ -6,7 +6,7 @@ import {
   getEngineCapabilities,
   type EngineCapabilities,
 } from "./engine";
-import { cacheComponentPaths } from "./cache-layout";
+import { cacheComponentPaths, isInsideDir } from "./cache-layout";
 import { humanBytes } from "./format";
 import { installHint } from "./install-hint";
 import { log } from "./log";
@@ -178,7 +178,7 @@ function collectDiskUsage(binPath: string, backend?: string): StatusDiskUsage {
 
   // Sum cache root + engine dir separately so `KESHA_ENGINE_BIN` overrides outside the cache are still counted.
   const cacheTotal = dirSizeBytes(cache);
-  const engineOutsideCache = engineDir.startsWith(cache) ? 0 : dirSizeBytes(engineDir);
+  const engineOutsideCache = isInsideDir(engineDir, cache) ? 0 : dirSizeBytes(engineDir);
   const fluidKokoro = fluidKokoroCacheInfo();
   // Only walked when it is the backend in play; otherwise the size is computed and dropped.
   const fluidAsr = coreml ? fluidAsrCacheInfo() : null;

--- a/tests/unit/cache-layout.test.ts
+++ b/tests/unit/cache-layout.test.ts
@@ -1,0 +1,41 @@
+import { describe, test, expect } from "bun:test";
+import { join, resolve, sep } from "path";
+import { isInsideDir } from "../../src/cache-layout";
+
+const cache = resolve(join(sep, "home", "u", ".cache", "kesha"));
+
+describe("isInsideDir (#790)", () => {
+  test("a directory is inside itself", () => {
+    expect(isInsideDir(cache, cache)).toBe(true);
+  });
+
+  test("a strict descendant is inside", () => {
+    expect(isInsideDir(join(cache, "engine"), cache)).toBe(true);
+    expect(isInsideDir(join(cache, "engine", "bin"), cache)).toBe(true);
+  });
+
+  test("a sibling whose name merely shares the prefix is outside", () => {
+    expect(isInsideDir(`${cache}-alt`, cache)).toBe(false);
+    expect(isInsideDir(`${cache}2`, cache)).toBe(false);
+    expect(isInsideDir(join(`${cache}-old`, "engine"), cache)).toBe(false);
+  });
+
+  test("an unrelated path is outside", () => {
+    expect(isInsideDir(resolve(join(sep, "opt", "kesha")), cache)).toBe(false);
+  });
+
+  test("the parent of the cache is outside", () => {
+    expect(isInsideDir(resolve(join(cache, "..")), cache)).toBe(false);
+  });
+
+  test("trailing separators do not change the answer", () => {
+    expect(isInsideDir(join(cache, "engine"), `${cache}${sep}`)).toBe(true);
+    expect(isInsideDir(`${cache}${sep}`, cache)).toBe(true);
+    expect(isInsideDir(`${cache}-alt`, `${cache}${sep}`)).toBe(false);
+  });
+
+  test("unnormalised traversal is resolved before comparing", () => {
+    expect(isInsideDir(join(cache, "engine", "bin", "..", ".."), cache)).toBe(true);
+    expect(isInsideDir(join(cache, "..", "kesha-alt"), cache)).toBe(false);
+  });
+});

--- a/tests/unit/doctor.test.ts
+++ b/tests/unit/doctor.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { gunzipSync } from "node:zlib";
@@ -10,6 +18,7 @@ import {
   redactDiagnosticValue,
   type DoctorReport,
 } from "../../src/doctor";
+import { collectStatus } from "../../src/status";
 import { createSupportBundle } from "../../src/support-bundle";
 import { engineVersion, packageName, packageVersion } from "../../src/package-info";
 import { enableStats } from "../../src/stats";
@@ -993,6 +1002,59 @@ describe("doctor separates corrupt components from missing ones", () => {
       expect(output).toContain(
         `Binary: ${report.engine.path} (installed but not executable (corrupt) - re-run \`kesha install\`)`,
       );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("doctor and status agree on the disk total (#790)", () => {
+  const savedEnv = {
+    HOME: process.env.HOME,
+    KESHA_ENGINE_BIN: process.env.KESHA_ENGINE_BIN,
+    KESHA_CACHE_DIR: process.env.KESHA_CACHE_DIR,
+    KESHA_STATS_DB: process.env.KESHA_STATS_DB,
+  };
+
+  function restoreEnv() {
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+
+  beforeEach(restoreEnv);
+  afterEach(restoreEnv);
+
+  posixEngineTest("an engine in a prefix-sharing sibling of the cache counts in both", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-doctor-status-sibling-"));
+    const cache = join(dir, ".cache", "kesha");
+    const binDir = join(`${cache}-alt`, "bin");
+    mkdirSync(binDir, { recursive: true });
+    const binPath = join(binDir, "kesha-engine");
+    writeFakeEngine(
+      binPath,
+      `#!/bin/sh
+if [ "$1" = "--capabilities-json" ]; then
+  printf '%s\\n' '{"protocolVersion":3,"backend":"onnx","features":[]}'
+  exit 0
+fi
+exit 2
+`,
+    );
+    mkdirSync(join(cache, "models", "kokoro-82m"), { recursive: true });
+    writeFileSync(join(cache, "models", "kokoro-82m", "voice.bin"), "x".repeat(64));
+
+    process.env.HOME = dir;
+    process.env.KESHA_ENGINE_BIN = binPath;
+    process.env.KESHA_CACHE_DIR = cache;
+    process.env.KESHA_STATS_DB = join(dir, "stats.sqlite");
+    try {
+      const doctorTotal = (await collectDoctorReport()).cache.totalBytes;
+      const statusTotal = (await collectStatus({ disk: true })).disk!.totalBytes;
+
+      expect(doctorTotal).toBe(64 + statSync(binPath).size);
+      expect(statusTotal).toBe(doctorTotal);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/tests/unit/status.test.ts
+++ b/tests/unit/status.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "fs";
-import { join } from "path";
+import { join, sep } from "path";
 import { tmpdir } from "os";
 import {
   formatStatusLine,
@@ -565,6 +565,61 @@ describe("collectStatus disk accounting (#647)", () => {
 
     process.env.KESHA_ENGINE_BIN = binPath;
     process.env.KESHA_CACHE_DIR = cache;
+    process.env.HOME = dir;
+    try {
+      const disk = (await collectStatus({ disk: true })).disk!;
+      expect(disk.totalBytes).toBe(64 + statSync(binPath).size);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  posixEngineTest("a sibling directory sharing the cache path prefix is counted (#790)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-status-disk-sibling-"));
+    const cache = join(dir, ".cache", "kesha");
+    // `<cache>-alt` is a string prefix match for the cache but is not inside it.
+    const binPath = writeFakeEngine(join(`${cache}-alt`, "bin"));
+    mkdirSync(join(cache, "models", "kokoro-82m"), { recursive: true });
+    writeFileSync(join(cache, "models", "kokoro-82m", "voice.bin"), "x".repeat(64));
+
+    process.env.KESHA_ENGINE_BIN = binPath;
+    process.env.KESHA_CACHE_DIR = cache;
+    process.env.HOME = dir;
+    try {
+      const disk = (await collectStatus({ disk: true })).disk!;
+      expect(disk.totalBytes).toBe(64 + statSync(binPath).size);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  posixEngineTest("an engine rooted at the cache itself is counted once", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-status-disk-atroot-"));
+    const cache = join(dir, ".cache", "kesha");
+    const binPath = writeFakeEngine(join(cache, "bin"));
+    mkdirSync(join(cache, "models", "kokoro-82m"), { recursive: true });
+    writeFileSync(join(cache, "models", "kokoro-82m", "voice.bin"), "x".repeat(64));
+
+    process.env.KESHA_ENGINE_BIN = binPath;
+    process.env.KESHA_CACHE_DIR = cache;
+    process.env.HOME = dir;
+    try {
+      const disk = (await collectStatus({ disk: true })).disk!;
+      expect(disk.totalBytes).toBe(64 + statSync(binPath).size);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  posixEngineTest("a trailing separator on KESHA_CACHE_DIR does not double-count", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-status-disk-trailing-"));
+    const cache = join(dir, ".cache", "kesha");
+    const binPath = writeFakeEngine(join(cache, "engine", "bin"));
+    mkdirSync(join(cache, "models", "kokoro-82m"), { recursive: true });
+    writeFileSync(join(cache, "models", "kokoro-82m", "voice.bin"), "x".repeat(64));
+
+    process.env.KESHA_ENGINE_BIN = binPath;
+    process.env.KESHA_CACHE_DIR = `${cache}${sep}`;
     process.env.HOME = dir;
     try {
       const disk = (await collectStatus({ disk: true })).disk!;


### PR DESCRIPTION
Closes #790

## The miscount

`kesha status --disk` asked whether the engine directory already sits inside the model cache with a bare prefix test:

```ts
const engineOutsideCache = engineDir.startsWith(cache) ? 0 : dirSizeBytes(engineDir);
```

A sibling directory whose *name* merely starts with the cache path is not inside it. With `KESHA_ENGINE_BIN=~/.cache/kesha-alt/bin/kesha-engine`, `engineDir` is `~/.cache/kesha-alt`, `startsWith("~/.cache/kesha")` is true, and the engine's bytes are counted as zero and dropped from the total. That override is exactly the case the line exists for, and `kesha install --engine-version` (#739) makes keeping a second engine around ordinary.

`doctor` answered the same question correctly with its own copy of the predicate, so the two commands reported different totals for the same machine. The regression test measured 206 bytes from `doctor` against 64 from `status` before the fix.

## The fix

Rather than paste doctor's predicate a second time — two hand-rolled copies is what produced the divergence — `isInsideDir(child, parent)` now lives in `src/cache-layout.ts`, the module that already exists so `status` and `doctor` cannot drift on cache layout, and both callers use it.

It `resolve()`s both sides before comparing, which also fixes a bug doctor's copy had on its own: `KESHA_CACHE_DIR` is taken verbatim, so a trailing separator made `${cache}${sep}` a double separator, and an engine genuinely inside the cache was classified as outside and counted twice.

## Tests (red first)

- `tests/unit/cache-layout.test.ts` (new) pins the predicate: self, strict descendant, prefix-sharing siblings (`-alt`, `2`, `-old`), unrelated path, the parent directory, trailing separators on either side, and unnormalised `..` traversal.
- `tests/unit/status.test.ts` adds the behavioural regression (sibling engine counted), plus guards for an engine rooted at the cache itself (counted once) and a trailing separator on `KESHA_CACHE_DIR` (not double-counted).
- `tests/unit/doctor.test.ts` adds a cross-check that `doctor` and `status --disk` report the same total for the sibling layout — the issue's headline symptom.

The two sibling tests fail on `main` and pass here; the rest pass either way as guards against over-correcting.

## Verification

- `bunx tsc --noEmit` — clean.
- `bun test` — 970 pass / 23 fail against a fresh `origin/main` baseline worktree's 959 pass / 23 fail. The failing test names are byte-identical between the two arms (the known #796 stub set); the 11 new passes are the tests above. No Rust touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBTpJjqyYFW6W8LHJ2nwy