### PR TITLE
ci(cache): stop pull requests writing rust-cache entries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,6 +409,10 @@ jobs:
         with:
           cache-path: |
             ~/.cache/kesha
+          # 94 MB today because this key predates #820, so the entry archives the
+          # ONNX layout only. Rotating it re-archives the ~450 MB FluidAudio
+          # bundle now rooted under the same tree — check the budget before you
+          # bump it, or move this lane off the PR path first (#741).
           cache-key: ${{ runner.os }}-kesha-engine-v1
           cache-restore-keys: ${{ runner.os }}-kesha-engine-
       - name: 🧪 Integration tests (real engine)
@@ -605,6 +609,7 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: rust
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: 🎧 Install system audio deps
         if: runner.os == 'Linux'
@@ -723,6 +728,9 @@ jobs:
           # with `clang_rt.osx not found` even after the Xcode 16.2 pin. Bump
           # this discriminator if the stale path ever resurfaces.
           key: xcode-16.2
+          # ci.yml runs on push to main, so this lane keeps a main-scoped entry
+          # every PR restores — the one rust cache that already worked that way.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: 🎚️ Setup Kokoro TTS models
         uses: ./.github/actions/setup-kokoro-models

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -49,6 +49,19 @@ jobs:
               - 'tests/fixtures/benchmark-en/03-review-pull-request.ogg'
               - '.github/workflows/rust-test.yml'
 
+  # GitHub scopes a cache written during a pull_request run to that PR's merge
+  # ref, so it can only ever serve re-runs of the same PR — measured on #838: the
+  # first run missed and saved, only later pushes hit. Four such entries at
+  # ~300 MB is ~1.2 GB per open PR, and since they are the most recently used,
+  # LRU evicts the main-scoped model bundles instead. That is the mechanism
+  # behind the parakeet evictions this ticket opened with (#741).
+  #
+  # So PR runs restore and never save. `rust-push-gate` is the only rust job that
+  # runs on main, so it writes the one Linux entry `lint-ubuntu` reads through a
+  # matching `shared-key` — that lane gets *warmer* than before, since its first
+  # run per PR used to be cold. Lanes with no main-side writer (macOS, Windows,
+  # coverage) trade their second-and-later pushes going cold for the headroom;
+  # their first push was already cold either way.
   lint-ubuntu:
     needs: changes
     if: github.event_name == 'pull_request' && needs.changes.outputs.rust == 'true'
@@ -61,6 +74,8 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: rust
+          shared-key: linux
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install system audio deps (Opus)
         run: |
@@ -108,6 +123,7 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: rust
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # `cargo nextest` replaces `cargo test` for the actual run — it
       # parallelizes per-binary, surfaces flakiness explicitly, and emits
@@ -244,6 +260,10 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: rust
+          # No main-side writer exists for the llvm-cov flavour: instrumented
+          # builds carry different RUSTFLAGS, so push-gate's plain artifacts
+          # would not match this job's fingerprints anyway (#741).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - uses: taiki-e/install-action@1beb33eee6d086258184383af9a538940be190ed # v2.85.6
         with:
@@ -329,6 +349,8 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: rust
+          # Sole rust job on main, so this is the entry `lint-ubuntu` restores.
+          shared-key: linux
       - name: Install system audio deps (Opus)
         run: |
           sudo apt-get update -qq
@@ -397,6 +419,7 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: rust
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@1beb33eee6d086258184383af9a538940be190ed # v2.85.6
         with:
           tool: nextest


