### PR TITLE
feat(status): count every FluidAudio root in `status --disk`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ binary.
 
 ## [Unreleased]
 
+### Changed
+- **BREAKING (`kesha status --json --disk` and `kesha doctor --json`):** the disk payload now accounts for every FluidAudio root. `disk.fluidAsr` and `disk.fluidKokoro` are **removed** and replaced by `disk.externalRoots` (each entry: `path`, `sizeBytes`, `subsystems[{label, path, sizeBytes}]`, `otherBytes`), `disk.externalTotalBytes` and `disk.grandTotalBytes`; `doctor`'s `cache` object gains the same three keys. The two removed keys pointed at the wrong directories — `fluidKokoro` reported the ~24 MB Kokoro G2P directory as the Kokoro cache while the ~799 MB ANE bundle tree and the ~235 MB compiled-Sortformer cache were not counted at all, so the reported total understated real disk use by gigabytes on a machine that predates the cache consolidation. Each subsystem is now counted once, at the copy the engine actually reads, and every root is printed with its full path ([#688](https://github.com/drakulavich/kesha-voice-kit/issues/688), [#828](https://github.com/drakulavich/kesha-voice-kit/pull/828)).
+
 ### Added
 - **`kesha --itn`:** opt-in inverse text normalization on transcript text — `"two hundred thirty two"` → `"232"`, `"five dollars and fifty cents"` → `"$5.50"`, `"four thirty p m"` → `"04:30 p.m."`. Off by default. The pass runs per segment, so `--timestamps` boundaries and `--speakers` labels are unaffected and the transcript stays equal to its segments joined. Available on every backend; the engine advertises `transcribe.itn` in `--capabilities-json` and the CLI validates the flag against it, so an older engine fails with an upgrade hint instead of silently ignoring it. English-only in practice — Russian and other non-English transcripts pass through byte-identical. Known limitation: a spoken `"period"` becomes `"."` with no part-of-speech check ([#710](https://github.com/drakulavich/kesha-voice-kit/issues/710)).
 

--- a/src/cache-layout.ts
+++ b/src/cache-layout.ts
@@ -6,12 +6,6 @@ export interface CachePathEntry {
 }
 
 /**
- * The Kesha-managed directories both `kesha status --disk` and `kesha doctor` report, in one
- * place so a new model dir cannot be added to only one of them. A CoreML engine never
- * populates the ONNX ASR dir and keeps its own bundle outside this cache, so that row is
- * dropped rather than rendered as missing; callers list it under external caches (#684).
- */
-/**
  * Whether `child` is `parent` itself or lives under it — the one answer `status --disk` and
  * `doctor` both need before deciding whether an engine dir is already inside the cache total.
  * A bare `startsWith` reads the sibling `~/.cache/kesha-alt` as inside `~/.cache/kesha` and
@@ -24,6 +18,14 @@ export function isInsideDir(child: string, parent: string): boolean {
   return resolvedChild === resolvedParent || resolvedChild.startsWith(`${resolvedParent}${sep}`);
 }
 
+/**
+ * The Kesha-managed directories both `kesha status --disk` and `kesha doctor` report, in one
+ * place so a new model dir cannot be added to only one of them. The two ASR rows are mutually
+ * exclusive: a CoreML engine never populates the ONNX dir, and instead roots FluidAudio's own
+ * subsystems under `<cache>/fluidaudio`, which is where the relocated bundles land (#688).
+ * Whatever stayed in FluidAudio's own trees is outside this cache and is reported separately
+ * by `fluidExternalRoots`.
+ */
 export function cacheComponentPaths(
   cacheRoot: string,
   engineDir: string,

--- a/src/cache-layout.ts
+++ b/src/cache-layout.ts
@@ -32,7 +32,7 @@ export function cacheComponentPaths(
   return [
     { label: "Engine", path: engineDir },
     ...(coreml
-      ? []
+      ? [{ label: "FluidAudio (in cache)", path: join(cacheRoot, "fluidaudio") }]
       : [{ label: "ASR (Parakeet)", path: join(cacheRoot, "models/parakeet-tdt-v3") }]),
     { label: "Language ID", path: join(cacheRoot, "models/lang-id-ecapa") },
     { label: "VAD (Silero)", path: join(cacheRoot, "models/silero-vad") },

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -18,7 +18,12 @@ import {
   fluidKokoroCacheInfo,
   type FluidKokoroCacheInfo,
 } from "./fluid-kokoro-cache";
-import { fluidAsrCacheInfo, isCoremlBackend } from "./fluid-asr-cache";
+import { isCoremlBackend } from "./fluid-asr-cache";
+import {
+  fluidExternalRoots,
+  fluidExternalTotalBytes,
+  type FluidExternalRoot,
+} from "./fluid-roots";
 import { diagnosticHomeDir, dirSizeBytes } from "./diagnostic-paths";
 import {
   getDiagnosticLogStatus,
@@ -41,6 +46,8 @@ const KNOWN_ENV_KEYS = [
 
 interface DoctorOptions {
   redact?: boolean;
+  /** Every legacy FluidAudio root is home-relative; injecting the home makes the report testable (#688). */
+  homeDir?: string;
 }
 
 interface PathSummary {
@@ -103,8 +110,13 @@ export interface DoctorReport {
   cache: {
     path: string;
     exists: boolean;
+    /** The Kesha cache plus an engine installed outside it. */
     totalBytes: number;
     components: CacheComponent[];
+    externalRoots: FluidExternalRoot[];
+    externalTotalBytes: number;
+    /** Everything Kesha put on disk, wherever it landed. */
+    grandTotalBytes: number;
   };
   optionalComponents: OptionalComponent[];
   stats: StatsStatus | (Partial<StatsStatus> & { error: string });
@@ -227,45 +239,41 @@ async function collectEngine(redact: boolean): Promise<DoctorReport["engine"]> {
   };
 }
 
+function redactExternalRoot(root: FluidExternalRoot, redact: boolean): FluidExternalRoot {
+  if (!redact) return root;
+  return {
+    ...root,
+    path: redactPath(root.path, true),
+    subsystems: root.subsystems.map((s) => ({ ...s, path: redactPath(s.path, true) })),
+  };
+}
+
 function collectCache(
   redact: boolean,
-  fluidKokoro: FluidKokoroCacheInfo,
   backend?: string,
+  homeDir?: string,
 ): DoctorReport["cache"] {
   const cache = keshaCacheDir();
   const binPath = getEngineBinPath();
   const engineDir = dirname(dirname(binPath));
-  const coreml = isCoremlBackend(backend);
-  const components: CacheComponent[] = cacheComponentPaths(cache, engineDir, coreml).map(
-    (component) => ({ label: component.label, ...pathSummary(component.path) }),
-  );
-  if (coreml) {
-    const fluidAsr = fluidAsrCacheInfo();
-    // A relocated bundle is inside the cache and already inside `totalBytes`; calling it
-    // external there would send a user hunting for a directory that no longer exists (#688).
-    const external = isInsideDir(fluidAsr.path, cache) ? "" : " (external)";
-    components.push({
-      label: `ASR (Parakeet, FluidAudio)${external}`,
-      path: fluidAsr.path,
-      exists: fluidAsr.exists,
-      sizeBytes: fluidAsr.sizeBytes,
-    });
-  }
-  if (fluidKokoro.supported) {
-    components.push({
-      label: "FluidAudio Kokoro cache (external)",
-      path: fluidKokoro.path,
-      exists: fluidKokoro.exists,
-      sizeBytes: fluidKokoro.sizeBytes,
-    });
-  }
+  const components: CacheComponent[] = cacheComponentPaths(
+    cache,
+    engineDir,
+    isCoremlBackend(backend),
+  ).map((component) => ({ label: component.label, ...pathSummary(component.path) }));
   const engineOutsideCache = isInsideDir(engineDir, cache) ? 0 : dirSizeBytes(engineDir);
+  const totalBytes = dirSizeBytes(cache) + engineOutsideCache;
+  const externalRoots = fluidExternalRoots({ homeDir, cacheRoot: cache });
+  const externalTotalBytes = fluidExternalTotalBytes(externalRoots);
 
   return {
     path: redactPath(cache, redact),
     exists: existsSync(cache),
-    totalBytes: dirSizeBytes(cache) + engineOutsideCache,
+    totalBytes,
     components: components.map((component) => redactComponent(component, redact)),
+    externalRoots: externalRoots.map((root) => redactExternalRoot(root, redact)),
+    externalTotalBytes,
+    grandTotalBytes: totalBytes + externalTotalBytes,
   };
 }
 
@@ -403,7 +411,7 @@ export async function collectDoctorReport(
       arch: process.arch,
     },
     engine,
-    cache: collectCache(redact, fluidKokoro, engine.capabilities?.backend),
+    cache: collectCache(redact, engine.capabilities?.backend, options.homeDir),
     optionalComponents: await collectOptionalComponents(redact, fluidKokoro),
     stats: collectStats(redact),
     diagnosticLogs: collectDiagnosticLogs(redact),
@@ -449,7 +457,24 @@ function formatCacheSection(cache: DoctorReport["cache"]): string[] {
   const rows = cache.components.map(
     (c) => `  ${c.label}: ${c.exists ? humanBytes(c.sizeBytes) : "missing"}`,
   );
-  return [header, ...rows];
+  return [header, ...rows, ...formatExternalRootsSection(cache)];
+}
+
+/** Roots FluidAudio keeps for itself. Named with full paths because there is no `kesha uninstall`. */
+function formatExternalRootsSection(cache: DoctorReport["cache"]): string[] {
+  if (cache.externalRoots.length === 0) return [];
+  const lines = ["", "FluidAudio caches outside the Kesha cache:"];
+  for (const root of cache.externalRoots) {
+    lines.push(`  ${root.path}: ${humanBytes(root.sizeBytes)}`);
+    for (const s of root.subsystems) {
+      lines.push(`    ${s.label}: ${humanBytes(s.sizeBytes)}`);
+    }
+    if (root.otherBytes > 0) {
+      lines.push(`    ${humanBytes(root.otherBytes)} not read by the engine`);
+    }
+  }
+  lines.push(`  Grand total: ${humanBytes(cache.grandTotalBytes)}`);
+  return lines;
 }
 
 function formatOptionalSection(components: DoctorReport["optionalComponents"]): string[] {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -470,7 +470,7 @@ function formatExternalRootsSection(cache: DoctorReport["cache"]): string[] {
       lines.push(`    ${s.label}: ${humanBytes(s.sizeBytes)}`);
     }
     if (root.otherBytes > 0) {
-      lines.push(`    ${humanBytes(root.otherBytes)} not read by the engine`);
+      lines.push(`    ${humanBytes(root.otherBytes)} not attributed to any subsystem above`);
     }
   }
   lines.push(`  Grand total: ${humanBytes(cache.grandTotalBytes)}`);

--- a/src/fluid-asr-cache.ts
+++ b/src/fluid-asr-cache.ts
@@ -1,7 +1,6 @@
 import { existsSync } from "fs";
 import { join } from "path";
-import { diagnosticHomeDir, dirSizeBytes } from "./diagnostic-paths";
-import { isDarwinArm64 } from "./fluid-kokoro-cache";
+import { diagnosticHomeDir } from "./diagnostic-paths";
 import { engineTarget } from "./engine-targets";
 import { keshaCacheDir } from "./paths";
 
@@ -22,13 +21,6 @@ export function isCoremlBackend(
   arch?: string,
 ): boolean {
   return (backend ?? engineTarget(platform, arch)?.backend) === "coreml";
-}
-
-export interface FluidAsrCacheInfo {
-  supported: boolean;
-  path: string;
-  exists: boolean;
-  sizeBytes: number;
 }
 
 /**
@@ -90,23 +82,4 @@ export const FLUID_ASR_REQUIRED = [
  */
 export function fluidAsrCacheReady(path: string): boolean {
   return FLUID_ASR_REQUIRED.every((f) => existsSync(join(path, f)));
-}
-
-export function fluidAsrCacheInfo(
-  options: {
-    platform?: typeof process.platform;
-    arch?: typeof process.arch;
-    homeDir?: string;
-    cacheRoot?: string;
-  } = {},
-): FluidAsrCacheInfo {
-  const supported = isDarwinArm64(options.platform, options.arch);
-  const path = fluidAsrCachePath(options.homeDir, options.cacheRoot);
-
-  return {
-    supported,
-    path,
-    exists: supported && fluidAsrCacheReady(path),
-    sizeBytes: supported ? dirSizeBytes(path) : 0,
-  };
 }

--- a/src/fluid-roots.ts
+++ b/src/fluid-roots.ts
@@ -1,0 +1,135 @@
+import { readdirSync } from "fs";
+import { join } from "path";
+import { isInsideDir } from "./cache-layout";
+import { diagnosticHomeDir, dirSizeBytes } from "./diagnostic-paths";
+import { fluidAsrCacheReady, legacyFluidAsrCachePath } from "./fluid-asr-cache";
+import { keshaCacheDir } from "./paths";
+
+export interface FluidRootsOptions {
+  homeDir?: string;
+  cacheRoot?: string;
+}
+
+/** One FluidAudio subsystem's directory, resolved the way the engine resolves it. */
+export interface FluidSubsystem {
+  label: string;
+  path: string;
+  /** True when the bytes are already inside the Kesha cache total. */
+  inCache: boolean;
+}
+
+export interface FluidRootSubsystem {
+  label: string;
+  path: string;
+  sizeBytes: number;
+}
+
+/** A FluidAudio tree outside the Kesha cache, and which subsystems the engine still reads from it. */
+export interface FluidExternalRoot {
+  path: string;
+  sizeBytes: number;
+  subsystems: FluidRootSubsystem[];
+  /** Bytes under the root no resolved subsystem accounts for — FluidAudio's own leftovers. */
+  otherBytes: number;
+}
+
+/**
+ * Mirrors `models.rs::dir_has_entries`. Deliberately weak: a false positive keeps a legacy
+ * directory in use, a false negative re-downloads it (#688).
+ */
+function dirHasEntries(dir: string): boolean {
+  try {
+    return readdirSync(dir).length > 0;
+  } catch {
+    return false;
+  }
+}
+
+function legacyKokoroAneDir(homeDir: string): string {
+  return join(homeDir, ".cache", "fluidaudio", "Models", "kokoro-82m-coreml");
+}
+
+/** Upstream pins `G2PModel.shared` to this path, so it is never re-rooted (#688). */
+function kokoroG2pDir(homeDir: string): string {
+  return join(homeDir, ".cache", "fluidaudio", "Models", "kokoro");
+}
+
+function legacySortformerDir(homeDir: string): string {
+  return join(homeDir, "Library", "Application Support", "fluidaudio-rs", "SortformerCompiled");
+}
+
+/** The three trees FluidAudio picks for itself, in the order `status` and `doctor` report them. */
+export function fluidLegacyRootPaths(homeDir = diagnosticHomeDir()): string[] {
+  return [
+    join(homeDir, "Library", "Application Support", "FluidAudio"),
+    join(homeDir, ".cache", "fluidaudio"),
+    join(homeDir, "Library", "Application Support", "fluidaudio-rs"),
+  ];
+}
+
+/**
+ * Where each FluidAudio subsystem's files are. Mirrors `models.rs::fluidaudio_location` and
+ * the per-subsystem probes it is called with — strong for ASR (`fluidaudio_asr_ready_in`),
+ * `dir_has_entries` for Kokoro and Sortformer — so a legacy bundle that is still being read
+ * is counted where it is, and a relocated one is counted only inside the cache (#688).
+ */
+export function fluidSubsystemDirs(options: FluidRootsOptions = {}): FluidSubsystem[] {
+  const homeDir = options.homeDir ?? diagnosticHomeDir();
+  const cacheRoot = options.cacheRoot ?? keshaCacheDir();
+  const modelsRoot = join(cacheRoot, "fluidaudio");
+  const asrLegacy = legacyFluidAsrCachePath(homeDir);
+  const aneLegacy = legacyKokoroAneDir(homeDir);
+  const sortformerLegacy = legacySortformerDir(homeDir);
+
+  const at = (legacy: string, legacyReady: boolean, ...repoSubpath: string[]): string =>
+    legacyReady ? legacy : join(modelsRoot, ...repoSubpath);
+
+  return [
+    {
+      label: "ASR (Parakeet)",
+      path: at(asrLegacy, fluidAsrCacheReady(asrLegacy), "parakeet-tdt-0.6b-v3"),
+    },
+    {
+      label: "TTS (Kokoro ANE)",
+      path: at(aneLegacy, dirHasEntries(aneLegacy), "kokoro-82m-coreml"),
+    },
+    { label: "TTS (Kokoro G2P)", path: kokoroG2pDir(homeDir) },
+    {
+      label: "Diarization (Sortformer)",
+      path: at(
+        sortformerLegacy,
+        dirHasEntries(sortformerLegacy),
+        "fluidaudio-rs",
+        "SortformerCompiled",
+      ),
+    },
+  ].map((subsystem) => ({ ...subsystem, inCache: isInsideDir(subsystem.path, cacheRoot) }));
+}
+
+/**
+ * Every FluidAudio tree holding bytes outside the Kesha cache. A root with no subsystem
+ * named is one the engine has stopped reading — still real disk usage, and the only way a
+ * user finds it to delete it (#688).
+ */
+export function fluidExternalRoots(options: FluidRootsOptions = {}): FluidExternalRoot[] {
+  const homeDir = options.homeDir ?? diagnosticHomeDir();
+  const cacheRoot = options.cacheRoot ?? keshaCacheDir();
+  const external = fluidSubsystemDirs({ homeDir, cacheRoot }).filter((s) => !s.inCache);
+
+  const roots: FluidExternalRoot[] = [];
+  for (const path of fluidLegacyRootPaths(homeDir)) {
+    if (isInsideDir(path, cacheRoot)) continue;
+    const sizeBytes = dirSizeBytes(path);
+    if (sizeBytes === 0) continue;
+    const subsystems = external
+      .filter((s) => isInsideDir(s.path, path))
+      .map((s) => ({ label: s.label, path: s.path, sizeBytes: dirSizeBytes(s.path) }));
+    const accounted = subsystems.reduce((n, s) => n + s.sizeBytes, 0);
+    roots.push({ path, sizeBytes, subsystems, otherBytes: Math.max(0, sizeBytes - accounted) });
+  }
+  return roots;
+}
+
+export function fluidExternalTotalBytes(roots: FluidExternalRoot[]): number {
+  return roots.reduce((n, root) => n + root.sizeBytes, 0);
+}

--- a/src/fluid-roots.ts
+++ b/src/fluid-roots.ts
@@ -54,6 +54,15 @@ function kokoroG2pDir(homeDir: string): string {
   return join(homeDir, ".cache", "fluidaudio", "Models", "kokoro");
 }
 
+/**
+ * FluidAudio's own VAD copy, distinct from the Silero model Kesha pins under `<cache>/models`.
+ * The bridge passes no directory for VAD, so this stays put whatever the models root is —
+ * and it is in use, which is why it is named rather than left in a root's residue (#688).
+ */
+function fluidVadDir(homeDir: string): string {
+  return join(homeDir, "Library", "Application Support", "FluidAudio", "Models", "silero-vad");
+}
+
 function legacySortformerDir(homeDir: string): string {
   return join(homeDir, "Library", "Application Support", "fluidaudio-rs", "SortformerCompiled");
 }
@@ -89,6 +98,7 @@ export function fluidSubsystemDirs(options: FluidRootsOptions = {}): FluidSubsys
       label: "ASR (Parakeet)",
       path: at(asrLegacy, fluidAsrCacheReady(asrLegacy), "parakeet-tdt-0.6b-v3"),
     },
+    { label: "VAD (Silero, FluidAudio)", path: fluidVadDir(homeDir) },
     {
       label: "TTS (Kokoro ANE)",
       path: at(aneLegacy, dirHasEntries(aneLegacy), "kokoro-82m-coreml"),
@@ -107,9 +117,9 @@ export function fluidSubsystemDirs(options: FluidRootsOptions = {}): FluidSubsys
 }
 
 /**
- * Every FluidAudio tree holding bytes outside the Kesha cache. A root with no subsystem
- * named is one the engine has stopped reading — still real disk usage, and the only way a
- * user finds it to delete it (#688).
+ * Every FluidAudio tree holding bytes outside the Kesha cache, with the subsystems still
+ * resolved into it. Bytes no subsystem claims stay in `otherBytes` rather than being dropped:
+ * they are real disk usage, and naming the root is the only way a user finds them (#688).
  */
 export function fluidExternalRoots(options: FluidRootsOptions = {}): FluidExternalRoot[] {
   const homeDir = options.homeDir ?? diagnosticHomeDir();
@@ -123,7 +133,8 @@ export function fluidExternalRoots(options: FluidRootsOptions = {}): FluidExtern
     if (sizeBytes === 0) continue;
     const subsystems = external
       .filter((s) => isInsideDir(s.path, path))
-      .map((s) => ({ label: s.label, path: s.path, sizeBytes: dirSizeBytes(s.path) }));
+      .map((s) => ({ label: s.label, path: s.path, sizeBytes: dirSizeBytes(s.path) }))
+      .filter((s) => s.sizeBytes > 0);
     const accounted = subsystems.reduce((n, s) => n + s.sizeBytes, 0);
     roots.push({ path, sizeBytes, subsystems, otherBytes: Math.max(0, sizeBytes - accounted) });
   }

--- a/src/status.ts
+++ b/src/status.ts
@@ -17,8 +17,12 @@ import { installHint } from "./install-hint";
 import { log } from "./log";
 import { packageVersion } from "./package-info";
 import { keshaCacheDir } from "./paths";
-import { fluidKokoroCacheInfo } from "./fluid-kokoro-cache";
-import { fluidAsrCacheInfo, isCoremlBackend } from "./fluid-asr-cache";
+import { isCoremlBackend } from "./fluid-asr-cache";
+import {
+  fluidExternalRoots,
+  fluidExternalTotalBytes,
+  type FluidExternalRoot,
+} from "./fluid-roots";
 import { dirSizeBytes } from "./diagnostic-paths";
 import pc from "picocolors";
 
@@ -35,6 +39,8 @@ export function formatStatusLine(
 
 export interface ShowStatusOptions {
   disk?: boolean;
+  /** Every legacy FluidAudio root is home-relative; injecting the home makes `--disk` testable (#688). */
+  homeDir?: string;
 }
 
 export interface StatusDiskComponent {
@@ -46,9 +52,12 @@ export interface StatusDiskUsage {
   cachePath: string;
   components: StatusDiskComponent[];
   componentTotalBytes: number;
+  /** The Kesha cache plus an engine installed outside it. */
   totalBytes: number;
-  fluidKokoro: { path: string; sizeBytes: number } | null;
-  fluidAsr: { path: string; sizeBytes: number } | null;
+  externalRoots: FluidExternalRoot[];
+  externalTotalBytes: number;
+  /** Everything Kesha put on disk, wherever it landed. */
+  grandTotalBytes: number;
 }
 
 /**
@@ -86,7 +95,10 @@ export async function collectStatus(options: ShowStatusOptions = {}): Promise<St
     modelMirror: activeModelMirror(),
     hint: engineHint(path, health.status),
     // Absent engine means no disk walk, matching the human path (#647).
-    disk: installed && options.disk ? collectDiskUsage(path, capabilities?.backend) : null,
+    disk:
+      installed && options.disk
+        ? collectDiskUsage(path, capabilities?.backend, options.homeDir)
+        : null,
   };
 }
 
@@ -168,28 +180,29 @@ function logDiskRows(rows: StatusDiskComponent[], total: number, componentTotal:
   }
 }
 
-function logExternalCaches(disk: StatusDiskUsage): void {
-  if (!disk.fluidKokoro && !disk.fluidAsr) return;
+function logExternalRoots(disk: StatusDiskUsage): void {
+  if (disk.externalRoots.length === 0) return;
   log.info("");
-  log.info(`External caches (not included in Kesha total):`);
-  if (disk.fluidAsr) {
-    log.info(`  FluidAudio ASR:    ${humanBytes(disk.fluidAsr.sizeBytes)} (${disk.fluidAsr.path})`);
+  log.info("FluidAudio caches outside the Kesha cache:");
+  for (const root of disk.externalRoots) {
+    log.info(`  ${root.path}: ${humanBytes(root.sizeBytes)}`);
+    for (const s of root.subsystems) {
+      log.info(`    ${s.label}: ${humanBytes(s.sizeBytes)}`);
+    }
+    if (root.otherBytes > 0) {
+      log.info(pc.dim(`    ${humanBytes(root.otherBytes)} not read by the engine`));
+    }
   }
-  if (disk.fluidKokoro) {
-    log.info(
-      `  FluidAudio Kokoro: ${humanBytes(disk.fluidKokoro.sizeBytes)} (${disk.fluidKokoro.path})`,
-    );
-  }
+  log.info(`  ${pc.bold("Grand total")}: ${pc.bold(humanBytes(disk.grandTotalBytes))}`);
 }
 
-function collectDiskUsage(binPath: string, backend?: string): StatusDiskUsage {
+function collectDiskUsage(binPath: string, backend?: string, homeDir?: string): StatusDiskUsage {
   const cache = keshaCacheDir();
   // Two levels up from the binary (`<cache>/engine/bin/`) so future engine-root siblings are counted.
   const engineDir = join(binPath, "..", "..");
-  const coreml = isCoremlBackend(backend);
 
   const components: StatusDiskComponent[] = [];
-  for (const c of cacheComponentPaths(cache, engineDir, coreml)) {
+  for (const c of cacheComponentPaths(cache, engineDir, isCoremlBackend(backend))) {
     const sizeBytes = dirSizeBytes(c.path);
     if (sizeBytes > 0) components.push({ label: c.label, sizeBytes });
   }
@@ -197,38 +210,27 @@ function collectDiskUsage(binPath: string, backend?: string): StatusDiskUsage {
   // Sum cache root + engine dir separately so `KESHA_ENGINE_BIN` overrides outside the cache are still counted.
   const cacheTotal = dirSizeBytes(cache);
   const engineOutsideCache = isInsideDir(engineDir, cache) ? 0 : dirSizeBytes(engineDir);
-  const fluidKokoro = fluidKokoroCacheInfo();
-  // Only walked when it is the backend in play; otherwise the size is computed and dropped.
-  // A relocated bundle sits inside the cache and is already counted in `totalBytes`, so
-  // listing it under "not included in Kesha total" would be a double count (#688).
-  const fluidAsrInfo = coreml ? fluidAsrCacheInfo() : null;
-  const fluidAsr =
-    fluidAsrInfo && !isInsideDir(fluidAsrInfo.path, cache) ? fluidAsrInfo : null;
+  const totalBytes = cacheTotal + engineOutsideCache;
+  const externalRoots = fluidExternalRoots({ homeDir, cacheRoot: cache });
+  const externalTotalBytes = fluidExternalTotalBytes(externalRoots);
 
   return {
     cachePath: cache,
     components,
     componentTotalBytes: components.reduce((n, c) => n + c.sizeBytes, 0),
-    totalBytes: cacheTotal + engineOutsideCache,
-    fluidKokoro:
-      fluidKokoro.exists && fluidKokoro.sizeBytes > 0
-        ? { path: fluidKokoro.path, sizeBytes: fluidKokoro.sizeBytes }
-        : null,
-    // Gate on readiness, not size, so a partial bundle is not shown as a present
-    // cache while doctor reports it missing.
-    fluidAsr:
-      fluidAsr?.exists && fluidAsr.sizeBytes > 0
-        ? { path: fluidAsr.path, sizeBytes: fluidAsr.sizeBytes }
-        : null,
+    totalBytes,
+    externalRoots,
+    externalTotalBytes,
+    grandTotalBytes: totalBytes + externalTotalBytes,
   };
 }
 
 function showDiskUsage(disk: StatusDiskUsage): void {
-  if (disk.components.length === 0) return;
+  if (disk.components.length === 0 && disk.externalRoots.length === 0) return;
 
   log.info(`Disk usage (${disk.cachePath}):`);
   logDiskRows(disk.components, disk.totalBytes, disk.componentTotalBytes);
-  logExternalCaches(disk);
+  logExternalRoots(disk);
   log.info("");
   log.info(
     pc.dim(`  To reset cache: rm -rf ${disk.cachePath} — next \`kesha install\` re-downloads.`),

--- a/src/status.ts
+++ b/src/status.ts
@@ -190,7 +190,7 @@ function logExternalRoots(disk: StatusDiskUsage): void {
       log.info(`    ${s.label}: ${humanBytes(s.sizeBytes)}`);
     }
     if (root.otherBytes > 0) {
-      log.info(pc.dim(`    ${humanBytes(root.otherBytes)} not read by the engine`));
+      log.info(pc.dim(`    ${humanBytes(root.otherBytes)} not attributed to any subsystem above`));
     }
   }
   log.info(`  ${pc.bold("Grand total")}: ${pc.bold(humanBytes(disk.grandTotalBytes))}`);

--- a/tests/unit/doctor.test.ts
+++ b/tests/unit/doctor.test.ts
@@ -172,24 +172,26 @@ describe("collectDoctorReport", () => {
       expect(report.diagnosticLogs.totalSizeBytes).toBeGreaterThan(report.diagnosticLogs.activeSizeBytes);
       expect(report.diagnosticLogs.rotatedFiles).toEqual(["kesha.1.ndjson"]);
 
-      const fluidCache = report.cache.components.find(
-        (component) => component.label === "FluidAudio Kokoro cache (external)",
-      );
+      expect(report.cache.externalRoots).toEqual([
+        {
+          path: "~/.cache/fluidaudio",
+          sizeBytes: 6,
+          subsystems: [
+            { label: "TTS (Kokoro G2P)", path: "~/.cache/fluidaudio/Models/kokoro", sizeBytes: 6 },
+          ],
+          otherBytes: 0,
+        },
+      ]);
+
       const fluidOptional = report.optionalComponents.find(
         (component) => component.name === "FluidAudio Kokoro cache",
       );
       if (process.platform === "darwin" && process.arch === "arm64") {
-        expect(fluidCache).toMatchObject({
-          path: "~/.cache/fluidaudio/Models/kokoro",
-          exists: true,
-        });
-        expect(fluidCache?.sizeBytes).toBeGreaterThan(0);
         expect(fluidOptional).toMatchObject({
           path: "~/.cache/fluidaudio/Models/kokoro",
           exists: true,
         });
       } else {
-        expect(fluidCache).toBeUndefined();
         expect(fluidOptional).toBeUndefined();
       }
     } finally {
@@ -197,7 +199,7 @@ describe("collectDoctorReport", () => {
     }
   });
 
-  test("reports unredacted FluidAudio Kokoro cache on darwin-arm64", async () => {
+  test("reports the FluidAudio root unredacted when redaction is off", async () => {
     const dir = mkdtempSync(join(tmpdir(), "kesha-doctor-fluid-kokoro-test-"));
     try {
       process.env.HOME = dir;
@@ -221,18 +223,12 @@ describe("collectDoctorReport", () => {
       );
 
       const report = await collectDoctorReport({ redact: false });
-      const fluidCache = report.cache.components.find(
-        (component) => component.label === "FluidAudio Kokoro cache (external)",
-      );
-      if (process.platform === "darwin" && process.arch === "arm64") {
-        expect(fluidCache).toMatchObject({
-          path: join(dir, ".cache", "fluidaudio", "Models", "kokoro"),
-          exists: true,
-        });
-        expect(fluidCache?.sizeBytes).toBeGreaterThan(0);
-      } else {
-        expect(fluidCache).toBeUndefined();
-      }
+      const root = report.cache.externalRoots[0];
+      expect(root?.path).toBe(join(dir, ".cache", "fluidaudio"));
+      expect(root?.subsystems.map((s) => s.path)).toEqual([
+        join(dir, ".cache", "fluidaudio", "Models", "kokoro"),
+      ]);
+      expect(report.cache.grandTotalBytes).toBe(report.cache.totalBytes + root!.sizeBytes);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -361,6 +357,19 @@ exit 2
 });
 
 describe("the human report states what each component is doing (#770)", () => {
+  function cacheReport(overrides: Partial<DoctorReport["cache"]> = {}): DoctorReport["cache"] {
+    return {
+      path: "/cache",
+      exists: true,
+      totalBytes: 4096,
+      components: [],
+      externalRoots: [],
+      externalTotalBytes: 0,
+      grandTotalBytes: 4096,
+      ...overrides,
+    };
+  }
+
   function doctorReport(overrides: Partial<DoctorReport> = {}): DoctorReport {
     return {
       generatedAt: "2026-05-17T12:00:00.000Z",
@@ -377,7 +386,7 @@ describe("the human report states what each component is doing (#770)", () => {
         capabilities: { protocolVersion: 3, backend: "onnx", features: ["tts", "diarize"] },
         probeError: null,
       },
-      cache: { path: "/cache", exists: true, totalBytes: 4096, components: [] },
+      cache: cacheReport({ totalBytes: 4096 }),
       optionalComponents: [],
       stats: {
         enabled: true,
@@ -492,15 +501,13 @@ describe("the human report states what each component is doing (#770)", () => {
   test("a cache row shows its size when present and `missing` when not", () => {
     const output = formatDoctorReport(
       doctorReport({
-        cache: {
-          path: "/cache",
-          exists: true,
+        cache: cacheReport({
           totalBytes: 8192,
           components: [
             { label: "Engine", path: "/cache/engine", exists: true, sizeBytes: 4096 },
             { label: "TTS (Vosk)", path: "/cache/models/vosk-ru", exists: false, sizeBytes: 0 },
           ],
-        },
+        }),
       }),
     );
     expect(output).toContain("Cache: /cache (8.0 KB)");
@@ -508,10 +515,35 @@ describe("the human report states what each component is doing (#770)", () => {
     expect(output).toContain("TTS (Vosk): missing");
 
     expect(
-      formatDoctorReport(
-        doctorReport({ cache: { path: "/cache", exists: false, totalBytes: 0, components: [] } }),
-      ),
+      formatDoctorReport(doctorReport({ cache: cacheReport({ exists: false, totalBytes: 0 }) })),
     ).toContain("Cache: /cache (missing)");
+  });
+
+  test("a FluidAudio root outside the cache is named with its path and the grand total", () => {
+    const output = formatDoctorReport(
+      doctorReport({
+        cache: cacheReport({
+          totalBytes: 8192,
+          externalRoots: [
+            {
+              path: "/home/Library/Application Support/FluidAudio",
+              sizeBytes: 4096,
+              subsystems: [{ label: "ASR (Parakeet)", path: "/home/asr", sizeBytes: 3072 }],
+              otherBytes: 1024,
+            },
+          ],
+          externalTotalBytes: 4096,
+          grandTotalBytes: 12288,
+        }),
+      }),
+    );
+    expect(output).toContain("FluidAudio caches outside the Kesha cache:");
+    expect(output).toContain("/home/Library/Application Support/FluidAudio: 4.0 KB");
+    expect(output).toContain("ASR (Parakeet): 3.0 KB");
+    expect(output).toContain("1.0 KB not read by the engine");
+    expect(output).toContain("Grand total: 12.0 KB");
+
+    expect(formatDoctorReport(doctorReport())).not.toContain("FluidAudio caches outside");
   });
 
   test("stats report either their counters or the error that hid them", () => {
@@ -633,7 +665,7 @@ describe("collectDoctorReport probe and cache accounting", () => {
     }
   });
 
-  posixEngineTest("a CoreML engine gets the FluidAudio ASR row, not the ONNX model dir", async () => {
+  posixEngineTest("a CoreML engine gets the in-cache FluidAudio row, not the ONNX model dir", async () => {
     const { dir, binDir } = stage("kesha-doctor-coreml-cache-");
     writeFakeEngine(
       join(binDir, "kesha-engine"),
@@ -647,16 +679,16 @@ exit 2
     );
     try {
       const labels = (await collectDoctorReport()).cache.components.map((c) => c.label);
-      // No legacy bundle here, so the engine roots it inside the cache — calling that row
-      // external would send the user hunting for a directory that is not there (#688).
-      expect(labels).toContain("ASR (Parakeet, FluidAudio)");
+      // The engine roots FluidAudio inside the cache, so those bytes belong to the cache
+      // breakdown rather than to the external-root list (#688).
+      expect(labels).toContain("FluidAudio (in cache)");
       expect(labels).not.toContain("ASR (Parakeet)");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
   });
 
-  posixEngineTest("an ONNX engine keeps the ONNX model dir and no external ASR row", async () => {
+  posixEngineTest("an ONNX engine keeps the ONNX model dir and no in-cache FluidAudio row", async () => {
     const { dir, binDir } = stage("kesha-doctor-onnx-cache-");
     writeFakeEngine(
       join(binDir, "kesha-engine"),
@@ -671,7 +703,7 @@ exit 2
     try {
       const labels = (await collectDoctorReport()).cache.components.map((c) => c.label);
       expect(labels).toContain("ASR (Parakeet)");
-      expect(labels).not.toContain("ASR (Parakeet, FluidAudio) (external)");
+      expect(labels).not.toContain("FluidAudio (in cache)");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -1090,6 +1122,63 @@ exit 2
       expect(statusTotal).toBe(doctorTotal);
     } finally {
       rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // Two commands reporting different FluidAudio totals is the #790 failure again, one root
+  // further out — so both read the same resolver and the same helper (#688).
+  posixEngineTest("both name the same FluidAudio roots and the same grand total", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-doctor-status-fluid-"));
+    const fluidHome = mkdtempSync(join(tmpdir(), "kesha-doctor-status-fluid-home-"));
+    const cache = join(dir, ".cache", "kesha");
+    const binDir = join(cache, "engine", "bin");
+    mkdirSync(binDir, { recursive: true });
+    const binPath = join(binDir, "kesha-engine");
+    writeFakeEngine(
+      binPath,
+      `#!/bin/sh
+if [ "$1" = "--capabilities-json" ]; then
+  printf '%s\\n' '{"protocolVersion":3,"backend":"coreml","features":[]}'
+  exit 0
+fi
+exit 2
+`,
+    );
+    const asr = join(
+      fluidHome,
+      "Library",
+      "Application Support",
+      "FluidAudio",
+      "Models",
+      "parakeet-tdt-0.6b-v3",
+    );
+    mkdirSync(asr, { recursive: true });
+    for (const file of [
+      "Preprocessor.mlmodelc",
+      "Encoder.mlmodelc",
+      "Decoder.mlmodelc",
+      "JointDecisionv3.mlmodelc",
+      "parakeet_vocab.json",
+    ]) {
+      writeFileSync(join(asr, file), "x".repeat(10));
+    }
+
+    process.env.HOME = dir;
+    process.env.KESHA_ENGINE_BIN = binPath;
+    process.env.KESHA_CACHE_DIR = cache;
+    process.env.KESHA_STATS_DB = join(dir, "stats.sqlite");
+    try {
+      const doctor = (await collectDoctorReport({ homeDir: fluidHome })).cache;
+      const disk = (await collectStatus({ disk: true, homeDir: fluidHome })).disk!;
+
+      expect(doctor.externalRoots).toEqual(disk.externalRoots);
+      expect(doctor.externalRoots[0]?.subsystems[0]?.path).toBe(asr);
+      expect(doctor.totalBytes).toBe(disk.totalBytes);
+      expect(doctor.grandTotalBytes).toBe(disk.grandTotalBytes);
+      expect(doctor.grandTotalBytes).toBe(doctor.totalBytes + 50);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+      rmSync(fluidHome, { recursive: true, force: true });
     }
   });
 });

--- a/tests/unit/doctor.test.ts
+++ b/tests/unit/doctor.test.ts
@@ -540,7 +540,7 @@ describe("the human report states what each component is doing (#770)", () => {
     expect(output).toContain("FluidAudio caches outside the Kesha cache:");
     expect(output).toContain("/home/Library/Application Support/FluidAudio: 4.0 KB");
     expect(output).toContain("ASR (Parakeet): 3.0 KB");
-    expect(output).toContain("1.0 KB not read by the engine");
+    expect(output).toContain("1.0 KB not attributed to any subsystem above");
     expect(output).toContain("Grand total: 12.0 KB");
 
     expect(formatDoctorReport(doctorReport())).not.toContain("FluidAudio caches outside");

--- a/tests/unit/fluid-asr-cache.test.ts
+++ b/tests/unit/fluid-asr-cache.test.ts
@@ -4,8 +4,8 @@ import { basename, join } from "path";
 import { tmpdir } from "os";
 import {
   FLUID_ASR_REQUIRED,
-  fluidAsrCacheInfo,
   fluidAsrCachePath,
+  fluidAsrCacheReady,
   isCoremlBackend,
   legacyFluidAsrCachePath,
 } from "../../src/fluid-asr-cache";
@@ -26,7 +26,7 @@ describe("isCoremlBackend", () => {
   });
 });
 
-describe("fluidAsrCacheInfo", () => {
+describe("the FluidAudio ASR bundle", () => {
   // `Repo.folderName` strips the `-coreml` suffix, and a `…-v3-coreml` sibling exists
   // on disk. Reporting that one would call a healthy install broken.
   test("points at the directory FluidAudio loads from, not the -coreml sibling", () => {
@@ -65,12 +65,8 @@ describe("fluidAsrCacheInfo", () => {
     try {
       const cache = seed(dir, COMPLETE);
 
-      const info = fluidAsrCacheInfo({ platform: "darwin", arch: "arm64", homeDir: dir });
-
-      expect(info.supported).toBe(true);
-      expect(info.path).toBe(cache);
-      expect(info.exists).toBe(true);
-      expect(info.sizeBytes).toBeGreaterThan(0);
+      expect(fluidAsrCachePath(dir, join(dir, "cache"))).toBe(cache);
+      expect(fluidAsrCacheReady(cache)).toBe(true);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -85,9 +81,7 @@ describe("fluidAsrCacheInfo", () => {
         ...COMPLETE.filter((f) => f !== "Encoder.mlmodelc"),
         "EncoderInt4.mlmodelc",
       ]);
-      expect(fluidAsrCacheInfo({ platform: "darwin", arch: "arm64", homeDir: dir }).exists).toBe(
-        false,
-      );
+      expect(fluidAsrCacheReady(legacyFluidAsrCachePath(dir))).toBe(false);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -99,9 +93,7 @@ describe("fluidAsrCacheInfo", () => {
     const dir = mkdtempSync(join(tmpdir(), "kesha-fluid-asr-cache-partial-"));
     try {
       seed(dir, ["Encoder.mlmodelc"]);
-      expect(fluidAsrCacheInfo({ platform: "darwin", arch: "arm64", homeDir: dir }).exists).toBe(
-        false,
-      );
+      expect(fluidAsrCacheReady(legacyFluidAsrCachePath(dir))).toBe(false);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -111,9 +103,7 @@ describe("fluidAsrCacheInfo", () => {
     const dir = mkdtempSync(join(tmpdir(), "kesha-fluid-asr-cache-bare-"));
     try {
       mkdirSync(legacyFluidAsrCachePath(dir), { recursive: true });
-      expect(fluidAsrCacheInfo({ platform: "darwin", arch: "arm64", homeDir: dir }).exists).toBe(
-        false,
-      );
+      expect(fluidAsrCacheReady(legacyFluidAsrCachePath(dir))).toBe(false);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -122,14 +112,7 @@ describe("fluidAsrCacheInfo", () => {
   test("reports absent rather than throwing when the bundle was never fetched", () => {
     const dir = mkdtempSync(join(tmpdir(), "kesha-fluid-asr-cache-empty-"));
     try {
-      const info = fluidAsrCacheInfo({
-        platform: "darwin",
-        arch: "arm64",
-        homeDir: dir,
-        cacheRoot: join(dir, "cache"),
-      });
-      expect(info.supported).toBe(true);
-      expect(info.exists).toBe(false);
+      expect(fluidAsrCacheReady(fluidAsrCachePath(dir, join(dir, "cache")))).toBe(false);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -176,12 +159,6 @@ describe("fluidAsrCacheInfo", () => {
     }
   });
 
-  test("stays inert off darwin-arm64, where the ONNX path is the real one", () => {
-    const info = fluidAsrCacheInfo({ platform: "linux", arch: "x64", homeDir: "/tmp/home" });
-    expect(info.supported).toBe(false);
-    expect(info.exists).toBe(false);
-    expect(info.sizeBytes).toBe(0);
-  });
 });
 
 describe("unavailableBackendError", () => {

--- a/tests/unit/fluid-roots.test.ts
+++ b/tests/unit/fluid-roots.test.ts
@@ -29,6 +29,8 @@ const legacy = {
     join(home, "Library", "Application Support", "FluidAudio", "Models", "parakeet-tdt-0.6b-v3"),
   ane: (home: string) => join(home, ".cache", "fluidaudio", "Models", "kokoro-82m-coreml"),
   g2p: (home: string) => join(home, ".cache", "fluidaudio", "Models", "kokoro"),
+  vad: (home: string) =>
+    join(home, "Library", "Application Support", "FluidAudio", "Models", "silero-vad"),
   sortformer: (home: string) =>
     join(home, "Library", "Application Support", "fluidaudio-rs", "SortformerCompiled"),
 };
@@ -50,11 +52,13 @@ describe("fluidSubsystemDirs", () => {
       write(join(legacy.ane(home), "bundle.bin"), 100);
       write(join(legacy.g2p(home), "g2p_vocab.json"), 30);
       write(join(legacy.sortformer(home), "compiled.bin"), 200);
+      write(join(legacy.vad(home), "model.mlmodelc"), 5);
 
       const resolved = fluidSubsystemDirs({ homeDir: home, cacheRoot });
       expect(resolved.every((s) => !s.inCache)).toBe(true);
       expect(dirsByLabel(home, cacheRoot)).toEqual({
         "ASR (Parakeet)": legacy.asr(home),
+        "VAD (Silero, FluidAudio)": legacy.vad(home),
         "TTS (Kokoro ANE)": legacy.ane(home),
         "TTS (Kokoro G2P)": legacy.g2p(home),
         "Diarization (Sortformer)": legacy.sortformer(home),
@@ -175,8 +179,9 @@ describe("fluidExternalRoots", () => {
     });
   });
 
-  // FluidAudio's own download leftovers — the `…-v3-coreml` sibling and silero-vad — are
-  // real bytes in a root Kesha created, so a total that drops them is not the honest one.
+  // FluidAudio's own download leftovers are real bytes in a root Kesha created, so a total
+  // that drops them is not the honest one. The `…-v3-coreml` sibling is genuinely orphaned;
+  // silero-vad is not, and must not be lumped in with it.
   test("bytes no subsystem accounts for are reported as residue, not dropped", () => {
     withHome((home, cacheRoot) => {
       writeCompleteAsr(legacy.asr(home));
@@ -186,7 +191,34 @@ describe("fluidExternalRoots", () => {
 
       const roots = fluidExternalRoots({ homeDir: home, cacheRoot });
       expect(roots[0]!.sizeBytes).toBe(125);
-      expect(roots[0]!.otherBytes).toBe(75);
+      expect(roots[0]!.subsystems.map((s) => s.label)).toEqual([
+        "ASR (Parakeet)",
+        "VAD (Silero, FluidAudio)",
+      ]);
+      expect(roots[0]!.otherBytes).toBe(70);
+    });
+  });
+
+  // The bridge passes no directory for VAD, so FluidAudio keeps its own copy here whatever
+  // the models root is — calling it unread would invite deleting a model still in use (#688).
+  test("FluidAudio's own VAD copy is named, and stays external on a fresh install", () => {
+    withHome((home, cacheRoot) => {
+      const vad = join(
+        home,
+        "Library",
+        "Application Support",
+        "FluidAudio",
+        "Models",
+        "silero-vad",
+      );
+      write(join(vad, "model.mlmodelc"), 12);
+
+      const resolved = fluidSubsystemDirs({ homeDir: home, cacheRoot }).find(
+        (s) => s.label === "VAD (Silero, FluidAudio)",
+      );
+      expect(resolved?.path).toBe(vad);
+      expect(resolved?.inCache).toBe(false);
+      expect(fluidExternalRoots({ homeDir: home, cacheRoot })[0]!.otherBytes).toBe(0);
     });
   });
 

--- a/tests/unit/fluid-roots.test.ts
+++ b/tests/unit/fluid-roots.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { dirname, join } from "path";
+import { tmpdir } from "os";
+import {
+  fluidExternalRoots,
+  fluidExternalTotalBytes,
+  fluidLegacyRootPaths,
+  fluidSubsystemDirs,
+} from "../../src/fluid-roots";
+import { FLUID_ASR_REQUIRED } from "../../src/fluid-asr-cache";
+
+function write(path: string, bytes: number): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, "x".repeat(bytes));
+}
+
+function withHome(run: (home: string, cacheRoot: string) => void): void {
+  const home = mkdtempSync(join(tmpdir(), "kesha-fluid-roots-"));
+  try {
+    run(home, join(home, ".cache", "kesha"));
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+}
+
+const legacy = {
+  asr: (home: string) =>
+    join(home, "Library", "Application Support", "FluidAudio", "Models", "parakeet-tdt-0.6b-v3"),
+  ane: (home: string) => join(home, ".cache", "fluidaudio", "Models", "kokoro-82m-coreml"),
+  g2p: (home: string) => join(home, ".cache", "fluidaudio", "Models", "kokoro"),
+  sortformer: (home: string) =>
+    join(home, "Library", "Application Support", "fluidaudio-rs", "SortformerCompiled"),
+};
+
+function writeCompleteAsr(dir: string, bytesPerFile = 10): void {
+  for (const file of FLUID_ASR_REQUIRED) write(join(dir, file), bytesPerFile);
+}
+
+function dirsByLabel(home: string, cacheRoot: string): Record<string, string> {
+  return Object.fromEntries(
+    fluidSubsystemDirs({ homeDir: home, cacheRoot }).map((s) => [s.label, s.path]),
+  );
+}
+
+describe("fluidSubsystemDirs", () => {
+  test("an install predating #688 keeps every subsystem in its legacy directory", () => {
+    withHome((home, cacheRoot) => {
+      writeCompleteAsr(legacy.asr(home));
+      write(join(legacy.ane(home), "bundle.bin"), 100);
+      write(join(legacy.g2p(home), "g2p_vocab.json"), 30);
+      write(join(legacy.sortformer(home), "compiled.bin"), 200);
+
+      const resolved = fluidSubsystemDirs({ homeDir: home, cacheRoot });
+      expect(resolved.every((s) => !s.inCache)).toBe(true);
+      expect(dirsByLabel(home, cacheRoot)).toEqual({
+        "ASR (Parakeet)": legacy.asr(home),
+        "TTS (Kokoro ANE)": legacy.ane(home),
+        "TTS (Kokoro G2P)": legacy.g2p(home),
+        "Diarization (Sortformer)": legacy.sortformer(home),
+      });
+    });
+  });
+
+  test("a fresh install roots every relocatable subsystem under the cache", () => {
+    withHome((home, cacheRoot) => {
+      const byLabel = dirsByLabel(home, cacheRoot);
+      expect(byLabel["ASR (Parakeet)"]).toBe(join(cacheRoot, "fluidaudio", "parakeet-tdt-0.6b-v3"));
+      expect(byLabel["TTS (Kokoro ANE)"]).toBe(join(cacheRoot, "fluidaudio", "kokoro-82m-coreml"));
+      expect(byLabel["Diarization (Sortformer)"]).toBe(
+        join(cacheRoot, "fluidaudio", "fluidaudio-rs", "SortformerCompiled"),
+      );
+    });
+  });
+
+  // `G2PModel.shared` is an upstream singleton pinned to this path, so it is external on
+  // every machine — a total that omits it is wrong even on a fresh install (#688).
+  test("the Kokoro G2P assets stay outside the cache even on a fresh install", () => {
+    withHome((home, cacheRoot) => {
+      const g2p = fluidSubsystemDirs({ homeDir: home, cacheRoot }).find(
+        (s) => s.label === "TTS (Kokoro G2P)",
+      );
+      expect(g2p?.path).toBe(legacy.g2p(home));
+      expect(g2p?.inCache).toBe(false);
+    });
+  });
+
+  test("a machine split across both layouts resolves each subsystem on its own", () => {
+    withHome((home, cacheRoot) => {
+      writeCompleteAsr(legacy.asr(home));
+      write(join(legacy.sortformer(home), "compiled.bin"), 200);
+
+      const byLabel = dirsByLabel(home, cacheRoot);
+      expect(byLabel["ASR (Parakeet)"]).toBe(legacy.asr(home));
+      expect(byLabel["Diarization (Sortformer)"]).toBe(legacy.sortformer(home));
+      expect(byLabel["TTS (Kokoro ANE)"]).toBe(join(cacheRoot, "fluidaudio", "kokoro-82m-coreml"));
+    });
+  });
+
+  test("an interrupted legacy ASR fetch does not pin the bundle in place", () => {
+    withHome((home, cacheRoot) => {
+      for (const file of FLUID_ASR_REQUIRED.slice(1)) write(join(legacy.asr(home), file), 10);
+      expect(dirsByLabel(home, cacheRoot)["ASR (Parakeet)"]).toBe(
+        join(cacheRoot, "fluidaudio", "parakeet-tdt-0.6b-v3"),
+      );
+    });
+  });
+
+  // Mirrors `models.rs::dir_has_entries`: keeping a legacy directory in use costs nothing,
+  // re-downloading ~800 MB of ANE bundles costs a lot (#688).
+  test("any entry at all pins the Kokoro and Sortformer caches in place", () => {
+    withHome((home, cacheRoot) => {
+      write(join(legacy.ane(home), "stray"), 1);
+      write(join(legacy.sortformer(home), "stray"), 1);
+
+      const byLabel = dirsByLabel(home, cacheRoot);
+      expect(byLabel["TTS (Kokoro ANE)"]).toBe(legacy.ane(home));
+      expect(byLabel["Diarization (Sortformer)"]).toBe(legacy.sortformer(home));
+    });
+  });
+});
+
+describe("fluidExternalRoots", () => {
+  test("a machine with no FluidAudio tree reports nothing", () => {
+    withHome((home, cacheRoot) => {
+      expect(fluidExternalRoots({ homeDir: home, cacheRoot })).toEqual([]);
+      expect(fluidExternalTotalBytes([])).toBe(0);
+    });
+  });
+
+  test("every legacy root that holds bytes is reported with its in-use subsystems", () => {
+    withHome((home, cacheRoot) => {
+      writeCompleteAsr(legacy.asr(home));
+      write(join(legacy.ane(home), "bundle.bin"), 100);
+      write(join(legacy.g2p(home), "g2p_vocab.json"), 30);
+      write(join(legacy.sortformer(home), "compiled.bin"), 200);
+
+      const roots = fluidExternalRoots({ homeDir: home, cacheRoot });
+      expect(roots.map((r) => r.path)).toEqual(fluidLegacyRootPaths(home));
+      expect(roots.map((r) => r.sizeBytes)).toEqual([50, 130, 200]);
+      expect(roots.map((r) => r.subsystems.map((s) => s.label))).toEqual([
+        ["ASR (Parakeet)"],
+        ["TTS (Kokoro ANE)", "TTS (Kokoro G2P)"],
+        ["Diarization (Sortformer)"],
+      ]);
+      expect(fluidExternalTotalBytes(roots)).toBe(380);
+    });
+  });
+
+  test("a root the engine no longer reads is still counted, with no subsystem named", () => {
+    withHome((home, cacheRoot) => {
+      // A relocated install: the bundle the engine reads is in the cache, the old copy is not.
+      writeCompleteAsr(join(cacheRoot, "fluidaudio", "parakeet-tdt-0.6b-v3"));
+      write(join(legacy.asr(home), "Encoder.mlmodelc", "model.mil"), 40);
+
+      const roots = fluidExternalRoots({ homeDir: home, cacheRoot });
+      expect(roots).toHaveLength(1);
+      expect(roots[0]!.subsystems).toEqual([]);
+      expect(roots[0]!.otherBytes).toBe(40);
+      expect(roots[0]!.sizeBytes).toBe(40);
+    });
+  });
+
+  test("a bundle present in both layouts is named once, at the copy the engine reads", () => {
+    withHome((home, cacheRoot) => {
+      writeCompleteAsr(legacy.asr(home));
+      writeCompleteAsr(join(cacheRoot, "fluidaudio", "parakeet-tdt-0.6b-v3"), 999);
+
+      const roots = fluidExternalRoots({ homeDir: home, cacheRoot });
+      expect(roots).toHaveLength(1);
+      expect(roots[0]!.subsystems).toEqual([
+        { label: "ASR (Parakeet)", path: legacy.asr(home), sizeBytes: 50 },
+      ]);
+      expect(fluidExternalTotalBytes(roots)).toBe(50);
+    });
+  });
+
+  // FluidAudio's own download leftovers — the `…-v3-coreml` sibling and silero-vad — are
+  // real bytes in a root Kesha created, so a total that drops them is not the honest one.
+  test("bytes no subsystem accounts for are reported as residue, not dropped", () => {
+    withHome((home, cacheRoot) => {
+      writeCompleteAsr(legacy.asr(home));
+      const root = join(home, "Library", "Application Support", "FluidAudio");
+      write(join(root, "Models", "parakeet-tdt-0.6b-v3-coreml", "Encoder.mlmodelc"), 70);
+      write(join(root, "Models", "silero-vad", "model.mlmodelc"), 5);
+
+      const roots = fluidExternalRoots({ homeDir: home, cacheRoot });
+      expect(roots[0]!.sizeBytes).toBe(125);
+      expect(roots[0]!.otherBytes).toBe(75);
+    });
+  });
+
+  // #790: containment decides whether bytes are already inside the cache total.
+  test("a legacy root that lives inside the cache root is left to the cache total", () => {
+    withHome((home) => {
+      write(join(legacy.ane(home), "bundle.bin"), 100);
+      expect(fluidExternalRoots({ homeDir: home, cacheRoot: home })).toEqual([]);
+    });
+  });
+});
+
+// The resolution rule is written out in both languages; nothing else fails when only one
+// side is edited, and a divergence here silently re-downloads gigabytes (#688).
+describe("Rust/TS FluidAudio root agreement", () => {
+  const rust = readFileSync(
+    join(import.meta.dir, "..", "..", "rust", "src", "models.rs"),
+    "utf8",
+  );
+
+  test("relocated subpaths match models.rs", () => {
+    withHome((home, cacheRoot) => {
+      const byLabel = dirsByLabel(home, cacheRoot);
+      for (const [subpath, label] of [
+        ["kokoro-82m-coreml", "TTS (Kokoro ANE)"],
+        ["fluidaudio-rs/SortformerCompiled", "Diarization (Sortformer)"],
+      ] as const) {
+        expect(rust).toContain(`fluidaudio_location(&legacy, `);
+        expect(rust).toContain(`, "${subpath}")`);
+        expect(byLabel[label]).toBe(join(cacheRoot, "fluidaudio", ...subpath.split("/")));
+      }
+    });
+  });
+
+  test("legacy directory names match models.rs", () => {
+    expect(rust).toContain(`.join("kokoro-82m-coreml")`);
+    expect(rust).toContain(`.join("SortformerCompiled")`);
+    expect(rust).toContain(`.join("fluidaudio-rs")`);
+  });
+
+  // Which probe each subsystem uses is the contract: strong for ASR, weak everywhere else.
+  test("each subsystem uses the same probe strength as models.rs", () => {
+    expect(rust).toContain("let complete = fluidaudio_asr_ready_in(&legacy);");
+    expect(rust).toContain("let staged = dir_has_entries(&legacy);");
+    expect(rust).toContain("let compiled = dir_has_entries(&legacy);");
+  });
+});

--- a/tests/unit/status.test.ts
+++ b/tests/unit/status.test.ts
@@ -532,7 +532,7 @@ describe("renderStatus turns a report into the states a user acts on", () => {
     expect(render(report({ disk: diskUsage() }))).not.toContain("FluidAudio");
   });
 
-  test("a root the engine has stopped reading says so rather than naming a subsystem", () => {
+  test("a root with nothing left to attribute says so rather than naming a subsystem", () => {
     const output = render(
       report({
         disk: diskUsage({
@@ -544,7 +544,7 @@ describe("renderStatus turns a report into the states a user acts on", () => {
         }),
       }),
     );
-    expect(output).toContain("not read by the engine");
+    expect(output).toContain("not attributed to any subsystem above");
     expect(output).not.toContain("ASR (Parakeet)");
   });
 

--- a/tests/unit/status.test.ts
+++ b/tests/unit/status.test.ts
@@ -121,21 +121,6 @@ describe("collectStatus + renderStatus", () => {
     writeFileSync(binPath, "not a real executable");
     mkdirSync(join(dir, "models", "parakeet-tdt-v3"), { recursive: true });
     writeFileSync(join(dir, "models", "parakeet-tdt-v3", "model.onnx"), "model");
-    mkdirSync(join(dir, ".cache", "fluidaudio", "Models", "kokoro", "kokoro_21_15s.mlmodelc"), {
-      recursive: true,
-    });
-    writeFileSync(
-      join(
-        dir,
-        ".cache",
-        "fluidaudio",
-        "Models",
-        "kokoro",
-        "kokoro_21_15s.mlmodelc",
-        "coremldata.bin",
-      ),
-      "coreml",
-    );
 
     process.env.KESHA_ENGINE_BIN = binPath;
     process.env.KESHA_CACHE_DIR = dir;
@@ -155,13 +140,6 @@ describe("collectStatus + renderStatus", () => {
       lines.length = 0;
       renderStatus(await collectStatus({ disk: true }));
       expect(lines.join("\n")).toContain("Disk usage");
-      if (process.platform === "darwin" && process.arch === "arm64") {
-        expect(lines.join("\n")).toContain("External caches (not included in Kesha total):");
-        expect(lines.join("\n")).toContain("FluidAudio Kokoro:");
-        expect(lines.join("\n")).toContain(".cache/fluidaudio/Models/kokoro");
-      } else {
-        expect(lines.join("\n")).not.toContain("FluidAudio Kokoro:");
-      }
     } finally {
       console.log = originalLog;
       console.error = originalError;
@@ -500,11 +478,15 @@ describe("renderStatus turns a report into the states a user acts on", () => {
       ],
       componentTotalBytes: 10_000,
       totalBytes: 10_000,
-      fluidKokoro: null,
-      fluidAsr: null,
+      externalRoots: [],
+      externalTotalBytes: 0,
+      grandTotalBytes: 10_000,
       ...overrides,
     };
   }
+
+  const fluidRoot = "/home/Library/Application Support/FluidAudio";
+  const asrDir = `${fluidRoot}/Models/parakeet-tdt-0.6b-v3`;
 
   test("each component is listed with its own size", () => {
     const output = render(report({ disk: diskUsage() }));
@@ -523,21 +505,69 @@ describe("renderStatus turns a report into the states a user acts on", () => {
     expect(exact).not.toContain("other cache files");
   });
 
-  test("external caches are reported apart from the Kesha total", () => {
+  test("a FluidAudio root outside the cache is named, sized and folded into a grand total", () => {
     const output = render(
       report({
-        disk: diskUsage({ fluidAsr: { path: "/fluid/asr", sizeBytes: 2_000_000 } }),
+        disk: diskUsage({
+          externalRoots: [
+            {
+              path: fluidRoot,
+              sizeBytes: 3_000_000,
+              subsystems: [{ label: "ASR (Parakeet)", path: asrDir, sizeBytes: 2_000_000 }],
+              otherBytes: 1_000_000,
+            },
+          ],
+          externalTotalBytes: 3_000_000,
+          grandTotalBytes: 3_010_000,
+        }),
       }),
     );
-    expect(output).toContain("External caches (not included in Kesha total):");
-    expect(output).toContain(`FluidAudio ASR:    ${humanBytes(2_000_000)} (/fluid/asr)`);
-    expect(output).not.toContain("FluidAudio Kokoro:");
+    expect(output).toContain(fluidRoot);
+    expect(output).toContain(humanBytes(3_000_000));
+    expect(output).toContain("ASR (Parakeet)");
+    expect(output).toContain(humanBytes(2_000_000));
+    expect(output).toContain(humanBytes(1_000_000));
+    expect(output).toContain(humanBytes(3_010_000));
 
-    expect(render(report({ disk: diskUsage() }))).not.toContain("External caches");
+    expect(render(report({ disk: diskUsage() }))).not.toContain("FluidAudio");
+  });
+
+  test("a root the engine has stopped reading says so rather than naming a subsystem", () => {
+    const output = render(
+      report({
+        disk: diskUsage({
+          externalRoots: [
+            { path: fluidRoot, sizeBytes: 900_000, subsystems: [], otherBytes: 900_000 },
+          ],
+          externalTotalBytes: 900_000,
+          grandTotalBytes: 910_000,
+        }),
+      }),
+    );
+    expect(output).toContain("not read by the engine");
+    expect(output).not.toContain("ASR (Parakeet)");
   });
 
   test("a cache with nothing in it prints no disk section", () => {
     expect(render(report({ disk: diskUsage({ components: [] }) }))).not.toContain("Disk usage");
+  });
+
+  test("an empty cache still reports a FluidAudio root that holds bytes", () => {
+    const output = render(
+      report({
+        disk: diskUsage({
+          components: [],
+          componentTotalBytes: 0,
+          totalBytes: 0,
+          externalRoots: [
+            { path: fluidRoot, sizeBytes: 900_000, subsystems: [], otherBytes: 900_000 },
+          ],
+          externalTotalBytes: 900_000,
+          grandTotalBytes: 900_000,
+        }),
+      }),
+    );
+    expect(output).toContain(fluidRoot);
   });
 
   test("the reset hint names the directory to remove", () => {
@@ -650,6 +680,137 @@ describe("collectStatus disk accounting (#647)", () => {
       expect(disk.totalBytes).toBe(64 + statSync(binPath).size);
     } finally {
       rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// Every legacy FluidAudio root is home-relative, so `--disk` was untestable until the home
+// could be injected — which is why the honest total was deferred out of #820 (#688).
+describe("collectStatus FluidAudio accounting (#688)", () => {
+  const restoreEnv = saveEngineEnv();
+
+  beforeEach(restoreEnv);
+  afterEach(restoreEnv);
+
+  const ASR_FILES = [
+    "Preprocessor.mlmodelc",
+    "Encoder.mlmodelc",
+    "Decoder.mlmodelc",
+    "JointDecisionv3.mlmodelc",
+    "parakeet_vocab.json",
+  ];
+
+  function write(path: string, bytes: number): void {
+    mkdirSync(join(path, ".."), { recursive: true });
+    writeFileSync(path, "x".repeat(bytes));
+  }
+
+  /** A cache with an engine and a Kokoro model, plus a home with no FluidAudio tree at all. */
+  function stage(
+    prefix: string,
+    backend = "fake-coreml",
+  ): { dir: string; fluidHome: string; cache: string; binPath: string } {
+    const dir = mkdtempSync(join(tmpdir(), prefix));
+    const fluidHome = mkdtempSync(join(tmpdir(), `${prefix}home-`));
+    const cache = join(dir, ".cache", "kesha");
+    const binPath = writeFakeEngine(join(cache, "engine", "bin"), {
+      protocolVersion: 3,
+      backend,
+      features: [],
+    });
+    write(join(cache, "models", "kokoro-82m", "voice.bin"), 64);
+
+    process.env.KESHA_ENGINE_BIN = binPath;
+    process.env.KESHA_CACHE_DIR = cache;
+    process.env.HOME = dir;
+    return { dir, fluidHome, cache, binPath };
+  }
+
+  posixEngineTest("a machine split across both layouts counts each subsystem once", async () => {
+    const { dir, fluidHome, cache, binPath } = stage("kesha-status-fluid-mixed-");
+    const fluidRoot = join(fluidHome, "Library", "Application Support", "FluidAudio");
+    for (const file of ASR_FILES) write(join(fluidRoot, "Models", "parakeet-tdt-0.6b-v3", file), 10);
+    write(join(fluidRoot, "Models", "parakeet-tdt-0.6b-v3-coreml", "Encoder.mlmodelc"), 20);
+    write(join(cache, "fluidaudio", "kokoro-82m-coreml", "bundle.bin"), 128);
+
+    try {
+      const disk = (await collectStatus({ disk: true, homeDir: fluidHome })).disk!;
+
+      expect(disk.totalBytes).toBe(statSync(binPath).size + 64 + 128);
+      expect(disk.externalRoots).toEqual([
+        {
+          path: fluidRoot,
+          sizeBytes: 70,
+          subsystems: [
+            {
+              label: "ASR (Parakeet)",
+              path: join(fluidRoot, "Models", "parakeet-tdt-0.6b-v3"),
+              sizeBytes: 50,
+            },
+          ],
+          otherBytes: 20,
+        },
+      ]);
+      expect(disk.externalTotalBytes).toBe(70);
+      expect(disk.grandTotalBytes).toBe(disk.totalBytes + 70);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+      rmSync(fluidHome, { recursive: true, force: true });
+    }
+  });
+
+  posixEngineTest("an install predating #688 puts all three legacy roots in the total", async () => {
+    const { dir, fluidHome, binPath } = stage("kesha-status-fluid-legacy-");
+    const support = join(fluidHome, "Library", "Application Support");
+    for (const file of ASR_FILES) {
+      write(join(support, "FluidAudio", "Models", "parakeet-tdt-0.6b-v3", file), 10);
+    }
+    write(join(fluidHome, ".cache", "fluidaudio", "Models", "kokoro-82m-coreml", "b.bin"), 100);
+    write(join(fluidHome, ".cache", "fluidaudio", "Models", "kokoro", "g2p_vocab.json"), 30);
+    write(join(support, "fluidaudio-rs", "SortformerCompiled", "c.mlmodelc"), 200);
+
+    try {
+      const disk = (await collectStatus({ disk: true, homeDir: fluidHome })).disk!;
+
+      expect(disk.externalRoots.map((r) => r.sizeBytes)).toEqual([50, 130, 200]);
+      expect(disk.externalRoots.flatMap((r) => r.subsystems.map((s) => s.label))).toEqual([
+        "ASR (Parakeet)",
+        "TTS (Kokoro ANE)",
+        "TTS (Kokoro G2P)",
+        "Diarization (Sortformer)",
+      ]);
+      expect(disk.grandTotalBytes).toBe(statSync(binPath).size + 64 + 380);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+      rmSync(fluidHome, { recursive: true, force: true });
+    }
+  });
+
+  // Otherwise a relocated ~800 MB of ANE bundles shows up only as "other cache files" (#688).
+  posixEngineTest("a CoreML engine itemises the FluidAudio bytes inside the cache", async () => {
+    const { dir, fluidHome, cache } = stage("kesha-status-fluid-incache-", "coreml");
+    write(join(cache, "fluidaudio", "kokoro-82m-coreml", "bundle.bin"), 128);
+
+    try {
+      const disk = (await collectStatus({ disk: true, homeDir: fluidHome })).disk!;
+      expect(disk.components.find((c) => c.label === "FluidAudio (in cache)")?.sizeBytes).toBe(128);
+      expect(disk.externalRoots).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+      rmSync(fluidHome, { recursive: true, force: true });
+    }
+  });
+
+  posixEngineTest("a fresh install reports no external root and no inflated total", async () => {
+    const { dir, fluidHome } = stage("kesha-status-fluid-fresh-");
+    try {
+      const disk = (await collectStatus({ disk: true, homeDir: fluidHome })).disk!;
+      expect(disk.externalRoots).toEqual([]);
+      expect(disk.externalTotalBytes).toBe(0);
+      expect(disk.grandTotalBytes).toBe(disk.totalBytes);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+      rmSync(fluidHome, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
## What

`kesha status --disk` now reports every FluidAudio root Kesha has caused to exist, not just the Kesha cache and one directory. On this machine that is the difference between a reported 3.9 GB and the 5.8 GB actually on disk.

This is the piece #820 deliberately staged out ("testing it deterministically needs home/cache injection threaded through `collectStatus`").

## Before / after, measured on a mixed machine

Read-only measurement against the real caches; nothing was installed, written or removed.

**Before** (`origin/main`, afadff1):

```
Disk usage (/Users/anton/.cache/kesha):
  Engine:        154 KB
  Language ID:   82.1 MB
  VAD (Silero):  2.2 MB
  TTS (Kokoro):  311 MB
  TTS (Vosk):    893 MB
  Total:         3.9 GB
  (includes 2.6 GB of other cache files)

External caches (not included in Kesha total):
  FluidAudio ASR:    461 MB (/Users/anton/Library/Application Support/FluidAudio/Models/parakeet-tdt-0.6b-v3)
```

**After**:

```
Disk usage (/Users/anton/.cache/kesha):
  Engine:        154 KB
  Language ID:   82.1 MB
  VAD (Silero):  2.2 MB
  TTS (Kokoro):  311 MB
  TTS (Vosk):    893 MB
  Total:         3.9 GB
  (includes 2.6 GB of other cache files)

FluidAudio caches outside the Kesha cache:
  /Users/anton/Library/Application Support/FluidAudio: 923 MB
    ASR (Parakeet): 461 MB
    462 MB not read by the engine
  /Users/anton/.cache/fluidaudio: 821 MB
    TTS (Kokoro ANE): 798 MB
    TTS (Kokoro G2P): 23.5 MB
  /Users/anton/Library/Application Support/fluidaudio-rs: 235 MB
    Diarization (Sortformer): 235 MB
  Grand total: 5.8 GB
```

`doctor` prints the same block and carries the same `grandTotalBytes`.

The three gaps #688 named are closed: the 799 MB ANE tree and the 235 MB Sortformer cache were missing entirely, and the row labelled "FluidAudio Kokoro" was the 24 MB G2P directory — not the bundles, and mislabelled either way.

## How each root is decided

`src/fluid-roots.ts` mirrors `models.rs::fluidaudio_location` and, crucially, the probes it is *called with* — `fluidaudio_asr_ready_in` for ASR, `dir_has_entries` for Kokoro and Sortformer. So a subsystem is counted at the copy the engine actually reads:

- a complete legacy bundle stays legacy, and is reported as an external root;
- anything else resolves under `<cache>/fluidaudio`, is already inside the cache total, and is *not* listed again outside it;
- `~/.cache/fluidaudio/Models/kokoro` (G2P) is external on every machine, fresh install included — `G2PModel.shared` is an upstream singleton pinned to that path.

A root with no subsystem named is one the engine has stopped reading. It stays in the total because the bytes are real, and it is printed with its full path because there is no `kesha uninstall` — that remains out of scope here, but a human can now find what to delete.

### Residue is named, not dropped

The `parakeet-tdt-0.6b-v3-coreml` sibling and FluidAudio's own silero-vad are 462 MB in a root Kesha created. They are not a directory Kesha's resolution names, so they are reported as "not read by the engine" rather than attributed to a subsystem — and they are in the grand total, which is the point of the ticket. Same shape as the existing "includes N of other cache files" line.

### Containment

Every containment question goes through `isInsideDir` (#790) — including "is this legacy root already inside `KESHA_CACHE_DIR`", which is the one way a byte could be counted twice. Test: `a legacy root that lives inside the cache root is left to the cache total`.

## Injection, not env vars

`collectStatus({ disk: true, homeDir })` and `collectDoctorReport({ homeDir })` default to `diagnosticHomeDir()`. The cache root keeps coming from `KESHA_CACHE_DIR` as before. Options rather than env because `os.homedir()` ignores a runtime `$HOME` change in-process, so an env-only approach is only half-testable.

## Drift between the two languages

`tests/unit/fluid-roots.test.ts` pins the relocated subpaths, the legacy directory names, and *which probe each subsystem uses*, against the text of `rust/src/models.rs` — the same technique #820 used for `FLUID_ASR_REQUIRED`. Editing one side alone fails the suite.

No Rust change was needed: everything the TS mirror asserts is already public contract in `models.rs`.

## API shape

`StatusDiskUsage.fluidAsr` / `.fluidKokoro` are replaced by `externalRoots`, `externalTotalBytes` and `grandTotalBytes`; `DoctorReport.cache` gains the same three. This is a breaking change to the `status --json` payload, and the intended one — the two removed fields were the wrong directories.

`fluidAsrCacheInfo` had no callers left after this and is deleted. Its contracts (int4-only rejected, partial bundle rejected, legacy-vs-cache resolution) are now asserted directly against `fluidAsrCacheReady` / `fluidAsrCachePath`, which `install-plan.ts` still uses.

## Tests

Red-first, and the fixtures are the cases the issue describes: mixed (subsystem split across layouts), all-legacy, all-new, both-present-no-double-count, empty. Plus `doctor` and `status` agreeing on the roots *and* the grand total for one injected fixture — the #790 lesson one root further out.

## Review follow-ups

Three of the four P3s from review are in the second commit:

- **CHANGELOG `Unreleased` entry** for the breaking `status --json --disk` / `doctor` shape change, so the next `release-cli` cut carries it.
- **`cache-layout.ts` header comment** rewritten — it still described the pre-#688 layout, where a CoreML engine dropped the ASR row and callers listed the bundle under external caches.
- **Residue label.** "not read by the engine" was accurate for the orphaned `…-v3-coreml` sibling and wrong for FluidAudio's own silero-vad, which lives in the same root and *is* read at runtime — the label invited deleting a live model. Rather than only reword, `VAD (Silero, FluidAudio)` is now a named subsystem, never re-rooted for the same reason as the Kokoro G2P assets (the bridge passes no directory for VAD), and the leftover is described as "not attributed to any subsystem above". Naming it exposed that a subsystem with zero bytes was still emitted as a 0 B row; those are dropped now. On this machine the 923 MB root reads: ASR 461 MB, VAD 1.0 MB, 461 MB unattributed.

**Declined: relabelling `doctor`'s `FluidAudio Kokoro cache` optional component.** It is not a relabel. The G2P-centric story is told from `fluidKokoroCachePath`, which also feeds `install-plan.ts:255`'s install preview through `FLUID_KOKORO_CACHE_NOTE` — so pointing only the doctor row at the ANE directory leaves the install plan contradicting it. Doing it properly also swaps the probe (bundle-name check → `dirHasEntries`), which changes a health signal's meaning, and strands `fluidKokoroCacheInfo` while `isDarwinArm64` still ships from that module to five other files. That is a coherent follow-up ticket, not a line in this PR.

## Gates

- `bun test`: 1064 pass, 32 skip, 0 fail (baseline `origin/main` in a clean worktree: 1042 pass, 0 fail — +22 net)
- Name-diff vs baseline: 60 tests added, 4 names gone — all four renamed or replaced in place (`a CoreML engine gets the FluidAudio ASR row…` → `…the in-cache FluidAudio row…`, `an ONNX engine keeps… no external ASR row` → `…no in-cache FluidAudio row`, `external caches are reported apart from the Kesha total` → two sharper render tests, `reports unredacted FluidAudio Kokoro cache on darwin-arm64` → `reports the FluidAudio root unredacted when redaction is off`)
- `bunx tsc --noEmit`: clean
- `bun run coverage:check:ts`: 81.10% total, every floor met
- Rust untouched

No models were downloaded and no cache root was written to.

Refs #688

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBTpJjqyYFW6W8LHJ2nwy

