### PR TITLE
ci(cache): stop downloading the Vosk-RU bundle no test reads

### DIFF
--- a/.github/actions/setup-kokoro-models/action.yml
+++ b/.github/actions/setup-kokoro-models/action.yml
@@ -1,8 +1,8 @@
 name: Setup Kokoro TTS models
 description: >
-  Restore-or-download the shared Kokoro + Vosk-RU + multilingual CharsiuG2P model
-  cache used by every TTS test lane (rust-test nextest + ci.yml say-e2e). One cache
-  key per OS so the macOS lanes share a single ~1.3 GB cache instead of duplicating it.
+  Restore-or-download the shared Kokoro + CharsiuG2P model cache used by every TTS
+  test lane (rust-test nextest + ci.yml say-e2e). One cache key per OS so the macOS
+  lanes share a single ~340 MB cache instead of duplicating it.
 
   Restore-only by design: writing is the job of cache-seed.yml on main. GitHub
   scopes a cache written during a pull_request run to that PR's merge ref, so only
@@ -31,15 +31,20 @@ runs:
     # an unchanged path — on main, for everyone.
     #
     # The prefix restore-key warm-starts from the previous bundle after an edit,
-    # so a model-set change tops up the delta instead of re-fetching ~1.1 GB.
+    # so a model-set change tops up the delta instead of re-fetching ~340 MB.
+    # That is also why the `v<n>` exists despite the argument above: dropping a
+    # model can only shrink the cache if the prefix stops matching the entries
+    # that still carry it, since the save persists the whole directory and would
+    # otherwise re-inherit what the script no longer downloads. Bump it when the
+    # change is a *removal* (#741), never for an addition.
     # Keep both in sync with the write side in .github/workflows/cache-seed.yml.
     - name: Restore TTS models
       uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ inputs.cache-dir }}
-        key: kokoro-models-v1-${{ runner.os }}-${{ hashFiles('rust/ci/download-kokoro.sh') }}
+        key: kokoro-models-v2-${{ runner.os }}-${{ hashFiles('rust/ci/download-kokoro.sh') }}
         restore-keys: |
-          kokoro-models-v1-${{ runner.os }}
+          kokoro-models-v2-${{ runner.os }}
 
     # Idempotent: downloads only the files the restore didn't provide, so a cold
     # cache still works (just slower) and a warm one costs nothing.

--- a/.github/actions/setup-kokoro-models/action.yml
+++ b/.github/actions/setup-kokoro-models/action.yml
@@ -19,6 +19,13 @@ inputs:
     description: Model cache directory (also used as KOKORO_CACHE by callers).
     required: false
     default: ${{ github.workspace }}/.kokoro-spike
+  vosk:
+    description: >
+      Also stage the ~935 MB Vosk-TTS-RU bundle. Only the one lane that runs
+      `tts::vosk::tests::synth_short_phrase_produces_audio` needs it; every other
+      caller leaves this false and keeps its cache entry ~935 MB smaller (#741).
+    required: false
+    default: "false"
 
 runs:
   using: composite
@@ -42,9 +49,9 @@ runs:
       uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ inputs.cache-dir }}
-        key: kokoro-models-v2-${{ runner.os }}-${{ hashFiles('rust/ci/download-kokoro.sh') }}
+        key: kokoro-models-v2-${{ runner.os }}-vosk${{ inputs.vosk }}-${{ hashFiles('rust/ci/download-kokoro.sh') }}
         restore-keys: |
-          kokoro-models-v2-${{ runner.os }}
+          kokoro-models-v2-${{ runner.os }}-vosk${{ inputs.vosk }}
 
     # Idempotent: downloads only the files the restore didn't provide, so a cold
     # cache still works (just slower) and a warm one costs nothing.
@@ -52,4 +59,5 @@ runs:
       shell: bash
       env:
         KOKORO_CACHE_DIR: ${{ inputs.cache-dir }}
+        WITH_VOSK: ${{ inputs.vosk == 'true' && '1' || '0' }}
       run: bash rust/ci/download-kokoro.sh "$KOKORO_CACHE_DIR"

--- a/.github/workflows/cache-seed.yml
+++ b/.github/workflows/cache-seed.yml
@@ -74,7 +74,7 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ env.KOKORO_CACHE }}
-          key: kokoro-models-v2-${{ runner.os }}-${{ hashFiles('rust/ci/download-kokoro.sh') }}
+          key: kokoro-models-v2-${{ runner.os }}-vosk${{ runner.os == 'Linux' }}-${{ hashFiles('rust/ci/download-kokoro.sh') }}
           lookup-only: true
 
       # Restores through the prefix key (so a model-set change tops up the delta
@@ -84,13 +84,15 @@ jobs:
         uses: ./.github/actions/setup-kokoro-models
         with:
           cache-dir: ${{ env.KOKORO_CACHE }}
+          # Only the Linux lane runs the Vosk synth test, so only Linux carries the bundle.
+          vosk: ${{ runner.os == 'Linux' }}
 
       - name: Save TTS models
         if: steps.probe.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ env.KOKORO_CACHE }}
-          key: kokoro-models-v2-${{ runner.os }}-${{ hashFiles('rust/ci/download-kokoro.sh') }}
+          key: kokoro-models-v2-${{ runner.os }}-vosk${{ runner.os == 'Linux' }}-${{ hashFiles('rust/ci/download-kokoro.sh') }}
 
   parakeet:
     name: Parakeet CoreML models

--- a/.github/workflows/cache-seed.yml
+++ b/.github/workflows/cache-seed.yml
@@ -60,7 +60,7 @@ jobs:
       KOKORO_CACHE: ${{ github.workspace }}/.kokoro-spike
     steps:
       # Needed before the probe: the cache key hashes rust/ci/download-kokoro.sh,
