### PR TITLE
test: close the three guard and isolation gaps a Beck-lens audit turned up

### DIFF
--- a/.github/scripts/alpha-tag.sh
+++ b/.github/scripts/alpha-tag.sh
@@ -26,4 +26,5 @@ else
 fi
 
 # Sibling, not cwd-relative: the caller's working directory is the repository being tagged.
-printf 'Alpha %s\n\n%s\n' "$TAG" "$body" | "$(dirname "$0")/push-annotated-tag.sh"
+# Run through bash rather than the exec bit, which a mode-dropping copy of the tree loses.
+printf 'Alpha %s\n\n%s\n' "$TAG" "$body" | bash "$(dirname "$0")/push-annotated-tag.sh"

--- a/src/__tests__/error-codes-drift.test.ts
+++ b/src/__tests__/error-codes-drift.test.ts
@@ -1,13 +1,14 @@
 import { describe, expect, test } from "bun:test";
-import { existsSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { join } from "node:path";
 import { KNOWN_TS_CODES } from "../error-codes";
+import { enginePublishesJson } from "../../tests/helpers/engine-probe";
 
 const ENGINE_BIN =
   process.env.KESHA_ENGINE_BIN ?? join(import.meta.dir, "../../rust/target/release/kesha-engine");
 
-const describeOrSkip = existsSync(ENGINE_BIN) ? describe : describe.skip;
+const describeOrSkip = enginePublishesJson(ENGINE_BIN, "--error-codes-json") ? describe : describe.skip;
 
 describeOrSkip("error-code drift", () => {
   test("engine codes ∪ TS-native codes == codes documented in docs/errors.md", () => {
@@ -21,9 +22,8 @@ describeOrSkip("error-code drift", () => {
     const documented = new Set<string>();
     for (const m of doc.matchAll(/`(E_[A-Z0-9_]+)`/g)) documented.add(m[1]);
 
-    // every known code is documented
-    for (const c of known) expect(documented.has(c)).toBe(true);
-    // every documented code is known (no stale doc rows)
-    for (const c of documented) expect(known.has(c)).toBe(true);
+    // Named both ways: a set-membership assertion only reports "false is not true".
+    expect([...known].filter((c) => !documented.has(c)).sort()).toEqual([]);
+    expect([...documented].filter((c) => !known.has(c)).sort()).toEqual([]);
   });
 });

--- a/tests/helpers/engine-probe.ts
+++ b/tests/helpers/engine-probe.ts
@@ -1,0 +1,28 @@
+import { existsSync } from "node:fs";
+
+/**
+ * Whether `bin` answers `flag` with a non-empty JSON array.
+ *
+ * Guards for engine-dependent suites must ask this rather than `existsSync`: the #796 stub
+ * was `#!/bin/sh\nexit 0`, which exists and runs and describes nothing, so a presence check
+ * un-skips the suite and the empty stdout surfaces as a JSON parse crash instead of a skip
+ * (#801). An empty array is treated as no answer for the same reason.
+ */
+export function enginePublishesJson(bin: string, flag: string): boolean {
+  if (!existsSync(bin)) return false;
+
+  let res: ReturnType<typeof Bun.spawnSync>;
+  try {
+    res = Bun.spawnSync([bin, flag], { stdout: "pipe", stderr: "ignore" });
+  } catch {
+    return false;
+  }
+  if (res.exitCode !== 0) return false;
+
+  try {
+    const parsed: unknown = JSON.parse(res.stdout.toString());
+    return Array.isArray(parsed) && parsed.length > 0;
+  } catch {
+    return false;
+  }
+}

--- a/tests/helpers/engine-probe.ts
+++ b/tests/helpers/engine-probe.ts
@@ -17,7 +17,7 @@ export function enginePublishesJson(bin: string, flag: string): boolean {
   } catch {
     return false;
   }
-  if (res.exitCode !== 0) return false;
+  if (res.exitCode !== 0 || res.stdout === undefined) return false;
 
   try {
     const parsed: unknown = JSON.parse(res.stdout.toString());

--- a/tests/unit/engine-probe.test.ts
+++ b/tests/unit/engine-probe.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { enginePublishesJson } from "../helpers/engine-probe";
+
+const posixTest = process.platform === "win32" ? test.skip : test;
+const dirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function stageEngine(body: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "kesha-engine-probe-"));
+  dirs.push(dir);
+  const binPath = join(dir, "kesha-engine");
+  writeFileSync(binPath, body);
+  chmodSync(binPath, 0o755);
+  return binPath;
+}
+
+describe("enginePublishesJson", () => {
+  test("an absent binary publishes nothing", () => {
+    expect(enginePublishesJson(join(tmpdir(), "kesha-absent-engine"), "--error-codes-json")).toBe(false);
+  });
+
+  // The #796 stub: exits 0 for every flag and answers nothing. `existsSync` and a bare
+  // exit-code probe both pass it, which is what un-skipped the drift test into a crash.
+  posixTest("an engine that exits 0 and prints nothing publishes nothing", () => {
+    expect(enginePublishesJson(stageEngine("#!/bin/sh\nexit 0\n"), "--error-codes-json")).toBe(false);
+  });
+
+  posixTest("an engine that fails the flag publishes nothing", () => {
+    expect(enginePublishesJson(stageEngine("#!/bin/sh\nexit 2\n"), "--error-codes-json")).toBe(false);
+  });
+
+  posixTest("an engine that prints non-JSON publishes nothing", () => {
+    expect(enginePublishesJson(stageEngine("#!/bin/sh\necho not-json\n"), "--error-codes-json")).toBe(false);
+  });
+
+  // An empty array parses, so parseability alone would still let a hollow engine through.
+  posixTest("an engine that publishes an empty list publishes nothing", () => {
+    expect(enginePublishesJson(stageEngine("#!/bin/sh\necho '[]'\n"), "--error-codes-json")).toBe(false);
+  });
+
+  posixTest("an engine that answers the flag with entries publishes them", () => {
+    const bin = stageEngine("#!/bin/sh\necho '[{\"code\":\"E_DEMO\"}]'\n");
+    expect(enginePublishesJson(bin, "--error-codes-json")).toBe(true);
+  });
+});

--- a/tests/unit/engine.test.ts
+++ b/tests/unit/engine.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { chmodSync, mkdtempSync, mkdirSync, writeFileSync } from "fs";
-import { tmpdir } from "os";
+import { homedir, tmpdir } from "os";
 import { join } from "path";
 import { waitForPidExit, waitForPidFile } from "../helpers/process";
 import {
@@ -122,41 +122,49 @@ function cacheDirWithVadModel(): string {
 
 const engineBasename = process.platform === "win32" ? "kesha-engine.exe" : "kesha-engine";
 
+/** Runs `fn` with the two path-resolution vars forced to `env`, restoring whatever the shell had. */
+function withPathEnv<T>(env: Record<"KESHA_CACHE_DIR" | "KESHA_ENGINE_BIN", string | undefined>, fn: () => T): T {
+  const saved = { ...process.env };
+  try {
+    for (const [key, value] of Object.entries(env)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    return fn();
+  } finally {
+    for (const key of ["KESHA_CACHE_DIR", "KESHA_ENGINE_BIN"]) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+  }
+}
+
 describe("engine", () => {
-  test("getEngineBinPath returns path under .cache kesha", () => {
-    const path = getEngineBinPath();
-    expect(path).toMatch(/\.cache[/\\]kesha/);
-    expect(path).toContain("kesha-engine");
+  test("getEngineBinPath defaults to the XDG-style cache under $HOME", () => {
+    withPathEnv({ KESHA_CACHE_DIR: undefined, KESHA_ENGINE_BIN: undefined }, () => {
+      expect(getEngineBinPath()).toBe(
+        join(homedir(), ".cache", "kesha", "engine", "bin", engineBasename),
+      );
+    });
+  });
+
+  test("getEngineBinPath lets KESHA_ENGINE_BIN outrank KESHA_CACHE_DIR", () => {
+    withPathEnv(
+      { KESHA_CACHE_DIR: "/tmp/kesha-cache", KESHA_ENGINE_BIN: "/tmp/kesha-explicit-engine" },
+      () => expect(getEngineBinPath()).toBe("/tmp/kesha-explicit-engine"),
+    );
   });
 
   test("getEngineBinPath follows KESHA_CACHE_DIR", () => {
-    const savedCacheDir = process.env.KESHA_CACHE_DIR;
-    const savedEngineBin = process.env.KESHA_ENGINE_BIN;
-    try {
-      delete process.env.KESHA_ENGINE_BIN;
-      process.env.KESHA_CACHE_DIR = "/tmp/kesha-cache";
+    withPathEnv({ KESHA_CACHE_DIR: "/tmp/kesha-cache", KESHA_ENGINE_BIN: undefined }, () => {
       expect(getEngineBinPath()).toBe(join("/tmp/kesha-cache", "engine", "bin", engineBasename));
-    } finally {
-      if (savedCacheDir === undefined) delete process.env.KESHA_CACHE_DIR;
-      else process.env.KESHA_CACHE_DIR = savedCacheDir;
-      if (savedEngineBin === undefined) delete process.env.KESHA_ENGINE_BIN;
-      else process.env.KESHA_ENGINE_BIN = savedEngineBin;
-    }
+    });
   });
 
   test("getEngineBinPath treats an empty KESHA_ENGINE_BIN as unset", () => {
-    const savedCacheDir = process.env.KESHA_CACHE_DIR;
-    const savedEngineBin = process.env.KESHA_ENGINE_BIN;
-    try {
-      process.env.KESHA_CACHE_DIR = "/tmp/kesha-cache";
-      process.env.KESHA_ENGINE_BIN = "";
+    withPathEnv({ KESHA_CACHE_DIR: "/tmp/kesha-cache", KESHA_ENGINE_BIN: "" }, () => {
       expect(getEngineBinPath()).toBe(join("/tmp/kesha-cache", "engine", "bin", engineBasename));
-    } finally {
-      if (savedCacheDir === undefined) delete process.env.KESHA_CACHE_DIR;
-      else process.env.KESHA_CACHE_DIR = savedCacheDir;
-      if (savedEngineBin === undefined) delete process.env.KESHA_ENGINE_BIN;
-      else process.env.KESHA_ENGINE_BIN = savedEngineBin;
-    }
+    });
   });
 
   test("parseLangResult parses valid JSON", () => {

--- a/tests/unit/engine.test.ts
+++ b/tests/unit/engine.test.ts
@@ -122,20 +122,25 @@ function cacheDirWithVadModel(): string {
 
 const engineBasename = process.platform === "win32" ? "kesha-engine.exe" : "kesha-engine";
 
-/** Runs `fn` with the two path-resolution vars forced to `env`, restoring whatever the shell had. */
-function withPathEnv<T>(env: Record<"KESHA_CACHE_DIR" | "KESHA_ENGINE_BIN", string | undefined>, fn: () => T): T {
-  const saved = { ...process.env };
-  try {
-    for (const [key, value] of Object.entries(env)) {
+type PathEnv = Record<"KESHA_CACHE_DIR" | "KESHA_ENGINE_BIN", string | undefined>;
+
+/** Runs `fn` with the two path-resolution vars forced to `env`, restoring the two it mutated. */
+function withPathEnv<T>(env: PathEnv, fn: () => T): T {
+  const saved: PathEnv = {
+    KESHA_CACHE_DIR: process.env.KESHA_CACHE_DIR,
+    KESHA_ENGINE_BIN: process.env.KESHA_ENGINE_BIN,
+  };
+  const apply = (values: PathEnv) => {
+    for (const [key, value] of Object.entries(values)) {
       if (value === undefined) delete process.env[key];
       else process.env[key] = value;
     }
+  };
+  try {
+    apply(env);
     return fn();
   } finally {
-    for (const key of ["KESHA_CACHE_DIR", "KESHA_ENGINE_BIN"]) {
-      if (saved[key] === undefined) delete process.env[key];
-      else process.env[key] = saved[key];
-    }
+    apply(saved);
   }
 }
 


### PR DESCRIPTION
A test-quality audit against Kent Beck's desiderata (isolated · deterministic · fast · behavioural · structure-insensitive · specific · predictive) turned up three live gaps. One cycle per commit.

### 1. The drift test asked whether the engine *exists*, not whether it *answers*

`src/__tests__/error-codes-drift.test.ts` guarded on `existsSync(ENGINE_BIN)`. The #796 stub (`#!/bin/sh\nexit 0`) exists, runs, and describes nothing — so the suite un-skipped and died on `JSON Parse error: Unexpected EOF` rather than skipping.

`e2e-engine` and `mcp-e2e` already moved to `engineFunctionalHealth()` in #801; this was the last presence-only guard. New `tests/helpers/engine-probe.ts` requires exit 0 **and** a non-empty JSON array, so an engine answering `[]` counts as no answer. Covered by `tests/unit/engine-probe.test.ts`.

Same file: the drift assertions were `expect(documented.has(c)).toBe(true)` in a loop, which can only report "false is not true" and leaves the reader to diff the code lists by hand. Now both directions name the offending codes.

### 2. `getEngineBinPath` test read the ambient environment

It asserted the path matches `/\.cache[/\\]kesha/` without controlling `KESHA_CACHE_DIR` — which the function honours. It failed for anyone with the var set (`KESHA_CACHE_DIR=/tmp/x bun test` reproduced it), and when it passed it only restated the implementation it had just called.

Replaced with the contract it was reaching for — both vars unset ⇒ `$HOME/.cache/kesha/engine/bin/<basename>` — plus the precedence case the file was missing. The save/restore block all four path tests each carried is now one helper.

### 3. `alpha-tag.sh` depended on an exec bit surviving a copy

It piped into its sibling as an executable, so a mode-dropping copy turns a release step into `Permission denied`. All six `alpha-tag` tests fail that way inside Stryker's sandbox, while the `push-annotated-tag` suite next door is immune because it already invokes via `bash`.

Those six failures aborted **every** Stryker run at "There were failed tests in the initial test run". After the fix the initial run completes. git still records `100755` and `build-engine.yml` still calls the script directly, so CI behaviour is unchanged.

### Verification

- `bun test` — 1049 pass / 32 skip / **0 fail** (was 1042/32/0; +7 tests)
- `bunx tsc --noEmit` — clean
- Guard fix demonstrated both ways: old guard on a stub ⇒ `JSON Parse error`; new guard ⇒ skip
- Fix 2 demonstrated red under `KESHA_CACHE_DIR`, green after
- Fix 3 demonstrated red with `chmod -x`, green after, mode restored
- No Rust changes, so `make rust-test` is not implicated

### Not in this PR

The audit also flagged, still open: `fluid-asr-cache.test.ts` asserting on Rust *source text* (`toContain('.join("…")')`, breaks on a pure refactor); 16 presence-only assertions in `e2e-engine.test.ts` that a hollow engine passes; and a wall-clock `toBeLessThan(5_000)` in `engine-install.test.ts`.