### PR TITLE
test: assert known answers across the unit suites, and share the stub two files copied

### DIFF
--- a/tests/helpers/fake-engine.ts
+++ b/tests/helpers/fake-engine.ts
@@ -55,3 +55,35 @@ export function writeFakeEngine(
   chmodSync(binPath, 0o755);
   return binPath;
 }
+
+/**
+ * Writes a stub in a fresh temp dir that answers `--capabilities-json` with `features`
+ * and `transcribe` with `transcribeBody`, and returns its path.
+ *
+ * `transcribeBody` is shell, so a caller that needs to vary the reply by flag can branch.
+ */
+export function writeTranscribingEngine(
+  prefix: string,
+  features: string[],
+  transcribeBody: string,
+): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  const path = join(dir, "kesha-engine");
+  const capabilities = JSON.stringify({ protocolVersion: 2, backend: "fake", features });
+  writeFileSync(
+    path,
+    `#!/bin/sh
+if [ "$1" = "--capabilities-json" ]; then
+  printf '%s\\n' '${capabilities}'
+  exit 0
+fi
+if [ "$1" = "transcribe" ]; then
+${transcribeBody}
+  exit 0
+fi
+exit 2
+`,
+  );
+  chmodSync(path, 0o755);
+  return path;
+}

--- a/tests/integration/e2e-engine.test.ts
+++ b/tests/integration/e2e-engine.test.ts
@@ -83,7 +83,8 @@ describe.skipIf(!engineInstalled)("e2e-engine", () => {
     expect(exitCode).toBe(0);
     const caps = JSON.parse(stdout);
     expect(caps.protocolVersion).toBe(3);
-    expect(caps.backend).toBeDefined();
+    // Exactly one backend is compiled in; "some string" would accept a build that named none.
+    expect(["coreml", "onnx"]).toContain(caps.backend);
     expect(caps.features).toContain("transcribe");
     expect(caps.features).toContain("detect-lang");
   });