### PR DESCRIPTION
Stage 2 of the ≤2 GB CI plan — [design](https://github.com/drakulavich/kesha-voice-kit/issues/741#issuecomment-5239888431), [correction](https://github.com/drakulavich/kesha-voice-kit/issues/741#issuecomment-5240471297). Workflow-only; no Rust or TS changed.

## The measurement changes the target

My design put rust-cache at **1487 MB** and targeted ~1086 MB. Re-measuring after stage 1 merged shows that figure conflated two different things:

| | MB | scope |
|---|---:|---|
| snapshot 2026-08-10 12:01Z, PR #835 open | 1487 | **1196 MB of it on `refs/pull/835/merge`**, 291 MB on `refs/heads/main` |
| now, 13:05Z, no PR open | **291** | one entry, `v0-rust-xcode-16.2-tts-e2e-Darwin-arm64`, main-scoped |

So rust-cache's **standing** cost is ~291–680 MB and was never 1487. The 1487 was a **peak with one PR open**, and `cache-cleanup.yml` reclaims those entries when the PR closes. This stage therefore cannot shrink the standing budget much — what it removes is the per-open-PR spike, which is precisely what evicts the model bundles.

## Why PR-scoped rust-cache entries buy almost nothing

GitHub scopes a cache written during a `pull_request` run to that PR's merge ref. It can be restored by re-runs of the same PR and by nothing else. Since `lint-ubuntu`, `test`, `coverage` and `coreml-regression` are all `if: github.event_name == 'pull_request'`, no main-scoped entry with their key prefix has ever existed for a first run to restore from.

Verified on this PR's predecessor rather than assumed — #838, `test (windows-latest)`:

- run 1 (b8797ee, first push): no rust-cache hit line at all, then `Post Run Swatinem/rust-cache … Saving cache`
- run 3 (f426c9e): `Cache hit for restore-key: v0-rust-test-Windows_NT-x64-8af1e26a-19b26bf5`
- after merge: the entry is gone from `gh cache list` — it was PR-scoped, and cache-cleanup deleted it

**Every PR's first rust run is already cold on every OS.** The entries only accelerate second-and-later pushes to the same PR, then die.

## Before / after

| | entries written per open PR | standing main entries |
|---|---:|---|
| before | up to 4 × ~300 MB ≈ **1196 MB** | `tts-e2e` 291 MB + `rust-push-gate` ~388 MB |
| after | **0** | same two, one renamed to the shared key |

Peak with two PRs open: `8299 + 2×1196 = 10691 MB` against a 10240 MB cap — over, so something evicts, and LRU picks the least recently touched entry, which is a model bundle rather than the active PR's build artifacts. After: `8299 MB`, under cap.

## Cost, measured honestly

From #838 run 1 (cold rust-cache) versus run 3 (warm). Both runs also had a cold Kokoro cache, so rust-cache is the main variable between them:

| job | cold | warm | penalty |
|---|---:|---:|---:|
| `test (windows-latest)` | 347 s | 195 s | **~150 s** |
| `test (macos-14)` | 254 s | 211 s | ~43 s |
| `lint-ubuntu` | 74 s | 49 s | ~25 s |
| `coverage` | 174 s | 449 s | **not attributable** — the Vosk bundle entered this lane mid-PR, so the arms are confounded |

That penalty applies only to the **second and later** pushes on a PR; the first push paid it already. A three-push PR pays roughly +300 s on Windows and +86 s on macOS in total.

`lint-ubuntu` moves the other way: `shared-key: linux` lets it restore `rust-push-gate`'s main-scoped entry, so its *first* run per PR is now warm instead of cold. That is a strict improvement on today.

## Key consolidation — only where the fingerprints actually match

Verified before merging keys rather than assuming, since a shared key with divergent build flags thrashes instead of sharing:

- **`lint-ubuntu` ↔ `rust-push-gate`** — both ubuntu, both `cargo fmt` + clippy, no RUSTFLAGS divergence, and push-gate additionally builds the nextest binaries, so its entry is a superset. Merged under `shared-key: linux`.
- **`coverage` — not merged.** `cargo llvm-cov` builds with instrumentation, which changes the fingerprint of every crate including dependencies. Sharing push-gate's plain artifacts would buy nothing and inflate the entry.
- **`tts-e2e` — not merged.** It builds `--release`; the `test` lane builds debug. It also carries the `key: xcode-16.2` discriminator from #554, and `key` is ignored whenever `shared-key` is set, so merging would silently drop that guard.
- **Windows/macOS `test` — no counterpart exists.** `rust-push-gate` is ubuntu-only, and its comment says "Ubuntu-only on purpose". Giving those lanes a warm first run means expanding push-gate to a 3-OS matrix, which contradicts a documented decision — not taken here.

## `macOS-kesha-engine-v1` — deferred, with reasoning

My design flagged this 94 MB entry as a landmine: the key predates #820, so it archives only the ONNX layout, and rotating it would re-archive the ~450 MB FluidAudio bundle now rooted under the same tree. Deferred rather than fixed, because `integration-tests-full` is slated to leave the PR path in stage 5, which removes the entry entirely — and repathing or rotating it *now* would trigger exactly the ~550 MB write this stage exists to avoid. A comment at the call site records the trap for whoever bumps the key first.

## Acceptance evidence from this PR's own CI

Both halves observable on run 31392095407:

1. **The save is suppressed.** `test (windows-latest)`'s `Post Run Swatinem/rust-cache` step logs `Post job cleanup.` and stops. The same step on #838 run 1 went on through `Cache Configuration` → `Saving cache`.
2. **No PR-scoped entries exist.** After a full CI run of this PR, `gh api actions/caches` filtered to `refs/pull/*` returns **nothing**. The equivalent run of #838 left ~1196 MB across four.

Repo total right now is 9818 MB across 19 entries — 96% of cap, with the Linux Kokoro entry re-seeded and no PR open. That is the headroom this stage is defending.

### Why `test (windows-latest)` reads 10m45s here

It is cold, as intended — no rust-cache hit line at all — but it is **not** comparable to the 347 s "cold" row above. Both #838 runs missed the Kokoro cache, so their gated Kokoro tests skipped; this run got `Cache hit for: kokoro-models-v2-Windows-voskfalse` and actually ran real synthesis. The 565 s test step is cold compile *plus* work the earlier runs never did. The 347 s vs 195 s pair remains the honest rust-cache-only comparison, because those two differ in nothing else.

## Verification

- `bun run check:workflows` — clean
- both workflows parse under `yaml.safe_load`
- `bun test` 1108 tests, 0 fail; `bunx tsc --noEmit` clean
- no Rust or TS source touched, so the rust gates are unchanged from main

The real proof is post-merge: `rust-push-gate` runs on this workflow's own path filter, so it writes `v0-rust-linux-*` immediately after merge, and the next PR's `lint-ubuntu` should report a restore-key hit against it.

Refs #741 (stage 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBTpJjqyYFW6W8LHJ2nwy