-      # and hashFiles resolves against the workspace. Cheap next to the 1.1 GB the
+      # and hashFiles resolves against the workspace. Cheap next to the 340 MB the
       # probe is deciding about.
       - name: 📥 Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -74,11 +74,11 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ env.KOKORO_CACHE }}
-          key: kokoro-models-v1-${{ runner.os }}-${{ hashFiles('rust/ci/download-kokoro.sh') }}
+          key: kokoro-models-v2-${{ runner.os }}-${{ hashFiles('rust/ci/download-kokoro.sh') }}
           lookup-only: true
 
       # Restores through the prefix key (so a model-set change tops up the delta
-      # instead of re-fetching ~1.1 GB) and downloads whatever is still missing.
+      # instead of re-fetching ~340 MB) and downloads whatever is still missing.
       - name: Populate models
         if: steps.probe.outputs.cache-hit != 'true'
         uses: ./.github/actions/setup-kokoro-models
@@ -90,7 +90,7 @@ jobs:
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ env.KOKORO_CACHE }}
-          key: kokoro-models-v1-${{ runner.os }}-${{ hashFiles('rust/ci/download-kokoro.sh') }}
+          key: kokoro-models-v2-${{ runner.os }}-${{ hashFiles('rust/ci/download-kokoro.sh') }}
 
   parakeet:
     name: Parakeet CoreML models

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -744,8 +744,8 @@ jobs:
         env:
           KOKORO_MODEL: ${{ env.KOKORO_CACHE }}/model.onnx
           KOKORO_VOICE: ${{ env.KOKORO_CACHE }}/am_michael.bin
-          # Vosk-ru lives under this dir (see rust/ci/download-kokoro.sh)
-          # — runtime loader resolves it via `models::vosk_ru_model_dir()`.
+          # Runtime Kokoro layout (models/kokoro-82m/…) lives under this dir. Vosk-ru
+          # no longer does — only the coverage lane stages that bundle (#741).
           KESHA_CACHE_DIR: ${{ env.KOKORO_CACHE }}
           KESHA_ENGINE_BIN: ${{ github.workspace }}/rust/target/release/kesha-engine
           DYLD_FALLBACK_LIBRARY_PATH: /opt/homebrew/lib

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -91,6 +91,10 @@ jobs:
     env:
       KOKORO_CACHE: ${{ github.workspace }}/.kokoro-spike
       MACOSX_DEPLOYMENT_TARGET: "14.0"
+      # This lane stages models, so a gate that can't find them is a broken
+      # layout, not a laptop — fail instead of skipping to a green run of
+      # nothing (#741). Lanes that stage nothing (rust-push-gate) leave it unset.
+      KESHA_REQUIRE_MODEL_TESTS: "1"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Select Xcode 16 (Swift 6)
@@ -225,6 +229,7 @@ jobs:
     env:
       KOKORO_CACHE: ${{ github.workspace }}/.kokoro-spike
       NEXTEST_PROFILE: ci
+      KESHA_REQUIRE_MODEL_TESTS: "1"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -260,20 +265,7 @@ jobs:
       - name: 📈 Rust coverage
         shell: bash
         run: |
-          if [[ -f "$KOKORO_CACHE/model.onnx" && -f "$KOKORO_CACHE/am_michael.bin" ]]; then
-            export KOKORO_MODEL="$KOKORO_CACHE/model.onnx"
-            export KOKORO_VOICE="$KOKORO_CACHE/am_michael.bin"
-            echo "KOKORO_MODEL=$KOKORO_CACHE/model.onnx" >> "$GITHUB_ENV"
-            echo "KOKORO_VOICE=$KOKORO_CACHE/am_michael.bin" >> "$GITHUB_ENV"
-          fi
-          if [[ -f "$KOKORO_CACHE/models/vosk-ru/model.onnx" && -f "$KOKORO_CACHE/models/vosk-ru/bert/model.onnx" ]]; then
-            export KESHA_CACHE_DIR="$KOKORO_CACHE"
-            echo "KESHA_CACHE_DIR=$KOKORO_CACHE" >> "$GITHUB_ENV"
-          fi
-          if [[ -f "$KOKORO_CACHE/models/g2p/byt5-tiny/encoder_model.onnx" ]]; then
-            export CHARSIU_ONNX="$KOKORO_CACHE/models/g2p/byt5-tiny"
-            echo "CHARSIU_ONNX=$KOKORO_CACHE/models/g2p/byt5-tiny" >> "$GITHUB_ENV"
-          fi
+          source rust/ci/kokoro-env.sh "$KOKORO_CACHE"
           bun run coverage:rust
 
       - name: 📤 Upload Ubuntu JUnit

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -230,6 +230,9 @@ jobs:
       KOKORO_CACHE: ${{ github.workspace }}/.kokoro-spike
       NEXTEST_PROFILE: ci
       KESHA_REQUIRE_MODEL_TESTS: "1"
+      # Separate from the flag above because this is the only lane staging Vosk;
+      # the macOS/Windows lanes promise Kokoro + G2P and nothing more.
+      KESHA_REQUIRE_VOSK_TESTS: "1"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -261,6 +264,10 @@ jobs:
 
       - name: 🎚️ Setup Kokoro TTS models
         uses: ./.github/actions/setup-kokoro-models
+        with:
+          # This is the one lane that runs the Vosk synth test, so it is the one
+          # lane that pays for the bundle (#741).
+          vosk: "true"
 
       - name: 📈 Rust coverage
         shell: bash

--- a/rust/ci/download-kokoro.sh
+++ b/rust/ci/download-kokoro.sh
@@ -1,12 +1,10 @@
 #!/usr/bin/env bash
