### PR TITLE
test(e2e): fail the heavy lane when the engine it installs is missing (#741 for TS)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,6 +397,9 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    env:
+      # This lane installs the engine, so self-skipping here is a green run of nothing (#741).
+      KESHA_REQUIRE_MODEL_TESTS: "1"
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/tests/helpers/model-gate.ts
+++ b/tests/helpers/model-gate.ts
@@ -5,22 +5,30 @@ export function modelsRequired(): boolean {
   return process.env.KESHA_REQUIRE_MODEL_TESTS === "1";
 }
 
+export interface EngineGate {
+  installed: boolean;
+  /** Non-null when the lane promised an engine and there isn't one; raise it from a test. */
+  requiredFailure: string | null;
+}
+
 /**
  * Whether the installed engine can describe itself, for suites that self-skip without one.
  *
- * Throws instead of returning false when the lane promised an engine: `integration-tests-full`
- * installs the model bundle, so a gate that cannot find it is a broken layout rather than a
- * laptop, and skipping there is a green run of nothing (#741).
+ * Returns the fault rather than throwing: a throw during module evaluation exits non-zero but
+ * produces no named testcase, so this lane's JUnit → step-summary → Flakiness pipeline would
+ * report a green run of nothing anyway.
  */
-export async function engineUsableOrRequired(): Promise<boolean> {
+export async function engineGate(): Promise<EngineGate> {
   const health = await engineFunctionalHealth();
-  if (health.status === "ok") return true;
-  if (modelsRequired()) {
-    throw new Error(
-      `engine is "${health.status}" while KESHA_REQUIRE_MODEL_TESTS is set — this lane ` +
-        `installs the engine, so skipping the model-dependent suites here would be a green ` +
-        `run of nothing (#741).`,
-    );
-  }
-  return false;
+  if (health.status === "ok") return { installed: true, requiredFailure: null };
+  if (!modelsRequired()) return { installed: false, requiredFailure: null };
+
+  const detail = "detail" in health ? ` (${health.detail})` : "";
+  return {
+    installed: false,
+    requiredFailure:
+      `engine is "${health.status}"${detail} while KESHA_REQUIRE_MODEL_TESTS is set — this ` +
+      `lane installs the engine, so skipping the model-dependent suites here would be a ` +
+      `green run of nothing (#741).`,
+  };
 }

--- a/tests/helpers/model-gate.ts
+++ b/tests/helpers/model-gate.ts
@@ -1,0 +1,26 @@
+import { engineFunctionalHealth } from "../../src/engine-health";
+
+/** Mirrors the Rust side's `models_required()` — set by the lanes that stage the engine (#741). */
+export function modelsRequired(): boolean {
+  return process.env.KESHA_REQUIRE_MODEL_TESTS === "1";
+}
+
+/**
+ * Whether the installed engine can describe itself, for suites that self-skip without one.
+ *
+ * Throws instead of returning false when the lane promised an engine: `integration-tests-full`
+ * installs the model bundle, so a gate that cannot find it is a broken layout rather than a
+ * laptop, and skipping there is a green run of nothing (#741).
+ */
+export async function engineUsableOrRequired(): Promise<boolean> {
+  const health = await engineFunctionalHealth();
+  if (health.status === "ok") return true;
+  if (modelsRequired()) {
+    throw new Error(
+      `engine is "${health.status}" while KESHA_REQUIRE_MODEL_TESTS is set — this lane ` +
+        `installs the engine, so skipping the model-dependent suites here would be a green ` +
+        `run of nothing (#741).`,
+    );
+  }
+  return false;
+}

--- a/tests/integration/e2e-engine.test.ts
+++ b/tests/integration/e2e-engine.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeAll } from "bun:test";
-import { engineUsableOrRequired } from "../helpers/model-gate";
+import { engineGate } from "../helpers/model-gate";
 import {
   getEngineBinPath,
   TRANSCRIBE_SEGMENTS_FEATURE,
@@ -12,7 +12,13 @@ const FIXTURE_RU = "tests/fixtures/benchmark/01-ne-nuzhno-slat-soobshcheniya.ogg
 const FIXTURE_EN = "tests/fixtures/benchmark-en/01-check-email.ogg";
 
 // Presence is not usability: the #796 stub existed, ran, and failed all 19 of these (#801).
-const engineInstalled = await engineUsableOrRequired();
+const engineGateResult = await engineGate();
+const engineInstalled = engineGateResult.installed;
+if (engineGateResult.requiredFailure) {
+  test("this lane must ship a functional engine (#741)", () => {
+    throw new Error(engineGateResult.requiredFailure!);
+  });
+}
 
 async function runCli(args: string[]): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   const proc = Bun.spawn([process.execPath, "run", "src/cli-entry.ts", ...args], {

--- a/tests/integration/e2e-engine.test.ts
+++ b/tests/integration/e2e-engine.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeAll } from "bun:test";
-import { engineFunctionalHealth } from "../../src/engine-health";
+import { engineUsableOrRequired } from "../helpers/model-gate";
 import {
   getEngineBinPath,
   TRANSCRIBE_SEGMENTS_FEATURE,
@@ -12,7 +12,7 @@ const FIXTURE_RU = "tests/fixtures/benchmark/01-ne-nuzhno-slat-soobshcheniya.ogg
 const FIXTURE_EN = "tests/fixtures/benchmark-en/01-check-email.ogg";
 
 // Presence is not usability: the #796 stub existed, ran, and failed all 19 of these (#801).
-const engineInstalled = (await engineFunctionalHealth()).status === "ok";
+const engineInstalled = await engineUsableOrRequired();
 
 async function runCli(args: string[]): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   const proc = Bun.spawn([process.execPath, "run", "src/cli-entry.ts", ...args], {

--- a/tests/integration/mcp-e2e.test.ts
+++ b/tests/integration/mcp-e2e.test.ts
@@ -3,12 +3,18 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { existsSync, mkdirSync, symlinkSync } from "fs";
 import { createKeshaMcpServer } from "../../src/mcp/server";
-import { engineUsableOrRequired } from "../helpers/model-gate";
+import { engineGate } from "../helpers/model-gate";
 
 const FIXTURE_RU = "tests/fixtures/benchmark/01-ne-nuzhno-slat-soobshcheniya.ogg";
 
 // Presence is not usability: the #796 stub existed, ran, and failed every case here (#801).
-const engineInstalled = await engineUsableOrRequired();
+const engineGateResult = await engineGate();
+const engineInstalled = engineGateResult.installed;
+if (engineGateResult.requiredFailure) {
+  test("this lane must ship a functional engine (#741)", () => {
+    throw new Error(engineGateResult.requiredFailure!);
+  });
+}
 
 async function client() {
   const server = createKeshaMcpServer();

--- a/tests/integration/mcp-e2e.test.ts
+++ b/tests/integration/mcp-e2e.test.ts
@@ -3,12 +3,12 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { existsSync, mkdirSync, symlinkSync } from "fs";
 import { createKeshaMcpServer } from "../../src/mcp/server";
-import { engineFunctionalHealth } from "../../src/engine-health";
+import { engineUsableOrRequired } from "../helpers/model-gate";
 
 const FIXTURE_RU = "tests/fixtures/benchmark/01-ne-nuzhno-slat-soobshcheniya.ogg";
 
 // Presence is not usability: the #796 stub existed, ran, and failed every case here (#801).
-const engineInstalled = (await engineFunctionalHealth()).status === "ok";
+const engineInstalled = await engineUsableOrRequired();
 
 async function client() {
   const server = createKeshaMcpServer();


### PR DESCRIPTION
Ports the #741 policy from the Rust suite to the TypeScript one.

### The hole

`e2e-engine` and `mcp-e2e` guard on `engineFunctionalHealth()` and self-skip when the engine can't describe itself. That is right on a laptop and wrong in `integration-tests-full`, whose whole purpose is to install the ~2.4 GB bundle and run those suites. If the install ever fails, the suites disappear and the lane stays green.

CLAUDE.md already admits this: *"Nothing enforces the guard: there is no meta-test."* Rust closed it in #741 with `KESHA_REQUIRE_MODEL_TESTS`; TS had no equivalent.

I saw both failure directions locally this week: a 17-byte stub engine silently un-skipped the suites into 18 failures, and an empty cache produced `20 passed` in 0.009 s.

### The change

`tests/helpers/model-gate.ts` mirrors the Rust `models_required()`: quiet skip by default, throw when the lane promised an engine. `ci.yml` sets the flag on `integration-tests-full` only — lanes that stage nothing leave it unset, same rule as `rust-test.yml`.

### Verification

Three arms, locally:

| Arm | Result |
|---|---|
| no engine, flag unset | 24 skip / 0 fail — unchanged laptop behaviour |
| no engine, flag set | fails with `engine is "missing" while KESHA_REQUIRE_MODEL_TESTS is set` |
| real engine (v1.24.9), flag set | 24 pass |

Full suite: 1103 pass / 5 skip / 0 fail. `tsc --noEmit` clean. No Rust changes.

### Deliberately left soft

The `SPIKE_AVAILABLE` gates (`say-e2e`, and `mcp-e2e`'s TTS cases) key off a `/tmp/kokoro-spike` layout plus a G2P directory. I could not confirm `integration-tests-full` stages those, and making them required on a guess would red the lane for a reason unrelated to the bug. They remain soft; worth a follow-up once someone confirms what that lane actually provides.