### PR TITLE
fix(tts): make OutputFormat::Wav mean one encoding on every engine

### DIFF
--- a/docs/tts.md
+++ b/docs/tts.md
@@ -73,7 +73,7 @@ kesha say --voice macos-com.apple.voice.compact.en-US.Samantha "Hello" > out.wav
 kesha say --voice macos-ru-RU "Привет, мир" > hello-ru.wav                   # language-code fallback
 ```
 
-Voice id format: `macos-<id>` where `<id>` is either a full Apple identifier (`com.apple.voice.compact.en-US.Samantha`) or a language code (`en-US`, `ru-RU`) — the Swift helper tries the identifier first and falls back to the language. Output is mono float32 @ 22050 Hz, structurally identical to Vosk.
+Voice id format: `macos-<id>` where `<id>` is either a full Apple identifier (`com.apple.voice.compact.en-US.Samantha`) or a language code (`en-US`, `ru-RU`) — the Swift helper tries the identifier first and falls back to the language. Output is mono float32, structurally identical to Vosk; the sample rate is whatever the chosen system voice renders at (22050 Hz for the legacy voices, 16000 Hz for the Eloquence set).
 
 Quality tradeoff is honest: macOS system voices are notification-grade. Use them when you want zero-install TTS on macOS; keep Kokoro/Vosk for anything that needs to sound good.
 

--- a/rust/src/tts/avspeech.rs
+++ b/rust/src/tts/avspeech.rs
@@ -3,7 +3,8 @@
 //! Shells out to a Swift sidecar (`swift/say-avspeech.swift`, compiled by
 //! `build.rs` into `$OUT_DIR/say-avspeech`). The Rust side pipes UTF-8 text on
 //! stdin, passes the voice identifier as argv\[1\], and reads a complete WAV
-//! (mono IEEE-float @ 22050 Hz) from stdout. Stderr is surfaced in the error
+//! (mono IEEE-float at the voice's own rate — 22050 Hz for the legacy voices,
+//! 16000 Hz for the Eloquence set) from stdout. Stderr is surfaced in the error
 //! message when synthesis fails.
 
 #![cfg(all(feature = "system_tts", target_os = "macos"))]

--- a/rust/src/tts/say.rs
+++ b/rust/src/tts/say.rs
@@ -625,8 +625,14 @@ fn encode_or_fail(
 }
 
 /// Re-encode WAV bytes from a Swift sidecar into the caller's chosen format.
-/// WAV → WAV short-circuits to avoid a hound round-trip.
+/// WAV → WAV goes through the round-trip too: #826 — passing sidecar PCM16
+/// through untouched made `OutputFormat::Wav` mean two different encodings
+/// depending on which engine served the request, and left those voices outside
+/// the #245 plain-IEEE-float guarantee that `tts::wav` exists to hold.
+// `test` joins the gate so the #826 regression test runs in the default
+// `--features tts` lane, not only under the darwin sidecar features.
 #[cfg(any(
+    test,
     all(feature = "system_tts", target_os = "macos"),
     all(
         feature = "system_kokoro",
@@ -635,9 +641,6 @@ fn encode_or_fail(
     )
 ))]
 fn transcode_to(wav_bytes: &[u8], format: OutputFormat) -> Result<Vec<u8>, TtsError> {
-    if matches!(format, OutputFormat::Wav) {
-        return Ok(wav_bytes.to_vec());
-    }
     let reader = hound::WavReader::new(std::io::Cursor::new(wav_bytes))
         .map_err(|e| TtsError::SynthesisFailed(format!("sidecar wav decode: {e}")))?;
     let spec = reader.spec();
@@ -649,6 +652,7 @@ fn transcode_to(wav_bytes: &[u8], format: OutputFormat) -> Result<Vec<u8>, TtsEr
 /// Mix WAV samples to mono f32. Generic so a future sidecar format change
 /// doesn't break us (AVSpeech currently emits 22.05 kHz 16-bit mono).
 #[cfg(any(
+    test,
     all(feature = "system_tts", target_os = "macos"),
     all(
         feature = "system_kokoro",
@@ -889,6 +893,74 @@ mod tests {
         assert!((super::compose_rate(0.5, 1.0) - 0.5).abs() < 1e-6);
         assert!((super::compose_rate(2.0, 1.0) - 2.0).abs() < 1e-6);
         assert!((super::compose_rate(1.0, 1.0) - 1.0).abs() < 1e-6);
+    }
+
+    /// Build a sidecar-shaped WAV: mono 16-bit PCM, the encoding AVSpeech and
+    /// FluidAudio Kokoro hand us.
+    fn pcm16_wav(samples: &[i16], sample_rate: u32) -> Vec<u8> {
+        let spec = hound::WavSpec {
+            channels: 1,
+            sample_rate,
+            bits_per_sample: 16,
+            sample_format: hound::SampleFormat::Int,
+        };
+        let mut buf = std::io::Cursor::new(Vec::new());
+        let mut writer = hound::WavWriter::new(&mut buf, spec).unwrap();
+        for s in samples {
+            writer.write_sample(*s).unwrap();
+        }
+        writer.finalize().unwrap();
+        buf.into_inner()
+    }
+
+    fn fmt_chunk(wav: &[u8]) -> (u16, u32, u16) {
+        let at = (0..wav.len() - 8)
+            .find(|i| &wav[*i..*i + 4] == b"fmt ")
+            .expect("fmt chunk not found");
+        let tag = u16::from_le_bytes([wav[at + 8], wav[at + 9]]);
+        let rate = u32::from_le_bytes([wav[at + 12], wav[at + 13], wav[at + 14], wav[at + 15]]);
+        let bits = u16::from_le_bytes([wav[at + 22], wav[at + 23]]);
+        (tag, rate, bits)
+    }
+
+    #[test]
+    fn wav_output_is_ieee_float_even_for_sidecar_pcm16() {
+        // #826: `OutputFormat::Wav` used to pass sidecar bytes through untouched,
+        // so the same voice emitted PCM16 for plain text and IEEE float for --ssml.
+        let src = pcm16_wav(&[0, 8192, -8192, 16384, -16384, 32767, -32768], 22_050);
+        assert_eq!(fmt_chunk(&src), (0x0001, 22_050, 16), "fixture shape");
+
+        let out = super::transcode_to(&src, OutputFormat::Wav).unwrap();
+
+        let (tag, rate, bits) = fmt_chunk(&out);
+        assert_eq!(
+            tag, 0x0003,
+            "expected WAVE_FORMAT_IEEE_FLOAT (0x0003), got 0x{tag:04x}"
+        );
+        assert_eq!(bits, 32);
+        assert_eq!(
+            rate, 22_050,
+            "sample rate stays per-voice; WAV pins the encoding, not the rate"
+        );
+    }
+
+    #[test]
+    fn wav_normalization_preserves_the_sidecar_audio() {
+        let pcm: Vec<i16> = (0..2048)
+            .map(|i| ((i as f32 * 0.05).sin() * 30_000.0) as i16)
+            .collect();
+        let out = super::transcode_to(&pcm16_wav(&pcm, 24_000), OutputFormat::Wav).unwrap();
+
+        let decoded: Vec<f32> = hound::WavReader::new(std::io::Cursor::new(&out))
+            .unwrap()
+            .into_samples::<f32>()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(decoded.len(), pcm.len());
+        for (i, (got, want)) in decoded.iter().zip(&pcm).enumerate() {
+            let want = *want as f32 / 32_768.0;
+            assert!((got - want).abs() < 1e-6, "sample {i}: {got} vs {want}");
+        }
     }
 }
 

--- a/rust/src/tts/say.rs
+++ b/rust/src/tts/say.rs
@@ -649,8 +649,9 @@ fn transcode_to(wav_bytes: &[u8], format: OutputFormat) -> Result<Vec<u8>, TtsEr
     encode_or_fail(&samples, spec.sample_rate, format)
 }
 
-/// Mix WAV samples to mono f32. Generic so a future sidecar format change
-/// doesn't break us (AVSpeech currently emits 22.05 kHz 16-bit mono).
+/// Mix WAV samples to mono f32. Generic because the sidecars disagree:
+/// FluidAudio Kokoro emits 16-bit PCM at 24 kHz, AVSpeech float32 at whatever
+/// rate the chosen system voice renders at.
 #[cfg(any(
     test,
     all(feature = "system_tts", target_os = "macos"),
@@ -895,11 +896,12 @@ mod tests {
         assert!((super::compose_rate(1.0, 1.0) - 1.0).abs() < 1e-6);
     }
 
-    /// Build a sidecar-shaped WAV: mono 16-bit PCM, the encoding AVSpeech and
-    /// FluidAudio Kokoro hand us.
-    fn pcm16_wav(samples: &[i16], sample_rate: u32) -> Vec<u8> {
+    /// Build a sidecar-shaped WAV: 16-bit PCM, the encoding FluidAudio Kokoro
+    /// hands us. `channels` interleaves, matching how a multi-channel sidecar
+    /// buffer would arrive.
+    fn pcm16_wav(samples: &[i16], sample_rate: u32, channels: u16) -> Vec<u8> {
         let spec = hound::WavSpec {
-            channels: 1,
+            channels,
             sample_rate,
             bits_per_sample: 16,
             sample_format: hound::SampleFormat::Int,
@@ -913,26 +915,65 @@ mod tests {
         buf.into_inner()
     }
 
-    fn fmt_chunk(wav: &[u8]) -> (u16, u32, u16) {
+    /// Byte-for-byte what `swift/say-avspeech.swift` writes: IEEE float 32-bit
+    /// with a 16-byte `fmt ` chunk and no `fact` chunk. hound reads it, but it
+    /// is not the shape `wav::encode_wav` produces.
+    fn avspeech_shaped_wav(samples: &[f32], sample_rate: u32) -> Vec<u8> {
+        let data_size = (samples.len() * 4) as u32;
+        let mut w = Vec::new();
+        w.extend_from_slice(b"RIFF");
+        w.extend_from_slice(&(36 + data_size).to_le_bytes());
+        w.extend_from_slice(b"WAVE");
+        w.extend_from_slice(b"fmt ");
+        w.extend_from_slice(&16_u32.to_le_bytes());
+        w.extend_from_slice(&3_u16.to_le_bytes());
+        w.extend_from_slice(&1_u16.to_le_bytes());
+        w.extend_from_slice(&sample_rate.to_le_bytes());
+        w.extend_from_slice(&(sample_rate * 4).to_le_bytes());
+        w.extend_from_slice(&4_u16.to_le_bytes());
+        w.extend_from_slice(&32_u16.to_le_bytes());
+        w.extend_from_slice(b"data");
+        w.extend_from_slice(&data_size.to_le_bytes());
+        for s in samples {
+            w.extend_from_slice(&s.to_le_bytes());
+        }
+        w
+    }
+
+    /// `(fmt chunk size, format tag, sample rate, bits per sample)`.
+    fn fmt_chunk(wav: &[u8]) -> (u32, u16, u32, u16) {
         let at = (0..wav.len() - 8)
             .find(|i| &wav[*i..*i + 4] == b"fmt ")
             .expect("fmt chunk not found");
+        let size = u32::from_le_bytes([wav[at + 4], wav[at + 5], wav[at + 6], wav[at + 7]]);
         let tag = u16::from_le_bytes([wav[at + 8], wav[at + 9]]);
         let rate = u32::from_le_bytes([wav[at + 12], wav[at + 13], wav[at + 14], wav[at + 15]]);
         let bits = u16::from_le_bytes([wav[at + 22], wav[at + 23]]);
-        (tag, rate, bits)
+        (size, tag, rate, bits)
+    }
+
+    fn has_fact_chunk(wav: &[u8]) -> bool {
+        (0..wav.len() - 4).any(|i| &wav[i..i + 4] == b"fact")
+    }
+
+    fn decode_f32(wav: &[u8]) -> Vec<f32> {
+        hound::WavReader::new(std::io::Cursor::new(wav))
+            .unwrap()
+            .into_samples::<f32>()
+            .collect::<Result<_, _>>()
+            .unwrap()
     }
 
     #[test]
     fn wav_output_is_ieee_float_even_for_sidecar_pcm16() {
         // #826: `OutputFormat::Wav` used to pass sidecar bytes through untouched,
         // so the same voice emitted PCM16 for plain text and IEEE float for --ssml.
-        let src = pcm16_wav(&[0, 8192, -8192, 16384, -16384, 32767, -32768], 22_050);
-        assert_eq!(fmt_chunk(&src), (0x0001, 22_050, 16), "fixture shape");
+        let src = pcm16_wav(&[0, 8192, -8192, 16384, -16384, 32767, -32768], 22_050, 1);
+        assert_eq!(fmt_chunk(&src), (16, 0x0001, 22_050, 16), "fixture shape");
 
         let out = super::transcode_to(&src, OutputFormat::Wav).unwrap();
 
-        let (tag, rate, bits) = fmt_chunk(&out);
+        let (_, tag, rate, bits) = fmt_chunk(&out);
         assert_eq!(
             tag, 0x0003,
             "expected WAVE_FORMAT_IEEE_FLOAT (0x0003), got 0x{tag:04x}"
@@ -945,17 +986,46 @@ mod tests {
     }
 
     #[test]
+    fn avspeech_shaped_float_wav_is_rewritten_to_the_canonical_layout() {
+        // AVSpeech already emits IEEE float, so #826 looked like a no-op here —
+        // but its `fmt ` chunk is 16 bytes with no `cbSize` and no `fact`, which
+        // is non-conformant for non-PCM. Now it goes through `wav::encode_wav`.
+        let pcm: Vec<f32> = (0..512).map(|i| (i as f32 * 0.02).sin()).collect();
+        let src = avspeech_shaped_wav(&pcm, 16_000);
+        assert_eq!(fmt_chunk(&src), (16, 0x0003, 16_000, 32), "fixture shape");
+        assert!(!has_fact_chunk(&src), "fixture must have no fact chunk");
+
+        let out = super::transcode_to(&src, OutputFormat::Wav).unwrap();
+
+        assert_eq!(fmt_chunk(&out), (18, 0x0003, 16_000, 32));
+        assert!(has_fact_chunk(&out), "non-PCM WAV needs a fact chunk");
+        assert_eq!(decode_f32(&out), pcm, "float input re-encodes exactly");
+    }
+
+    #[test]
+    fn stereo_sidecar_input_is_mixed_down_to_mono() {
+        // The downmix is defensive — no shipping voice returns stereo — but it
+        // silently doubles the sample count if it ever regresses.
+        let interleaved: Vec<i16> = vec![16384, -16384, 8192, 8192, 0, 32766];
+        let out =
+            super::transcode_to(&pcm16_wav(&interleaved, 24_000, 2), OutputFormat::Wav).unwrap();
+
+        let decoded = decode_f32(&out);
+        let expected = [0.0, 8192.0 / 32_768.0, 16383.0 / 32_768.0];
+        assert_eq!(decoded.len(), 3, "three frames in, three samples out");
+        for (i, (got, want)) in decoded.iter().zip(expected).enumerate() {
+            assert!((got - want).abs() < 1e-6, "frame {i}: {got} vs {want}");
+        }
+    }
+
+    #[test]
     fn wav_normalization_preserves_the_sidecar_audio() {
         let pcm: Vec<i16> = (0..2048)
             .map(|i| ((i as f32 * 0.05).sin() * 30_000.0) as i16)
             .collect();
-        let out = super::transcode_to(&pcm16_wav(&pcm, 24_000), OutputFormat::Wav).unwrap();
+        let out = super::transcode_to(&pcm16_wav(&pcm, 24_000, 1), OutputFormat::Wav).unwrap();
 
-        let decoded: Vec<f32> = hound::WavReader::new(std::io::Cursor::new(&out))
-            .unwrap()
-            .into_samples::<f32>()
-            .collect::<Result<_, _>>()
-            .unwrap();
+        let decoded = decode_f32(&out);
         assert_eq!(decoded.len(), pcm.len());
         for (i, (got, want)) in decoded.iter().zip(&pcm).enumerate() {
             let want = *want as f32 / 32_768.0;

--- a/rust/swift/say-avspeech.swift
+++ b/rust/swift/say-avspeech.swift
@@ -2,7 +2,8 @@
 //
 // Invoked by the Rust `avspeech` backend when a `macos-*` voice is selected.
 // Emits mono float32 WAV (IEEE_FLOAT) at the voice's native sample rate
-// (22050 Hz on every macOS voice we've tested). Stderr carries progress + errors.
+// (22050 Hz for the legacy voices, 16000 Hz for the Eloquence set). Stderr
+// carries progress + errors.
 //
 // Usage:
 //   say-avspeech <voiceId> [--rate <speed>] [text]   # synthesize (stdin if text is omitted)
@@ -139,8 +140,10 @@ guard !samples.isEmpty, sampleRate > 0, channels > 0 else {
 }
 
 // Minimal WAV-float32 encoder (mono). IEEE_FLOAT (wFormatTag = 3) so downstream
-// consumers can read the stream without re-quantization. Matches the shape
-// emitted by `tts::wav::encode_wav` in the Rust engine.
+// consumers can read the stream without re-quantization. Deliberately NOT the
+// shape `tts::wav::encode_wav` writes — no cbSize, no fact chunk — which is why
+// `tts::say::transcode_to` re-encodes these bytes rather than passing them
+// through (#826).
 func appendLE32(_ v: UInt32, to data: inout Data) {
   var le = v.littleEndian
   withUnsafeBytes(of: &le) { data.append(contentsOf: $0) }


### PR DESCRIPTION
Closes #826

## Step 1 verdict: the `--ssml` flip is real

The issue's sharpest claim was read from the code, not measured. It holds. One binary built from `d2b9730` with `--features tts,system_kokoro,system_tts` on darwin-arm64, voice `en-am_michael`, same sentence:

```
plain text  666d 7420 1000 0000 0100 0100 c05d 0000   fmt 16B, format 1 (PCM),        16-bit, 24000 Hz
--ssml      666d 7420 1200 0000 0300 0100 c05d 0000   fmt 18B, format 3 (IEEE float), 32-bit, 24000 Hz
```

So this is a within-build contradiction, not only a cross-platform annoyance: `say_fluid_kokoro` sends SSML through `synth_segments` → `encode_or_fail`, and plain text through `transcode_to`, which returned the sidecar's bytes untouched.

## One routing-table row in the issue is wrong

The issue predicted AVSpeech would passthrough **PCM16 22.05 kHz**. Measured, it already emits **IEEE float 32-bit** — its divergence was the chunk *layout*, not the sample format: a 16-byte `fmt ` chunk with no `cbSize` and no `fact` chunk, which is non-conformant for a non-PCM WAV. And the rate is per-voice, not a fixed 22050.

## Before / after

`fmt ` chunk as parsed from `--out`, same sentence throughout:

| build / voice | before | after |
|---|---|---|
| ONNX Kokoro, `en-am_michael` | fmt 18B, 0x0003, 32-bit, 24000, fact | unchanged |
| ANE `system_kokoro`, `en-am_michael`, plain | fmt 16B, **0x0001, 16-bit**, 24000, no fact | fmt 18B, 0x0003, 32-bit, 24000, fact |
| ANE `system_kokoro`, `en-am_michael`, `--ssml` | fmt 18B, 0x0003, 32-bit, 24000, fact | unchanged |
| AVSpeech `…eloquence.en-US.Eddy` | fmt **16B**, 0x0003, 32-bit, 16000, **no fact** | fmt 18B, 0x0003, 32-bit, 16000, fact |
| AVSpeech `…synthesis.voice.Albert` | fmt **16B**, 0x0003, 32-bit, 22050, **no fact** | fmt 18B, 0x0003, 32-bit, 22050, fact |

Every row now agrees: plain `WAVE_FORMAT_IEEE_FLOAT`, 32-bit, canonical `fmt`+`fact` layout — the #245 contract that `tts::wav` exists to hold. The ANE plain-text file doubles in size (134444 → 268858 bytes), which is the honest cost of the chosen direction.

**Sample rate stays per-voice.** `transcode_to` reads `spec.sample_rate` off the sidecar header and hands it to `encode_or_fail` unchanged — no resampling anywhere, matching what the Vosk path already does with its 22.05 kHz. The AVSpeech rows above are the evidence: 16000 stays 16000, 22050 stays 22050.

## The fork, not taken

Normalizing on PCM16 instead would halve file size and widen compatibility, but it contradicts `wav.rs`'s stated contract and needs its own decision. Not done here, per the issue.

## Test

Red-first at the `transcode_to` seam with fake sidecar PCM16 bytes — no model needed:

- `wav_output_is_ieee_float_even_for_sidecar_pcm16` — asserts format tag `0x0003`, 32 bits, and that a 22050 Hz input comes out at 22050 Hz. Failed before the fix with `got 0x0001`.
- `wav_normalization_preserves_the_sidecar_audio` — decodes both ends and compares samples. Failed before the fix with `InvalidSampleFormat`, since passthrough bytes aren't readable as f32.

`writes_plain_ieee_float_not_extensible` (#245) stays green.

`transcode_to` and `wav_to_mono_f32` were gated to the darwin sidecar features, which CI only compile-checks (`rust-test.yml`'s darwin clippy step) and never runs. `test` joins that gate so these two run in the default `--features tts` lane. **The `--ssml` divergence itself has no direct regression test** — it needs a real ANE model, which CI does not have. The fix removes the divergence by construction: both arms now terminate in `wav::encode_wav`, and there is no longer any path where `OutputFormat::Wav` skips it.

## Docs

`docs/tts.md:20` already promised "mono float32" for WAV output; that promise was false for the ANE path and is now true everywhere. Corrected the AVSpeech line's fixed "@ 22050 Hz" claim, which the measurements above contradict.

## Verification

```
cargo fmt --check                                                        OK
cargo nextest run --features tts                        486 passed, 0 skipped
cargo clippy --all-targets -- -D warnings                                OK
cargo clippy --all-targets --features coreml,tts,system_tts,system_kokoro,system_diarize,system_text_lang --no-default-features -- -D warnings   OK
cargo check --features coreml --no-default-features --all-targets        OK
cargo check --features system_kokoro --no-default-features --all-targets OK
```

No TypeScript touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBTpJjqyYFW6W8LHJ2nwy