-# Download Kokoro + Vosk-TTS-Russian ONNX models for CI tts_e2e tests.
+# Download the Kokoro + CharsiuG2P models the CI tts lanes actually read.
 # Called by rust-test.yml; cache warms on subsequent runs.
 #
 # Kokoro files land directly in $DEST (legacy layout — the test env vars
-# KOKORO_MODEL / KOKORO_VOICE take direct paths). Vosk files land under
-# $DEST/models/vosk-ru/, matching `models::vosk_ru_model_dir()` so the
-# runtime loader finds them when KESHA_CACHE_DIR=$DEST is set by the
-# test runner.
+# KOKORO_MODEL / KOKORO_VOICE take direct paths) and are hardlinked into the
+# runtime layout below, which is what KESHA_CACHE_DIR=$DEST resolves against.
 set -euo pipefail
 
 DEST="${1:?usage: download-kokoro.sh <dest_dir>}"
@@ -43,40 +41,13 @@ if [[ ! -f "$DEST/am_michael.bin" ]]; then
     https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices/am_michael.bin
 fi
 
-# Vosk-TTS Russian (replaces old engine as of #213). Multi-speaker model,
-# 5 files, ~935 MB total. SHA-256 pinned in rust/src/models.rs::vosk_ru_manifest().
-# Downloads run in parallel to keep cold-cache CI times bounded.
-VOSK_DIR="$DEST/models/vosk-ru"
-mkdir -p "$VOSK_DIR/bert"
-VOSK_BASE="https://huggingface.co/drakulavich/vosk-tts-ru-0.9-multi/resolve/main"
-download_if_missing() {
-  local rel="$1"
-  if [[ ! -f "$VOSK_DIR/$rel" ]]; then
-    echo "Downloading Vosk $rel..."
-    fetch "$VOSK_DIR/$rel" "$VOSK_BASE/$rel"
-  fi
-}
-# Bare `wait` reports success even when a background job failed, so a partial
-# bundle used to reach the caller as exit 0 — and cache-seed.yml would then
-# persist it on main under an immutable key that never self-heals. Wait on each
-# PID and propagate the first failure instead.
-vosk_pids=()
-for rel in model.onnx dictionary config.json bert/model.onnx bert/vocab.txt; do
-  download_if_missing "$rel" &
-  vosk_pids+=("$!")
-done
-vosk_failed=0
-for pid in "${vosk_pids[@]}"; do
-  wait "$pid" || vosk_failed=1
-done
-if [[ "$vosk_failed" -ne 0 ]]; then
-  echo "error: at least one Vosk download failed; refusing to report a partial bundle" >&2
-  exit 1
-fi
+# Vosk-TTS Russian used to be fetched here — ~935 MB per OS, cached on three,
+# and read by nothing: `vosk_ru_cache_dir_or_skip` had no callers and
+# smoke-synthesis.ts deliberately excludes Russian (#741). Russian synthesis is
+# covered by unit tests and the fake-engine `say.test.ts`. Re-adding it needs a
+# test that consumes it, not just a manifest entry.
 
 ls -lh "$DEST"
-ls -lh "$VOSK_DIR"
-ls -lh "$VOSK_DIR/bert"
 
 # Runtime cache layout (models/kokoro-82m/...) for tests that resolve Kokoro via
 # KESHA_CACHE_DIR instead of the flat KOKORO_MODEL env — tts_multilang_audio.

--- a/rust/ci/download-kokoro.sh
+++ b/rust/ci/download-kokoro.sh
@@ -41,11 +41,42 @@ if [[ ! -f "$DEST/am_michael.bin" ]]; then
     https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices/am_michael.bin
 fi
 
-# Vosk-TTS Russian used to be fetched here — ~935 MB per OS, cached on three,
-# and read by nothing: `vosk_ru_cache_dir_or_skip` had no callers and
-# smoke-synthesis.ts deliberately excludes Russian (#741). Russian synthesis is
-# covered by unit tests and the fake-engine `say.test.ts`. Re-adding it needs a
-# test that consumes it, not just a manifest entry.
+# Vosk-TTS Russian, ~935 MB. Exactly one consumer:
+# `tts::vosk::tests::synth_short_phrase_produces_audio`, which needs real weights
+# (the ONNX sessions live inside the vosk_tts crate, so nothing can stand in for
+# them). One lane running it is the whole boundary — Vosk behaves the same on
+# every OS — so only the caller that passes WITH_VOSK=1 pays for it instead of
+# all three (#741).
+if [[ "${WITH_VOSK:-0}" == "1" ]]; then
+  VOSK_DIR="$DEST/models/vosk-ru"
+  mkdir -p "$VOSK_DIR/bert"
+  VOSK_BASE="https://huggingface.co/drakulavich/vosk-tts-ru-0.9-multi/resolve/main"
+  download_if_missing() {
+    local rel="$1"
+    if [[ ! -f "$VOSK_DIR/$rel" ]]; then
+      echo "Downloading Vosk $rel..."
+      fetch "$VOSK_DIR/$rel" "$VOSK_BASE/$rel"
+    fi
+  }
+  # Bare `wait` reports success even when a background job failed, so a partial
+  # bundle used to reach the caller as exit 0 — and cache-seed.yml would then
+  # persist it on main under an immutable key that never self-heals. Wait on each
+  # PID and propagate the first failure instead.
+  vosk_pids=()
+  for rel in model.onnx dictionary config.json bert/model.onnx bert/vocab.txt; do
+    download_if_missing "$rel" &
+    vosk_pids+=("$!")
+  done
+  vosk_failed=0
+  for pid in "${vosk_pids[@]}"; do
+    wait "$pid" || vosk_failed=1
+  done
+  if [[ "$vosk_failed" -ne 0 ]]; then
+    echo "error: at least one Vosk download failed; refusing to report a partial bundle" >&2
+    exit 1
+  fi
+  ls -lh "$VOSK_DIR" "$VOSK_DIR/bert"
+fi
 
 ls -lh "$DEST"
 

