### PR TITLE
fix(tts): make the English pronunciation table reach the ANE G2P

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -677,7 +677,7 @@ dependencies = [
 [[package]]
 name = "fluidaudio-rs"
 version = "0.15.5"
-source = "git+https://github.com/drakulavich/fluidaudio-rs?rev=91d80ea0b9066d7b5254ea68b1836f7ae46d8cb9#91d80ea0b9066d7b5254ea68b1836f7ae46d8cb9"
+source = "git+https://github.com/drakulavich/fluidaudio-rs?rev=861d4da8561f601039d85a9e89abc9c9b599ec19#861d4da8561f601039d85a9e89abc9c9b599ec19"
 dependencies = [
  "thiserror 1.0.69",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -81,7 +81,7 @@ ndarray = { version = "0.17" }
 # bindings are gone because 0.15.3 removed the backend upstream.
 # `init_kokoro` still takes `lang` → `zh` selects `.mandarin` (tone-aware
 # Mandarin G2P), else `.english` (#492); `--rate` stays model-native (#475).
-fluidaudio-rs = { git = "https://github.com/drakulavich/fluidaudio-rs", rev = "91d80ea0b9066d7b5254ea68b1836f7ae46d8cb9", optional = true }
+fluidaudio-rs = { git = "https://github.com/drakulavich/fluidaudio-rs", rev = "861d4da8561f601039d85a9e89abc9c9b599ec19", optional = true }
 audioadapter-buffers = "3.0.0"
 
 # ITN for `--itn` (#710). Called directly: fluidaudio-rs::itn_normalize is a dlsym shim over a libnemo_text_processing nothing links, so it returns its input verbatim.

--- a/rust/src/tts/en/acronym.rs
+++ b/rust/src/tts/en/acronym.rs
@@ -26,7 +26,7 @@ const STOP_LIST: &[&str] = &[
 /// Token → IPA phoneme map. Keys are case-sensitive. Values use IPA without
 /// syllable separators — `infer_ipa` accepts stress (`ˈ` `ˌ`) and length (`ː`)
 /// marks but not `.` separators.
-const IPA_LEXICON: &[(&str, &str)] = &[
+pub(super) const IPA_LEXICON: &[(&str, &str)] = &[
     ("EPAM", "ˈiːpæm"),
     ("JSON", "ˈdʒeɪsən"),
     ("JPEG", "ˈdʒeɪpɛɡ"),
@@ -239,31 +239,26 @@ mod tests {
         }
     }
 
-    /// A failure here is a maintainer-side data error (typo/wrong char), not a code bug.
+    /// A failure here is a maintainer-side data error (typo/wrong char), not a
+    /// code bug. Both Kokoro paths encode an IPA string character by character
+    /// against the same vocab and drop what it does not cover — silently, on
+    /// purpose, matching upstream misaki — so a wrong character costs the
+    /// phoneme rather than raising anything. FluidAudio's ANE chain ships a
+    /// byte-identical `vocab.json`, which is what lets the ANE path take these
+    /// values verbatim through `setEnglishCustomLexicon` (#818).
     #[test]
-    fn ipa_lexicon_values_are_well_formed() {
+    fn ipa_lexicon_values_survive_kokoro_tokenization() {
+        let tokenizer = crate::tts::tokenizer::Tokenizer::load().expect("kokoro vocab");
         for (key, ipa) in IPA_LEXICON {
             assert!(!ipa.is_empty(), "IPA_LEXICON entry {key:?} has empty value");
-            for ch in ipa.chars() {
-                let ok = ch.is_ascii_lowercase()           // a-z (rare in IPA but ok)
-                    || ch.is_whitespace()                  // space-separated phoneme groups
-                    || matches!(
-                        ch,
-                        // Stress + length + syllable separator
-                        'ˈ' | 'ˌ' | 'ː' | '.' |
-                        // Vowel symbols
-                        'ə' | 'ɛ' | 'ɪ' | 'ɒ' | 'ɔ' | 'ʌ' | 'ʊ' | 'æ' | 'ɑ' |
-                        // Consonant symbols
-                        'ʃ' | 'ʒ' | 'ʧ' | 'ʤ' | 'ŋ' | 'θ' | 'ð' | 'ɹ' | 'ɾ' | 'ɫ' |
-                        // Velar g (IPA U+0261, distinct from ASCII 'g') + tie / glottal
-                        'ɡ' | 'ʔ' | '͡'
-                    );
-                assert!(
-                    ok,
-                    "IPA_LEXICON[{key:?}] contains unexpected char {ch:?} (U+{:04X})",
-                    ch as u32
-                );
-            }
+            let dropped: Vec<char> = ipa
+                .chars()
+                .filter(|c| tokenizer.encode(&c.to_string()).is_empty())
+                .collect();
+            assert!(
+                dropped.is_empty(),
+                "IPA_LEXICON[{key:?}] = {ipa:?} has characters Kokoro cannot encode: {dropped:?}"
+            );
         }
     }
 }

--- a/rust/src/tts/en/mod.rs
+++ b/rust/src/tts/en/mod.rs
@@ -16,6 +16,15 @@ pub fn is_en(lang: &str) -> bool {
     lang.starts_with("en")
 }
 
+/// The pronunciation overrides as `(word, IPA)` pairs.
+///
+/// [`normalize_segments`] applies them by substitution, which suits an engine
+/// taking IPA. FluidAudio does its own G2P from raw text and instead accepts the
+/// table itself, so the ANE path hands it these pairs at init (#818).
+pub fn ipa_overrides() -> &'static [(&'static str, &'static str)] {
+    acronym::IPA_LEXICON
+}
+
 /// Normalize a segment list for the Kokoro path.
 /// `ProsodyRate` content is recursively normalized so that IPA_LEXICON
 /// overrides, `<say-as characters>`, and `<emphasis>` warnings remain active

--- a/rust/src/tts/fluid_kokoro.rs
+++ b/rust/src/tts/fluid_kokoro.rs
@@ -241,6 +241,17 @@ fn with_kokoro<R>(voice_id: &str, f: impl FnOnce(&FluidAudio) -> Result<R>) -> R
                     incomplete_bundle_hint()
                 ))
             })?;
