### PR TITLE
test: retire the last structure-sensitive and presence-only assertions

### DIFF
--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -552,8 +552,14 @@ pub struct FluidAudioLocation {
 /// base that each subsystem appends its own repo folder to, so Parakeet ASR, the Kokoro ANE
 /// chain and the compiled-Sortformer cache become siblings here instead of three separate
 /// home-directory roots FluidAudio picks for itself.
+/// Mirrored by `src/fluid-asr-cache.ts`; `fluid-asr-cache.test.ts` reads this value to pin them.
+pub const FLUIDAUDIO_ROOT_DIR: &str = "fluidaudio";
+
+/// FluidAudio's repo folder for the Parakeet bundle, mirrored TS-side the same way (#684).
+pub const FLUID_ASR_REPO_DIR: &str = "parakeet-tdt-0.6b-v3";
+
 pub fn fluidaudio_models_root() -> PathBuf {
-    cache_dir().join("fluidaudio")
+    cache_dir().join(FLUIDAUDIO_ROOT_DIR)
 }
 
 /// Resolve one subsystem, preferring a legacy location that already holds a usable bundle.
@@ -706,7 +712,7 @@ pub fn fluidaudio_asr_location() -> FluidAudioLocation {
     if let Some(notice) = stale_legacy_notice(&legacy, complete, &ANNOUNCED) {
         with_stderr(|| eprintln!("{notice}"));
     }
-    fluidaudio_location(&legacy, complete, "parakeet-tdt-0.6b-v3")
+    fluidaudio_location(&legacy, complete, FLUID_ASR_REPO_DIR)
 }
 
 /// The Application Support tree FluidAudio picks on its own, kept as the read-fallback.
@@ -723,7 +729,7 @@ fn legacy_fluidaudio_asr_dir() -> PathBuf {
         .join("Application Support")
         .join("FluidAudio")
         .join("Models")
-        .join("parakeet-tdt-0.6b-v3")
+        .join(FLUID_ASR_REPO_DIR)
 }
 
 /// Where `fluidaudio-rs` keeps compiled Sortformer `.mlmodelc` bundles, and the root that

--- a/tests/integration/e2e-engine.test.ts
+++ b/tests/integration/e2e-engine.test.ts
@@ -342,8 +342,8 @@ describe.skipIf(!engineInstalled)("e2e-transcribe", () => {
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
     expect(Array.isArray(parsed)).toBe(true);
-    // Presence-only assertions could not tell this fixture from the English one.
-    expect(parsed[0].text).toContain("сообщения");
+    // Backend-stable word: CoreML and ONNX disagree on "сообщения"/"сообщение" for this clip.
+    expect(parsed[0].text).toContain("транскрипцией");
     expect(parsed[0].lang).toBe("ru");
     expect(parsed[0].textLanguage.code).toBe("ru");
     expect(parsed[0].textLanguage.confidence).toBeGreaterThan(0.5);
@@ -415,7 +415,7 @@ describe.skipIf(!engineInstalled)("e2e-transcribe", () => {
     expect(Array.isArray(parsed)).toBe(true);
     expect(parsed).toHaveLength(1);
     expect(parsed[0].file).toBe(FIXTURE_RU);
-    expect(parsed[0].text).toContain("сообщения");
+    expect(parsed[0].text).toContain("транскрипцией");
   }, 60_000);
 
   test("--toon output decodes to the same shape as --json (#138)", async () => {

--- a/tests/integration/e2e-engine.test.ts
+++ b/tests/integration/e2e-engine.test.ts
@@ -342,11 +342,12 @@ describe.skipIf(!engineInstalled)("e2e-transcribe", () => {
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
     expect(Array.isArray(parsed)).toBe(true);
-    expect(parsed[0].text.length).toBeGreaterThan(0);
-    expect(parsed[0].lang).toBeDefined();
-    expect(parsed[0].textLanguage).toBeDefined();
-    expect(parsed[0].textLanguage.code).toBeDefined();
-    expect(parsed[0].textLanguage.confidence).toBeGreaterThan(0);
+    // Presence-only assertions could not tell this fixture from the English one.
+    expect(parsed[0].text).toContain("сообщения");
+    expect(parsed[0].lang).toBe("ru");
+    expect(parsed[0].textLanguage.code).toBe("ru");
+    expect(parsed[0].textLanguage.confidence).toBeGreaterThan(0.5);
+    expect(parsed[0].textLanguage.confidence).toBeLessThanOrEqual(1);
   }, 60_000);
 
   test("kesha --json --timestamps includes transcript segments", async () => {
@@ -361,12 +362,13 @@ describe.skipIf(!engineInstalled)("e2e-transcribe", () => {
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
     expect(Array.isArray(parsed)).toBe(true);
-    expect(parsed[0].text.length).toBeGreaterThan(0);
+    expect(parsed[0].text).toContain("email");
     expect(Array.isArray(parsed[0].segments)).toBe(true);
     if (parsed[0].segments.length > 0) {
       expect(parsed[0].segments[0].start).toBeGreaterThanOrEqual(0);
       expect(parsed[0].segments[0].end).toBeGreaterThan(parsed[0].segments[0].start);
-      expect(parsed[0].segments[0].text.length).toBeGreaterThan(0);
+      // The segment texts must reconstruct the transcript, not merely be non-empty.
+      expect(parsed[0].segments.map((s: { text: string }) => s.text).join(" ")).toBe(parsed[0].text);
     }
   }, 60_000);
 
@@ -413,7 +415,7 @@ describe.skipIf(!engineInstalled)("e2e-transcribe", () => {
     expect(Array.isArray(parsed)).toBe(true);
     expect(parsed).toHaveLength(1);
     expect(parsed[0].file).toBe(FIXTURE_RU);
-    expect(parsed[0].text.length).toBeGreaterThan(0);
+    expect(parsed[0].text).toContain("сообщения");
   }, 60_000);
 
   test("--toon output decodes to the same shape as --json (#138)", async () => {
@@ -438,10 +440,10 @@ describe.skipIf(!engineInstalled)("e2e-lang-detection", () => {
     const { stdout, exitCode } = await runCli(["--json", FIXTURE_RU]);
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
-    if (parsed[0].audioLanguage) {
-      expect(parsed[0].audioLanguage.code).toBeDefined();
-      expect(parsed[0].audioLanguage.confidence).toBeGreaterThan(0);
-    }
+    // Guarding the body on `if (audioLanguage)` made the named contract a silent pass.
+    expect(parsed[0].audioLanguage.code).toBe("ru");
+    expect(parsed[0].audioLanguage.confidence).toBeGreaterThan(0);
+    expect(parsed[0].audioLanguage.confidence).toBeLessThanOrEqual(1);
   }, 60_000);
 
   test("--verbose shows audio language when detected", async () => {

--- a/tests/unit/fluid-asr-cache.test.ts
+++ b/tests/unit/fluid-asr-cache.test.ts
@@ -202,20 +202,26 @@ describe("Rust/TS FluidAudio contract agreement", () => {
     return [...block[1]!.matchAll(/"([^"]+)"/g)].map((m) => m[1]!);
   }
 
+  // Reads the value, not the expression using it: matching `.join("…")` broke on refactors.
+  function rustStr(constName: string): string {
+    const block = rust.match(new RegExp(`const ${constName}: &str = "([^"]+)"`));
+    if (!block) throw new Error(`${constName} not found in rust/src/models.rs`);
+    return block[1]!;
+  }
+
   test("required entry lists match", () => {
     expect(rustList("FLUID_ASR_REQUIRED").sort()).toEqual([...FLUID_ASR_REQUIRED].sort());
   });
 
   test("cache directory name matches", () => {
-    expect(rust).toContain(`.join("${basename(legacyFluidAsrCachePath("/tmp/home"))}")`);
+    expect(rustStr("FLUID_ASR_REPO_DIR")).toBe(basename(legacyFluidAsrCachePath("/tmp/home")));
   });
 
   // Both sides derive the relocated bundle from the cache root; a rename on one side alone
   // would point doctor at a directory the engine never writes (#688).
   test("relocated bundle path matches", () => {
-    expect(rust).toContain(`cache_dir().join("fluidaudio")`);
     expect(fluidAsrCachePath("/tmp/home", "/tmp/cache")).toBe(
-      join("/tmp/cache", "fluidaudio", "parakeet-tdt-0.6b-v3"),
+      join("/tmp/cache", rustStr("FLUIDAUDIO_ROOT_DIR"), rustStr("FLUID_ASR_REPO_DIR")),
     );
   });
 });


### PR DESCRIPTION
Round two of the Beck-lens audit, after #829. Two findings closed, one deliberately left alone.

### 1. The Rust/TS contract tests matched call syntax, not values

`tests/unit/fluid-asr-cache.test.ts` asserted on the *text* of `rust/src/models.rs`:

```ts
expect(rust).toContain(`.join("${basename(legacyFluidAsrCachePath("/tmp/home"))}")`);
expect(rust).toContain(`cache_dir().join("fluidaudio")`);
```

Rewriting either call — hoisting the receiver into a local, say — turned a pure refactor into a red test, while proving nothing about the value the two languages must agree on.

Now the Rust side names the two directories and the test reads the **constants' values**, the way the sibling `FLUID_ASR_REQUIRED` test already worked. Verified by reshaping `fluidaudio_models_root` to `let root = cache_dir(); root.join(FLUIDAUDIO_ROOT_DIR)` — green after, and the old assertion would have failed.

Side benefit: retires a magic string the file repeated at three production sites.

### 2. Sixteen presence-only assertions in `e2e-engine.test.ts`

`text.length > 0`, `lang` defined, `textLanguage.code` defined — all pass for any engine returning well-formed but hollow JSON, and none could tell the Russian fixture from the English one. This is the suite whose whole job is catching engine regressions.

Pinned to the known answers: language codes are `"ru"` for the Russian clip, transcripts contain a distinctive word, confidences sit inside `(0, 1]`, and timestamped segments must reconstruct the transcript rather than merely be non-empty.

Worst of the set — `--json audioLanguage is present for Russian audio` wrapped its entire body in `if (parsed[0].audioLanguage)`, so an absent field, the one thing the test is named for, was a silent pass.

Verified by feeding the English fixture to the Russian expectations: **fails now, passed before**.

### Deliberately not changed

`engine-install.test.ts` asserts `Date.now() - startedAt < 5_000` against a 60 s deadline. It is a wall-clock assertion, but the contract *is* about time ("fails fast instead of waiting out the deadline") and the 12× margin is not a realistic flake source. Rewriting it would trade a working test for a worse one.

### Verification

- `bun test` — 1099 pass / 5 skip / **0 fail**, with the real engine (v1.24.9) so `e2e-engine` and `mcp-e2e` actually run rather than skip
- `bunx tsc --noEmit` — clean
- Rust: `cargo fmt --check`, `cargo clippy --all-targets --features tts -- -D warnings`, `cargo check --features coreml --no-default-features`, `cargo nextest run --features tts` — **484/484**

### Incidental finding

Engine **v1.24.7** fails the Russian Opus fixture with `E_INTERNAL: audio duration is unavailable for timestamped segments`; the pinned **v1.24.9** transcribes it correctly. Noting it in case that regression window matters for anyone still on 1.24.7.