### PR TITLE
feat(cache): say when a legacy FluidAudio bundle stops being read

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -185,6 +185,14 @@ a full install. Only what is absent lands under the cache, so in practice the
 new layout applies to fresh installs. Nothing is ever moved or deleted; the two
 layouts simply coexist, and `kesha doctor` prints whichever is in play.
 
+The one case that needs saying out loud is a legacy ASR bundle that exists but
+no longer satisfies its probe — a fetch that died half-way, or a pin bump that
+changed the required model set. The engine then reads from the cache instead and
+prints one stderr line naming the abandoned directory, because otherwise ~461 MB
+sits in Application Support with nothing pointing at it. It still deletes
+nothing; a complete legacy bundle and a machine that never had one both stay
+silent.
+
 Two directories stay outside the cache regardless, both upstream constraints
 rather than choices:
 

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -3,7 +3,7 @@ use std::ffi::OsString;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Mutex;
 use std::time::Duration;
 
@@ -603,16 +603,37 @@ pub fn fluidaudio_bridge(
 /// True when `dir` exists and holds at least one entry. Deliberately weak: the cost of a
 /// false positive is keeping a legacy directory in use, the cost of a false negative is
 /// re-downloading it (#688).
-#[cfg(any(
-    all(
-        feature = "system_kokoro",
-        target_os = "macos",
-        target_arch = "aarch64"
-    ),
-    feature = "system_diarize"
-))]
 fn dir_has_entries(dir: &Path) -> bool {
     fs::read_dir(dir).is_ok_and(|mut e| e.next().is_some())
+}
+
+/// One stderr line for the moment a legacy bundle stops being read, or `None` when there is
+/// nothing to say.
+///
+/// When a probe rejects a directory that still holds files — a fetch that died half-way, or a
+/// pin bump that changed the required model set — the subsystem moves under
+/// [`fluidaudio_models_root`] and ~461 MB stays behind with nothing pointing at it (#688).
+/// Silent otherwise: a legacy bundle that passes its probe is the one in use, and a machine
+/// that never had one is the common case, where a warning would name a path the user has
+/// never seen. `latched` holds it to once per process — the location is resolved per bridge
+/// construction, not once.
+///
+/// Only the ASR path can reach the firing case. Kokoro and the compiled diarizer probe with
+/// [`dir_has_entries`], where a rejection *means* the directory is missing or empty, so by
+/// construction they never abandon anything.
+pub fn stale_legacy_notice(
+    legacy: &Path,
+    legacy_ready: bool,
+    latched: &AtomicBool,
+) -> Option<String> {
+    if legacy_ready || !dir_has_entries(legacy) || latched.swap(true, Ordering::Relaxed) {
+        return None;
+    }
+    Some(format!(
+        "warning: legacy FluidAudio bundle at {} is no longer read (incomplete, or superseded by a model-set change); models now load from {}, so the old directory can be deleted",
+        legacy.display(),
+        fluidaudio_models_root().display()
+    ))
 }
 
 /// FluidAudio's Kokoro CoreML cache root. Each KokoroAne variant gets its own
@@ -679,8 +700,12 @@ pub fn fluidaudio_asr_dir() -> PathBuf {
 /// Where the Parakeet bundle lives, and the root that puts it there.
 #[cfg(feature = "coreml")]
 pub fn fluidaudio_asr_location() -> FluidAudioLocation {
+    static ANNOUNCED: AtomicBool = AtomicBool::new(false);
     let legacy = legacy_fluidaudio_asr_dir();
     let complete = fluidaudio_asr_ready_in(&legacy);
+    if let Some(notice) = stale_legacy_notice(&legacy, complete, &ANNOUNCED) {
+        with_stderr(|| eprintln!("{notice}"));
+    }
     fluidaudio_location(&legacy, complete, "parakeet-tdt-0.6b-v3")
 }
 
@@ -2661,6 +2686,72 @@ mod characterization_tests {
         assert_eq!(asr.root, kokoro.root);
         assert_eq!(kokoro.root, sortformer.root);
         assert_eq!(asr.dir.parent(), kokoro.dir.parent());
+    }
+
+    /// The transition the notice exists for: a pin bump changes the required model set, the
+    /// probe rejects a bundle that still holds ~461 MB, and nothing ever reads it again. It
+    /// was silent before #688, so the bytes stranded with nothing pointing at them.
+    #[test]
+    fn a_rejected_legacy_bundle_that_still_holds_files_names_itself() {
+        let tmp = tempfile::tempdir().unwrap();
+        let legacy = tmp.path().join("parakeet-tdt-0.6b-v3");
+        fs::create_dir_all(&legacy).unwrap();
+        fs::write(legacy.join("Encoder.mlmodelc"), b"x").unwrap();
+
+        let notice = stale_legacy_notice(&legacy, false, &AtomicBool::new(false))
+            .expect("a bundle the probe rejected but that still holds files must be announced");
+
+        assert!(
+            notice.contains(&legacy.display().to_string()),
+            "the notice must name the directory to delete: {notice}"
+        );
+        assert_eq!(
+            notice.lines().count(),
+            1,
+            "one line, not a paragraph: {notice}"
+        );
+    }
+
+    /// The common case is a machine that never had a legacy bundle, and a warning there would
+    /// greet every first-run user with a path they have never seen.
+    #[test]
+    fn a_missing_legacy_directory_is_silent() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(
+            stale_legacy_notice(&tmp.path().join("absent"), false, &AtomicBool::new(false))
+                .is_none()
+        );
+    }
+
+    /// An empty directory strands no bytes, so there is nothing to tell anyone to delete.
+    #[test]
+    fn an_empty_legacy_directory_is_silent() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(stale_legacy_notice(tmp.path(), false, &AtomicBool::new(false)).is_none());
+    }
+
+    /// A bundle that still passes its probe is the one being read — announcing it as
+    /// abandoned would invite a healthy install to delete the models it is using.
+    #[test]
+    fn a_legacy_bundle_still_in_use_is_silent() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("Encoder.mlmodelc"), b"x").unwrap();
+        assert!(stale_legacy_notice(tmp.path(), true, &AtomicBool::new(false)).is_none());
+    }
+
+    /// The location is resolved per bridge construction, not once — five sites do it, and a
+    /// single `kesha transcribe` reaches more than one.
+    #[test]
+    fn the_notice_is_emitted_once_per_process() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("Encoder.mlmodelc"), b"x").unwrap();
+        let latched = AtomicBool::new(false);
+
+        assert!(stale_legacy_notice(tmp.path(), false, &latched).is_some());
+        assert!(
+            stale_legacy_notice(tmp.path(), false, &latched).is_none(),
+            "a second resolution must stay quiet"
+        );
     }
 
     /// An interrupted FluidAudio fetch leaves the directory present but partial.


