### PR TITLE
fix(doctor): make an engine that runs but describes nothing a fault

### DIFF
--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -3,13 +3,13 @@ import { cacheComponentPaths, isInsideDir } from "./cache-layout";
 import { errorMessage } from "./error-utils";
 import { humanBytes } from "./format";
 import { dirname, join } from "path";
+import { getEngineBinPath, isEngineInstalled, type EngineCapabilities } from "./engine";
 import {
-  getEngineBinPath,
-  getEngineCapabilities,
-  isEngineInstalled,
-  type EngineCapabilities,
-} from "./engine";
-import { probeExecutable } from "./engine-health";
+  CORRUPT_STATE,
+  engineFunctionalHealth,
+  NOT_FUNCTIONAL_STATE,
+  probeExecutable,
+} from "./engine-health";
 import { readInstalledEngineVersion } from "./engine-version-marker";
 import { keshaCacheDir } from "./paths";
 import { engineVersion, packageName, packageVersion } from "./package-info";
@@ -199,21 +199,18 @@ async function collectEngine(redact: boolean): Promise<DoctorReport["engine"]> {
   const installed = isEngineInstalled();
   let capabilities: EngineCapabilities | null = null;
   let probeError: string | null = null;
-  // A truncated download exists, so `installed` alone would report a bricked engine as
-  // healthy; probing the loader separates that from an old engine with no capabilities JSON.
+  // A truncated download exists and the #796 stub even runs, so neither `installed` nor a
+  // clean spawn says the engine works — only its own account of itself does (#801).
   const health = installed
-    ? await probeExecutable(binPath, ["--version"])
+    ? await engineFunctionalHealth()
     : ({ status: "missing" } as const);
 
   if (health.status === "unusable") {
     probeError = `binary is present but does not run (${health.detail}); re-run \`kesha install\``;
-  } else if (installed) {
-    try {
-      capabilities = await getEngineCapabilities();
-      if (!capabilities) probeError = "capabilities probe returned no data";
-    } catch (err) {
-      probeError = errorMessage(err);
-    }
+  } else if (health.status === "mute") {
+    probeError = `${health.detail}; re-run \`kesha install\``;
+  } else if (health.status === "ok") {
+    capabilities = health.capabilities;
   }
 
   const versionMarker = readInstalledEngineVersion(binPath);
@@ -224,7 +221,7 @@ async function collectEngine(redact: boolean): Promise<DoctorReport["engine"]> {
     versionMarker,
     pinnedVersion: engineVersion,
     versionState: engineVersionState(versionMarker, engineVersion),
-    runnable: health.status === "ok",
+    runnable: health.status !== "missing" && health.status !== "unusable",
     capabilities,
     probeError: redactString("probeError", probeError, redact),
   };
@@ -411,8 +408,6 @@ export async function collectDoctorReport(
   };
 }
 
