### PR TITLE
fix(ci): gate darwin synthesis on what an ANE-less runner can actually run

### DIFF
--- a/.github/scripts/smoke-synthesis.ts
+++ b/.github/scripts/smoke-synthesis.ts
@@ -5,12 +5,13 @@
  * no lane covered — rust-test.yml runs unit and contract tests, and the Linux
  * engine smokes transcribe a fixture but never synthesise.
  *
- * Usage: bun .github/scripts/smoke-synthesis.ts [--no-roundtrip] [--voice <id>] <work-dir>
+ * Usage: bun .github/scripts/smoke-synthesis.ts [--no-roundtrip] [--voice <id>] [--text <s>] <work-dir>
  *
  * `--no-roundtrip` stops after synthesis and drops to English only. It exists for
  * build-engine.yml's pre-upload gate (#671), which runs on a release builder with no ASR
  * model set — transcribing back there would cost a multi-GB download per platform.
  * `--voice` overrides the voice, for platforms whose default engine can't run in CI.
+ * `--text` overrides the sentence, for hosts that cannot synthesise the default one (#742).
  */
 import { mkdirSync } from "fs";
 import { join } from "path";
@@ -26,15 +27,27 @@ export type SmokeArgs = { workDir: string; noRoundtrip: boolean; voices: typeof 
 /** Returns null when argv is unusable; the caller prints usage and exits 2. */
 export function parseArgs(argv: string[]): SmokeArgs | null {
   const noRoundtrip = argv.includes("--no-roundtrip");
-  const voiceFlag = argv.indexOf("--voice");
-  const voiceOverride = voiceFlag === -1 ? undefined : argv[voiceFlag + 1];
-  if (voiceFlag !== -1 && (!voiceOverride || voiceOverride.startsWith("--"))) return null;
+  const valueAt: number[] = [];
+  const valueOf = (flag: string): string | null | undefined => {
+    const at = argv.indexOf(flag);
+    if (at === -1) return undefined;
+    const value = argv[at + 1];
+    if (!value || value.startsWith("--")) return null;
+    valueAt.push(at + 1);
+    return value;
+  };
 
-  const voiceValueAt = voiceFlag === -1 ? -1 : voiceFlag + 1;
-  const workDir = argv.find((arg, i) => !arg.startsWith("--") && i !== voiceValueAt);
+  const voiceOverride = valueOf("--voice");
+  const textOverride = valueOf("--text");
+  if (voiceOverride === null || textOverride === null) return null;
+
+  const workDir = argv.find((arg, i) => !arg.startsWith("--") && !valueAt.includes(i));
   if (!workDir) return null;
 
-  const voices = voiceOverride ? [{ voice: voiceOverride, text: ENGLISH }] : ALL_VOICES;
+  const text = textOverride ?? ENGLISH;
+  const voices = voiceOverride
+    ? [{ voice: voiceOverride, text }]
+    : ALL_VOICES.map((v) => ({ ...v, text }));
   return { workDir, noRoundtrip, voices };
 }
 

--- a/.github/scripts/smoke-synthesis.ts
+++ b/.github/scripts/smoke-synthesis.ts
@@ -78,7 +78,9 @@ function fail(message: string): never {
 if (import.meta.main) {
   const parsed = parseArgs(process.argv.slice(2));
   if (!parsed) {
-    console.error("usage: smoke-synthesis.ts [--no-roundtrip] [--voice <id>] <work-dir>");
+    console.error(
+      "usage: smoke-synthesis.ts [--no-roundtrip] [--voice <id>] [--text <sentence>] <work-dir>",
+    );
     process.exit(2);
   }
   const { workDir, noRoundtrip, voices } = parsed;

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -347,10 +347,12 @@ jobs:
           path: kesha-textlang-darwin-arm64
 
   # Exercises the macos-14 artifact elsewhere: that image is required to build, and cannot run the vocoder (#678).
-  # Hosted macOS runners are VMs with no Neural Engine, so CoreML runs Kokoro through libBNNS on
-  # the CPU, which overflows the dispatch worker's stack on longer input (#742). Every prefix of
-  # the default pangram up to 31 chars synthesises; 32-33 and 38+ die on SIGBUS. This lane
-  # therefore gates a short sentence — long-utterance darwin synthesis stays uncovered in CI.
+  # Hosted macOS runners are VMs with no Neural Engine, so CoreML runs Kokoro through libBNNS on the
+  # CPU, where a shape-proportional stack allocation overflows the dispatch worker's 512 KB stack and
+  # the process takes SIGBUS (#742). Length is only a proxy for that shape, and not a monotonic one:
+  # prefixes of the default pangram survive to 31 chars, die at 32-33, survive again at 34-37, and die
+  # from 38 on. So do not swap in another "short enough" sentence — this one was measured 20/20 clean
+  # on a runner. Long-utterance darwin synthesis stays uncovered in CI.
   darwin-synthesis-smoke:
     name: Darwin synthesis smoke
     needs: build
@@ -409,8 +411,12 @@ jobs:
         shell: bash
         run: bun .github/scripts/smoke-synthesis.ts --no-roundtrip --text "Kesha speaks." synthesis-smoke
 
+  # Gating on the darwin smoke as well as the matrix is what makes it a gate over artifacts rather
+  # than run colour (#737): a red smoke has to stop the draft below, and the alpha auto-publish with
+  # it. Accepted tradeoff — the pinned sentence measured 20/20, so a failure here is environment
+  # drift that should hold the release until a human looks (#742).
   release:
-    needs: build
+    needs: [build, darwin-synthesis-smoke]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -347,13 +347,15 @@ jobs:
           path: kesha-textlang-darwin-arm64
 
   # Exercises the macos-14 artifact elsewhere: that image is required to build, and cannot run the vocoder (#678).
-  # Advisory until the longer-sentence SIGBUS is fixed (#742) — a permanently red gate only teaches people to ignore red.
+  # Hosted macOS runners are VMs with no Neural Engine, so CoreML runs Kokoro through libBNNS on
+  # the CPU, which overflows the dispatch worker's stack on longer input (#742). Every prefix of
+  # the default pangram up to 31 chars synthesises; 32-33 and 38+ die on SIGBUS. This lane
+  # therefore gates a short sentence — long-utterance darwin synthesis stays uncovered in CI.
   darwin-synthesis-smoke:
-    name: Darwin synthesis smoke (advisory)
+    name: Darwin synthesis smoke
     needs: build
     runs-on: macos-15
     timeout-minutes: 30
-    continue-on-error: true
     env:
       KESHA_ENGINE_BIN: ${{ github.workspace }}/kesha-engine-darwin-arm64
       # FluidAudio reports CoreML failures on stdout, which the bridge guard discards; this routes them to stderr (#678).
@@ -405,7 +407,7 @@ jobs:
 
       - name: 🗣️ Synthesis smoke
         shell: bash
-        run: bun .github/scripts/smoke-synthesis.ts --no-roundtrip synthesis-smoke
+        run: bun .github/scripts/smoke-synthesis.ts --no-roundtrip --text "Kesha speaks." synthesis-smoke
 
   release:
     needs: build

--- a/src/synth.ts
+++ b/src/synth.ts
@@ -101,6 +101,47 @@ export class SayError extends Error {
   }
 }
 
+/** Fault signals, by number. SIGBUS is 10 on darwin but 7 on linux. */
+const FAULT_SIGNALS: Record<number, string> = { 4: "SIGILL", 6: "SIGABRT", 8: "SIGFPE", 11: "SIGSEGV" };
+
+/**
+ * Explain an engine death that produced no error of its own, or null when the
+ * engine exited normally with a non-zero status. A signal kill leaves stderr
+ * without an `error [CODE]:` line, so without this the caller only sees a bare
+ * "exited 138".
+ *
+ * The wait status is the authority, not `signalCode`: Bun names signal 10
+ * SIGUSR1 (its linux value) even on darwin, where it is SIGBUS.
+ */
+export function engineCrashMessage(
+  exitCode: number,
+  signalCode: string | null,
+  platform: string = process.platform,
+): string | null {
+  const number = exitCode > 128 ? exitCode - 128 : undefined;
+  const sigbus = platform === "darwin" ? 10 : 7;
+  const signal =
+    number === undefined
+      ? (signalCode ?? undefined)
+      : number === sigbus
+        ? "SIGBUS"
+        : (FAULT_SIGNALS[number] ?? signalCode ?? undefined);
+  if (!signal) return null;
+  const base = `kesha-engine was killed by ${signal} and produced no audio`;
+  // Every physical Apple Silicon Mac has a Neural Engine; virtualised macOS has
+  // none, so CoreML runs Kokoro's stages through libBNNS on the CPU, where some
+  // input shapes overflow the dispatch worker's stack (#742).
+  if (platform === "darwin" && (signal === "SIGBUS" || signal === "SIGSEGV")) {
+    return (
+      `${base}. On a Mac with no Apple Neural Engine — virtualised macOS, such as a CI ` +
+      `runner — CoreML falls back to the CPU for Kokoro synthesis and crashes on some ` +
+      `inputs. Shorter text, or a \`macos-*\` AVSpeech voice, avoids it. ` +
+      `See https://github.com/drakulavich/kesha-voice-kit/issues/742`
+    );
+  }
+  return `${base}.`;
+}
+
 export async function say(opts: SayOptions): Promise<Uint8Array> {
   const text = opts.text ?? "";
   if (text.length === 0) {
@@ -161,10 +202,16 @@ export async function say(opts: SayOptions): Promise<Uint8Array> {
     process.stderr.write(stderrText.endsWith("\n") ? stderrText : stderrText + "\n");
   }
   if (exitCode !== 0) {
+    // The crash line goes into `stderr` too: `cli/say.ts` prints that in
+    // preference to the message, and a crash leaves progress lines behind that
+    // would otherwise hide the diagnosis.
+    const detail = [stderrText.trim(), engineCrashMessage(exitCode, proc.signalCode)]
+      .filter((part): part is string => Boolean(part))
+      .join("\n");
     throw new SayError(
-      stderrText.trim() || `kesha-engine say exited ${exitCode}`,
+      detail || `kesha-engine say exited ${exitCode}`,
       exitCode,
-      stderrText,
+      detail,
       engineErrorCode(stderrText),
     );
   }

--- a/src/synth.ts
+++ b/src/synth.ts
@@ -133,10 +133,11 @@ export function engineCrashMessage(
   // input shapes overflow the dispatch worker's stack (#742).
   if (platform === "darwin" && (signal === "SIGBUS" || signal === "SIGSEGV")) {
     return (
-      `${base}. On a Mac with no Apple Neural Engine — virtualised macOS, such as a CI ` +
-      `runner — CoreML falls back to the CPU for Kokoro synthesis and crashes on some ` +
-      `inputs. Shorter text, or a \`macos-*\` AVSpeech voice, avoids it. ` +
-      `See https://github.com/drakulavich/kesha-voice-kit/issues/742`
+      `${base}. This is commonly a virtualised macOS host with no Apple Neural Engine — a ` +
+      `GitHub-hosted CI runner — where CoreML falls back to the CPU for Kokoro synthesis and ` +
+      `crashes on some inputs; shorter text or a \`macos-*\` AVSpeech voice avoids it there. ` +
+      `On a physical Mac the cause is something else, so please report it: ` +
+      `https://github.com/drakulavich/kesha-voice-kit/issues/742`
     );
   }
   return `${base}.`;

--- a/tests/unit/smoke-synthesis-args.test.ts
+++ b/tests/unit/smoke-synthesis-args.test.ts
@@ -35,4 +35,21 @@ describe("parseArgs", () => {
     expect(parseArgs(["out", "--voice"])).toBeNull();
     expect(parseArgs(["--voice", "--no-roundtrip", "out"])).toBeNull();
   });
+
+  // The darwin lane synthesises a shorter sentence than everyone else (#742).
+  test("--text overrides the sentence for every voice", () => {
+    const parsed = parseArgs(["--text", "Kesha speaks.", "out"]);
+    expect(parsed?.workDir).toBe("out");
+    expect(parsed?.voices.map((v) => v.text)).toEqual(["Kesha speaks."]);
+  });
+
+  test("the text value is never mistaken for the work-dir", () => {
+    expect(parseArgs(["--text", "Kesha speaks."])).toBeNull();
+    expect(parseArgs(["out", "--text"])).toBeNull();
+  });
+
+  test("--text and --voice combine", () => {
+    const parsed = parseArgs(["out", "--voice", "macos-Sam", "--text", "Hi."]);
+    expect(parsed?.voices).toEqual([{ voice: "macos-Sam", text: "Hi." }]);
+  });
 });

--- a/tests/unit/smoke-synthesis-args.test.ts
+++ b/tests/unit/smoke-synthesis-args.test.ts
@@ -36,7 +36,16 @@ describe("parseArgs", () => {
     expect(parseArgs(["--voice", "--no-roundtrip", "out"])).toBeNull();
   });
 
-  // The darwin lane synthesises a shorter sentence than everyone else (#742).
+  // Only the darwin lane passes --text (#742); every other lane must keep the pangram.
+  test("keeps the default sentence when --text is absent", () => {
+    expect(parseArgs(["out"])?.voices.map((v) => v.text)).toEqual([
+      "The quick brown fox jumps over the lazy dog.",
+    ]);
+    expect(parseArgs(["out", "--voice", "macos-Sam"])?.voices.map((v) => v.text)).toEqual([
+      "The quick brown fox jumps over the lazy dog.",
+    ]);
+  });
+
   test("--text overrides the sentence for every voice", () => {
     const parsed = parseArgs(["--text", "Kesha speaks.", "out"]);
     expect(parsed?.workDir).toBe("out");

--- a/tests/unit/synth.test.ts
+++ b/tests/unit/synth.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, spyOn } from "bun:test";
-import { buildSayArgs, say, SayError } from "../../src/synth";
+import { buildSayArgs, engineCrashMessage, say, SayError } from "../../src/synth";
 import { log } from "../../src/log";
 
 describe("buildSayArgs", () => {
@@ -108,5 +108,46 @@ describe("say input preflight", () => {
       expect((err as SayError).exitCode).toBe(2);
       expect((err as Error).message).toBe("text is empty");
     }
+  });
+});
+
+describe("engineCrashMessage", () => {
+  it("says nothing for an ordinary non-zero exit", () => {
+    expect(engineCrashMessage(1, null)).toBeNull();
+    expect(engineCrashMessage(2, null)).toBeNull();
+  });
+
+  it("names the signal that killed the engine", () => {
+    expect(engineCrashMessage(139, "SIGSEGV", "darwin")).toContain("SIGSEGV");
+    expect(engineCrashMessage(134, "SIGABRT", "darwin")).toContain("SIGABRT");
+  });
+
+  it("derives the signal from the exit code when Bun reports none", () => {
+    expect(engineCrashMessage(139, null, "darwin")).toContain("SIGSEGV");
+  });
+
+  // Bun names signal 10 SIGUSR1 — its linux value — even on darwin, where the
+  // engine's exit 138 means SIGBUS. The wait status wins.
+  it("does not repeat Bun's linux signal name on darwin", () => {
+    const msg = engineCrashMessage(138, "SIGUSR1", "darwin");
+    expect(msg).toContain("SIGBUS");
+    expect(msg).not.toContain("SIGUSR1");
+  });
+
+  it("uses each platform's own SIGBUS number", () => {
+    expect(engineCrashMessage(135, null, "linux")).toContain("SIGBUS");
+    expect(engineCrashMessage(138, null, "darwin")).toContain("SIGBUS");
+  });
+
+  it("explains the ANE-less CoreML crash for a darwin SIGBUS (#742)", () => {
+    const msg = engineCrashMessage(138, "SIGBUS", "darwin");
+    expect(msg).toContain("Neural Engine");
+    expect(msg).toContain("742");
+  });
+
+  it("keeps the CoreML explanation off non-darwin platforms", () => {
+    const msg = engineCrashMessage(135, null, "linux");
+    expect(msg).toContain("SIGBUS");
+    expect(msg).not.toContain("Neural Engine");
   });
 });


### PR DESCRIPTION
## Root cause

`darwin-synthesis-smoke` has failed every run since #737 landed it: `kesha say --voice en-am_michael` on the 44-char pangram dies with exit 138 (SIGBUS) and prints nothing.

The crash is below kesha, in Apple's CoreML CPU fallback. Full backtrace from `lldb` on a `macos-15` runner:

```
thread #2, queue = 'com.apple.e5rt.concurrentExecutionQueue',
stop reason = EXC_BAD_ACCESS (code=2, address=0x16fe03ff8)
  #0 libsystem_pthread`___chkstk_darwin
  #1 libBNNS.dylib`...
  #5 libBNNS.dylib`BNNSGraphContextExecute_v2
  #6 Espresso`E5RT::Ops::BnnsCpuInferenceOperation::Impl::ExecuteSync()
  #15 libdispatch`_dispatch_worker_thread2
```

`___chkstk_darwin` is the stack probe; faulting there with `code=2` at an address inside the thread stack is a guard-page hit, i.e. **stack overflow on a libdispatch worker thread** (512 KB, versus the main thread's 8 MB). The frame doing it is a libBNNS kernel whose stack allocation scales with the tensor shape.

Why it only happens on hosted runners: they are `Apple M1 (Virtual)` VMs with **no Neural Engine and no GPU** — `ioreg -c AppleARMIODevice | grep -ci ane` reports 0 (32 on a real M2), and `system_profiler SPDisplaysDataType` reports no device at all. Every stage of FluidAudio's 7-stage Kokoro chain therefore executes through `BnnsCpuInferenceOperation` instead of the ANE it was converted for.

## Falsified hypotheses

| Hypothesis | Verdict |
|---|---|
| Truncated / misaligned model mmap | **Refuted.** Guard-page fault in `___chkstk_darwin`, not a mapping fault; all model files present at expected sizes; 44 GB free. |
| Compute-unit preset (`KESHA_KOKORO_COMPUTE_UNITS`) | **Refuted.** All four presets crash on exactly the same inputs and emit byte-identical WAVs elsewhere — with neither ANE nor GPU the preset selects nothing. |
| A length threshold | **Refuted.** Non-monotonic. Sweeping every prefix of the pangram: 1-31 ✅, 32-33 ✗, 34-37 ✅, 38+ ✗. The boundary is a predicted-duration-derived tensor shape, not a character count. |
| Content / specific phonemes | **Refuted.** An unrelated 45-char pangram crashes too. |
| Memory pressure / no swap | **Refuted.** Peak tensors are tens of MB against 7.5 GB; the fault address is a stack guard page. |
| #807 chunking missing from the released binary | **Irrelevant.** The lane builds the binary in the same run, and the crash is under Apple's runtime, not our code. |

Six CI probe runs, all on `macos-15` against the published v1.24.9 darwin engine.

## What this changes

**The lane becomes a gate.** It can prove short-utterance darwin synthesis and nothing longer, so that is what it asserts: `continue-on-error` is gone, and `smoke-synthesis.ts` grows `--text` so the darwin lane pins a sentence inside the region the host survives. Every other lane keeps the pangram. The chosen sentence ran 20/20 clean on a runner, and the exact gated command was verified green there before this PR opened.

Long-utterance darwin synthesis stays uncovered in CI. That is a property of the hardware, and the workflow comment says so rather than leaving the next reader to rediscover it.

**`kesha say` stops swallowing crashes.** A signal death reported `kesha-engine say exited 138`. It now reads:

> kesha-engine was killed by SIGBUS and produced no audio. On a Mac with no Apple Neural Engine — virtualised macOS, such as a CI runner — CoreML falls back to the CPU for Kokoro synthesis and crashes on some inputs. Shorter text, or a `macos-*` AVSpeech voice, avoids it. See …/issues/742

Verified on a runner, not just in tests. The wait status is the authority for the signal name, not Bun's `signalCode`: Bun reports signal 10 as `SIGUSR1` (its linux value) even on darwin, where 10 is `SIGBUS`. The first draft trusted `signalCode` and printed `SIGUSR1` in CI — the regression test pins that.

## Verification

- `bun test tests/unit/` — 887 pass, 0 fail
- `bunx tsc --noEmit` — clean
- `bun run check:workflows` — clean
- `bun run coverage:check:ts` — 80.67% total, every floor met
- Runner verification of both the new gate command (passes) and the old one (fails with the new diagnosis)

No Rust changed. The scratch probe workflow used for the investigation is not in this diff.

Closes #742