### PR DESCRIPTION
## What

#820 made a legacy FluidAudio bundle that fails its probe fall through to the new cache root. That transition is silent, so an incomplete download — or a pin bump that changed the required model set — leaves ~461 MB in Application Support with nothing pointing at it and nothing telling the user.

One stderr line now names the abandoned directory. Nothing is moved, nothing is deleted; the change is words only.

```
warning: legacy FluidAudio bundle at /Users/you/Library/Application Support/FluidAudio/Models/parakeet-tdt-0.6b-v3 is no longer read (incomplete, or superseded by a model-set change); models now load from /Users/you/.cache/kesha/fluidaudio, so the old directory can be deleted
```

stderr only, so `--json` / `--toon` stdout stays pipe-clean, and it goes through `with_stderr` so it never lands inside an open progress-bar row.

## Fire / no-fire matrix

| Legacy directory | Probe verdict | Notice |
|---|---|---|
| holds files | rejects (some-but-not-all required files) | **fires**, once |
| holds files | passes | silent — this is the bundle in use |
| exists, empty | rejects | silent — nothing is stranded |
| absent | rejects | silent — the fresh-machine case, and the common one |

## Only the ASR path can reach it

The question the task raised — is the hint even reachable per subsystem — has a clean answer, and it is why this touches one call site rather than three:

- **ASR** (`fluidaudio_asr_location`) probes with `fluidaudio_asr_ready_in`, which demands all five `FLUID_ASR_REQUIRED` entries. A rejection is compatible with a directory full of files, so the firing case is real. Wired here.
- **Kokoro** and the **compiled diarizer** probe with `dir_has_entries`. A rejection there *means* the directory is missing or empty, so "rejected but still holding files" is a contradiction — by construction they never abandon anything. No hint, and none would ever fire.

That also settles once-per-process: a single `AtomicBool` on the ASR path is enough, no per-subsystem plumbing. It matters because the location is resolved per bridge construction (five sites), not once — a `kesha transcribe` reaches more than one.

## Feature gating

`fluidaudio_asr_location` is `#[cfg(feature = \"coreml\")]`, so the emission is too and ONNX builds grow no dead code. The pure `stale_legacy_notice` is feature-independent — deliberately, following `fluidaudio_location` from #820 — so its tests actually run in `make rust-test` instead of only in the `coreml` arms, which no test lane exercises. `dir_has_entries` loses its cfg for the same reason.

## Tests

TDD, red first: the five cases failed to compile against a missing `stale_legacy_notice`, then passed. They cover the fire case (partial bundle names its own path, one line), both no-fire cases (absent, empty), the still-in-use case, and the latch (second resolution stays quiet). Temp dirs throughout; no real cache root is read or written.

Then verified end-to-end against a real `--features coreml` binary rather than trusting the unit tests:

- healthy run on this machine, which has a **complete** legacy bundle: `--capabilities-json` produced **0 bytes** of stderr
- partial bundle under an injected `HOME`: the line above, once, on stderr, stdout untouched
- fresh machine (no legacy directory) and empty legacy directory: both silent

No models were downloaded and `kesha install` was never run.

## Gates

- `cargo fmt --check` clean
- `cargo clippy --all-targets -- -D warnings`: default, `coreml`, `system_kokoro`, `system_diarize` — all pass
- `cargo check --no-default-features` for `coreml`, `system_kokoro`, `system_diarize` — all pass
- `make rust-test`: 484/484 (479 before, +5)
- `cargo nextest run --features coreml --no-default-features`: 205/205

No TypeScript touched, so `bun test` / `tsc` are unaffected.

Refs #688

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBTpJjqyYFW6W8LHJ2nwy