### PR TITLE
test(helpers): share the staged engine home, and what the 60% duplication figure actually is

### DIFF
--- a/tests/helpers/fake-engine.ts
+++ b/tests/helpers/fake-engine.ts
@@ -4,6 +4,33 @@ import { join } from "path";
 
 const ENGINE_ENV = ["KESHA_ENGINE_BIN", "KESHA_CACHE_DIR", "HOME", "KESHA_MODEL_MIRROR"] as const;
 
+export interface StagedEngineHome {
+  /** The temp directory standing in for `$HOME`. Remove it when the test finishes. */
+  dir: string;
+  cache: string;
+  binDir: string;
+  binPath: string;
+}
+
+/**
+ * Creates a temp `$HOME` holding the engine cache layout and points `HOME`, `KESHA_CACHE_DIR`
+ * and `KESHA_ENGINE_BIN` at it. The bin directory exists; no engine is written, so the caller
+ * decides whether it is healthy, mute or absent.
+ *
+ * Restore the environment with `saveEngineEnv()`'s undo, and `rmSync` the returned `dir`.
+ */
+export function stageEngineHome(prefix: string): StagedEngineHome {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  const cache = join(dir, ".cache", "kesha");
+  const binDir = join(cache, "engine", "bin");
+  mkdirSync(binDir, { recursive: true });
+  const binPath = join(binDir, "kesha-engine");
+  process.env.HOME = dir;
+  process.env.KESHA_CACHE_DIR = cache;
+  process.env.KESHA_ENGINE_BIN = binPath;
+  return { dir, cache, binDir, binPath };
+}
+
 /** Snapshots the engine-related env so a test can point them at a temp dir and restore afterwards. */
 export function saveEngineEnv(): () => void {
   const saved = ENGINE_ENV.map((key) => [key, process.env[key]] as const);

--- a/tests/unit/doctor.test.ts
+++ b/tests/unit/doctor.test.ts
@@ -19,6 +19,7 @@ import {
   type DoctorReport,
 } from "../../src/doctor";
 import { collectStatus } from "../../src/status";
+import { stageEngineHome } from "../helpers/fake-engine";
 import { createSupportBundle } from "../../src/support-bundle";
 import { engineVersion, packageName, packageVersion } from "../../src/package-info";
 import { enableStats } from "../../src/stats";
@@ -609,15 +610,9 @@ describe("collectDoctorReport probe and cache accounting", () => {
   afterEach(restoreEnv);
 
   function stage(prefix: string): { dir: string; cache: string; binDir: string } {
-    const dir = mkdtempSync(join(tmpdir(), prefix));
-    const cache = join(dir, ".cache", "kesha");
-    const binDir = join(cache, "engine", "bin");
-    mkdirSync(binDir, { recursive: true });
-    process.env.HOME = dir;
-    process.env.KESHA_ENGINE_BIN = join(binDir, "kesha-engine");
-    process.env.KESHA_CACHE_DIR = cache;
-    process.env.KESHA_STATS_DB = join(dir, "stats.sqlite");
-    return { dir, cache, binDir };
+    const staged = stageEngineHome(prefix);
+    process.env.KESHA_STATS_DB = join(staged.dir, "stats.sqlite");
+    return staged;
   }
 
   test("an absent engine is not probed, so it carries no probe error", async () => {

--- a/tests/unit/status.test.ts
+++ b/tests/unit/status.test.ts
@@ -12,7 +12,7 @@ import {
 } from "../../src/status";
 import { humanBytes } from "../../src/format";
 import { starSeenPath } from "../../src/star";
-import { saveEngineEnv, writeFakeEngine } from "../helpers/fake-engine";
+import { saveEngineEnv, stageEngineHome, writeFakeEngine } from "../helpers/fake-engine";
 
 const posixEngineTest = process.platform === "win32" ? test.skip : test;
 
@@ -209,13 +209,9 @@ describe("collectStatus --json payload (#647)", () => {
   afterEach(restoreEnv);
 
   function healthyEngine(): { dir: string; cache: string; binPath: string } {
-    const dir = mkdtempSync(join(tmpdir(), "kesha-status-json-"));
-    const cache = join(dir, ".cache", "kesha");
-    const binPath = writeFakeEngine(join(cache, "engine", "bin"));
-    process.env.KESHA_ENGINE_BIN = binPath;
-    process.env.KESHA_CACHE_DIR = cache;
-    process.env.HOME = dir;
-    return { dir, cache, binPath };
+    const staged = stageEngineHome("kesha-status-json-");
+    writeFakeEngine(staged.binDir);
+    return staged;
   }
 
   posixEngineTest("engine installed: presence, path, capabilities, voices", async () => {


### PR DESCRIPTION
Follow-up to #834, aimed at the duplication repowise reports on the test suites.

### What landed

`doctor.test.ts` and `status.test.ts` each carried a private helper building the same thing: a temp `$HOME`, the `.cache/kesha/engine/bin` layout, and the `HOME` / `KESHA_CACHE_DIR` / `KESHA_ENGINE_BIN` triple. Both now call one `stageEngineHome` in `tests/helpers/fake-engine.ts`.

It returns the layout and does **not** write an engine, so a caller can still stage a healthy, mute, or absent one — which is exactly the axis those two suites vary.

### What I found out, and why this PR is small

I went in expecting the ~500-line change the duplication numbers imply (repowise: `doctor` 65%, `status` 59%, `engine` 57%, `cli` 60%). That is not what the number is made of.

- `cli.test.ts` — 60% duplicated, and **zero** engine-staging sites. Its duplication is elsewhere entirely.
- `doctor` + `status` — 45 sites touch the cache layout, but only **2** match the canonical block byte for byte. The rest each differ: some declare `cache`, some only `binDir`, some skip `dir`, some set the env triple from variables built three different ways.

I tried the mechanical pass anyway, on the theory that the shapes were close enough: a regex collapse of the block plus removal of the now-redundant env assignments. It **broke 11 tests in `status.test.ts`**, because the env-removal pattern also matched sites whose `binPath`/`cache`/`dir` came from somewhere else. Reverted, and kept only the change verified above.

So the honest position: the 60% figure is real, but it is many small near-identical fragments with genuinely different shapes, not one block repeated. Collapsing it is a per-site judgement call across ~45 sites in two files that carry 7 and 4 prior defects respectively — worth doing, but as deliberate work with a test run per file, not as a regex sweep. I would rather report that than land a sweep I could not stand behind.

### Verification

- `bun test` — 1099 pass / 5 skip / **0 fail** (real engine v1.24.9)
- `bunx tsc --noEmit` — clean
- No Rust changes