### PR TITLE
[do not merge] CI control: coreml-regression at main's pin

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -677,7 +677,7 @@ dependencies = [
 [[package]]
 name = "fluidaudio-rs"
 version = "0.15.5"
-source = "git+https://github.com/drakulavich/fluidaudio-rs?rev=91d80ea0b9066d7b5254ea68b1836f7ae46d8cb9#91d80ea0b9066d7b5254ea68b1836f7ae46d8cb9"
+source = "git+https://github.com/drakulavich/fluidaudio-rs?rev=861d4da8561f601039d85a9e89abc9c9b599ec19#861d4da8561f601039d85a9e89abc9c9b599ec19"
 dependencies = [
  "thiserror 1.0.69",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -81,7 +81,7 @@ ndarray = { version = "0.17" }
 # bindings are gone because 0.15.3 removed the backend upstream.
 # `init_kokoro` still takes `lang` → `zh` selects `.mandarin` (tone-aware
 # Mandarin G2P), else `.english` (#492); `--rate` stays model-native (#475).
-fluidaudio-rs = { git = "https://github.com/drakulavich/fluidaudio-rs", rev = "91d80ea0b9066d7b5254ea68b1836f7ae46d8cb9", optional = true }
+fluidaudio-rs = { git = "https://github.com/drakulavich/fluidaudio-rs", rev = "861d4da8561f601039d85a9e89abc9c9b599ec19", optional = true }
 audioadapter-buffers = "3.0.0"
 
 # ITN for `--itn` (#710). Called directly: fluidaudio-rs::itn_normalize is a dlsym shim over a libnemo_text_processing nothing links, so it returns its input verbatim.

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -108,3 +108,5 @@ fn build_text_lang_helper() {
         out_bin.display()
     );
 }
+
+// CI control for #818: exercise the coreml-regression guard at main's fluidaudio-rs pin.


### PR DESCRIPTION
Temporary diagnostic for #835 (issue #818). That PR bumps the fluidaudio-rs pin, which fires the `coreml-regression` guard, and the guard fails. This branch is origin/main plus a one-line comment in `rust/build.rs` so the same guard runs at main's pin, in the same environment, on the same day — the control I need before deciding whether #835's failure is caused by the bump.

Will be closed as soon as the job reports.