+        // FluidAudio phonemizes raw text itself, so `en::normalize_segments`
+        // never runs here and substituting IPA into the text is not an option.
+        // Handing it the table instead makes our pronunciations authoritative
+        // ahead of its bundled Misaki lexicon and its G2P fallback (#818).
+        if crate::tts::en::is_en(lang) {
+            audio
+                .set_kokoro_english_lexicon(crate::tts::en::ipa_overrides())
+                .map_err(|e| {
+                    anyhow::Error::new(e).context("install the English pronunciation overrides")
+                })?;
+        }
         f(&audio)
     })
 }


### PR DESCRIPTION
Closes #818

## What was broken

FluidAudio does its own G2P from raw text, so the darwin-arm64 Kokoro path never builds a segment list and never runs `en::normalize_segments`. `IPA_LEXICON` — plus `STOP_LIST` and the letter-spell rule — therefore applied on Linux/Windows and not on the Mac, the platform every Apple Silicon release serves.

Upstream 0.15.5 added `KokoroAneManager.setEnglishCustomLexicon(_:)`: it takes the *table* instead of pre-substituted IPA, which is the shape that fits an engine owning its own G2P. This binds it and feeds it `IPA_LEXICON` at Kokoro init for English voices.

## Fork branch

`drakulavich/fluidaudio-rs` → [`feat/english-custom-lexicon`](https://github.com/drakulavich/fluidaudio-rs/tree/feat/english-custom-lexicon), one commit `861d4da`, branched from `91d80ea` (the rev main pinned, `feat/diarize-control`) so nothing from #806 is dropped. Swift `@_cdecl` + `extern "C"` + safe wrapper + public API, mirroring the compute-units surface. The pin moves `91d80ea` → `861d4da`.

#823 (offline mode) can ride the same pattern: branch from `861d4da`, add its symbol, bump the pin once.

## The format question, answered before writing the binding

`setEnglishCustomLexicon` takes `[String: String]` — word → Misaki-style IPA — and `KokoroAneEnglishPhonemizer.resolveWord` returns the value **verbatim** into the phoneme string, which `KokoroAneVocab.encode` then encodes character by character, silently dropping anything outside the vocab.

That vocab is `~/.cache/fluidaudio/Models/kokoro-82m-coreml/ANE/vocab.json`. It is **byte-identical** to the `rust/fixtures/tts/kokoro_vocab.json` the ONNX tokenizer embeds (114 entries, same keys, same ids). Every one of the 19 `IPA_LEXICON` values encodes with nothing dropped. So there is no Misaki-vs-decomposed conversion to do, and no wrong-alphabet risk to report.

The old `ipa_lexicon_values_are_well_formed` test guarded that with a hand-maintained charset which permitted ASCII `g`, `ɫ` and the tie bar `͡` — three characters neither engine can encode. It is replaced with one that runs the values through `Tokenizer::encode` and fails on anything dropped. Verified both ways: it passes today, and fails with `IPA_LEXICON["GIF"] = "gɪɫf" has characters Kokoro cannot encode: ['g', 'ɫ']`.

## Before/after on this machine

Three release binaries from the same tree, real ANE, models already staged: ONNX (`--release`), ANE-before (`origin/main` + `system_kokoro`), ANE-after (this branch + `system_kokoro`). Each sentence synthesized with `en-am_michael` and read back with the same Parakeet build. WAVs are in the scratchpad for the audio-QC pass.

The decisive rows — where ANE-before was FluidAudio's own pronunciation and ANE-after is the lexicon's, matching ONNX:

| word | ONNX | ANE-before | ANE-after |
|---|---|---|---|
| Kubernetes | Ocuberinides | Kubernetes | **Ocuberinides** |
| PostgreSQL | a Post-Gres | Post-Greskell | Apostres |
| JSON | a JSON | J SON | Adjacent |
| GraphQL | AgraphicUL | GraphCall | a GraphiQL |
| Tokio | Otokio | Tokyo | O Tokyo |
| macOS | Amakois | Maccos | Amakoas |
| OAuth | OAuth | Oath | OAuth |

`Kubernetes` is the cleanest single proof: ANE-after is character-for-character the ONNX transcript and character-for-character different from ANE-before. `EPAM`, `GIF`, `Claude`, `Linux` are unchanged on all three arms — the table already agreed with FluidAudio there.

Exact transcript equality across engines is a poor score (the two chains produce acoustically different audio, cf. #826, so ASR differs on leading articles even where the pronunciation matches) — the per-row before→after movement is the signal, not the 6/19 exact-match count.

## Rows I am not sure about — owner's ear

Four entries render with a spurious leading vowel on **both** engines once the table applies: `Kubernetes` → "Ocuberinides", `Tokio` → "O Tokyo", `macOS` → "Amakoas", `Anthropic` → "Anotropic". This is pre-existing ONNX behaviour, not introduced here — the change is that darwin now shares it. On those four, FluidAudio's native G2P arguably sounded better before. That is a question about the table's IPA, not about the binding, and it needs a listen rather than an ASR transcript; happy to open a follow-up to prune or repair those rows if they sound wrong.

## Letter-spell rule, `STOP_LIST`, and the capability (#818 items 4 and 5)

Measured, not assumed. On ANE at 0.15.5, `FBI`/`IBM`/`HTTP` are already spelled as letter names — upstream's own `EnglishInitialisms` (their #710) does it after a lexicon miss, so that half needs nothing from us and the pronunciation matches ONNX.

What does *not* carry over is the opt-out: `--no-expand-abbrev` produces a byte-identical WAV on ANE (`c6d16d40` both ways for the FBI sentence), because there is no upstream knob to suppress native initialism spelling. So `tts.en_acronym_expansion` is now genuinely served on darwin `system_kokoro` — the table applies and acronyms are letter-spelled — and `capabilities.rs` is left advertising it, now truthfully. The residual `--no-expand-abbrev` gap is narrower than the capability string and worth its own issue; note also that `--help` already documents that flag as Russian-only ("No effect for non-`ru-vosk-*` voices") while it does affect English on ONNX, which is the same inconsistency seen from the other side.

## Verification

- `cargo fmt --check` — clean
- `make rust-test` — 488 passed, 0 failed
- `cargo clippy --all-targets -- -D warnings` — clean; also clean with `--features system_kokoro`
- `cargo check --features coreml --no-default-features` — ok
- `cargo check --features system_kokoro --no-default-features` — ok
- `cargo check --features system_diarize --no-default-features` — ok
- `bunx tsc --noEmit` — clean; `bun test` — 1100 pass, 4 skip, 0 fail
- Fork: `cargo test --test ffi_bindings` — 22 passed; the real-engine `english_lexicon_changes_the_synthesized_audio` passes under `--ignored`, proving the table reaches the G2P

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBTpJjqyYFW6W8LHJ2nwy