--- a/rust/ci/kokoro-env.sh
+++ b/rust/ci/kokoro-env.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Point the model-gated Rust tests at a staged Kokoro + CharsiuG2P cache.
+# Source it — it only exports. usage: source rust/ci/kokoro-env.sh <cache_dir>
+#
+# Both nextest lanes (rust-test.yml `test` via run-cargo-test.sh, and `coverage`)
+# read this one copy: they used to carry the same conditions inline, so a fix to
+# one silently left the other gating on something else (#741).
+
+_kokoro_cache="${1:?usage: source kokoro-env.sh <cache_dir>}"
+
+_kokoro_export() {
+  export "$1=$2"
+  if [[ -n "${GITHUB_ENV:-}" ]]; then
+    echo "$1=$2" >>"$GITHUB_ENV"
+  fi
+}
+
+if [[ -f "$_kokoro_cache/model.onnx" && -f "$_kokoro_cache/am_michael.bin" ]]; then
+  _kokoro_export KOKORO_MODEL "$_kokoro_cache/model.onnx"
+  _kokoro_export KOKORO_VOICE "$_kokoro_cache/am_michael.bin"
+  echo "Running with real Kokoro models from $_kokoro_cache"
+else
+  echo "Kokoro cache empty — gated tests will skip"
+fi
+
+# Gate on the runtime layout `common::kokoro_cache_dir_or_skip` resolves against.
+# This used to gate on the Vosk-RU bundle, which no test ever read — deleting
+# that bundle would then have left KESHA_CACHE_DIR unset and skipped
+# tts_multilang_audio silently, on a green run (#741).
+if [[ -f "$_kokoro_cache/models/kokoro-82m/model.onnx" ]]; then
+  _kokoro_export KESHA_CACHE_DIR "$_kokoro_cache"
+  echo "KESHA_CACHE_DIR=$_kokoro_cache (cache-resolved gated tests enabled)"
+fi
+
+if [[ -f "$_kokoro_cache/models/g2p/byt5-tiny/encoder_model.onnx" ]]; then
+  _kokoro_export CHARSIU_ONNX "$_kokoro_cache/models/g2p/byt5-tiny"
+  echo "CHARSIU_ONNX=$_kokoro_cache/models/g2p/byt5-tiny (multilingual TTS gated tests enabled)"
+fi
+
+unset _kokoro_cache

--- a/rust/ci/run-cargo-test.sh
+++ b/rust/ci/run-cargo-test.sh
@@ -1,13 +1,11 @@
 #!/usr/bin/env bash
-# Run `cargo test` with Kokoro env vars + KESHA_CACHE_DIR pointing at the
-# workflow's warm model cache. Skips the real-inference tests if the cache
-# is empty.
+# Run the nextest suite against the workflow's warm model cache. The env
+# staging lives in kokoro-env.sh so the coverage lane gates identically.
 set -euo pipefail
 
 KOKORO_CACHE="${1:?usage: run-cargo-test.sh <kokoro_cache> <runner_os>}"
 RUNNER_OS="${2:?}"
-
-cd rust
+CI_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 case "$RUNNER_OS" in
   macOS|Linux|Windows) ;;
@@ -17,28 +15,9 @@ case "$RUNNER_OS" in
     ;;
 esac
 
-if [[ -f "$KOKORO_CACHE/model.onnx" && -f "$KOKORO_CACHE/am_michael.bin" ]]; then
-  export KOKORO_MODEL="$KOKORO_CACHE/model.onnx"
-  export KOKORO_VOICE="$KOKORO_CACHE/am_michael.bin"
-  echo "Running with real Kokoro models from $KOKORO_CACHE"
-else
-  echo "Kokoro cache empty — gated tests will skip"
-fi
+# shellcheck source=rust/ci/kokoro-env.sh
+source "$CI_DIR/kokoro-env.sh" "$KOKORO_CACHE"
 
-# Vosk-ru lives under $KOKORO_CACHE/models/vosk-ru/... matching the
-# runtime `models::vosk_ru_model_dir()` layout (see download-kokoro.sh).
-if [[ -f "$KOKORO_CACHE/models/vosk-ru/model.onnx" && -f "$KOKORO_CACHE/models/vosk-ru/bert/model.onnx" ]]; then
-  export KESHA_CACHE_DIR="$KOKORO_CACHE"
-  echo "KESHA_CACHE_DIR=$KESHA_CACHE_DIR (Vosk gated tests enabled)"
-fi
-
-# CharsiuG2P for tts_multilang_audio (es/fr/it/pt). The runtime-layout Kokoro
-# model + multilang voices are staged by download-kokoro.sh; the test also gates
-# on CHARSIU_ONNX pointing at the byt5-tiny dir (KESHA_CACHE_DIR set above lets
-# kokoro_cache_dir_or_skip resolve the voices).
-if [[ -f "$KOKORO_CACHE/models/g2p/byt5-tiny/encoder_model.onnx" ]]; then
-  export CHARSIU_ONNX="$KOKORO_CACHE/models/g2p/byt5-tiny"
-  echo "CHARSIU_ONNX=$CHARSIU_ONNX (multilingual TTS gated tests enabled)"
-fi
+cd rust
 
 cargo nextest run --profile ci