-const CORRUPT_STATE = "installed but not executable (corrupt) - re-run `kesha install`";
-
 function formatComponentState(component: OptionalComponent): string {
   if (!component.exists) return "missing";
   return component.runnable === false ? CORRUPT_STATE : "installed";
@@ -420,7 +415,8 @@ function formatComponentState(component: OptionalComponent): string {
 
 function formatEngineBinaryState(engine: DoctorReport["engine"]): string {
   if (!engine.installed) return "missing";
-  return engine.runnable ? "installed" : CORRUPT_STATE;
+  if (!engine.runnable) return CORRUPT_STATE;
+  return engine.capabilities ? "installed" : NOT_FUNCTIONAL_STATE;
 }
 
 function formatVersionState(engine: DoctorReport["engine"]): string {

--- a/src/engine-health.ts
+++ b/src/engine-health.ts
@@ -1,5 +1,6 @@
 import { existsSync } from "fs";
 import { errorMessage } from "./error-utils";
+import { getEngineBinPath, getEngineCapabilities, type EngineCapabilities } from "./engine";
 
 export type ExecutableHealth =
   | { status: "ok" }
@@ -52,4 +53,37 @@ export async function probeExecutable(
   }
   if (proc.signalCode) return { status: "unusable", detail: `killed by ${proc.signalCode}` };
   return { status: "ok" };
+}
+
+export type EngineFunctionalHealth =
+  | { status: "ok"; capabilities: EngineCapabilities }
+  | { status: "missing" }
+  | { status: "unusable"; detail: string }
+  | { status: "mute"; detail: string };
+
+export const CORRUPT_STATE = "installed but not executable (corrupt) - re-run `kesha install`";
+export const NOT_FUNCTIONAL_STATE =
+  "installed but not functional (reports no capabilities) - re-run `kesha install`";
+const MUTE_DETAIL = "reports no capabilities";
+
+/**
+ * The single "does this engine describe itself" verdict — doctor, status and the install
+ * cache-validity check all consult it so they cannot disagree (#801).
+ *
+ * Spawning is not working: the #796 stub was `#!/bin/sh\nexit 0`, which passes
+ * `probeExecutable` and answers nothing. `mute` is that engine, and it is a fault of the
+ * same severity as `unusable`; only `missing` is not a fault, because an absent engine is
+ * already reported loudly everywhere (#770).
+ */
+export async function engineFunctionalHealth(): Promise<EngineFunctionalHealth> {
+  try {
+    const capabilities = await getEngineCapabilities();
+    if (capabilities) return { status: "ok", capabilities };
+  } catch {
+    // Nothing is swallowed: only an engine that cannot be spawned throws here, and the
+    // probe below reports that as `unusable` with the loader's own reason.
+  }
+  const executable = await probeExecutable(getEngineBinPath(), ["--version"]);
+  if (executable.status !== "ok") return executable;
+  return { status: "mute", detail: MUTE_DETAIL };
 }

--- a/src/engine-health.ts
+++ b/src/engine-health.ts
@@ -74,14 +74,27 @@ const MUTE_DETAIL = "reports no capabilities";
  * `probeExecutable` and answers nothing. `mute` is that engine, and it is a fault of the
  * same severity as `unusable`; only `missing` is not a fault, because an absent engine is
  * already reported loudly everywhere (#770).
+ *
+ * Capabilities are asked for first, so a healthy engine costs one spawn — and they carry
+ * the same deadline as the `--version` probe, because a binary that never answers is one
+ * that could not be made to answer (`unusable`), not one that answered nothing (`mute`).
  */
-export async function engineFunctionalHealth(): Promise<EngineFunctionalHealth> {
+export async function engineFunctionalHealth(
+  timeoutMs = PROBE_TIMEOUT_MS,
+): Promise<EngineFunctionalHealth> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const capabilities = await getEngineCapabilities();
+    const capabilities = await getEngineCapabilities({ signal: controller.signal });
     if (capabilities) return { status: "ok", capabilities };
   } catch {
-    // Nothing is swallowed: only an engine that cannot be spawned throws here, and the
-    // probe below reports that as `unusable` with the loader's own reason.
+    // Nothing is swallowed: an engine that cannot be spawned, or that outlived the
+    // deadline, is classified below rather than reported as a bare stack trace.
+  } finally {
+    clearTimeout(timer);
+  }
+  if (controller.signal.aborted) {
+    return { status: "unusable", detail: `no exit within ${timeoutMs / 1000}s` };
   }
   const executable = await probeExecutable(getEngineBinPath(), ["--version"]);
   if (executable.status !== "ok") return executable;

--- a/src/engine-install.ts
+++ b/src/engine-install.ts
@@ -8,7 +8,7 @@ import {
   TRANSCRIBE_DIARIZE_FEATURE,
   type EngineCapabilities,
 } from "./engine";
-import { probeExecutable } from "./engine-health";
+import { engineFunctionalHealth, probeExecutable } from "./engine-health";
 import { engineTarget } from "./engine-targets";
 import { isDarwinArm64 } from "./fluid-kokoro-cache";
 import { log } from "./log";
@@ -413,11 +413,19 @@ export async function waitUntilSpawnable(binPath: string, deadlineMs = 60_000): 
 
 /**
  * Cache-validity health check: an install interrupted before `chmod`/marker-write, or a
- * binary from another architecture, exists at the right version yet cannot start (#770).
+ * binary from another architecture, exists at the right version yet cannot start (#770) —
+ * or starts and cannot describe itself, which is just as unusable (#801).
  */
-async function engineRuns(binPath: string): Promise<boolean> {
-  const health = await probeExecutable(binPath, ["--version"]);
+async function engineWorks(binPath: string): Promise<boolean> {
+  const health = await engineFunctionalHealth();
   if (health.status === "ok") return true;
+  if (health.status === "mute") {
+    log.warn(
+      `Installed engine at ${binPath} runs but ${health.detail}; it is corrupt or truncated ` +
+        "— re-downloading it.",
+    );
+    return false;
+  }
   const detail = health.status === "unusable" ? health.detail : "binary disappeared";
   log.warn(
     `Installed engine at ${binPath} does not run (${detail}); it is corrupt or built for ` +
@@ -617,7 +625,7 @@ export async function installEngine(request: EngineInstallRequest = {}): Promise
   // dir: nothing there can be repaired, so a failed probe would only turn a usable Nix
   // install into a hard error.
   const versionMatches =
-    markerMatches && (!canWriteEngineDir || (await engineRuns(binPath)));
+    markerMatches && (!canWriteEngineDir || (await engineWorks(binPath)));
   // On read-only fs, --no-cache can't re-download; treat as cache-valid and forward flag to model install.
   const cacheValid = versionMatches && (!noCache || !canWriteEngineDir);
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -467,7 +467,9 @@ let cachedEngineCapabilities:
   | { binPath: string; mtime: number; capabilities: EngineCapabilities }
   | null = null;
 
-export async function getEngineCapabilities(): Promise<EngineCapabilities | null> {
+export async function getEngineCapabilities(
+  opts: RunEngineOptions = {},
+): Promise<EngineCapabilities | null> {
   const binPath = getEngineBinPath();
   // #248: include mtimeMs so an in-place `kesha install` overwite invalidates the cache.
   // statSync throws on missing file — catch returns null, no separate isEngineInstalled() needed.
@@ -483,7 +485,7 @@ export async function getEngineCapabilities(): Promise<EngineCapabilities | null
   ) {
     return cachedEngineCapabilities.capabilities;
   }
-  const { stdout, exitCode } = await runEngine(["--capabilities-json"]);
+  const { stdout, exitCode } = await runEngine(["--capabilities-json"], opts);
   if (exitCode !== 0) return null;
   try {
     const capabilities = parseCapabilities(JSON.parse(stdout));

--- a/src/status.ts
+++ b/src/status.ts
@@ -3,9 +3,14 @@ import { join } from "path";
 import {
   isEngineInstalled,
   getEngineBinPath,
-  getEngineCapabilities,
   type EngineCapabilities,
 } from "./engine";
+import {
+  CORRUPT_STATE,
+  engineFunctionalHealth,
+  NOT_FUNCTIONAL_STATE,
+  type EngineFunctionalHealth,
+} from "./engine-health";
 import { cacheComponentPaths, isInsideDir } from "./cache-layout";
 import { humanBytes } from "./format";
 import { installHint } from "./install-hint";
@@ -70,7 +75,8 @@ export interface StatusReport {
 export async function collectStatus(options: ShowStatusOptions = {}): Promise<StatusReport> {
   const path = getEngineBinPath();
   const installed = isEngineInstalled();
-  const capabilities = installed ? await getEngineCapabilities().catch(() => null) : null;
+  const health = installed ? await engineFunctionalHealth() : ({ status: "missing" } as const);
+  const capabilities = health.status === "ok" ? health.capabilities : null;
 
   return {
     cliVersion: packageVersion,
@@ -78,12 +84,24 @@ export async function collectStatus(options: ShowStatusOptions = {}): Promise<St
     voices: installed ? listInstalledVoices() : [],
     runtime: { bun: Bun.version, platform: process.platform, arch: process.arch },
     modelMirror: activeModelMirror(),
-    hint: installed
-      ? null
-      : `Run \`${installHint()}\` to download the engine and models.`,
+    hint: engineHint(path, health.status),
     // Absent engine means no disk walk, matching the human path (#647).
     disk: installed && options.disk ? collectDiskUsage(path, capabilities?.backend) : null,
   };
+}
+
+/** An engine that runs but describes nothing needs the same repair as a missing one (#801). */
+function engineHint(path: string, health: EngineFunctionalHealth["status"]): string | null {
+  switch (health) {
+    case "missing":
+      return `Run \`${installHint()}\` to download the engine and models.`;
+    case "mute":
+      return `Engine at ${path} is ${NOT_FUNCTIONAL_STATE}`;
+    case "unusable":
+      return `Engine at ${path} is ${CORRUPT_STATE}`;
+    default:
+      return null;
+  }
 }
 
 function logEngineCapabilities(caps: EngineCapabilities | null): void {

--- a/tests/integration/e2e-engine.test.ts
+++ b/tests/integration/e2e-engine.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, beforeAll } from "bun:test";
+import { engineFunctionalHealth } from "../../src/engine-health";
 import {
-  isEngineInstalled,
   getEngineBinPath,
   TRANSCRIBE_SEGMENTS_FEATURE,
   TRANSCRIBE_DIARIZE_FEATURE,
@@ -11,7 +11,8 @@ const CWD = import.meta.dir + "/../..";
 const FIXTURE_RU = "tests/fixtures/benchmark/01-ne-nuzhno-slat-soobshcheniya.ogg";
 const FIXTURE_EN = "tests/fixtures/benchmark-en/01-check-email.ogg";
 
-const engineInstalled = isEngineInstalled();
+// Presence is not usability: the #796 stub existed, ran, and failed all 19 of these (#801).
+const engineInstalled = (await engineFunctionalHealth()).status === "ok";
 
 async function runCli(args: string[]): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   const proc = Bun.spawn([process.execPath, "run", "src/cli-entry.ts", ...args], {

--- a/tests/integration/mcp-e2e.test.ts
+++ b/tests/integration/mcp-e2e.test.ts
@@ -3,11 +3,12 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { existsSync, mkdirSync, symlinkSync } from "fs";
 import { createKeshaMcpServer } from "../../src/mcp/server";
-import { isEngineInstalled } from "../../src/engine";
+import { engineFunctionalHealth } from "../../src/engine-health";
 
 const FIXTURE_RU = "tests/fixtures/benchmark/01-ne-nuzhno-slat-soobshcheniya.ogg";
 
-const engineInstalled = isEngineInstalled();
+// Presence is not usability: the #796 stub existed, ran, and failed every case here (#801).
+const engineInstalled = (await engineFunctionalHealth()).status === "ok";
 
 async function client() {
   const server = createKeshaMcpServer();

--- a/tests/unit/doctor.test.ts
+++ b/tests/unit/doctor.test.ts
@@ -421,6 +421,18 @@ describe("the human report states what each component is doing (#770)", () => {
     expect(corrupt).not.toContain("(installed)");
   });
 
+  // #801: an engine that spawns is not thereby working. Nothing may read clean while
+  // the binary is present and its capabilities are null.
+  test("a runnable engine with no capabilities is a fault of its own", () => {
+    const mute = engineLine(
+      doctorReport({ engine: { ...doctorReport().engine, capabilities: null } }),
+    );
+    expect(mute).toContain("installed but not functional (reports no capabilities)");
+    expect(mute).toContain("kesha install");
+    expect(mute).not.toContain("(installed)");
+    expect(mute).not.toContain("corrupt");
+  });
+
   test("an optional component's state separates corrupt from missing", () => {
     const output = formatDoctorReport(
       doctorReport({
@@ -589,14 +601,33 @@ describe("collectDoctorReport probe and cache accounting", () => {
     }
   });
 
-  posixEngineTest("an engine that runs but describes nothing says so", async () => {
+  // #801: this is the #796 stub verbatim — it ran, so doctor called it installed.
+  posixEngineTest("an engine that runs but describes nothing is a fault, not a footnote", async () => {
+    const { dir, binDir } = stage("kesha-doctor-mute-engine-");
+    writeFakeEngine(join(binDir, "kesha-engine"), "#!/bin/sh\nexit 0\n");
+    try {
+      const report = await collectDoctorReport();
+      expect(report.engine.installed).toBe(true);
+      expect(report.engine.runnable).toBe(true);
+      expect(report.engine.capabilities).toBeNull();
+      const binaryLine = formatDoctorReport(report)
+        .split("\n")
+        .find((l) => l.includes("Binary:"))!;
+      expect(binaryLine).toContain("installed but not functional (reports no capabilities)");
+      expect(binaryLine).toContain("kesha install");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  posixEngineTest("capabilities that do not parse read as the same fault as none", async () => {
     const { dir, binDir } = stage("kesha-doctor-silent-engine-");
     writeFakeEngine(join(binDir, "kesha-engine"), "#!/bin/sh\nexit 2\n");
     try {
       const report = await collectDoctorReport();
       expect(report.engine.runnable).toBe(true);
       expect(report.engine.capabilities).toBeNull();
-      expect(report.engine.probeError).toBe("capabilities probe returned no data");
+      expect(report.engine.probeError).toContain("reports no capabilities");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/tests/unit/engine-install-decisions.test.ts
+++ b/tests/unit/engine-install-decisions.test.ts
@@ -224,15 +224,23 @@ describe("capabilities gate the flags forwarded to the engine (#772)", () => {
   }, 30_000);
 
   // A pre-capabilities engine cannot be asked, and forwarding --diarize blind would surface
-  // as clap's generic "unexpected argument".
+  // as clap's generic "unexpected argument". Reached through a download because a cached
+  // engine that describes nothing is repaired before any flag is validated (#801).
   posixTest("--diarize is refused when the engine cannot describe itself", async () => {
-    const binPath = stageInstalledEngine("kesha-caps-silent-", { caps: null });
-    const before = readFileSync(binPath, "utf8");
-    stubRelease();
+    stageEmptyEngineDir("kesha-caps-silent-");
+    stubRelease({ caps: null });
+
+    await expect(installEngine({ diarize: true })).rejects.toThrow(/system_diarize/);
+  }, 30_000);
+
+  posixTest("a cached engine that describes nothing is repaired before the flag is judged", async () => {
+    const binPath = stageInstalledEngine("kesha-caps-mute-cache-", { caps: null });
+    const urls = stubRelease();
 
     await expect(installEngine({ diarize: true })).rejects.toThrow(/system_diarize/);
 
-    expect(readFileSync(binPath, "utf8")).toBe(before);
+    expect(engineDownloads(urls)).toHaveLength(1);
+    expect(readFileSync(binPath, "utf8")).toContain("--capabilities-json");
   }, 30_000);
 
   posixTest("--diarize reaches the engine, and pulls --vad with it (#768)", async () => {

--- a/tests/unit/engine-repair.test.ts
+++ b/tests/unit/engine-repair.test.ts
@@ -4,7 +4,7 @@ import { dirname, join } from "path";
 import { tmpdir } from "os";
 import { getEngineBinaryName, installEngine, SIDECARS } from "../../src/engine-install";
 import { installableTtsLangs, probeCapabilitiesForInstall, resolveTtsLangs } from "../../src/cli/install";
-import { probeExecutable } from "../../src/engine-health";
+import { engineFunctionalHealth, probeExecutable } from "../../src/engine-health";
 import { getEngineCapabilities } from "../../src/engine";
 import { isDarwinArm64 } from "../../src/fluid-kokoro-cache";
 import { engineVersion } from "../../src/package-info";
@@ -13,9 +13,22 @@ import { isolateEngineCache } from "../helpers/fake-engine";
 // #770: an interrupted `kesha install` left a truncated binary that the kernel refuses to
 // load, while the `.version` marker still vouched for it. Every repair path then failed.
 
-const WORKING_ENGINE = "#!/bin/sh\nexit 0\n";
+const WORKING_ENGINE = `#!/bin/sh
+if [ "$1" = "--capabilities-json" ]; then
+  printf '%s\\n' '{"protocolVersion":3,"backend":"onnx","features":[]}'
+fi
+exit 0
+`;
 /** Mode 0o755 but not a loadable image: `posix_spawn` fails with ENOEXEC, as on a truncated Mach-O. */
 const CORRUPT_ENGINE = "\x7fELF\x00\x01\x02truncated";
+/** The #796 stub verbatim: it spawns and exits 0, and describes nothing (#801). */
+const MUTE_ENGINE = "#!/bin/sh\nexit 0\n";
+const BABBLING_ENGINE = `#!/bin/sh
+if [ "$1" = "--capabilities-json" ]; then
+  printf '%s\\n' 'not json'
+fi
+exit 0
+`;
 
 const savedFetch = globalThis.fetch;
 const tempDirs: string[] = [];
@@ -90,9 +103,55 @@ describe("probeExecutable (#770)", () => {
   });
 });
 
+// #801: the developer machine's engine was MUTE_ENGINE for weeks and every health surface
+// called it fine, because exit 0 was the whole test.
+describe("engineFunctionalHealth (#801)", () => {
+  posixTest("an engine that runs but describes nothing is mute, not ok", async () => {
+    stageEngine("kesha-functional-mute-", MUTE_ENGINE);
+    const health = await engineFunctionalHealth();
+    expect(health.status).toBe("mute");
+  });
+
+  posixTest("capabilities that do not parse are the same fault as none at all", async () => {
+    stageEngine("kesha-functional-babble-", BABBLING_ENGINE);
+    const health = await engineFunctionalHealth();
+    expect(health.status).toBe("mute");
+  });
+
+  posixTest("an engine that describes itself is functional, and hands back what it said", async () => {
+    stageEngine("kesha-functional-ok-", WORKING_ENGINE);
+    const health = await engineFunctionalHealth();
+    expect(health.status).toBe("ok");
+    expect(health.status === "ok" && health.capabilities.backend).toBe("onnx");
+  });
+
+  test("an absent engine is missing, never mute — nothing to repair is not a fault", async () => {
+    process.env.KESHA_ENGINE_BIN = join(tmpdir(), "kesha-does-not-exist", "kesha-engine");
+    expect(await engineFunctionalHealth()).toEqual({ status: "missing" });
+  });
+
+  posixTest("a binary the loader refuses stays unusable, distinct from mute", async () => {
+    stageEngine("kesha-functional-corrupt-", CORRUPT_ENGINE);
+    const health = await engineFunctionalHealth();
+    expect(health.status).toBe("unusable");
+  });
+});
+
 describe("install repairs a corrupt engine (#770)", () => {
   posixTest("a matching version marker no longer vouches for a binary that cannot run", async () => {
     const binPath = stageEngine("kesha-repair-corrupt-", CORRUPT_ENGINE);
+    const urls = stubRelease();
+
+    await installEngine();
+
+    expect(engineDownloads(urls)).toHaveLength(1);
+    expect(readFileSync(binPath, "utf8")).toBe(WORKING_ENGINE);
+  }, 30_000);
+
+  // #801: exit 0 satisfied the #770 probe, so the marker vouched for a binary that
+  // could not answer a single question about itself.
+  posixTest("a cached engine that describes nothing is re-downloaded, marker or not", async () => {
+    const binPath = stageEngine("kesha-repair-mute-", MUTE_ENGINE);
     const urls = stubRelease();
 
     await installEngine();

--- a/tests/unit/engine-repair.test.ts
+++ b/tests/unit/engine-repair.test.ts
@@ -29,6 +29,29 @@ if [ "$1" = "--capabilities-json" ]; then
 fi
 exit 0
 `;
+/**
+ * `exec` so the terminate signal lands on `sleep` itself, not on a shell that ignores it.
+ * The duration doubles as a per-test marker, so one hang test never observes another's child.
+ */
+function hangingEngine(marker: string): string {
+  return `#!/bin/sh\nexec sleep ${marker}\n`;
+}
+const SLOW_ENGINE = `#!/bin/sh
+if [ "$1" = "--capabilities-json" ]; then
+  sleep 1
+  printf '%s\\n' '{"protocolVersion":3,"backend":"onnx","features":[]}'
+fi
+exit 0
+`;
+
+async function sleepingEngineSurvives(marker: string): Promise<boolean> {
+  const proc = Bun.spawn(["pgrep", "-f", `sleep ${marker}`], {
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  const [out] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
+  return out.trim().length > 0;
+}
 
 const savedFetch = globalThis.fetch;
 const tempDirs: string[] = [];
@@ -135,6 +158,37 @@ describe("engineFunctionalHealth (#801)", () => {
     const health = await engineFunctionalHealth();
     expect(health.status).toBe("unusable");
   });
+
+  // The capabilities probe is the primary one, so it carries the deadline the `--version`
+  // probe has had since #775 — otherwise a hung binary stalls doctor, status and the
+  // install cache check for as long as it likes.
+  posixTest("a binary that hangs is unusable within the deadline, never mute", async () => {
+    stageEngine("kesha-functional-hang-", hangingEngine("61.5"));
+
+    const startedAt = performance.now();
+    const health = await engineFunctionalHealth(500);
+    const elapsed = performance.now() - startedAt;
+
+    expect(health.status).toBe("unusable");
+    expect(health.status === "unusable" && health.detail).toContain("no exit within");
+    expect(elapsed).toBeLessThan(5_000);
+  }, 15_000);
+
+  posixTest("the hung engine is killed, not left running behind us", async () => {
+    stageEngine("kesha-functional-hang-kill-", hangingEngine("62.5"));
+
+    await engineFunctionalHealth(500);
+
+    // SIGTERM first, SIGKILL after a 1s grace, so give the tree time to actually go.
+    for (let i = 0; i < 30 && (await sleepingEngineSurvives("62.5")); i++) await Bun.sleep(100);
+    expect(await sleepingEngineSurvives("62.5")).toBe(false);
+  }, 15_000);
+
+  posixTest("an engine that answers slowly is ok, not timed out", async () => {
+    stageEngine("kesha-functional-slow-", SLOW_ENGINE);
+    const health = await engineFunctionalHealth(10_000);
+    expect(health.status).toBe("ok");
+  }, 20_000);
 });
 
 describe("install repairs a corrupt engine (#770)", () => {

--- a/tests/unit/engine-version-override.test.ts
+++ b/tests/unit/engine-version-override.test.ts
@@ -14,7 +14,14 @@ import { engineVersion } from "../../src/package-info";
 import { isolateEngineCache } from "../helpers/fake-engine";
 
 const OVERRIDE = "9.9.9-alpha.1";
-const FAKE_ENGINE = "#!/bin/sh\nexit 0\n";
+// It has to answer `--capabilities-json`: an engine that describes nothing is re-downloaded
+// rather than treated as a cache hit (#801).
+const FAKE_ENGINE = `#!/bin/sh
+if [ "$1" = "--capabilities-json" ]; then
+  printf '%s\\n' '{"protocolVersion":3,"backend":"onnx","features":[]}'
+fi
+exit 0
+`;
 
 const savedFetch = globalThis.fetch;
 const tempDirs: string[] = [];

--- a/tests/unit/status.test.ts
+++ b/tests/unit/status.test.ts
@@ -278,7 +278,9 @@ describe("collectStatus --json payload (#647)", () => {
     }
   });
 
-  posixEngineTest("binary present but capabilities unreadable: installed, caps null", async () => {
+  // #801: `installed: true` with `capabilities: null` used to carry no hint at all, so
+  // status read clean for an engine that could not answer a single question.
+  posixEngineTest("binary present but capabilities unreadable: installed, caps null, hint", async () => {
     const dir = mkdtempSync(join(tmpdir(), "kesha-status-json-broken-"));
     const cache = join(dir, ".cache", "kesha");
     const binPath = writeFakeEngine(join(cache, "engine", "bin"), null);
@@ -289,7 +291,29 @@ describe("collectStatus --json payload (#647)", () => {
       const report = await collectStatus();
       expect(report.engine.installed).toBe(true);
       expect(report.engine.capabilities).toBeNull();
-      expect(report.hint).toBeNull();
+      expect(report.hint).toContain("not functional (reports no capabilities)");
+      expect(report.hint).toContain("kesha install");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  posixEngineTest("an engine that exits 0 and says nothing is not a clean bill", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-status-json-mute-"));
+    const cache = join(dir, ".cache", "kesha");
+    const binDir = join(cache, "engine", "bin");
+    mkdirSync(binDir, { recursive: true });
+    const binPath = join(binDir, "kesha-engine");
+    writeFileSync(binPath, "#!/bin/sh\nexit 0\n");
+    chmodSync(binPath, 0o755);
+    process.env.KESHA_ENGINE_BIN = binPath;
+    process.env.KESHA_CACHE_DIR = cache;
+    process.env.HOME = dir;
+    try {
+      const report = await collectStatus();
+      expect(report.engine.installed).toBe(true);
+      expect(report.engine.capabilities).toBeNull();
+      expect(report.hint).toContain("not functional (reports no capabilities)");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -799,4 +823,38 @@ describe("human status output is a load-bearing contract (#647)", () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  // #801: the human path is where the false clean bill was read — the mute engine printed
+  // a green Binary line and nothing on stderr at all.
+  posixEngineTest("a mute engine reaches stderr with the repair command", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-status-mute-"));
+    const binDir = join(dir, ".cache", "kesha", "engine", "bin");
+    mkdirSync(binDir, { recursive: true });
+    const binPath = join(binDir, "kesha-engine");
+    writeFileSync(binPath, "#!/bin/sh\nexit 0\n");
+    chmodSync(binPath, 0o755);
+    const proc = Bun.spawn([process.execPath, "bin/kesha.js", "status"], {
+      stdout: "pipe",
+      stderr: "pipe",
+      cwd: `${import.meta.dir}/../..`,
+      env: {
+        ...process.env,
+        KESHA_ENGINE_BIN: binPath,
+        KESHA_CACHE_DIR: join(dir, ".cache", "kesha"),
+        HOME: dir,
+        NO_COLOR: "1",
+      },
+    });
+    try {
+      const [, stderr] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+      ]);
+      await proc.exited;
+      expect(stderr).toContain("not functional (reports no capabilities)");
+      expect(stderr).toContain("kesha install");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 15_000);
 });


### PR DESCRIPTION
Closes #801

## The defect

The developer machine's engine was a 17-byte `#!/bin/sh\nexit 0` stub for weeks and every health surface passed it: `installed` is `existsSync`, the `.version` marker was coherent, and the #775 probe only asks the binary to exit. The one signal that betrayed it — no parseable `--capabilities-json` — was a silent `capabilities: null` field, not a fault.

## The predicate

One choke point, `engineFunctionalHealth()` in `src/engine-health.ts`, returns the verdict every surface consults (the #790/#815 lesson: one predicate, N callers, not three null-checks):

| verdict | means | fault? |
| --- | --- | --- |
| `ok` | described itself; carries the parsed capabilities | no |
| `missing` | no binary | **no** — an absent engine is already loud (#770) |
| `unusable` | the loader refuses it (#770) | yes |
| `mute` | spawns, exits, describes nothing (#801) | yes, same severity |

`missing` deliberately stays clean: `capabilities: null` with no engine is the expected case, and every command already fails loudly on it. The fault is only exists + runs + mute.

Capabilities are asked for **first**, so a healthy engine still costs exactly one spawn (doctor used to cost two); only a failing engine pays the second `--version` spawn, which is what separates `unusable` from `mute`.

Both legs are bounded by the same `PROBE_TIMEOUT_MS` (15s, #775). A binary that **hangs** rather than exiting is `unusable`, never `mute` — it could not be made to answer, which is a different fault from answering nothing — and `runEngine`'s abort path terminates the process tree, so the hung child is killed rather than orphaned. This is the grok P2 (second commit): making capabilities primary had dropped the deadline that `engineRuns` used to get for free from `probeExecutable`, so a hung engine would have stalled doctor, status, the install cache check and e2e module load indefinitely.

Callers:

- **doctor** — Binary line reads `installed but not functional (reports no capabilities) - re-run kesha install`, the same shape as the existing corrupt state. `runnable` stays true (it does run); the capability line names the fault.
- **status** — `hint` is no longer null-when-installed: a mute engine gets the fault + repair command, and a corrupt one now gets a hint too (it had none before). The hint reaches stderr on the human path and the payload on `--json`.
- **install cache-validity** — `engineRuns` → `engineWorks`: a cached engine that describes nothing is re-downloaded instead of being vouched for by its marker.
- **e2e guards** — `isEngineInstalled()` in `e2e-engine` / `mcp-e2e` was the third false-positive consumer (issue comment): against the stub, 19 real-engine tests failed loudly instead of skipping with a reason. They now guard on the same predicate.

## Should `isEngineInstalled()` stop being a bare `existsSync`?

**No — kept as is, deliberately.** It is a synchronous presence check on the hot path of `transcribe`, `say`, `record` and the MCP server, where the only question is "do we have a binary to spawn" and the answer to "no" is already the loud, actionable missing-engine error. Making it async and spawning would put a subprocess in front of every command to re-derive what the command itself is about to discover. Installed ≠ functional; **doctor, status and install own functional**, and they now say so. The tests' `describe.skipIf` guards are the one place that needed the stronger question, so they ask it directly rather than by redefining `isEngineInstalled`.

**Declined (grok P3): no functional check after download.** `waitUntilSpawnable` stays exec-only. `build-engine.yml` smoke-tests every uploaded asset with `--capabilities-json` before it can be released, so a mute release binary is not a state this path has to invent a policy for; adding a post-download capabilities spawn would double-probe every healthy install to guard a case CI already excludes, and the next `install`, `doctor` or `status` catches drift anyway. Same reasoning as the `isEngineInstalled` decision above: presence and loader-acceptance are cheap checks on the install path, functional proof belongs to the health surfaces.

**Grok P3: e2e top-level spawn can hang** — resolved by the P2 bound. The guards call the same `engineFunctionalHealth()`, so they inherit the 15s ceiling; with no engine on disk they still cost zero spawns (`stat` fails, then `existsSync` fails).

## Verified against the live defect

The dev machine's real engine **is** the fixture. Read-only spawn of the local stub, before (`origin/main`) and after:

```
# before — clean bill
  Binary: /Users/anton/.cache/kesha/engine/bin/kesha-engine (installed)
  Version state: matches the pin
  Capabilities: capabilities probe returned no data
$ kesha status   # stderr: (nothing)

# after
  Binary: /Users/anton/.cache/kesha/engine/bin/kesha-engine (installed but not functional (reports no capabilities) - re-run `kesha install`)
  Version state: matches the pin
  Capabilities: reports no capabilities; re-run `kesha install`
$ kesha status   # stderr:
Engine at /Users/anton/.cache/kesha/engine/bin/kesha-engine is installed but not functional (reports no capabilities) - re-run `kesha install`
```

No install was run and nothing was downloaded; the stub is untouched (still 17 bytes).

## Red-first

The timeout regression got its own red first: a `#!/bin/sh\nexec sleep 61.5` stub made `engineFunctionalHealth` never return, and the test failed by timing out at 15s. `exec` is deliberate — it puts `sleep` in the process image so the terminate signal lands on it rather than on a shell that ignores it. Three tests pin the behaviour: hung binary is `unusable` within the deadline and never `mute`; the hung child is actually reaped (`pgrep` finds nothing afterwards, each test using its own sleep duration as a marker so they cannot observe each other); and a **slow but answering** engine (`sleep 1`, then valid JSON) still classifies as `ok`, so the bound cannot misread slow-healthy as broken. End-to-end against a real hanging stub, doctor now returns in 15s with `binary is present but does not run (no exit within 15s)` and leaves no orphan — it hung forever before.

Every assertion failed before the implementation existed: the predicate tests failed at import (`Export named 'engineFunctionalHealth' not found`), doctor's Binary line said `(installed)`, and status' hint was `""`. Coverage: mute stub, unparseable capabilities (same fault class), engine missing entirely (unchanged, **not** the new fault), healthy capabilities (clean bill), corrupt image (stays `unusable`), install re-downloads a mute cache hit, and the asymmetry pin — a report with `installed: true` and `capabilities: null` may not render `(installed)`.

Two existing fixtures were themselves the bug: `WORKING_ENGINE` / `FAKE_ENGINE` in the install suites were literally `#!/bin/sh\nexit 0`, i.e. a stub asserted to be a valid cache hit. They now answer `--capabilities-json`. The #772 `--diarize is refused when the engine cannot describe itself` case is reached through a download now, because a cached mute engine is repaired before any flag is judged — a second test pins that repair.

## Gates

- `bunx tsc --noEmit` — clean.
- `bun test` — 1003 pass, 32 skip, **0 fail** (1035 across 83 files); the three hang/slow tests re-run 3x clean.
- Baseline (`origin/main`, same machine, same stub) — 991 pass, 7 skip, **23 fail**.
- Delta by name: the 23 baseline failures are exactly the real-engine e2e cases (`e2e-engine`, `e2e-transcribe`, `e2e-lang-detection`, `mcp e2e`) that the mute stub broke; they now skip (+25 skips). No suite failures introduced — the three that appeared mid-work were the stale fixtures above and are fixed, not silenced.
- `bun run coverage:check:ts` — total 80.70%, all floors held (`engine.ts` 89.33/80, `engine-install.ts` 91.63/15, `say.ts` 51.75/50, `main.ts` 39.96/35).
- No Rust changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBTpJjqyYFW6W8LHJ2nwy
