### PR TITLE
feat(cache): root FluidAudio's models under KESHA_CACHE_DIR

### DIFF
--- a/.github/workflows/cache-seed.yml
+++ b/.github/workflows/cache-seed.yml
@@ -108,8 +108,11 @@ jobs:
         id: probe
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: ~/Library/Application Support/FluidAudio/Models/parakeet-tdt-0.6b-v3
-          key: parakeet-coreml-models-v1-${{ runner.os }}-${{ hashFiles('rust/Cargo.lock') }}
+          # Tracks `models::fluidaudio_asr_location`: a cold runner has no legacy bundle, so
+          # the engine downloads here. Saving the old Application Support path would archive
+          # an empty directory and poison every PR that restores it (#688, the #675 shape).
+          path: ~/.cache/kesha/fluidaudio/parakeet-tdt-0.6b-v3
+          key: parakeet-coreml-models-v2-${{ runner.os }}-${{ hashFiles('rust/Cargo.lock') }}
           lookup-only: true
 
       - name: Select Xcode 16 (Swift 6)
@@ -148,8 +151,8 @@ jobs:
         if: steps.probe.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: ~/Library/Application Support/FluidAudio/Models/parakeet-tdt-0.6b-v3
-          key: parakeet-coreml-models-v1-${{ runner.os }}-${{ hashFiles('rust/Cargo.lock') }}
+          path: ~/.cache/kesha/fluidaudio/parakeet-tdt-0.6b-v3
+          key: parakeet-coreml-models-v2-${{ runner.os }}-${{ hashFiles('rust/Cargo.lock') }}
 
   kesha-models:
     name: Kesha models (${{ matrix.os }})

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -414,13 +414,16 @@ jobs:
       - name: 🎧 Restore Parakeet CoreML models
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: ~/Library/Application Support/FluidAudio/Models/parakeet-tdt-0.6b-v3
+          # Must track `models::fluidaudio_asr_location`. A runner has no legacy bundle, so
+          # the engine roots it under the Kesha cache; caching the old Application Support
+          # path would restore where nothing reads and save where nothing wrote (#688).
+          path: ~/.cache/kesha/fluidaudio/parakeet-tdt-0.6b-v3
           # Keyed on the fluidaudio-rs pin (Cargo.lock): a bump changes the model
           # set. The prefix restore-key warm-starts from the prior bundle so a
           # bump tops up the delta instead of re-fetching everything.
-          key: parakeet-coreml-models-v1-${{ runner.os }}-${{ hashFiles('rust/Cargo.lock') }}
+          key: parakeet-coreml-models-v2-${{ runner.os }}-${{ hashFiles('rust/Cargo.lock') }}
           restore-keys: |