--- a/rust/src/tts/vosk.rs
+++ b/rust/src/tts/vosk.rs
@@ -104,6 +104,14 @@ mod tests {
         }
         let dir = crate::models::model_dir(crate::models::ModelKind::VoskRu);
         if !crate::models::is_cached(crate::models::ModelKind::VoskRu) {
+            // This is the only consumer of the ~935 MB bundle, so a silent skip
+            // here is how CI would lose Russian synthesis coverage without any
+            // signal — the lane that stages it says so and gets a failure (#741).
+            assert!(
+                std::env::var_os("KESHA_REQUIRE_VOSK_TESTS").is_none(),
+                "vosk model not cached at {} while KESHA_REQUIRE_VOSK_TESTS is set",
+                dir.display()
+            );
             eprintln!(
                 "vosk model not cached at {} — skipping synth e2e test",
                 dir.display()

--- a/rust/tests/common/mod.rs
+++ b/rust/tests/common/mod.rs
@@ -135,6 +135,29 @@ pub fn kokoro_cache_dir_or_skip() -> Option<PathBuf> {
     None
 }
 
+/// Kokoro graph + `voice_name`'s pack under `cache`, or `None` when either is
+/// absent. Same policy as the gates above: a lane that promised models fails.
+pub fn kokoro_voice_or_skip(
+    cache: &std::path::Path,
+    voice_name: &str,
+) -> Option<(PathBuf, PathBuf)> {
+    let model = cache.join("models/kokoro-82m/model.onnx");
+    let voice = cache
+        .join("models/kokoro-82m/voices")
+        .join(format!("{voice_name}.bin"));
+    if model.exists() && voice.exists() {
+        return Some((model, voice));
+    }
+    assert!(
+        !models_required(),
+        "Kokoro graph or voice {voice_name} missing under {} while \
+         KESHA_REQUIRE_MODEL_TESTS is set — this lane stages the voice packs, so \
+         skipping here would be a green run of nothing (#741)",
+        cache.display()
+    );
+    None
+}
+
 /// Resolve the cache base used by every cache-based skip gate.
 /// `KESHA_CACHE_DIR` if set, else `$HOME/.cache/kesha`. Falls back to
 /// `/tmp/.cache/kesha` if `HOME` is unset (matches the historical

--- a/rust/tests/common/mod.rs
+++ b/rust/tests/common/mod.rs
@@ -80,6 +80,19 @@ pub fn assert_kokoro_speech(wav: &[u8], ctx: &str) -> Vec<f32> {
     samples
 }
 
+/// True when the lane promised to stage models, so a missing one must fail the
+/// run rather than skip. Every gate below returns `None` on a missing model and
+/// its callers return early, which nextest reports as a pass — so a lane whose
+/// layout stopped matching what the gates read goes green having run nothing
+/// (#741). CI lanes that stage models set `KESHA_REQUIRE_MODEL_TESTS`.
+pub fn missing_model_is_fatal(flag: Option<&str>) -> bool {
+    !matches!(flag, None | Some("") | Some("0"))
+}
+
+pub fn models_required() -> bool {
+    missing_model_is_fatal(std::env::var("KESHA_REQUIRE_MODEL_TESTS").ok().as_deref())
+}
+
 /// `KOKORO_MODEL` + `KOKORO_VOICE` env-var skip gate.
 ///
 /// Returns `Some((model, voice))` when both vars are set, `None` otherwise.
@@ -87,10 +100,15 @@ pub fn assert_kokoro_speech(wav: &[u8], ctx: &str) -> Vec<f32> {
 /// skip silently on CI runs that don't stage them. Callers print the skip
 /// reason themselves so each test owns its own message.
 pub fn kokoro_paths_or_skip() -> Option<(String, String)> {
-    match (std::env::var("KOKORO_MODEL"), std::env::var("KOKORO_VOICE")) {
-        (Ok(m), Ok(v)) => Some((m, v)),
-        _ => None,
+    if let (Ok(m), Ok(v)) = (std::env::var("KOKORO_MODEL"), std::env::var("KOKORO_VOICE")) {
+        return Some((m, v));
     }
+    assert!(
+        !models_required(),
+        "KOKORO_MODEL/KOKORO_VOICE unset while KESHA_REQUIRE_MODEL_TESTS is set — \
+         this lane stages models, so skipping here would be a green run of nothing (#741)"
+    );
+    None
 }
 
 /// Cache-based skip gate for Kokoro: returns the cache base
@@ -106,31 +124,15 @@ pub fn kokoro_cache_dir_or_skip() -> Option<PathBuf> {
     let model = base.join("models/kokoro-82m/model.onnx");
     let voice = base.join("models/kokoro-82m/voices/am_michael.bin");
     if model.exists() && voice.exists() {
-        Some(base)
-    } else {
-        None
+        return Some(base);
     }
-}
-
-/// Cache-based skip gate for Vosk-RU: returns the cache base
-/// (`KESHA_CACHE_DIR` if set, else `~/.cache/kesha`) when all three
-/// runtime files (`model.onnx`, `dictionary`, `bert/model.onnx`) are
-/// present under `models/vosk-ru`. Returns `None` otherwise.
-///
-/// Returning the base (rather than the model dir) lets callers both
-/// reuse it as `KESHA_CACHE_DIR` for child processes AND derive the
-/// model dir via `.join("models/vosk-ru")`.
-pub fn vosk_ru_cache_dir_or_skip() -> Option<PathBuf> {
-    let base = cache_base();
-    let model_dir = base.join("models/vosk-ru");
-    if model_dir.join("model.onnx").exists()
-        && model_dir.join("dictionary").exists()
-        && model_dir.join("bert/model.onnx").exists()
-    {
-        Some(base)
-    } else {
-        None
-    }
+    assert!(
+        !models_required(),
+        "no Kokoro runtime layout under {} while KESHA_REQUIRE_MODEL_TESTS is set — \
+         this lane stages models, so skipping here would be a green run of nothing (#741)",
+        base.display()
+    );
+    None
 }
 
 /// Resolve the cache base used by every cache-based skip gate.

--- a/rust/tests/model_gate.rs
+++ b/rust/tests/model_gate.rs
@@ -1,0 +1,42 @@
+//! Guard for the model-gate policy the TTS test files share.
+//!
+//! A gate that returns `None` makes its callers return early, which nextest
+//! reports as a pass. That is right for a laptop with no models staged and
+//! wrong for a CI lane that just downloaded them: #741 found `run-cargo-test.sh`
+//! exporting `KESHA_CACHE_DIR` off the presence of a bundle no test reads, so
+//! removing that bundle would have silently stopped five tests from running
+//! while the lane stayed green. `KESHA_REQUIRE_MODEL_TESTS` turns that silence
+//! into a failure in the lanes that promise to stage models.
+
+mod common;
+
+#[test]
+fn a_missing_model_skips_by_default_and_fails_where_models_are_promised() {
+    assert!(!common::missing_model_is_fatal(None));
+    assert!(!common::missing_model_is_fatal(Some("")));
+    assert!(!common::missing_model_is_fatal(Some("0")));
+    assert!(common::missing_model_is_fatal(Some("1")));
+}
+
+#[test]
+fn the_kokoro_gate_fails_loudly_rather_than_skipping_when_models_are_promised() {
+    let empty = std::env::temp_dir().join(format!("kesha-model-gate-{}", std::process::id()));
+    std::fs::create_dir_all(&empty).expect("temp cache root");
+    std::env::set_var("KESHA_CACHE_DIR", &empty);
+
+    std::env::remove_var("KESHA_REQUIRE_MODEL_TESTS");
+    assert!(
+        common::kokoro_cache_dir_or_skip().is_none(),
+        "an unstaged laptop must still skip"
+    );
+
+    std::env::set_var("KESHA_REQUIRE_MODEL_TESTS", "1");
+    let outcome = std::panic::catch_unwind(common::kokoro_cache_dir_or_skip);
+    std::env::remove_var("KESHA_REQUIRE_MODEL_TESTS");
+    std::fs::remove_dir_all(&empty).ok();
+
+    assert!(
+        outcome.is_err(),
+        "a lane that staged models must fail on an unreadable layout, not skip"
+    );
+}

--- a/rust/tests/model_gate.rs
+++ b/rust/tests/model_gate.rs
@@ -4,9 +4,17 @@
 //! reports as a pass. That is right for a laptop with no models staged and
 //! wrong for a CI lane that just downloaded them: #741 found `run-cargo-test.sh`
 //! exporting `KESHA_CACHE_DIR` off the presence of a bundle no test reads, so
-//! removing that bundle would have silently stopped five tests from running
+//! removing that bundle would have silently stopped four tests from running
 //! while the lane stayed green. `KESHA_REQUIRE_MODEL_TESTS` turns that silence
 //! into a failure in the lanes that promise to stage models.
+//!
+//! The rule is meant to be complete: every model-gated skip site either asserts
+//! the flag or is listed here as deliberately exempt. Exempt today:
+//! `kokoro_rate_e2e.rs` and `diarize_e2e.rs` (ANE/Sortformer bundles no lane
+//! stages), `vosk.rs`'s synth test (its own `KESHA_REQUIRE_VOSK_TESTS`, since
+//! only one lane carries that bundle), and the `KESHA_*` env skips inside
+//! `rust/src/tts/` — those sit behind integration gates that already fail loudly,
+//! so covering them is defense-in-depth for a later stage, not a hole today.
 
 mod common;
 
@@ -18,25 +26,47 @@ fn a_missing_model_skips_by_default_and_fails_where_models_are_promised() {
     assert!(common::missing_model_is_fatal(Some("1")));
 }
 
+/// Both gates live in one test because it mutates process env: nextest gives
+/// each test its own process, but plain `cargo test` would race them.
 #[test]
-fn the_kokoro_gate_fails_loudly_rather_than_skipping_when_models_are_promised() {
-    let empty = std::env::temp_dir().join(format!("kesha-model-gate-{}", std::process::id()));
-    std::fs::create_dir_all(&empty).expect("temp cache root");
-    std::env::set_var("KESHA_CACHE_DIR", &empty);
-
+fn the_kokoro_gates_fail_loudly_rather_than_skipping_when_models_are_promised() {
+    let root = std::env::temp_dir().join(format!("kesha-model-gate-{}", std::process::id()));
+    let voices = root.join("models/kokoro-82m/voices");
+    std::fs::create_dir_all(&voices).expect("temp cache root");
+    std::env::set_var("KESHA_CACHE_DIR", &root);
     std::env::remove_var("KESHA_REQUIRE_MODEL_TESTS");
+
     assert!(
         common::kokoro_cache_dir_or_skip().is_none(),
         "an unstaged laptop must still skip"
     );
 
+    // A cache that has the graph and the default voice but not a multilang one:
+    // the cache-dir gate passes and only the per-voice gate can catch it.
+    std::fs::write(root.join("models/kokoro-82m/model.onnx"), b"stub").expect("graph");
+    std::fs::write(voices.join("am_michael.bin"), b"stub").expect("default voice");
+    assert!(
+        common::kokoro_cache_dir_or_skip().is_some(),
+        "graph + default voice present, so the cache-dir gate must pass"
+    );
+    assert!(
+        common::kokoro_voice_or_skip(&root, "em_alex").is_none(),
+        "a missing multilang voice must still skip on an unstaged laptop"
+    );
+
     std::env::set_var("KESHA_REQUIRE_MODEL_TESTS", "1");
-    let outcome = std::panic::catch_unwind(common::kokoro_cache_dir_or_skip);
+    let voice_outcome = std::panic::catch_unwind(|| common::kokoro_voice_or_skip(&root, "em_alex"));
+    std::fs::remove_file(root.join("models/kokoro-82m/model.onnx")).expect("unstage graph");
+    let cache_outcome = std::panic::catch_unwind(common::kokoro_cache_dir_or_skip);
     std::env::remove_var("KESHA_REQUIRE_MODEL_TESTS");
-    std::fs::remove_dir_all(&empty).ok();
+    std::fs::remove_dir_all(&root).ok();
 
     assert!(
-        outcome.is_err(),
+        voice_outcome.is_err(),
+        "a missing voice pack must fail the lane, not skip it"
+    );
+    assert!(
+        cache_outcome.is_err(),
         "a lane that staged models must fail on an unreadable layout, not skip"
     );
 }

--- a/rust/tests/tts_multilang_audio.rs
+++ b/rust/tests/tts_multilang_audio.rs
@@ -37,6 +37,11 @@ fn default_voice(lang: &str) -> &'static str {
 fn multilang_paths_or_skip(lang: &str) -> Option<(PathBuf, PathBuf)> {
     // Gate 1: G2P model present.
     if std::env::var_os("CHARSIU_ONNX").is_none() {
+        assert!(
+            !common::models_required(),
+            "CHARSIU_ONNX unset while KESHA_REQUIRE_MODEL_TESTS is set — \
+             this lane stages CharsiuG2P, so skipping here would be a green run of nothing (#741)"
+        );
         eprintln!("skipping tts_multilang_audio: CHARSIU_ONNX not set");
         return None;
     }

--- a/rust/tests/tts_multilang_audio.rs
+++ b/rust/tests/tts_multilang_audio.rs
@@ -47,16 +47,12 @@ fn multilang_paths_or_skip(lang: &str) -> Option<(PathBuf, PathBuf)> {
     }
     // Gate 2: Kokoro model + voice from cache.
     let cache = common::kokoro_cache_dir_or_skip()?;
-    let model = cache.join("models/kokoro-82m/model.onnx");
     let voice_name = default_voice(lang);
-    let voice = cache
-        .join("models/kokoro-82m/voices")
-        .join(format!("{voice_name}.bin"));
-    if !model.exists() || !voice.exists() {
+    let paths = common::kokoro_voice_or_skip(&cache, voice_name);
+    if paths.is_none() {
         eprintln!("skipping tts_multilang_audio[{lang}]: model or voice {voice_name} not in cache");
-        return None;
     }
-    Some((model, voice))
+    paths
 }
 
 fn run_corpus_for_lang(lang: &str, sentences: &[String]) {

--- a/rust/tests/tts_stdin_loop.rs
+++ b/rust/tests/tts_stdin_loop.rs
@@ -152,6 +152,12 @@ fn loop_synthesises_kokoro_and_caches_session() {
         return;
     };
     if !std::path::Path::new(&model).exists() || !std::path::Path::new(&voice).exists() {
+        assert!(
+            !common::models_required(),
+            "KOKORO_MODEL/KOKORO_VOICE point at missing files while \
+             KESHA_REQUIRE_MODEL_TESTS is set — this lane stages models, so skipping \
+             here would be a green run of nothing (#741)"
+        );
         eprintln!("skipping: KOKORO_MODEL / KOKORO_VOICE files missing");
         return;
     }


### PR DESCRIPTION
Stage 1 of the ≤2 GB CI plan — [design comment on #741](https://github.com/drakulavich/kesha-voice-kit/issues/741#issuecomment-5239888431). Highest byte-per-effort item in that plan, and it costs no confidence: nothing consumes what it deletes.

## What the bundle actually buys, corrected

The first pass of this PR deleted the Vosk-TTS-RU bundle outright, on the claim that nothing read it. `vosk_ru_cache_dir_or_skip` genuinely had no callers — but **`tts::vosk::tests::synth_short_phrase_produces_audio` consumes it** through `models::is_cached(VoskRu)`, a path a `rust/tests/`-scoped grep never covered. Measured on the same checkout:

```
### Vosk bundle present ###   PASS [  25.557s] tts::vosk::tests::synth_short_phrase_produces_audio
### Vosk bundle absent  ###   PASS [   0.009s] tts::vosk::tests::synth_short_phrase_produces_audio
```

25.6 s of real Russian synthesis versus a 9 ms silent skip. The first pass therefore deleted live coverage and CI went green anyway — the exact failure class this PR exists to close, which is the most useful thing it could have demonstrated. Second commit fixes it.

That test needs real weights (Vosk's ONNX sessions live inside the `vosk_tts` crate, so nothing can stand in for them), but it does not need to run three times: Vosk behaves identically on every OS, so one lane covers the boundary. `setup-kokoro-models` now takes a `vosk` input, only the `coverage` lane sets it, and the cache key carries the choice so a Linux entry seeded without the bundle can never be restored by a lane that needs it.

## Byte arithmetic

The `kokoro-models-v1-*` trio is **3393 MB of a 10240 MB cap** (measured 2026-08-10 12:01Z; the repo was at 10857 MB, i.e. already evicting). Each 1131 MB entry stores roughly 310 MB Kokoro + 935 MB Vosk + 30 MB CharsiuG2P + 2.6 MB voice packs.

Dropping Vosk from the macOS and Windows entries — keeping it on Linux — should take those two to **~200–330 MB apiece, freeing ≈1.6–1.9 GB**, with no coverage lost. That is less than the ≈2.4–2.8 GB the design comment projected, and the difference is exactly the coverage that projection had wrongly written off. Worth measuring on the first re-seed rather than trusting the estimate; the entries are compressed and hardlink-deduplicated.

## The trap, and why this is not a one-line delete

`run-cargo-test.sh` exported `KESHA_CACHE_DIR` **if and only if the Vosk files were present**. `KESHA_CACHE_DIR` is what `common::kokoro_cache_dir_or_skip` resolves against, which gates the four `tts_multilang_audio` tests (es/fr/it/pt). Deleting the download without moving that condition would have stopped those four tests running while the lane stayed green.

Demonstrated rather than argued, on a runner-shaped Vosk-free layout with `HOME` pointed at an empty dir:

```
### identical broken layout, guard NOT set (what would have shipped) ###
    Starting 4 tests across 1 binary
        PASS [   0.010s] (1/4) tts_multilang_audio multilang_audio_regression_fr
        PASS [   0.010s] (2/4) tts_multilang_audio multilang_audio_regression_es
        PASS [   0.011s] (3/4) tts_multilang_audio multilang_audio_regression_pt
        PASS [   0.011s] (4/4) tts_multilang_audio multilang_audio_regression_it
     Summary [   0.011s] 4 tests run: 4 passed, 0 skipped
```

Four passes in 11 ms, having synthesized nothing.

Correction to the design comment, which said five tests: it is four. `tts_smoke::resolves_from_cache_when_installed` gates on `KOKORO_MODEL`/`KOKORO_VOICE` and stages its own temp cache, so it was never exposed. Every suite except `tts_multilang_audio` passes its own `KESHA_CACHE_DIR` explicitly.

## The guard

A skip in these gates returns `None`, the caller returns early, and nextest reports a pass — so no JUnit or marker-file meta-assertion can see it after the fact. The only place the silence is visible is the skip site itself, so that is where the check goes: `KESHA_REQUIRE_MODEL_TESTS`, set at job level on the two lanes that stage models, turns a missing model from a skip into a failure. Lanes that stage nothing (`rust-push-gate`) and laptops leave it unset and keep skipping.

Same layout with the guard on:

```
    thread 'multilang_audio_regression_it' panicked at tests/common/mod.rs:129:5:
    no Kokoro runtime layout under …/fakehome/.cache/kesha while
    KESHA_REQUIRE_MODEL_TESTS is set — this lane stages models, so skipping
    here would be a green run of nothing (#741)
     Summary: 4 tests run: 0 passed, 4 failed
```

Writing it surfaced two more instances of the same class. `tts_multilang_audio.rs` checked `CHARSIU_ONNX` itself, bypassing the shared gate, so a missing G2P bundle would also have skipped silently. And the Vosk synth test above has its own `models::is_cached` gate — now behind `KESHA_REQUIRE_VOSK_TESTS`, a separate flag because only one lane stages that bundle while all three promise Kokoro and G2P. Verified both directions: bundle absent on a lane that promised it fails in 26 ms; bundle present passes with 25 s of real synthesis.

`rust/tests/model_gate.rs` covers the policy: the flag parses as expected, and the real gate panics rather than returning `None` when a lane promised models.

## Also in this diff

- The `coverage` job carried its own **inline duplicate** of the same three conditions (13 lines, over the 3-line inline-script rule). Two copies of a gate that must agree is how the original drift happened, so the staging now lives in one sourced `rust/ci/kokoro-env.sh` that both nextest lanes read.
- Cache key `v1` → `v2`. The key already hashes `download-kokoro.sh`, and `action.yml` argues against hand-bumped versions — but the **prefix restore-key** would match the old fat entries, restore the deleted Vosk bytes, and save them again under the new key, so a removal cannot shrink the cache without rotating the prefix. Recorded in the comment so the next person removing a model knows the rule is "bump on removal, never on addition".
- Stale size comments corrected (~1.1 GB → ~340 MB) where they describe current cost; the `#661` history keeps its original numbers.

## Not in scope

The `*-kesha-models-tts-v1` pair and the surviving `kokoro-models` entries are stage 6 of the plan. This PR stops *writing* Vosk bytes; the existing v1 entries age out or get deleted there.

## Review follow-up

Grok's P2 and three P3s taken in the third commit: the multilang per-voice check, `tts_stdin_loop`'s secondary files-missing check, the stale `ci.yml` say-e2e comment about Vosk-ru, and the "five tests" figure in `model_gate.rs`. The per-voice path now goes through a shared `common::kokoro_voice_or_skip` so `model_gate.rs` covers the real function rather than a copy of its logic, and the module doc enumerates the deliberately exempt sites so the rule reads as complete.

**Declined:** the in-`src` env skips in `kokoro.rs` / `charsiu` / `sessions.rs`. Grok rates them as not silent-green today because the integration gates above them already fail loudly; wiring them up is defense-in-depth that belongs with the mini-model work in a later stage, not here.

## Verification

- `cargo fmt -- --check`, `cargo clippy --all-targets --features tts -- -D warnings` — clean
- `CI=true make rust-test` — 494 passed, 0 skipped (includes the real Vosk synth test at 31.8 s)
- Re-gated env + guard on, against a Vosk-free layout with real Kokoro weights: `tts_e2e` + `tts_smoke` + `tts_stdin_loop` + `model_gate` — **21 passed, 0 skipped**, real synthesis running (9 s), so the guard does not false-fire
- `bash -n` on all three touched scripts; `bun run check:workflows`; `bun test` 1099 pass / 0 fail; `bunx tsc --noEmit`

Refs #741

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBTpJjqyYFW6W8LHJ2nwy
