### PR TITLE
fix(release): gate the engine release notes on a real tag annotation

### DIFF
--- a/.claude/skills/release-engine/SKILL.md
+++ b/.claude/skills/release-engine/SKILL.md
@@ -71,14 +71,14 @@ That window must stay short. While it is open, `main` pins an engine with no rel
 
 ### Step 3 — Tag with the notes inside it
 
-Write the notes first, then create an **annotated** tag whose message is the notes. `build-engine.yml` reads `git tag -l --format='%(contents)'` into the draft body, so this sidesteps the published-release notes trap entirely.
+Write the notes first, then create an **annotated** tag whose message is the notes. `build-engine.yml` reads the annotation into the draft body via `engine-release-notes.mjs`, so this sidesteps the published-release notes trap entirely.
 
 ```bash
 git tag -a vX.Y.Z --cleanup=verbatim -F notes.md
 git push origin refs/tags/vX.Y.Z
 ```
 
-`--cleanup=verbatim` keeps the `#` heading lines a release body needs. Do **not** run `.github/scripts/push-annotated-tag.sh` locally — it sets `user.name`/`user.email` to github-actions[bot] in the repo config, which is right in CI and wrong on a laptop.
+`--cleanup=verbatim` keeps the `#` heading lines a release body needs; git's default cleanup strips every line starting with `#`. The `-a` is equally load-bearing: a lightweight tag carries no annotation, and the notes are dropped with a `::notice::` rather than published — before #815 the lane read `%(contents)` unguarded and shipped the *commit* message as the release body instead. Do **not** run `.github/scripts/push-annotated-tag.sh` locally — it sets `user.name`/`user.email` to github-actions[bot] in the repo config, which is right in CI and wrong on a laptop.
 
 The build produces 3 platform binaries, smoke-tests each with `--capabilities-json`, and creates a **draft** release with SBOM, manifest, `SHA256SUMS` and Sigstore bundles. Engine tags do **not** attach Linux `.deb`/`.rpm` — those ship on the `-cli` marker release now (#728).
 

--- a/.claude/skills/release-mechanics/SKILL.md
+++ b/.claude/skills/release-mechanics/SKILL.md
@@ -47,7 +47,7 @@ Two things do *not* go through this lane. A **beta marker** (`vX.Y.Z-beta.N-cli`
 
 1. Bump `rust/Cargo.toml`, `rust/Cargo.lock` (`cargo check`), `package.json#keshaEngine.version` — leave `package.json#version` alone, it carries the next unreleased CLI (#691). An engine tag publishes nothing to npm; the bumped pin reaches users with the next `-cli` release (#729). If the engine would overtake the CLI line, raise it to match — rule 2 (`cli >= engine`) rejects the commit otherwise — but never lower it.
 2. Merge to main.
-3. Tag/push **annotated, with the notes as the message**: `git tag -a vX.Y.Z --cleanup=verbatim -F notes.md && git push origin refs/tags/vX.Y.Z` → `build-engine.yml`, whose release job reads `git tag -l --format='%(contents)'` into the draft body. A lightweight tag leaves the body empty.
+3. Tag/push **annotated, with the notes as the message**: `git tag -a vX.Y.Z --cleanup=verbatim -F notes.md && git push origin refs/tags/vX.Y.Z` → `build-engine.yml`, whose release job composes the draft body with `engine-release-notes.mjs`: the annotation, then the asset-verification section. A lightweight tag has no annotation, so its notes are dropped with a `::notice::` and the body is the verification section alone — `%(contents)` returns the *commit* message there, and publishing that leaked internal subjects into public releases until #815.
 4. If the tag was lightweight, write the notes before publishing:
 
    ```bash

--- a/.github/scripts/cli-release-body.mjs
+++ b/.github/scripts/cli-release-body.mjs
@@ -5,11 +5,11 @@
  * A CLI release is how a new engine reaches users, so the engine line is the one thing the body
  * must get right; it used to be a fixed string asserting "(unchanged)" even on the releases that
  * moved the pin (#788). Here it is computed against the previous release's pin, and the notes on
- * top of it come from the annotated tag message the way the engine lane already reads them.
+ * top of it come from the annotated tag message, read through the gate both lanes share.
  */
-import { spawnSync } from "node:child_process";
 import { CLI_MARKER, STABLE_CLI_TAG_RE, cliPublishTarget } from "./release-tags.mjs";
 import { isEntry } from "./script-entry.mjs";
+import { git, readTagNotes } from "./tag-notes.mjs";
 import { cmp, parseSemver } from "../../src/semver.mjs";
 
 /**
@@ -43,33 +43,6 @@ export function composeCliReleaseBody({ version, engineVersion, previousEngineVe
   const generated = `v${version} (CLI-only). ${engine}`;
   const authored = notes?.trim();
   return authored ? `${authored}\n\n${generated}\n` : `${generated}\n`;
-}
-
-function git(args) {
-  const result = spawnSync("git", args, { encoding: "utf8" });
-  if (result.error) throw result.error;
-  return result.status === 0 ? result.stdout : undefined;
-}
-
-/**
- * A lightweight tag has no annotation, and `%(contents)` falls through to the *commit* message —
- * shipping a commit subject as the release body. Only a real tag object carries notes.
- */
-function tagNotes(tag) {
-  const kind = git(["cat-file", "-t", tag])?.trim();
-  if (kind !== "tag") {
-    console.error(
-      `::notice::${tag} carries no annotation (git reads it as ${kind ?? "unreadable"}), so the body is the ` +
-        `generated line alone. To author notes: git tag -a --cleanup=verbatim ${tag} -F notes.md`,
-    );
-    return undefined;
-  }
-
-  const notes = git(["tag", "-l", "--format=%(contents)", tag]);
-  if (notes === undefined) {
-    console.error(`::notice::the annotation on ${tag} could not be read, so the body is the generated line alone.`);
-  }
-  return notes;
 }
 
 function enginePinAt(tag) {
@@ -110,7 +83,7 @@ function main() {
       version,
       engineVersion,
       previousEngineVersion: previous ? enginePinAt(previous) : undefined,
-      notes: tagNotes(tag),
+      notes: readTagNotes(tag),
     }),
   );
 }

--- a/.github/scripts/engine-release-notes.d.mts
+++ b/.github/scripts/engine-release-notes.d.mts
@@ -1,0 +1,2 @@
+// The module stays .mjs so build-engine.yml can run it under node, like its siblings.
+export function composeEngineReleaseNotes(tag: string, notes?: string): string;

--- a/.github/scripts/engine-release-notes.mjs
+++ b/.github/scripts/engine-release-notes.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+/**
+ * The draft release body for an engine tag: the tag's own notes, then how to verify the assets.
+ *
+ * The notes half goes through the annotation gate — an unguarded `%(contents)` publishes the
+ * commit message when the tag is lightweight (#815). The verification half is unconditional:
+ * it is what a downloader needs, and it does not depend on anyone having authored anything.
+ */
+import { isEntry } from "./script-entry.mjs";
+import { readTagNotes } from "./tag-notes.mjs";
+
+const REPO = "drakulavich/kesha-voice-kit";
+
+function verifySection(tag) {
+  return `### Verify release assets
+
+Download the published binaries and checksums, then verify them:
+
+\`\`\`bash
+gh release download ${tag} -p SHA256SUMS -p kesha-release-manifest.json -p '*.sigstore.json' -p 'kesha-*' -p 'say-*'
+sha256sum -c SHA256SUMS
+
+cosign verify-blob \\
+  --bundle kesha-engine-darwin-arm64.sigstore.json \\
+  --certificate-identity "https://github.com/${REPO}/.github/workflows/build-engine.yml@refs/tags/${tag}" \\
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \\
+  kesha-engine-darwin-arm64
+\`\`\`
+
+The release also includes packaging metadata in \`kesha-release-manifest.json\`
+and a source SBOM in \`kesha-voice-kit-${tag}.spdx.json\`.
+`;
+}
+
+export function composeEngineReleaseNotes(tag, notes) {
+  const authored = notes?.trim();
+  return authored ? `${authored}\n\n${verifySection(tag)}` : verifySection(tag);
+}
+
+function main() {
+  const tag = process.env.TAG_NAME;
+  if (!tag) {
+    console.error("usage: TAG_NAME=… node .github/scripts/engine-release-notes.mjs > release-notes.md");
+    process.exit(2);
+  }
+  process.stdout.write(composeEngineReleaseNotes(tag, readTagNotes(tag)));
+}
+
+if (isEntry(import.meta.url)) main();

--- a/.github/scripts/tag-notes.d.mts
+++ b/.github/scripts/tag-notes.d.mts
@@ -1,0 +1,3 @@
+// The module stays .mjs: both release workflows run their scripts under node.
+export function git(args: string[]): string | undefined;
+export function readTagNotes(tag: string): string | undefined;

--- a/.github/scripts/tag-notes.mjs
+++ b/.github/scripts/tag-notes.mjs
@@ -1,0 +1,33 @@
+/**
+ * Reading release notes out of a tag, for the one lane and the other.
+ *
+ * `%(contents)` does not fall through to an empty string on a lightweight tag — git resolves the
+ * ref to the commit and hands back the *commit message*, so an unguarded read publishes an
+ * internal commit subject as a release body (#815). `git cat-file -t` is what tells a real tag
+ * object from a commit, and both release lanes gate on it here rather than each keeping a copy.
+ */
+import { spawnSync } from "node:child_process";
+
+/** Undefined rather than a throw when git exits non-zero: every caller has a fallback. */
+export function git(args) {
+  const result = spawnSync("git", args, { encoding: "utf8" });
+  if (result.error) throw result.error;
+  return result.status === 0 ? result.stdout : undefined;
+}
+
+export function readTagNotes(tag) {
+  const kind = git(["cat-file", "-t", tag])?.trim();
+  if (kind !== "tag") {
+    console.error(
+      `::notice::${tag} carries no annotation (git reads it as ${kind ?? "unreadable"}), so no authored ` +
+        `notes go into the release body. To author them: git tag -a --cleanup=verbatim ${tag} -F notes.md`,
+    );
+    return undefined;
+  }
+
+  const notes = git(["tag", "-l", "--format=%(contents)", tag]);
+  if (notes === undefined) {
+    console.error(`::notice::the annotation on ${tag} could not be read, so the release body carries no notes.`);
+  }
+  return notes;
+}

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -419,9 +419,10 @@ jobs:
       # actions/checkout doesn't fetch tag objects under `on.push.tags`, so
       # `fetch-tags: true` is explicit. The `tag` job (fix #306) writes the
       # release notes into the annotated tag's message; this checkout + the
-      # extract step below recover it. Lightweight tags (manual
-      # `git tag vX.Y.Z` from a laptop, no `-a`) produce an empty annotation,
-      # which falls through to today's empty-body behavior.
+      # extract step below recover it. A lightweight tag (manual
+      # `git tag vX.Y.Z` from a laptop, no `-a`) has no annotation to recover —
+      # `%(contents)` returns the *commit* message there, so the extract step
+      # gates on `git cat-file -t` and drops it rather than publishing it (#815).
       - name: Checkout at tag
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -432,28 +433,7 @@ jobs:
       - name: Prepare release notes from tag annotation
         env:
           TAG_NAME: ${{ github.ref_name }}
-        run: |
-          git tag -l --format='%(contents)' "$TAG_NAME" > release-notes.md
-          cat >> release-notes.md <<EOF
-
-          ### Verify release assets
-
-          Download the published binaries and checksums, then verify them:
-
-          \`\`\`bash
-          gh release download $TAG_NAME -p SHA256SUMS -p kesha-release-manifest.json -p '*.sigstore.json' -p 'kesha-*' -p 'say-*'
-          sha256sum -c SHA256SUMS
-
-          cosign verify-blob \\
-            --bundle kesha-engine-darwin-arm64.sigstore.json \\
-            --certificate-identity "https://github.com/drakulavich/kesha-voice-kit/.github/workflows/build-engine.yml@refs/tags/$TAG_NAME" \\
-            --certificate-oidc-issuer https://token.actions.githubusercontent.com \\
-            kesha-engine-darwin-arm64
-          \`\`\`
-
-          The release also includes packaging metadata in \`kesha-release-manifest.json\`
-          and a source SBOM in \`kesha-voice-kit-$TAG_NAME.spdx.json\`.
-          EOF
+        run: node .github/scripts/engine-release-notes.mjs > release-notes.md
 
       - name: Prepare release asset directory
         run: mkdir -p release-assets

--- a/tests/unit/engine-release-notes.test.ts
+++ b/tests/unit/engine-release-notes.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import { composeEngineReleaseNotes } from "../../.github/scripts/engine-release-notes.mjs";
+import { parseRepoYaml, readRepoFile } from "../helpers/repo";
+
+const BUILD_ENGINE = ".github/workflows/build-engine.yml";
+
+describe("composeEngineReleaseNotes", () => {
+  test("authored notes lead, and the verification section follows them", () => {
+    const body = composeEngineReleaseNotes("v1.25.0", "## Highlights\n\n- faster decode\n");
+
+    expect(body.startsWith("## Highlights")).toBe(true);
+    expect(body).toContain("- faster decode");
+    expect(body.indexOf("### Verify release assets")).toBeGreaterThan(body.indexOf("- faster decode"));
+  });
+
+  // A lightweight tag hands git the *commit* message; the release keeps its verification
+  // section and loses only the notes it never had (#815).
+  test("a tag with no annotation still gets the verification section", () => {
+    const body = composeEngineReleaseNotes("v1.25.0", undefined);
+
+    expect(body.startsWith("### Verify release assets")).toBe(true);
+    expect(body).not.toContain("undefined");
+  });
+
+  test("whitespace-only notes are not notes", () => {
+    expect(composeEngineReleaseNotes("v1.25.0", "  \n\n ")).toBe(composeEngineReleaseNotes("v1.25.0", undefined));
+  });
+
+  test("the verification steps name the tag being released", () => {
+    const body = composeEngineReleaseNotes("v1.25.0", undefined);
+
+    expect(body).toContain("gh release download v1.25.0");
+    expect(body).toContain("build-engine.yml@refs/tags/v1.25.0");
+    expect(body).toContain("kesha-voice-kit-v1.25.0.spdx.json");
+  });
+
+  // The heredoc this replaced fenced a bash block; a body that lost the fence renders as prose.
+  test("the verification commands stay inside a fenced block", () => {
+    const body = composeEngineReleaseNotes("v1.25.0", undefined);
+
+    expect(body).toContain("```bash");
+    expect(body.match(/```/g)?.length).toBe(2);
+  });
+});
+
+describe("the engine release lane", () => {
+  // `%(contents)` on a lightweight tag returns the commit message, so reading it unguarded
+  // publishes an internal commit subject as the release body (#815).
+  test("the notes step delegates to the gated script instead of reading the tag inline", () => {
+    const steps = parseRepoYaml(BUILD_ENGINE).jobs.release.steps;
+    const notes = steps.find((s: { name?: string }) => s.name?.includes("release notes"));
+
+    expect(notes.run).toContain("engine-release-notes.mjs");
+    expect(notes.run).not.toContain("%(contents)");
+    expect(notes.run).not.toContain("${{");
+  });
+
+  // Comment lines are prose about the hazard, not a step that publishes one, so they are
+  // stripped the way forbidLinuxPackaging strips them.
+  test("no step in the workflow reads tag contents directly", () => {
+    const code = readRepoFile(BUILD_ENGINE)
+      .split("\n")
+      .filter((line) => !/^\s*#/.test(line))
+      .join("\n");
+
+    expect(code).not.toContain("%(contents)");
+  });
+});


### PR DESCRIPTION
`build-engine.yml` built its draft release body by reading `git tag -l --format='%(contents)'` on whatever tag it was pushed. That does **not** return an empty string for a lightweight tag — git resolves the ref to its commit and hands back the *commit message* — so an engine release cut with `git tag vX.Y.Z` (no `-a`) publishes the internal commit subject and body as public release notes. The workflow's own comment claimed the opposite.

Closes #815

## The leak, measured against `origin/main`

Not reconstructed by hand: the check extracts the `run:` script from `git show origin/main:.github/workflows/build-engine.yml`, executes it verbatim in a throwaway repo, and compares it with the new script in the same repo.

```
=== OLD (origin/main) body, first 3 lines ===
internal commit subject nobody should read in a release

=== NEW body, first 3 lines ===
### Verify release assets

Download the published binaries and checksums, then verify them:
=== NEW stderr ===
::notice::v1.26.0 carries no annotation (git reads it as commit), so no authored notes go into
the release body. To author them: git tag -a --cleanup=verbatim v1.26.0 -F notes.md

=== does the commit subject appear? ===
old: 1
new: 0
```

## Design

**One predicate, two callers.** The gate #814 added to `cli-release-body.mjs` moves to `.github/scripts/tag-notes.mjs` as `readTagNotes`, and both lanes import it. `cli-release-body.mjs` loses its private copy rather than gaining a divergent twin — the #790 lesson. The shared module also owns the `git()` runner both callers were duplicating.

**The verification section is unconditional.** A lightweight tag loses only the notes it never had; the asset-verification block is what a downloader needs and does not depend on anyone having authored anything. So the fallback body is strictly better than the old one, which published a commit message.

**The step became a script.** The old notes step was a ~22-line inline heredoc, already past the repo's 3-line limit for inline CI; adding a gate to it inline was not an option. It is now `node .github/scripts/engine-release-notes.mjs > release-notes.md` — one line, `TAG_NAME` still arriving through `env:` (#291), and the body composition under `bun test`.

## No regression in the body itself

The markdown template was retyped from a shell heredoc into a JS template literal, which is exactly where a stray backslash or backtick would hide. For an **annotated** tag, old and new output are **byte-identical** (`diff` reports no difference) — same reproduction as above, comparing against the real pre-change step rather than my memory of it.

## Test evidence

Red first — `tests/unit/engine-release-notes.test.ts` before any implementation:

```
error: Cannot find module '../../.github/scripts/engine-release-notes.mjs'
0 pass, 1 fail
```

One red I did not expect and did not paper over: my first version of the "no step reads tag contents" test asserted the whole file lacks `%(contents)`, and it failed on the explanatory comment I had just written. Rather than delete the assertion I scoped it to non-comment lines, matching `forbidLinuxPackaging`'s existing treatment of workflow comments as prose about a policy rather than a step enacting it.

Seven cases: authored notes lead with the verification section after them; a tag with no annotation still gets the verification section and renders no `undefined`; whitespace-only notes are indistinguishable from none; the verification steps name the tag in all three places it appears (download, cosign certificate-identity, SBOM filename); the bash fence survives the heredoc-to-template move (exactly two fences); the workflow step delegates to the script with no `%(contents)` and no `${{ }}` in its `run:`; and no non-comment line of the workflow reads tag contents at all.

The CLI lane's own end-to-end was re-run after the extraction — annotated and lightweight arms both still behave as #814 shipped them.

## Gates

- `bunx tsc --noEmit` — clean
- `bun run check` (lint + workflows + specs + versions + unit) — **876 pass, 0 fail** (869 on main; +7 new)
- `bun run check:workflows`, `check:versions`, `check:release-manifest` — clean. `check:specs` exits 0; its stderr `AbortError` is openspec's telemetry failing to reach PostHog in a sandbox, not a validation failure.
- No `src/` change, so no `bun test` delta to report; no `.sh` touched, so nothing for `bash -n`.

## Docs

`release-engine` and `release-mechanics` both described the lane as reading `%(contents)` and claimed a lightweight tag "leaves the body empty". Both now describe the script, and both say what actually happens: notes dropped with a notice, verification section kept. `--cleanup=verbatim` was already documented in both; the `-a` is now called out as equally load-bearing, since that is the flag whose absence caused this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBTpJjqyYFW6W8LHJ2nwy