-            parakeet-coreml-models-v1-${{ runner.os }}-
+            parakeet-coreml-models-v2-${{ runner.os }}-
 
       - name: 🧪 CoreML decoder-state regression (ANE)
         run: |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -168,6 +168,36 @@ darwin) and the native `fluidaudio-rs` CoreML path (`coreml` / `system_diarize`)
   identity, so a recompile is a cold ~98 s cost (see
   [#444](https://github.com/drakulavich/kesha-voice-kit/issues/444)).
 
+### Where FluidAudio's models live
+
+FluidAudio picks its own directories, historically three of them outside
+`KESHA_CACHE_DIR` entirely. On darwin-arm64 the engine now hands it a root of
+`<cache>/fluidaudio` instead, and each subsystem appends its own repo folder
+underneath: `parakeet-tdt-0.6b-v3/` (ASR), `kokoro-82m-coreml/ANE/` (Kokoro
+bundles and the voice packs Kesha pre-stages) and
+`fluidaudio-rs/SortformerCompiled/` (compiled diarizer). See
+[#688](https://github.com/drakulavich/kesha-voice-kit/issues/688).
+
+**Existing installs do not move.** Each subsystem is resolved independently,
+and a legacy directory that already holds a usable bundle keeps being read from
+where it is — relocating would make FluidAudio re-download it, roughly 2 GB on
+a full install. Only what is absent lands under the cache, so in practice the
+new layout applies to fresh installs. Nothing is ever moved or deleted; the two
+layouts simply coexist, and `kesha doctor` prints whichever is in play.
+
+Two directories stay outside the cache regardless, both upstream constraints
+rather than choices:
+
+| Path | Why |
+|---|---|
+| `~/Library/Application Support/FluidAudio/Models/silero-vad` | The bridge accepts a root for ASR, Kokoro and the compiled diarizer only; VAD and the offline diarizer are not plumbed yet. ~1 MB. |
+| `~/.cache/fluidaudio/Models/kokoro` | Kokoro's G2P assets. `KokoroAneManager` passes `nil` for these deliberately — `G2PModel.shared` is a singleton pinned to this path, so honouring a custom directory would download to a path it cannot read. ~24 MB. |
+
+So a full uninstall is `rm -rf ~/.cache/kesha` plus those two, and on a
+pre-#688 install also `~/Library/Application Support/FluidAudio`,
+`~/.cache/fluidaudio` and `~/Library/Application Support/fluidaudio-rs`. Run
+`kesha status --disk` first: it prints every root actually in use.
+
 ## Build, test & release
 
 - **TS tests:** `tests/unit/` + `tests/integration/`, run with `bun test` /

--- a/docs/tts.md
+++ b/docs/tts.md
@@ -1,6 +1,6 @@
 # Text-to-Speech
 
-Kesha speaks back via Kokoro-82M (English plus selected multilingual voices on Apple Silicon) and Vosk-TTS (Russian). Voice is auto-picked from the input text's language — `en` routes to Kokoro, `ru` to Vosk. Pass `--voice` to override. On darwin-arm64 release builds, Kokoro runs through FluidAudio CoreML instead of the ONNX Kokoro model; Linux/Windows keep the ONNX path. FluidAudio keeps its CoreML Kokoro cache at `~/.cache/fluidaudio/Models/kokoro`; those files are managed by FluidAudio, not Kesha's pinned model downloader.
+Kesha speaks back via Kokoro-82M (English plus selected multilingual voices on Apple Silicon) and Vosk-TTS (Russian). Voice is auto-picked from the input text's language — `en` routes to Kokoro, `ru` to Vosk. Pass `--voice` to override. On darwin-arm64 release builds, Kokoro runs through FluidAudio CoreML instead of the ONNX Kokoro model; Linux/Windows keep the ONNX path. The CoreML Kokoro bundles live under `<cache>/fluidaudio/kokoro-82m-coreml/`, or stay in FluidAudio's own `~/.cache/fluidaudio/Models/kokoro-82m-coreml/` on an install that already had them ([#688](https://github.com/drakulavich/kesha-voice-kit/issues/688)); the G2P assets beside them at `~/.cache/fluidaudio/Models/kokoro` never move, because upstream pins that path. Either way those files are managed by FluidAudio, not Kesha's pinned model downloader.
 
 ```bash
 kesha install --tts                 # English only (~326 MB on Linux/Windows; on macOS FluidAudio fetches its own models during warm-up)

--- a/rust/src/backend/fluidaudio.rs
+++ b/rust/src/backend/fluidaudio.rs
@@ -25,7 +25,8 @@ pub struct FluidAudioBackend {
 
 impl FluidAudioBackend {
     pub fn new() -> Result<Self> {
-        let audio = FluidAudio::new().context("failed to initialize FluidAudio bridge")?;
+        let audio = crate::models::fluidaudio_bridge(&crate::models::fluidaudio_asr_location())
+            .context("failed to initialize FluidAudio bridge")?;
         audio
             .init_asr()
             .context("failed to initialize FluidAudio ASR (first run compiles models for ANE)")?;

--- a/rust/src/cli/install.rs
+++ b/rust/src/cli/install.rs
@@ -98,7 +98,7 @@ pub fn run(args: InstallArgs) -> Result<()> {
         );
         let t = std::time::Instant::now();
         let result = crate::fluid_stdout::with_silenced_stdout_oneshot(|| {
-            fluidaudio_rs::FluidAudio::new()
+            models::fluidaudio_bridge(&models::fluidaudio_diarize_location())
                 .and_then(|fa| fa.compile_diarization_model(&diarize_pkg))
         });
         match result {

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -540,6 +540,81 @@ fn ane_voices_for(langs: &[&str]) -> Vec<&'static ModelFile> {
         .collect()
 }
 
+/// Where one FluidAudio subsystem's files live, and the root that puts them there.
+pub struct FluidAudioLocation {
+    /// The directory the subsystem reads and writes.
+    pub dir: PathBuf,
+    /// Base to hand `FluidAudio::with_models_dir`. `None` keeps FluidAudio's own defaults.
+    pub root: Option<PathBuf>,
+}
+
+/// FluidAudio's models root inside Kesha's cache (#688). `with_models_dir` treats this as a
+/// base that each subsystem appends its own repo folder to, so Parakeet ASR, the Kokoro ANE
+/// chain and the compiled-Sortformer cache become siblings here instead of three separate
+/// home-directory roots FluidAudio picks for itself.
+pub fn fluidaudio_models_root() -> PathBuf {
+    cache_dir().join("fluidaudio")
+}
+
+/// Resolve one subsystem, preferring a legacy location that already holds a usable bundle.
+///
+/// An install predating #688 holds ~2 GB under FluidAudio's own defaults, and injecting a
+/// root would make FluidAudio re-download all of it. So `legacy_ready` pins the subsystem
+/// where it already is and injects nothing; only what is absent — a fresh install, or a
+/// bundle the user deleted — lands under [`fluidaudio_models_root`]. Nothing is ever moved
+/// or removed, so the fallback is pure reading.
+///
+/// Returning both halves of the decision together is the point: `dir` and `root` must agree,
+/// or Kesha stages voice packs into a directory FluidAudio never reads.
+pub fn fluidaudio_location(
+    legacy: &Path,
+    legacy_ready: bool,
+    repo_subpath: &str,
+) -> FluidAudioLocation {
+    if legacy_ready {
+        return FluidAudioLocation {
+            dir: legacy.to_path_buf(),
+            root: None,
+        };
+    }
+    let root = fluidaudio_models_root();
+    FluidAudioLocation {
+        dir: root.join(repo_subpath),
+        root: Some(root),
+    }
+}
+
+/// Open a FluidAudio bridge honouring `at`. Routing every construction site through this
+/// keeps the directory Kesha reports and the directory FluidAudio writes to from drifting.
+#[cfg(any(
+    feature = "coreml",
+    feature = "system_kokoro",
+    feature = "system_diarize"
+))]
+pub fn fluidaudio_bridge(
+    at: &FluidAudioLocation,
+) -> std::result::Result<fluidaudio_rs::FluidAudio, fluidaudio_rs::FluidAudioError> {
+    match &at.root {
+        Some(root) => fluidaudio_rs::FluidAudio::with_models_dir(root),
+        None => fluidaudio_rs::FluidAudio::new(),
+    }
+}
+
+/// True when `dir` exists and holds at least one entry. Deliberately weak: the cost of a
+/// false positive is keeping a legacy directory in use, the cost of a false negative is
+/// re-downloading it (#688).
+#[cfg(any(
+    all(
+        feature = "system_kokoro",
+        target_os = "macos",
+        target_arch = "aarch64"
+    ),
+    feature = "system_diarize"
+))]
+fn dir_has_entries(dir: &Path) -> bool {
+    fs::read_dir(dir).is_ok_and(|mut e| e.next().is_some())
+}
+
 /// FluidAudio's Kokoro CoreML cache root. Each KokoroAne variant gets its own
 /// subdirectory of bundles here (`ANE` for English/Latin, `ANE-zh` for the
 /// Mandarin variant, and so on per `ModelNames.Repo.subPath`).
@@ -549,19 +624,14 @@ fn ane_voices_for(langs: &[&str]) -> Vec<&'static ModelFile> {
     target_arch = "aarch64"
 ))]
 pub fn fluidaudio_kokoro_cache_dir() -> PathBuf {
-    dirs::home_dir()
-        .expect("cannot determine home directory")
-        .join(".cache")
-        .join("fluidaudio")
-        .join("Models")
-        .join("kokoro-82m-coreml")
+    fluidaudio_kokoro_location().dir
 }
 
-/// FluidAudio's Kokoro ANE voice-pack cache directory. NOT under
-/// `KESHA_CACHE_DIR` — FluidAudio 0.15.5 owns this path and reads voice packs
-/// from here local-first. We pre-stage onnx-community packs here so the full
-/// advertised Kokoro catalog (and the male `am_michael` default) resolve
-/// without a 404 against the ANE bundle.
+/// FluidAudio's Kokoro ANE voice-pack cache directory. FluidAudio 0.15.5 reads voice packs
+/// from here local-first, so we pre-stage onnx-community packs into it and the full
+/// advertised Kokoro catalog (and the male `am_michael` default) resolve without a 404
+/// against the ANE bundle. Follows [`fluidaudio_kokoro_location`], so staging always lands
+/// wherever the bridge is actually pointed.
 #[cfg(all(
     feature = "system_kokoro",
     target_os = "macos",
@@ -571,14 +641,57 @@ pub fn fluidaudio_ane_kokoro_dir() -> PathBuf {
     fluidaudio_kokoro_cache_dir().join("ANE")
 }
 
-/// FluidAudio's ASR bundle directory. Not under `KESHA_CACHE_DIR` — FluidAudio
-/// downloads and reads it here, and `AsrModels` resolves it as
-/// `<ApplicationSupport>/FluidAudio/Models/<repo.folderName>`, where `folderName`
-/// **strips** the `-coreml` suffix from `parakeet-tdt-0.6b-v3-coreml`. Keying on
-/// the `…-v3-coreml` sibling that also exists on disk would report a healthy
-/// install as broken (#684).
+/// Where FluidAudio's Kokoro CoreML bundles live, and the root that puts them there.
+#[cfg(all(
+    feature = "system_kokoro",
+    target_os = "macos",
+    target_arch = "aarch64"
+))]
+pub fn fluidaudio_kokoro_location() -> FluidAudioLocation {
+    let legacy = legacy_fluidaudio_kokoro_cache_dir();
+    let staged = dir_has_entries(&legacy);
+    fluidaudio_location(&legacy, staged, "kokoro-82m-coreml")
+}
+
+/// The `.cache/fluidaudio` tree FluidAudio picks on its own. Kept as the read-fallback so an
+/// upgrade never re-fetches the ~800 MB of ANE bundles already sitting here (#688).
+#[cfg(all(
+    feature = "system_kokoro",
+    target_os = "macos",
+    target_arch = "aarch64"
+))]
+fn legacy_fluidaudio_kokoro_cache_dir() -> PathBuf {
+    dirs::home_dir()
+        .expect("cannot determine home directory")
+        .join(".cache")
+        .join("fluidaudio")
+        .join("Models")
+        .join("kokoro-82m-coreml")
+}
+
+/// FluidAudio's ASR bundle directory — the one `AsrModels` loads from, wherever that
+/// currently is. See [`fluidaudio_asr_location`] for which of the two it can be.
 #[cfg(feature = "coreml")]
 pub fn fluidaudio_asr_dir() -> PathBuf {
+    fluidaudio_asr_location().dir
+}
+
+/// Where the Parakeet bundle lives, and the root that puts it there.
+#[cfg(feature = "coreml")]
+pub fn fluidaudio_asr_location() -> FluidAudioLocation {
+    let legacy = legacy_fluidaudio_asr_dir();
+    let complete = fluidaudio_asr_ready_in(&legacy);
+    fluidaudio_location(&legacy, complete, "parakeet-tdt-0.6b-v3")
+}
+
+/// The Application Support tree FluidAudio picks on its own, kept as the read-fallback.
+///
+/// `AsrModels` resolves it as `<ApplicationSupport>/FluidAudio/Models/<repo.folderName>`,
+/// where `folderName` **strips** the `-coreml` suffix from `parakeet-tdt-0.6b-v3-coreml`.
+/// Keying on the `…-v3-coreml` sibling that also exists on disk would report a healthy
+/// install as broken (#684).
+#[cfg(feature = "coreml")]
+fn legacy_fluidaudio_asr_dir() -> PathBuf {
     dirs::home_dir()
         .expect("cannot determine home directory")
         .join("Library")
@@ -586,6 +699,26 @@ pub fn fluidaudio_asr_dir() -> PathBuf {
         .join("FluidAudio")
         .join("Models")
         .join("parakeet-tdt-0.6b-v3")
+}
+
+/// Where `fluidaudio-rs` keeps compiled Sortformer `.mlmodelc` bundles, and the root that
+/// puts them there. Relocating this costs a ~100 s ANE recompile rather than a download, but
+/// the fallback rule is the same: an existing cache stays where it is.
+#[cfg(feature = "system_diarize")]
+pub fn fluidaudio_diarize_location() -> FluidAudioLocation {
+    let legacy = legacy_sortformer_compiled_dir();
+    let compiled = dir_has_entries(&legacy);
+    fluidaudio_location(&legacy, compiled, "fluidaudio-rs/SortformerCompiled")
+}
+
+#[cfg(feature = "system_diarize")]
+fn legacy_sortformer_compiled_dir() -> PathBuf {
+    dirs::home_dir()
+        .expect("cannot determine home directory")
+        .join("Library")
+        .join("Application Support")
+        .join("fluidaudio-rs")
+        .join("SortformerCompiled")
 }
 
 /// What FluidAudio's own `modelsExist` requires. The encoder is pinned to int8
@@ -2452,13 +2585,82 @@ mod characterization_tests {
     #[test]
     #[cfg(feature = "coreml")]
     fn fluidaudio_asr_dir_is_the_directory_fluidaudio_loads_from() {
-        let dir = fluidaudio_asr_dir();
+        let dir = legacy_fluidaudio_asr_dir();
         assert!(dir.ends_with("parakeet-tdt-0.6b-v3"), "{dir:?}");
         assert!(
             dir.to_string_lossy()
                 .contains("Library/Application Support/FluidAudio/Models"),
             "{dir:?} is not FluidAudio's ASR root"
         );
+    }
+
+    /// A machine with nothing staged yet gets one tree: the injected root and the directory
+    /// we report must be the same decision, or `kesha install` stages voice packs into a
+    /// directory FluidAudio never reads and re-fetches the bundle anyway (#688).
+    #[test]
+    fn a_missing_bundle_lands_under_the_kesha_cache() {
+        let _lock = crate::util::test_env::lock();
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = crate::util::test_env::EnvGuard::set(
+            "KESHA_CACHE_DIR",
+            tmp.path().to_str().expect("utf-8 temp path"),
+        );
+
+        let legacy = PathBuf::from("/nonexistent/FluidAudio/Models/parakeet-tdt-0.6b-v3");
+        let at = fluidaudio_location(&legacy, false, "parakeet-tdt-0.6b-v3");
+
+        let root = at
+            .root
+            .as_ref()
+            .expect("a missing bundle must inject a root");
+        assert_eq!(root, &tmp.path().join("fluidaudio"));
+        assert_eq!(
+            at.dir,
+            root.join("parakeet-tdt-0.6b-v3"),
+            "the reported directory must be where the injected root puts it"
+        );
+    }
+
+    /// The whole point of the read-fallback: an existing install holds ~2 GB under
+    /// FluidAudio's own defaults, and injecting a root would re-download all of it (#688).
+    #[test]
+    fn an_existing_bundle_stays_put_and_injects_no_root() {
+        let _lock = crate::util::test_env::lock();
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = crate::util::test_env::EnvGuard::set(
+            "KESHA_CACHE_DIR",
+            tmp.path().to_str().expect("utf-8 temp path"),
+        );
+
+        let legacy = PathBuf::from("/somewhere/FluidAudio/Models/parakeet-tdt-0.6b-v3");
+        let at = fluidaudio_location(&legacy, true, "parakeet-tdt-0.6b-v3");
+
+        assert_eq!(at.dir, legacy);
+        assert!(
+            at.root.is_none(),
+            "a usable legacy bundle must keep FluidAudio's defaults rather than relocate"
+        );
+    }
+
+    /// Every subsystem appends its own repo folder to the same base, so they end up as
+    /// siblings under one root rather than three home-directory trees.
+    #[test]
+    fn subsystems_share_one_root_as_siblings() {
+        let _lock = crate::util::test_env::lock();
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = crate::util::test_env::EnvGuard::set(
+            "KESHA_CACHE_DIR",
+            tmp.path().to_str().expect("utf-8 temp path"),
+        );
+
+        let missing = PathBuf::from("/nonexistent");
+        let asr = fluidaudio_location(&missing, false, "parakeet-tdt-0.6b-v3");
+        let kokoro = fluidaudio_location(&missing, false, "kokoro-82m-coreml");
+        let sortformer = fluidaudio_location(&missing, false, "fluidaudio-rs/SortformerCompiled");
+
+        assert_eq!(asr.root, kokoro.root);
+        assert_eq!(kokoro.root, sortformer.root);
+        assert_eq!(asr.dir.parent(), kokoro.dir.parent());
     }
 
     /// An interrupted FluidAudio fetch leaves the directory present but partial.

--- a/rust/src/streaming_asr.rs
+++ b/rust/src/streaming_asr.rs
@@ -41,7 +41,8 @@ impl StreamingAsrSession {
             .ok()
             .map(OwnedFd::from);
 
-        let audio = FluidAudio::new().context("failed to initialize FluidAudio bridge")?;
+        let audio = crate::models::fluidaudio_bridge(&crate::models::fluidaudio_asr_location())
+            .context("failed to initialize FluidAudio bridge")?;
         with_silenced_stdout(devnull.as_ref(), || audio.init_streaming_asr()).context(
             "failed to initialize FluidAudio streaming ASR \
              (first run compiles models for ANE)",

--- a/rust/src/transcribe/diarize.rs
+++ b/rust/src/transcribe/diarize.rs
@@ -16,7 +16,6 @@ use std::time::{Duration, Instant};
 use crate::{dtrace, dtrace_json};
 use fluidaudio_rs::{
     DiarizationSegment, DiarizeCancelToken, DiarizeComputeUnits, DiarizeEvent, DiarizeOutcome,
-    FluidAudio,
 };
 
 use super::TranscriptionSegment;
@@ -402,7 +401,9 @@ fn spawn_worker(
         // handled by `StdoutShield` at the CLI layer (fd 1 stays redirected past exit). (#259/#397/#434)
         let result = crate::fluid_stdout::with_silenced_stdout_oneshot(
             || -> Result<Option<Vec<DiarizeSpan>>> {
-                let audio = FluidAudio::new().context("failed to initialize FluidAudio bridge")?;
+                let audio =
+                    crate::models::fluidaudio_bridge(&crate::models::fluidaudio_diarize_location())
+                        .context("failed to initialize FluidAudio bridge")?;
                 let mut on_event = |event: DiarizeEvent| {
                     let _ = progress_tx.send(match event {
                         DiarizeEvent::ModelReady => WorkerEvent::ModelReady,

--- a/rust/src/tts/fluid_kokoro.rs
+++ b/rust/src/tts/fluid_kokoro.rs
@@ -230,7 +230,8 @@ fn with_kokoro<R>(voice_id: &str, f: impl FnOnce(&FluidAudio) -> Result<R>) -> R
     let lang = lang_for_fluid_id(voice_id).unwrap_or("en-us");
     let compute_units = compute_units_from_env()?;
     crate::fluid_stdout::with_silenced_stdout_oneshot(|| {
-        let audio = FluidAudio::new().context("init FluidAudio bridge")?;
+        let audio = crate::models::fluidaudio_bridge(&crate::models::fluidaudio_kokoro_location())
+            .context("init FluidAudio bridge")?;
         audio
             .init_kokoro_with_compute_units(voice_id, lang, compute_units)
             .map_err(|e| {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -241,8 +241,11 @@ function collectCache(
   );
   if (coreml) {
     const fluidAsr = fluidAsrCacheInfo();
+    // A relocated bundle is inside the cache and already inside `totalBytes`; calling it
+    // external there would send a user hunting for a directory that no longer exists (#688).
+    const external = isInsideDir(fluidAsr.path, cache) ? "" : " (external)";
     components.push({
-      label: "ASR (Parakeet, FluidAudio) (external)",
+      label: `ASR (Parakeet, FluidAudio)${external}`,
       path: fluidAsr.path,
       exists: fluidAsr.exists,
       sizeBytes: fluidAsr.sizeBytes,

--- a/src/fluid-asr-cache.ts
+++ b/src/fluid-asr-cache.ts
@@ -3,9 +3,13 @@ import { join } from "path";
 import { diagnosticHomeDir, dirSizeBytes } from "./diagnostic-paths";
 import { isDarwinArm64 } from "./fluid-kokoro-cache";
 import { engineTarget } from "./engine-targets";
+import { keshaCacheDir } from "./paths";
 
+// Says nothing about location: since #688 the bundle may sit inside the Kesha cache or in
+// FluidAudio's own tree, and either way it is the backend that fetches it, not the pinned
+// downloader — which is what the note is actually warning about.
 export const FLUID_ASR_CACHE_NOTE =
-  "required for speech-to-text; fetched by the backend during warm-up, outside Kesha's model cache";
+  "required for speech-to-text; fetched by the backend during warm-up, not by Kesha's pinned downloader";
 
 /**
  * Which ASR layout applies. The reported backend is authoritative; when the capabilities
@@ -30,9 +34,10 @@ export interface FluidAsrCacheInfo {
 /**
  * FluidAudio loads ASR from `<ApplicationSupport>/FluidAudio/Models/<repo folder>`,
  * and that folder name has the `-coreml` suffix stripped — the `…-v3-coreml` sibling
- * that also appears on disk is not what it reads (#684).
+ * that also appears on disk is not what it reads (#684). This is the location FluidAudio
+ * picks unaided, which #688 keeps as a read-fallback.
  */
-export function fluidAsrCachePath(homeDir = diagnosticHomeDir()): string {
+export function legacyFluidAsrCachePath(homeDir = diagnosticHomeDir()): string {
   return join(
     homeDir,
     "Library",
@@ -41,6 +46,21 @@ export function fluidAsrCachePath(homeDir = diagnosticHomeDir()): string {
     "Models",
     "parakeet-tdt-0.6b-v3",
   );
+}
+
+/**
+ * Where the Parakeet bundle actually is. Mirrors `models.rs::fluidaudio_asr_location`: a
+ * complete legacy bundle keeps its place so an upgrade never re-downloads ~460 MB, and
+ * anything else lives under the Kesha cache, where the engine roots a fresh install (#688).
+ */
+export function fluidAsrCachePath(
+  homeDir = diagnosticHomeDir(),
+  cacheRoot = keshaCacheDir(),
+): string {
+  const legacy = legacyFluidAsrCachePath(homeDir);
+  return fluidAsrCacheReady(legacy)
+    ? legacy
+    : join(cacheRoot, "fluidaudio", "parakeet-tdt-0.6b-v3");
 }
 
 /**
@@ -77,10 +97,11 @@ export function fluidAsrCacheInfo(
     platform?: typeof process.platform;
     arch?: typeof process.arch;
     homeDir?: string;
+    cacheRoot?: string;
   } = {},
 ): FluidAsrCacheInfo {
   const supported = isDarwinArm64(options.platform, options.arch);
-  const path = fluidAsrCachePath(options.homeDir);
+  const path = fluidAsrCachePath(options.homeDir, options.cacheRoot);
 
   return {
     supported,

--- a/src/status.ts
+++ b/src/status.ts
@@ -199,7 +199,11 @@ function collectDiskUsage(binPath: string, backend?: string): StatusDiskUsage {
   const engineOutsideCache = isInsideDir(engineDir, cache) ? 0 : dirSizeBytes(engineDir);
   const fluidKokoro = fluidKokoroCacheInfo();
   // Only walked when it is the backend in play; otherwise the size is computed and dropped.
-  const fluidAsr = coreml ? fluidAsrCacheInfo() : null;
+  // A relocated bundle sits inside the cache and is already counted in `totalBytes`, so
+  // listing it under "not included in Kesha total" would be a double count (#688).
+  const fluidAsrInfo = coreml ? fluidAsrCacheInfo() : null;
+  const fluidAsr =
+    fluidAsrInfo && !isInsideDir(fluidAsrInfo.path, cache) ? fluidAsrInfo : null;
 
   return {
     cachePath: cache,

--- a/tests/unit/doctor.test.ts
+++ b/tests/unit/doctor.test.ts
@@ -633,7 +633,7 @@ describe("collectDoctorReport probe and cache accounting", () => {
     }
   });
 
-  posixEngineTest("a CoreML engine gets the external ASR row, not the ONNX model dir", async () => {
+  posixEngineTest("a CoreML engine gets the FluidAudio ASR row, not the ONNX model dir", async () => {
     const { dir, binDir } = stage("kesha-doctor-coreml-cache-");
     writeFakeEngine(
       join(binDir, "kesha-engine"),
@@ -647,7 +647,9 @@ exit 2
     );
     try {
       const labels = (await collectDoctorReport()).cache.components.map((c) => c.label);
-      expect(labels).toContain("ASR (Parakeet, FluidAudio) (external)");
+      // No legacy bundle here, so the engine roots it inside the cache — calling that row
+      // external would send the user hunting for a directory that is not there (#688).
+      expect(labels).toContain("ASR (Parakeet, FluidAudio)");
       expect(labels).not.toContain("ASR (Parakeet)");
     } finally {
       rmSync(dir, { recursive: true, force: true });

--- a/tests/unit/fluid-asr-cache.test.ts
+++ b/tests/unit/fluid-asr-cache.test.ts
@@ -7,8 +7,10 @@ import {
   fluidAsrCacheInfo,
   fluidAsrCachePath,
   isCoremlBackend,
+  legacyFluidAsrCachePath,
 } from "../../src/fluid-asr-cache";
 import { defaultBackendForPlatform, unavailableBackendError } from "../../src/cli/install";
+import { isInsideDir } from "../../src/cache-layout";
 
 describe("isCoremlBackend", () => {
   test("trusts the engine's reported backend over the host platform", () => {
@@ -28,7 +30,7 @@ describe("fluidAsrCacheInfo", () => {
   // `Repo.folderName` strips the `-coreml` suffix, and a `…-v3-coreml` sibling exists
   // on disk. Reporting that one would call a healthy install broken.
   test("points at the directory FluidAudio loads from, not the -coreml sibling", () => {
-    const path = fluidAsrCachePath("/tmp/home");
+    const path = legacyFluidAsrCachePath("/tmp/home");
     expect(path).toBe(
       join("/tmp/home", "Library", "Application Support", "FluidAudio", "Models", "parakeet-tdt-0.6b-v3"),
     );
@@ -45,7 +47,7 @@ describe("fluidAsrCacheInfo", () => {
 
   // `.mlmodelc` are compiled-model directories holding `coremldata.bin`, not flat files.
   function seed(homeDir: string, entries: string[]): string {
-    const cache = fluidAsrCachePath(homeDir);
+    const cache = legacyFluidAsrCachePath(homeDir);
     mkdirSync(cache, { recursive: true });
     for (const e of entries) {
       if (e.endsWith(".mlmodelc")) {
@@ -108,7 +110,7 @@ describe("fluidAsrCacheInfo", () => {
   test("reports an empty bundle directory as absent", () => {
     const dir = mkdtempSync(join(tmpdir(), "kesha-fluid-asr-cache-bare-"));
     try {
-      mkdirSync(fluidAsrCachePath(dir), { recursive: true });
+      mkdirSync(legacyFluidAsrCachePath(dir), { recursive: true });
       expect(fluidAsrCacheInfo({ platform: "darwin", arch: "arm64", homeDir: dir }).exists).toBe(
         false,
       );
@@ -120,9 +122,55 @@ describe("fluidAsrCacheInfo", () => {
   test("reports absent rather than throwing when the bundle was never fetched", () => {
     const dir = mkdtempSync(join(tmpdir(), "kesha-fluid-asr-cache-empty-"));
     try {
-      const info = fluidAsrCacheInfo({ platform: "darwin", arch: "arm64", homeDir: dir });
+      const info = fluidAsrCacheInfo({
+        platform: "darwin",
+        arch: "arm64",
+        homeDir: dir,
+        cacheRoot: join(dir, "cache"),
+      });
       expect(info.supported).toBe(true);
       expect(info.exists).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // Relocating a bundle FluidAudio already holds would re-download ~460 MB, so a complete
+  // legacy copy wins and nothing moves (#688).
+  test("keeps a complete legacy bundle where FluidAudio already put it", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-fluid-asr-legacy-"));
+    try {
+      const legacy = seed(dir, COMPLETE);
+      expect(fluidAsrCachePath(dir, join(dir, "cache"))).toBe(legacy);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // A fresh install has no legacy bundle, so the engine roots it under the Kesha cache.
+  // Reporting the old path here would call every new install broken (#688).
+  test("follows the engine into the Kesha cache when there is no legacy bundle", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-fluid-asr-fresh-"));
+    try {
+      const cacheRoot = join(dir, "cache");
+      expect(fluidAsrCachePath(dir, cacheRoot)).toBe(
+        join(cacheRoot, "fluidaudio", "parakeet-tdt-0.6b-v3"),
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // `status --disk` and `doctor` both branch on this to decide whether the bundle is already
+  // inside the cache total, and so whether calling it "external" is a double count (#688/#790).
+  test("containment in the cache root tracks which location won", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-fluid-asr-inside-"));
+    try {
+      const cacheRoot = join(dir, "cache");
+      expect(isInsideDir(fluidAsrCachePath(dir, cacheRoot), cacheRoot)).toBe(true);
+
+      seed(dir, COMPLETE);
+      expect(isInsideDir(fluidAsrCachePath(dir, cacheRoot), cacheRoot)).toBe(false);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -182,6 +230,15 @@ describe("Rust/TS FluidAudio contract agreement", () => {
   });
 
   test("cache directory name matches", () => {
-    expect(rust).toContain(`.join("${basename(fluidAsrCachePath("/tmp/home"))}")`);
+    expect(rust).toContain(`.join("${basename(legacyFluidAsrCachePath("/tmp/home"))}")`);
+  });
+
+  // Both sides derive the relocated bundle from the cache root; a rename on one side alone
+  // would point doctor at a directory the engine never writes (#688).
+  test("relocated bundle path matches", () => {
+    expect(rust).toContain(`cache_dir().join("fluidaudio")`);
+    expect(fluidAsrCachePath("/tmp/home", "/tmp/cache")).toBe(
+      join("/tmp/cache", "fluidaudio", "parakeet-tdt-0.6b-v3"),
+    );
   });
 });


### PR DESCRIPTION
## What

`KESHA_CACHE_DIR` now governs where FluidAudio keeps its models. The engine hands the bridge a root of `<cache>/fluidaudio`, and Parakeet ASR, the Kokoro ANE chain and the compiled-Sortformer cache land there as siblings instead of in three separate home-directory trees.

## The blocker was not upstream

The issue proposed an upstream PR to `fluidaudio-rs`. That work is already done and already pinned: rev `91d80ea` (the rev `main` pins today) carries `FluidAudio::with_models_dir`, `fluidaudio_bridge_create_with_models_dir`, `FluidAudioBridgeInternal(modelsRoot:)`, `KokoroAneManager(directory:)` and `compiledCacheDir(root:)`. It landed alongside the diarize-control work. Kesha simply never called it — all five construction sites were a bare `FluidAudio::new()`.

**So there is no fork branch and no pin bump in this PR.** Nothing was pushed to the fork.

## Measured footprint

The issue said ~1.1 GB; it has grown.

| Root | Size | Rootable |
|---|---|---|
| `~/Library/Application Support/FluidAudio` | 923M (parakeet 461M + `-coreml` sibling 461M + silero-vad 1M) | ASR yes, VAD no |
| `~/.cache/fluidaudio` | 822M (kokoro-82m-coreml 799M + kokoro G2P 24M) | bundles yes, G2P no |
| `~/Library/Application Support/fluidaudio-rs` | 235M SortformerCompiled | yes |

~1.95 GB of ~1.98 GB moves for a fresh install.

## Migration stance: read-fallback, nothing moves

Each subsystem resolves independently through `models::fluidaudio_location`, and a legacy directory that already holds a usable bundle keeps being read from where it is — relocating would make FluidAudio re-download it. Nothing is moved or deleted; the two layouts coexist. In practice the new layout applies to fresh installs, which is the conservative reading of the issue's "do not re-download what users already have".

No new env var, no flag, no migration command.

`fluidaudio_location` returns the directory and the injected root as one value on purpose. If those two disagreed, `stage_ane_kokoro_voices` would write voice packs into a directory FluidAudio never reads — that is the failure mode the type prevents.

## Why this cannot close #688

Two directories stay outside the cache, both upstream constraints:

- **FluidAudio's silero-vad** (~1 MB). Upstream accepts a directory; the bridge does not pass one for VAD or the offline diarizer yet. This is the one piece of genuine remaining fork work.
- **Kokoro G2P assets** (~24 MB, `~/.cache/fluidaudio/Models/kokoro`). `KokoroAneManager` passes `nil` here deliberately — `G2PModel.shared` is a singleton pinned to that path, so honouring a custom directory would download to a path it cannot read. Closing this needs a change in FluidAudio itself, not the fork.

Verified against FluidAudio v0.15.5 sources, not inferred. The four-root table collapses to one root plus ~25 MB of residue.

## Reporting

`doctor` and `status --disk` follow the same resolution and stop labelling a relocated bundle "external" — it is inside the cache and already inside the total, so the old label was a double count and pointed at a directory that no longer exists.

The deeper `status --disk` rework is **not** here and is a follow-up: it still reports the 24 MB G2P directory as "FluidAudio Kokoro" while missing the 799 MB ANE tree and the 235 MB Sortformer cache entirely — a pre-existing gap (#688's "does not account for the other two at all"). Testing it deterministically needs home/cache injection threaded through `collectStatus`, which is why it is staged separately rather than bolted on here.

## Tests

TDD on the derivation, which is where a mistake costs a multi-GB re-download:

- `models::fluidaudio_location` — a missing bundle lands under the cache with `dir` and `root` agreeing; a usable legacy bundle stays put and injects nothing; all subsystems share one root as siblings. Feature-independent, so `make rust-test` actually runs them (the `coreml` arms do not).
- `fluid-asr-cache` — legacy wins when complete, cache root when not, and containment in the cache root tracks which won (the fact `status`/`doctor` branch on, per #790's `isInsideDir`).

Verified the Kokoro subpath empirically rather than trusting the doc comment: `KokoroAneResourceDownloader.ensureModels` computes `modelsDirectory + repo.folderName`, and the observed on-disk layout pins `folderName` to `kokoro-82m-coreml/ANE`, matching what `fluidaudio_ane_kokoro_dir` derives.

## Gates

- `cargo fmt --check` clean
- `cargo clippy --all-targets -- -D warnings`: default, `coreml`, `system_kokoro`, `system_diarize` — all pass
- `cargo nextest run --features tts`: 469/469
- `cargo nextest run --features system_diarize`: 517/517 (includes `diarize_e2e`)
- `bun test`: 1021 pass, 0 fail
- `bunx tsc --noEmit` clean

No models were downloaded and no existing cache directory was written to or removed.

Refs #688