@@ -383,7 +384,8 @@ describe.skipIf(!engineInstalled)("e2e-transcribe", () => {
     const { stdout, stderr, exitCode } = await runCli(["--lang", "en", FIXTURE_RU]);
     expect(exitCode).toBe(0);
     expect(stderr).toContain("expected language");
-    expect(stdout.length).toBeGreaterThan(0);
+    // The warning must not suppress the transcript, which a length check never showed.
+    expect(stdout).toContain("транскрипцией");
   }, 60_000);
 
   test("kesha transcribes English audio", async () => {

--- a/tests/integration/mcp-e2e.test.ts
+++ b/tests/integration/mcp-e2e.test.ts
@@ -49,8 +49,9 @@ describe.skipIf(!engineInstalled)("mcp e2e", () => {
   test("transcribe_audio returns non-empty text", async () => {
     const cl = await client();
     const res = await cl.callTool({ name: "transcribe_audio", arguments: { path: FIXTURE_RU } });
-    expect(res.isError).toBeFalsy();
-    expect((res.content as Array<{ text: string }>)[0].text.length).toBeGreaterThan(0);
+    expect(res.isError).toBeUndefined();
+    // Backend-stable word: CoreML and ONNX disagree on "сообщения"/"сообщение" for this clip.
+    expect((res.content as Array<{ text: string }>)[0].text).toContain("транскрипцией");
   }, 60_000);
 
   test.skipIf(!SPIKE_AVAILABLE)(
@@ -61,7 +62,7 @@ describe.skipIf(!engineInstalled)("mcp e2e", () => {
         name: "synthesize_speech",
         arguments: { text: "Hello world", voice: "en-am_michael", format: "wav" },
       });
-      expect(res.isError).toBeFalsy();
+      expect(res.isError).toBeUndefined();
       const link = (res.content as Array<{ type: string; uri: string }>).find((c) => c.type === "resource_link");
       expect(link?.uri.startsWith("kesha-audio://")).toBe(true);
       const sc = res.structuredContent as { uri: string; path: string; bytes: number };

--- a/tests/unit/doctor.test.ts
+++ b/tests/unit/doctor.test.ts
@@ -29,7 +29,7 @@ const fakeCapabilities = {
   features: ["transcribe.segments", "transcribe.diarize"],
 };
 
-function writeFakeEngine(path: string, body: string): void {
+function writeEngineStub(path: string, body: string): void {
   writeFileSync(path, body);
   chmodSync(path, 0o755);
 }
@@ -310,7 +310,7 @@ describe("collectDoctorReport", () => {
       const binDir = join(dir, "engine", "bin");
       mkdirSync(binDir, { recursive: true });
       const binPath = join(binDir, "kesha-engine");
-      writeFakeEngine(
+      writeEngineStub(
         binPath,
         `#!/bin/sh
 if [ "$1" = "--capabilities-json" ]; then
@@ -636,7 +636,7 @@ describe("collectDoctorReport probe and cache accounting", () => {
   // #801: this is the #796 stub verbatim — it ran, so doctor called it installed.
   posixEngineTest("an engine that runs but describes nothing is a fault, not a footnote", async () => {
     const { dir, binDir } = stage("kesha-doctor-mute-engine-");
-    writeFakeEngine(join(binDir, "kesha-engine"), "#!/bin/sh\nexit 0\n");
+    writeEngineStub(join(binDir, "kesha-engine"), "#!/bin/sh\nexit 0\n");
     try {
       const report = await collectDoctorReport();
       expect(report.engine.installed).toBe(true);
@@ -654,7 +654,7 @@ describe("collectDoctorReport probe and cache accounting", () => {
 
   posixEngineTest("capabilities that do not parse read as the same fault as none", async () => {
     const { dir, binDir } = stage("kesha-doctor-silent-engine-");
-    writeFakeEngine(join(binDir, "kesha-engine"), "#!/bin/sh\nexit 2\n");
+    writeEngineStub(join(binDir, "kesha-engine"), "#!/bin/sh\nexit 2\n");
     try {
       const report = await collectDoctorReport();
       expect(report.engine.runnable).toBe(true);
@@ -667,7 +667,7 @@ describe("collectDoctorReport probe and cache accounting", () => {
 
   posixEngineTest("a CoreML engine gets the in-cache FluidAudio row, not the ONNX model dir", async () => {
     const { dir, binDir } = stage("kesha-doctor-coreml-cache-");
-    writeFakeEngine(
+    writeEngineStub(
       join(binDir, "kesha-engine"),
       `#!/bin/sh
 if [ "$1" = "--capabilities-json" ]; then
@@ -690,7 +690,7 @@ exit 2
 
   posixEngineTest("an ONNX engine keeps the ONNX model dir and no in-cache FluidAudio row", async () => {
     const { dir, binDir } = stage("kesha-doctor-onnx-cache-");
-    writeFakeEngine(
+    writeEngineStub(
       join(binDir, "kesha-engine"),
       `#!/bin/sh
 if [ "$1" = "--capabilities-json" ]; then
@@ -711,7 +711,7 @@ exit 2
 
   posixEngineTest("an engine inside the cache is counted once, outside it is added", async () => {
     const { dir, cache, binDir } = stage("kesha-doctor-cache-total-");
-    writeFakeEngine(join(binDir, "kesha-engine"), "#!/bin/sh\nexit 2\n");
+    writeEngineStub(join(binDir, "kesha-engine"), "#!/bin/sh\nexit 2\n");
     mkdirSync(join(cache, "models", "silero-vad"), { recursive: true });
     writeFileSync(join(cache, "models", "silero-vad", "model.onnx"), "x".repeat(128));
     const engineBytes = readFileSync(join(binDir, "kesha-engine")).length;
@@ -720,7 +720,7 @@ exit 2
 
       const outside = join(dir, "opt", "engine", "bin");
       mkdirSync(outside, { recursive: true });
-      writeFakeEngine(join(outside, "kesha-engine"), "#!/bin/sh\nexit 2\n");
+      writeEngineStub(join(outside, "kesha-engine"), "#!/bin/sh\nexit 2\n");
       process.env.KESHA_ENGINE_BIN = join(outside, "kesha-engine");
       expect((await collectDoctorReport()).cache.totalBytes).toBe(
         engineBytes + 128 + engineBytes,
@@ -906,7 +906,7 @@ describe("engine version drift (#738)", () => {
     const binPath = join(dir, "engine", "bin", "kesha-engine");
     mkdirSync(join(dir, "engine", "bin"), { recursive: true });
     process.env.KESHA_ENGINE_BIN = binPath;
-    writeFakeEngine(binPath, "#!/bin/sh\nexit 1\n");
+    writeEngineStub(binPath, "#!/bin/sh\nexit 1\n");
     if (marker !== null) writeFileSync(`${binPath}.version`, `${marker}\n`);
     return dir;
   }
@@ -990,10 +990,10 @@ describe("doctor separates corrupt components from missing ones", () => {
     const dir = mkdtempSync(join(tmpdir(), prefix));
     const binDir = join(dir, "engine", "bin");
     mkdirSync(binDir, { recursive: true });
-    writeFakeEngine(join(binDir, "kesha-engine"), engineBody);
+    writeEngineStub(join(binDir, "kesha-engine"), engineBody);
     if (sidecarBody !== null) {
-      writeFakeEngine(join(binDir, "say-avspeech"), sidecarBody);
-      writeFakeEngine(join(binDir, "kesha-textlang"), sidecarBody);
+      writeEngineStub(join(binDir, "say-avspeech"), sidecarBody);
+      writeEngineStub(join(binDir, "kesha-textlang"), sidecarBody);
     }
     process.env.HOME = dir;
     process.env.KESHA_ENGINE_BIN = join(binDir, "kesha-engine");
@@ -1097,7 +1097,7 @@ describe("doctor and status agree on the disk total (#790)", () => {
     const binDir = join(`${cache}-alt`, "bin");
     mkdirSync(binDir, { recursive: true });
     const binPath = join(binDir, "kesha-engine");
-    writeFakeEngine(
+    writeEngineStub(
       binPath,
       `#!/bin/sh
 if [ "$1" = "--capabilities-json" ]; then
@@ -1134,7 +1134,7 @@ exit 2
     const binDir = join(cache, "engine", "bin");
     mkdirSync(binDir, { recursive: true });
     const binPath = join(binDir, "kesha-engine");
-    writeFakeEngine(
+    writeEngineStub(
       binPath,
       `#!/bin/sh
 if [ "$1" = "--capabilities-json" ]; then

--- a/tests/unit/doctor.test.ts
+++ b/tests/unit/doctor.test.ts
@@ -159,7 +159,7 @@ describe("collectDoctorReport", () => {
       expect(report.engine.installed).toBe(false);
       expect(report.engine.path).toBe("~/engine/bin/kesha-engine");
       expect(report.cache.path).toBe("~/.cache/kesha");
-      expect(report.cache.totalBytes).toBeGreaterThan(0);
+      expect(report.cache.totalBytes).toBe("vad".length);
       expect(report.env.KESHA_MODEL_MIRROR).toBe("https://example.com/kesha");
       expect(report.env.KESHA_DEBUG).toBe("1");
       expect("runCount" in report.stats).toBe(true);
@@ -168,8 +168,8 @@ describe("collectDoctorReport", () => {
       expect(report.diagnosticLogs.activePath).toBe("~/logs/kesha.ndjson");
       expect(report.diagnosticLogs.statePath).toBe("~/logs/diagnostic-logs.json");
       expect(report.diagnosticLogs.exists).toBe(true);
-      expect(report.diagnosticLogs.activeSizeBytes).toBeGreaterThan(0);
-      expect(report.diagnosticLogs.totalSizeBytes).toBeGreaterThan(report.diagnosticLogs.activeSizeBytes);
+      expect(report.diagnosticLogs.activeSizeBytes).toBe("diagnostic\n".length);
+      expect(report.diagnosticLogs.totalSizeBytes).toBe("diagnostic\n".length + "rotated\n".length);
       expect(report.diagnosticLogs.rotatedFiles).toEqual(["kesha.1.ndjson"]);
 
       expect(report.cache.externalRoots).toEqual([

--- a/tests/unit/engine.test.ts
+++ b/tests/unit/engine.test.ts
@@ -3,6 +3,7 @@ import { chmodSync, mkdtempSync, mkdirSync, writeFileSync } from "fs";
 import { homedir, tmpdir } from "os";
 import { join } from "path";
 import { waitForPidExit, waitForPidFile } from "../helpers/process";
+import { writeTranscribingEngine } from "../helpers/fake-engine";
 import {
   detectTextLanguageEngine,
   parseLangResult,
@@ -18,24 +19,11 @@ import {
 } from "../../src/engine";
 
 function fakeEngine(features: string[]): string {
-  const dir = mkdtempSync(join(tmpdir(), "kesha-engine-test-"));
-  const path = join(dir, "kesha-engine");
-  writeFileSync(
-    path,
-    `#!/bin/sh
-if [ "$1" = "--capabilities-json" ]; then
-  printf '%s\\n' '${JSON.stringify({ protocolVersion: 2, backend: "fake", features })}'
-  exit 0
-fi
-if [ "$1" = "transcribe" ]; then
-  printf '%s\\n' '{"text":"ok","segments":[{"start":0,"end":1,"text":"ok","speaker":0}]}'
-  exit 0
-fi
-exit 2
-`,
+  return writeTranscribingEngine(
+    "kesha-engine-test-",
+    features,
+    `  printf '%s\\n' '{"text":"ok","segments":[{"start":0,"end":1,"text":"ok","speaker":0}]}'`,
   );
-  chmodSync(path, 0o755);
-  return path;
 }
 
 const fakeEngineTest = process.platform === "win32" ? test.skip : test;

--- a/tests/unit/fluid-kokoro-cache.test.ts
+++ b/tests/unit/fluid-kokoro-cache.test.ts
@@ -19,8 +19,9 @@ describe("fluidKokoroCacheInfo", () => {
     const dir = mkdtempSync(join(tmpdir(), "kesha-fluid-kokoro-cache-test-"));
     try {
       const cache = fluidKokoroCachePath(dir);
+      const body = "coreml";
       mkdirSync(join(cache, "kokoro_21_15s.mlmodelc"), { recursive: true });
-      writeFileSync(join(cache, "kokoro_21_15s.mlmodelc", "coremldata.bin"), "coreml");
+      writeFileSync(join(cache, "kokoro_21_15s.mlmodelc", "coremldata.bin"), body);
 
       const info = fluidKokoroCacheInfo({
         platform: "darwin",
@@ -31,7 +32,7 @@ describe("fluidKokoroCacheInfo", () => {
       expect(info.supported).toBe(true);
       expect(info.path).toBe(cache);
       expect(info.exists).toBe(true);
-      expect(info.sizeBytes).toBeGreaterThan(0);
+      expect(info.sizeBytes).toBe(body.length);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/tests/unit/lib.test.ts
+++ b/tests/unit/lib.test.ts
@@ -3,6 +3,7 @@ import { chmodSync, mkdtempSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { transcribe } from "../../src/lib";
+import { writeTranscribingEngine } from "../helpers/fake-engine";
 import {
   preflightTranscribeWithSegments,
   transcribe as transcribeWrapper,
@@ -10,28 +11,15 @@ import {
 } from "../../src/transcribe";
 
 function fakeEngine(features: string[]): string {
-  const dir = mkdtempSync(join(tmpdir(), "kesha-transcribe-test-"));
-  const path = join(dir, "kesha-engine");
-  writeFileSync(
-    path,
-    `#!/bin/sh
-if [ "$1" = "--capabilities-json" ]; then
-  printf '%s\\n' '${JSON.stringify({ protocolVersion: 2, backend: "fake", features })}'
-  exit 0
-fi
-if [ "$1" = "transcribe" ]; then
-  if [ "$3" = "--json" ] || [ "$2" = "--json" ]; then
+  return writeTranscribingEngine(
+    "kesha-transcribe-test-",
+    features,
+    `  if [ "$3" = "--json" ] || [ "$2" = "--json" ]; then
     printf '%s\\n' '{"text":"ok","segments":[{"start":0,"end":1,"text":"ok"}]}'
   else
     printf '%s\\n' 'ok'
-  fi
-  exit 0
-fi
-exit 2
-`,
+  fi`,
   );
-  chmodSync(path, 0o755);
-  return path;
 }
 
 const fakeEngineIt = process.platform === "win32" ? it.skip : it;

--- a/tests/unit/logs-action.test.ts
+++ b/tests/unit/logs-action.test.ts
@@ -54,7 +54,11 @@ describe("runLogsAction", () => {
     const result = runLogsAction({ action: "status", json: true });
     if (!result.ok) throw new Error(result.error);
     expect(result.messages).toEqual([]);
-    expect(JSON.parse(result.stdout ?? "").mode).toBeDefined();
+    const status = JSON.parse(result.stdout ?? "");
+    expect(status.mode).toBe("retain-on-failure");
+    expect(status.dir).toBe(dir);
+    expect(status.activePath).toBe(join(dir, "kesha.ndjson"));
+    expect(status).toMatchObject({ exists: false, activeSizeBytes: 0, rotatedFiles: [] });
   });
 
   test("--json is rejected for any action other than status", () => {

--- a/tests/unit/mcp-list-voices.test.ts
+++ b/tests/unit/mcp-list-voices.test.ts
@@ -82,10 +82,10 @@ describe("list_voices guard when the engine is present but not executable", () =
 // Skip the full tool test if the engine is not installed (unit environment).
 // The integration path (tests/integration/) covers the full round-trip with a
 // real engine binary.
+// Guarding on "any voice" let a Russian-only `--tts ru` install run the English assertions.
 let engineAvailable = false;
 try {
-  const voices = await listVoices();
-  engineAvailable = voices.length > 0;
+  engineAvailable = (await listVoices()).some((v) => v.voiceId === "en-am_michael");
 } catch {
   engineAvailable = false;
 }
@@ -130,10 +130,12 @@ describe("list_languages tool", () => {
       languageCode: "en-US",
       languageName: "American English",
     });
-    // voiceCount must count the voices actually listed, not be a shape-check placeholder.
-    const voices = (await listVoices()) as Array<{ languageCode: string }>;
+
+    // Cross-tool agreement, not a re-implementation; the maths has its oracle in mcp-voices.
+    const voicesRes = await client.callTool({ name: "list_voices", arguments: {} });
+    const listed = (voicesRes.structuredContent as { voices: Array<{ languageCode: string }> }).voices;
     for (const lang of sc.languages) {
-      expect(lang.voiceCount).toBe(voices.filter((v) => v.languageCode === lang.languageCode).length);
+      expect(lang.voiceCount).toBe(listed.filter((v) => v.languageCode === lang.languageCode).length);
     }
   });
 });

--- a/tests/unit/mcp-list-voices.test.ts
+++ b/tests/unit/mcp-list-voices.test.ts
@@ -98,18 +98,19 @@ describe("list_voices tool", () => {
     const client = new Client({ name: "t", version: "0" });
     await client.connect(c);
     const res = await client.callTool({ name: "list_voices", arguments: {} });
-    expect(res.isError).toBeFalsy();
+    expect(res.isError).toBeUndefined();
     const sc = res.structuredContent as {
       voices: Array<{ voiceId: string; modelId: string; modelName: string; languageCode: string; languageName: string; gender: string | null }>;
     };
-    expect(Array.isArray(sc.voices)).toBe(true);
-    expect(sc.voices.length).toBeGreaterThan(0);
-    expect(sc.voices[0]).toHaveProperty("voiceId");
-    expect(sc.voices[0]).toHaveProperty("modelId");
-    expect(sc.voices[0]).toHaveProperty("modelName");
-    expect(sc.voices[0]).toHaveProperty("languageCode");
-    expect(sc.voices[0]).toHaveProperty("languageName");
-    expect(sc.voices[0]).toHaveProperty("gender");
+    // The English default is a brand contract; naming it pins every field, BCP-47 tag included.
+    expect(sc.voices.find((v) => v.voiceId === "en-am_michael")).toEqual({
+      voiceId: "en-am_michael",
+      modelId: "kokoro",
+      modelName: "Kokoro-82M",
+      languageCode: "en-US",
+      languageName: "American English",
+      gender: "male",
+    });
   });
 });
 
@@ -121,15 +122,18 @@ describe("list_languages tool", () => {
     const client = new Client({ name: "t", version: "0" });
     await client.connect(c);
     const res = await client.callTool({ name: "list_languages", arguments: {} });
-    expect(res.isError).toBeFalsy();
+    expect(res.isError).toBeUndefined();
     const sc = res.structuredContent as {
       languages: Array<{ languageCode: string; languageName: string; voiceCount: number }>;
     };
-    expect(Array.isArray(sc.languages)).toBe(true);
-    expect(sc.languages.length).toBeGreaterThan(0);
-    expect(sc.languages[0]).toHaveProperty("languageCode");
-    expect(sc.languages[0]).toHaveProperty("languageName");
-    expect(sc.languages[0]).toHaveProperty("voiceCount");
-    expect(typeof sc.languages[0].voiceCount).toBe("number");
+    expect(sc.languages.find((l) => l.languageCode === "en-US")).toMatchObject({
+      languageCode: "en-US",
+      languageName: "American English",
+    });
+    // voiceCount must count the voices actually listed, not be a shape-check placeholder.
+    const voices = (await listVoices()) as Array<{ languageCode: string }>;
+    for (const lang of sc.languages) {
+      expect(lang.voiceCount).toBe(voices.filter((v) => v.languageCode === lang.languageCode).length);
+    }
   });
 });

--- a/tests/unit/stats-action.test.ts
+++ b/tests/unit/stats-action.test.ts
@@ -57,14 +57,17 @@ describe("runStatsAction", () => {
     const result = runStatsAction({ action: "export", format: "json" });
     if (!result.ok) throw new Error(result.error);
     expect(result.messages).toEqual([]);
-    expect(() => JSON.parse(result.stdout ?? "")).not.toThrow();
+    const exported = JSON.parse(result.stdout ?? "");
+    expect(exported).toMatchObject({ runs: [], artifacts: [] });
   });
 
   test("export accepts the format as a positional value", () => {
     enableStats();
     const result = runStatsAction({ action: "export", value: "csv" });
     if (!result.ok) throw new Error(result.error);
-    expect(result.stdout).toBeDefined();
+    // `toBeDefined` passed for the JSON payload too, so it never proved the positional took effect.
+    expect(result.stdout?.split("\n")[0]).toContain(",");
+    expect(result.stdout?.trimStart().startsWith("{")).toBe(false);
   });
 
   test("export rejects an unknown format with a usage hint", () => {
@@ -99,8 +102,8 @@ describe("runStatsAction", () => {
   });
 
   test("week and errors render without an existing database", () => {
-    expect(texts(runStatsAction({ action: "week" })).length).toBeGreaterThan(0);
-    expect(texts(runStatsAction({ action: "errors" })).length).toBeGreaterThan(0);
+    expect(texts(runStatsAction({ action: "week" }))[0]).toContain("Runs: 0 (0 success, 0 failed)");
+    expect(texts(runStatsAction({ action: "errors" }))[0]).toBe("Kesha Stats - no recorded errors");
   });
 
   test("reset and vacuum report what they changed", () => {

--- a/tests/unit/status.test.ts
+++ b/tests/unit/status.test.ts
@@ -337,14 +337,17 @@ describe("collectStatus --json payload (#647)", () => {
 
   posixEngineTest("--disk toggles the disk section", async () => {
     const { dir, cache } = healthyEngine();
+    const model = "model";
     mkdirSync(join(cache, "models", "parakeet-tdt-v3"), { recursive: true });
-    writeFileSync(join(cache, "models", "parakeet-tdt-v3", "model.onnx"), "model");
+    writeFileSync(join(cache, "models", "parakeet-tdt-v3", "model.onnx"), model);
     try {
       expect((await collectStatus()).disk).toBeNull();
       const withDisk = await collectStatus({ disk: true });
-      expect(withDisk.disk).not.toBeNull();
-      expect(withDisk.disk!.components.length).toBeGreaterThan(0);
-      expect(withDisk.disk!.totalBytes).toBeGreaterThan(0);
+      const disk = withDisk.disk!;
+      expect(disk.components.map((c) => c.label)).toEqual(["Engine", "ASR (Parakeet)"]);
+      expect(disk.components.find((c) => c.label === "ASR (Parakeet)")!.sizeBytes).toBe(model.length);
+      // The stub engine's own byte count is incidental; that the total sums them is not.
+      expect(disk.totalBytes).toBe(disk.components.reduce((n, c) => n + c.sizeBytes, 0));
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -976,8 +979,7 @@ describe("human status output is a load-bearing contract (#647)", () => {
       ]);
       await proc.exited;
       const binaryLine = stdout.split("\n").find((l) => l.includes("Binary:"));
-      expect(binaryLine).toBeDefined();
-      expect(binaryLine!).toContain("not installed");
+      expect(binaryLine).toContain("not installed");
       // The human path has no payload to carry the hint, so it has to reach stderr.
       expect(stderr).toContain("kesha install");
     } finally {


### PR DESCRIPTION
Round three of the Beck-lens audit, after #829 and #833. Ten files, two themes.

### 1. Presence checks replaced with the known answer

Sizes are pinned to the bytes the test itself writes, so a size that stops being computed fails instead of staying `> 0`:

| Site | Was | Now |
|---|---|---|
| `doctor` cache | `totalBytes > 0` | `"vad".length` |
| `doctor` logs | `activeSizeBytes > 0` | `"diagnostic\n".length`, and the total is active + rotated |
| `fluid-kokoro-cache` | `sizeBytes > 0` | `"coreml".length` |
| `status --disk` | `components.length > 0` | which components are reported, the model's exact size, and that the total sums them |

`status --disk` deliberately does **not** hardcode the stub engine's own 154 bytes — that number is incidental, the summation invariant is not.

`list_voices` now pins `en-am_michael` field by field. That is a brand contract (CLAUDE.md), and doing it surfaced something six `toHaveProperty` calls never showed: `languageCode` is a BCP-47 tag (`"en-US"`), not `"en"`. `list_languages` now checks `voiceCount` against the voices actually listed rather than that the field exists.

`stats-action`'s CSV-export test asserted only `stdout` was defined — which the JSON payload also satisfies, so it never proved the positional format took effect.

### 2. `not.toThrow()` and `> 0` that are *correct*, and stayed

The census found ~40 hits; only about half were genuinely weak. Left alone deliberately:

- `not.toThrow()` on a validator's happy path (`derive-alpha-version`, `engine-install-decisions`) — that *is* the contract of an assert-function.
- `cmp(a, b) > 0` in `semver` — a comparator's contract is the sign, not a value.
- `renderStatus(report)` in `status` — it returns `undefined` and prints, so not-throwing is the only assertable contract, and the #647 bug was literally a crash. Capturing its stdout would be the console-spy pattern CLAUDE.md warns against.

### 3. Two files hand-rolling the same stub

`doctor.test.ts` defined a local `writeFakeEngine(path, body)` while `tests/helpers` exports `writeFakeEngine(binDir, capabilities)` — same name, different contract, and the shared one is importable from that file. Renamed the local to `writeEngineStub`.

`engine.test.ts` and `lib.test.ts` each carried a ~19-line copy of the same capabilities+transcribe stub, differing only in the transcribe reply; both now call a shared `writeTranscribingEngine`.

### Verification

- `bun test` — 1099 pass / 5 skip / **0 fail**, against the real engine (v1.24.9), so `e2e-engine` and `mcp-e2e` run rather than skip
- `bunx tsc --noEmit` — clean
- Assertion count rose 2810 → 2858 on the same test count
- No Rust changes

### On size

This is ~150 lines, not the ~500 you asked for. The remaining assertion work genuinely was this small once the false positives above were excluded, and I would rather not pad it. The real bulk is still open and wants its own focused pass: repowise puts `status.test.ts` at 63% duplicated (320 clone pairs), `cli.test.ts` and `engine.test.ts` at 60%, and `cli-contracts.test.ts` at 44% with a 65-line clone shared with `engine.test.ts`. Consolidating those staging helpers is a few hundred lines on its own and is easy to get subtly wrong, so it deserves to be the whole of the next PR rather than a rider on this one.