### PR TITLE
test: gate flag routing per published target on a recorded capability pact

### DIFF
--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -14,6 +14,7 @@
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { parse, YAMLParseError } from "yaml";
+import { engineTargetEntries, targetKey } from "../../src/engine-targets";
 
 const dirs = [".github/workflows", ".github/actions"];
 
@@ -201,6 +202,33 @@ export function requireNpmPublishAfterPackaging(path: string, document: unknown)
  * `check:versions` and the unit tests run inside `unit-tests`, which that filter gates,
  * so an uncovered script means edits to a gate skip the tests that prove it works.
  */
+/**
+ * Fails when a script covered by a unit test sits outside ci.yml's `code` filter.
+ * `check:versions` and the unit tests run inside `unit-tests`, which that filter gates,
+ * so an uncovered script means edits to a gate skip the tests that prove it works.
+ */
+/**
+ * Fails when a published engine target has no runner verifying its capability pact.
+ *
+ * The per-PR pact tests are only sound while the recordings still match the binaries, and
+ * a pact nothing re-derives rots into a false green. A target absent from this matrix keeps
+ * its committed pact and loses the only thing checking it, which is the failure mode #798
+ * exists to prevent — so adding a platform to `src/engine-targets.ts` must add a row here.
+ */
+export function requirePactVerificationCoversEveryTarget(path: string, document: unknown): string[] {
+  if (!path.endsWith("capability-pact.yml")) return [];
+
+  const include = (document as { jobs?: { pact?: { strategy?: { matrix?: { include?: unknown } } } } })
+    ?.jobs?.pact?.strategy?.matrix?.include;
+  if (!Array.isArray(include)) return [`${path}: expected a \`pact\` job with a \`strategy.matrix.include\` list`];
+
+  const covered = new Set(include.map((row) => String((row as { target?: unknown })?.target)));
+  return engineTargetEntries()
+    .map(({ platform, arch }) => targetKey(platform, arch))
+    .filter((target) => !covered.has(target))
+    .map((target) => `${path}: no runner verifies ${target}'s pact, so nothing would catch it drifting (#798)`);
+}
+
 export function requireTestedScriptsInCodeFilter(
   path: string,
   document: unknown,
@@ -258,6 +286,7 @@ function checkFile(path: string, testedScripts: string[]): string[] {
       ...requireDarwinSmokeCoversBothEngines(path, document),
       ...forbidLinuxPackaging(path, contents),
       ...requireNpmPublishAfterPackaging(path, document),
+      ...requirePactVerificationCoversEveryTarget(path, document),
       ...requireTestedScriptsInCodeFilter(path, document, testedScripts),
     ];
   } catch (err) {

--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -198,16 +198,6 @@ export function requireNpmPublishAfterPackaging(path: string, document: unknown)
 }
 
 /**
- * Fails when a script covered by a unit test sits outside ci.yml's `code` filter.
- * `check:versions` and the unit tests run inside `unit-tests`, which that filter gates,
- * so an uncovered script means edits to a gate skip the tests that prove it works.
- */
-/**
- * Fails when a script covered by a unit test sits outside ci.yml's `code` filter.
- * `check:versions` and the unit tests run inside `unit-tests`, which that filter gates,
- * so an uncovered script means edits to a gate skip the tests that prove it works.
- */
-/**
  * Fails when a published engine target has no runner verifying its capability pact.
  *
  * The per-PR pact tests are only sound while the recordings still match the binaries, and
@@ -229,6 +219,11 @@ export function requirePactVerificationCoversEveryTarget(path: string, document:
     .map((target) => `${path}: no runner verifies ${target}'s pact, so nothing would catch it drifting (#798)`);
 }
 
+/**
+ * Fails when a script covered by a unit test sits outside ci.yml's `code` filter.
+ * `check:versions` and the unit tests run inside `unit-tests`, which that filter gates,
+ * so an uncovered script means edits to a gate skip the tests that prove it works.
+ */
 export function requireTestedScriptsInCodeFilter(
   path: string,
   document: unknown,

--- a/.github/scripts/record-capability-pacts.ts
+++ b/.github/scripts/record-capability-pacts.ts
@@ -1,0 +1,198 @@
+#!/usr/bin/env bun
+/**
+ * Record (or verify) one target's capability pact from a real engine binary.
+ *
+ * A pact is `--capabilities-json` frozen per released target, so a PR can gate flag routing
+ * against every platform without running an engine. Its whole value is being a recording of
+ * the artifact users actually get — never hand-edit one. Recording needs no models;
+ * `--capabilities-json` is a compile-time dump.
+ *
+ *   bun .github/scripts/record-capability-pacts.ts --binary ./kesha-engine-linux-x64
+ *   bun .github/scripts/record-capability-pacts.ts --from-release --check
+ *
+ * `--from-release` fetches the binary `keshaEngine.version` pins. `--check` re-derives the
+ * pact and exits 1 on drift. Re-record per `.github/workflows/capability-pact.yml`, which
+ * owns the procedure; a target can only be recorded on its own OS.
+ */
+import { createHash } from "node:crypto";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { engineTarget, engineTargetEntries, targetKey, type EngineTarget } from "../../src/engine-targets";
+import { engineVersion } from "../../src/package-info";
+
+const REPO = "drakulavich/kesha-voice-kit";
+const PACT_DIR = join("tests", "fixtures", "capabilities");
+
+/**
+ * Provenance sits beside each pact rather than in one shared manifest: the three targets are
+ * recorded on three runners that never see each other's output, and a shared file would let
+ * whichever artifact is committed last overwrite the other two with its stale copies.
+ */
+export interface PactProvenance {
+  engineVersion: string;
+  assetName: string;
+  /** SHA-256 of the recorded binary. `--check` re-hashes what it downloads and compares. */
+  sha256: string;
+  recordedFrom: string;
+}
+
+export function pactPath(key: string): string {
+  return join(PACT_DIR, `${key}.json`);
+}
+
+export function provenancePath(key: string): string {
+  return join(PACT_DIR, `${key}.provenance.json`);
+}
+
+function targetByKey(key: string): EngineTarget | undefined {
+  return engineTargetEntries().find((e) => targetKey(e.platform, e.arch) === key)?.target;
+}
+
+/** Keys stay in the engine's own order, so an upstream reordering shows up as a diff. */
+const serialize = (value: unknown): string => `${JSON.stringify(value, null, 2)}\n`;
+
+function usage(message: string): never {
+  console.error(
+    `${message}\n\nusage: record-capability-pacts.ts (--binary <path> | --from-release) [--target <key>] [--check]`,
+  );
+  process.exit(2);
+}
+
+function parseArgs(argv: string[]): { binary: string; target: string; check: boolean; fromRelease: boolean } {
+  let binary = "";
+  let target = "";
+  let check = false;
+  let fromRelease = false;
+  const operand = (flag: string, value: string | undefined): string => {
+    if (value === undefined || value.startsWith("--")) usage(`${flag} needs a value`);
+    return value;
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!;
+    if (arg === "--check") check = true;
+    else if (arg === "--from-release") fromRelease = true;
+    else if (arg === "--binary") binary = operand(arg, argv[++i]);
+    else if (arg === "--target") target = operand(arg, argv[++i]);
+    else usage(`unrecognised argument: ${arg}`);
+  }
+  if (!binary && !fromRelease) usage("pass --binary <path> or --from-release");
+  if (binary && fromRelease) usage("--binary and --from-release are mutually exclusive");
+  if (!target) {
+    if (!engineTarget()) usage(`no published engine target for this host (${targetKey()}); pass --target`);
+    target = targetKey();
+  }
+  // A binary only answers for the platform it was built for, so a matrix row whose runner and
+  // target disagree would file that runner's shape under the wrong name.
+  if (target !== targetKey()) {
+    usage(`--target ${target} cannot be recorded on ${targetKey()}; run it on that target's own OS`);
+  }
+  return { binary, target, check, fromRelease };
+}
+
+/**
+ * Fetch the pinned release's binary — the artifact `kesha install` hands users. ~65 MB of
+ * executable, no models. A failure must be loud: a lane that quietly skips proves nothing (#838).
+ */
+async function downloadPinnedBinary(target: EngineTarget): Promise<string> {
+  const dir = mkdtempSync(join(tmpdir(), "kesha-pact-"));
+  const proc = Bun.spawn(
+    ["gh", "release", "download", `v${engineVersion}`, "-R", REPO, "-p", target.assetName, "-D", dir],
+    { stdout: "inherit", stderr: "inherit" },
+  );
+  if ((await proc.exited) !== 0) {
+    console.error(
+      `FAIL: could not download ${target.assetName} from v${engineVersion}.\n` +
+        "  Check GH_TOKEN, and that the tag exists — between a release merge and its tag, " +
+        "keshaEngine.version legitimately points at an unpublished release.",
+    );
+    process.exit(1);
+  }
+  const path = join(dir, target.assetName);
+  if (process.platform !== "win32") chmodSync(path, 0o755);
+  return path;
+}
+
+async function readCapabilities(binary: string): Promise<unknown> {
+  const proc = Bun.spawn([binary, "--capabilities-json"], { stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (exitCode !== 0) {
+    console.error(`${binary} --capabilities-json exited ${exitCode}`);
+    if (stderr.trim()) console.error(stderr.trim());
+    process.exit(1);
+  }
+  try {
+    return JSON.parse(stdout);
+  } catch {
+    console.error(`${binary} --capabilities-json did not emit JSON:\n${stdout}`);
+    process.exit(1);
+  }
+}
+
+const readNormalised = (path: string): string => readFileSync(path, "utf8").replace(/\r\n/g, "\n");
+
+const RE_RECORD =
+  "Re-record per .github/workflows/capability-pact.yml: dispatch it with `record: true` and " +
+  "commit the artifacts it uploads.";
+
+function verify(target: string, binary: string, recorded: string): void {
+  const path = pactPath(target);
+  const provenance = provenancePath(target);
+  if (!existsSync(path) || !existsSync(provenance)) {
+    console.error(`FAIL: ${target} has no recorded pact. ${RE_RECORD}`);
+    process.exit(1);
+  }
+
+  const previous = JSON.parse(readNormalised(provenance)) as PactProvenance;
+  const failures: string[] = [];
+  if (previous.engineVersion !== engineVersion) {
+    failures.push(
+      `recorded from engine v${previous.engineVersion} but keshaEngine.version pins v${engineVersion}`,
+    );
+  }
+  const sha256 = createHash("sha256").update(readFileSync(binary)).digest("hex");
+  if (previous.sha256 !== sha256) {
+    failures.push(`binary hashes to ${sha256}, provenance records ${previous.sha256}`);
+  }
+  const committed = readNormalised(path);
+  if (committed !== recorded) {
+    failures.push(`--- committed ${path}\n${committed}\n+++ ${binary} --capabilities-json\n${recorded}`);
+  }
+
+  if (failures.length === 0) {
+    console.log(`${target}: pact matches the published binary (engine v${engineVersion}).`);
+    return;
+  }
+  console.error(`FAIL: ${target} drifted from the real binary. ${RE_RECORD}\n`);
+  for (const failure of failures) console.error(failure);
+  process.exit(1);
+}
+
+async function main(): Promise<void> {
+  const { binary: given, target, check, fromRelease } = parseArgs(process.argv.slice(2));
+  const asset = targetByKey(target);
+  if (!asset) usage(`unknown target '${target}' — it has no row in src/engine-targets.ts`);
+
+  const binary = fromRelease ? await downloadPinnedBinary(asset) : given;
+  const recorded = serialize(await readCapabilities(binary));
+
+  if (check) return verify(target, binary, recorded);
+
+  writeFileSync(pactPath(target), recorded);
+  writeFileSync(
+    provenancePath(target),
+    serialize({
+      engineVersion,
+      assetName: asset.assetName,
+      sha256: createHash("sha256").update(readFileSync(binary)).digest("hex"),
+      recordedFrom: `${asset.assetName} from release v${engineVersion}`,
+    } satisfies PactProvenance),
+  );
+  console.log(`Recorded ${pactPath(target)} and ${provenancePath(target)} for engine v${engineVersion}.`);
+}
+
+if (import.meta.main) await main();

--- a/.github/scripts/upsert-audit-issue.sh
+++ b/.github/scripts/upsert-audit-issue.sh
@@ -3,16 +3,17 @@
 # problems. Reuses one issue (by exact title + label) instead of opening a new
 # one each week. Mirrors the upsert pattern in cargo-dependency-maintenance.yml.
 #
-# Usage: upsert-audit-issue.sh <body-file> [title]
+# Usage: upsert-audit-issue.sh <body-file> [title] [label]
 #   <title> defaults to the Rust findings issue. The bun-audit job passes its
 #   own title so Rust and JS findings live in separate issues and never clobber
-#   each other's body on a shared cron run.
+#   each other's body on a shared cron run. <label> defaults to `security`; a
+#   caller reporting something else (capability-pact drift) passes its own.
 #   Env: GH_TOKEN, REPO (owner/name)
 set -euo pipefail
 
 body_file="$1"
 title="${2:-Security audit findings (weekly)}"
-label="security"
+label="${3:-security}"
 
 existing="$(
   gh issue list -R "$REPO" --state open --label "$label" \
@@ -27,6 +28,6 @@ if [[ -n "$existing" ]]; then
     --body "Re-checked $(date -u +%Y-%m-%d): findings updated above."
 else
   gh label create "$label" -R "$REPO" --color B60205 \
-    --description "Automated security-audit findings" 2>/dev/null || true
+    --description "Automated findings from a scheduled check" 2>/dev/null || true
   gh issue create -R "$REPO" --title "$title" --label "$label" --body-file "$body_file"
 fi

--- a/.github/workflows/capability-pact.yml
+++ b/.github/workflows/capability-pact.yml
@@ -1,0 +1,119 @@
+name: "📜 Capability Pact"
+
+# Provider verification for the recorded capability pacts (#798).
+#
+# `tests/unit/capabilities-pact.test.ts` gates flag routing per target on every PR without
+# downloading anything, which is only sound while the recordings still match the binaries.
+# This job re-derives each pact from the artifact `kesha install` hands users and fails on
+# drift. It downloads the engine executable (~65 MB) and no models.
+#
+# RE-RECORDING — the canonical procedure. A new engine release that adds, removes or renames
+# a capability fails this job on purpose, and the fix is to re-record, never to relax the check:
+#
+#   1. bump `keshaEngine.version` to the new release and merge it
+#   2. run this workflow with `record: true` (Actions → 📜 Capability Pact → Run workflow)
+#   3. commit the contents of all three `capability-pact-<target>` artifacts
+#
+# Each target is recorded on its own OS — a binary only answers for the platform it was built
+# for — and each artifact carries only its own two files, so committing all three cannot
+# clobber. `matrix.target` is passed to the recorder, which refuses a row whose runner and
+# target disagree.
+#
+# Never runs on a pull request, so it cannot interfere with a `release/*` branch. The window
+# where `keshaEngine.version` names an unpublished tag fails loudly here, which is the point:
+# it is the check the PR lane deliberately does not carry, because a release PR must be able
+# to go green before the tag it names exists.
+
+on:
+  schedule:
+    # Weekly. A release is the moment the re-record is owed; this is the backstop for one
+    # that forgot, and the only thing standing between a pact and rotting into a false green.
+    - cron: "0 5 * * 1"
+  workflow_dispatch:
+    inputs:
+      record:
+        description: "Re-record the pacts and upload them as artifacts instead of verifying."
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  pact:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-14
+            target: darwin-arm64
+          - os: ubuntu-latest
+            target: linux-x64
+          - os: windows-latest
+            target: win32-x64
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      # Only the scheduled run upserts the drift issue; one per target, so three runners
+      # failing together cannot race each other into duplicates.
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: 🍞 Setup Bun workspace
+        uses: ./.github/actions/setup-bun
+
+      # Explicitly not `!inputs.record`: were `inputs` ever to resolve unexpectedly, both
+      # steps would skip and the job would go green having verified nothing.
+      - name: 🔍 Verify ${{ matrix.target }} against the published binary
+        id: verify
+        if: github.event_name != 'workflow_dispatch' || !inputs.record
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET: ${{ matrix.target }}
+        run: bun .github/scripts/record-capability-pacts.ts --from-release --target "$TARGET" --check
+
+      - name: 📣 Report drift (scheduled only)
+        if: github.event_name == 'schedule' && steps.verify.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          {
+            echo "## $TARGET's capability pact no longer matches the published engine"
+            echo
+            echo "\`tests/fixtures/capabilities/$TARGET.json\` was recorded from an engine that"
+            echo "no longer matches what \`kesha install\` downloads, so every per-PR assertion"
+            echo "derived from it is now gating against a binary nobody has."
+            echo
+            echo "Re-record per the header of \`.github/workflows/capability-pact.yml\`."
+            echo
+            echo "Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          } > /tmp/pact-body.md
+          bash .github/scripts/upsert-audit-issue.sh /tmp/pact-body.md "Capability pact drift: $TARGET" ci
+
+      - name: ❌ Fail on drift
+        if: steps.verify.outcome == 'failure'
+        run: exit 1
+
+      - name: 📝 Re-record ${{ matrix.target }}
+        if: github.event_name == 'workflow_dispatch' && inputs.record
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET: ${{ matrix.target }}
+        run: bun .github/scripts/record-capability-pacts.ts --from-release --target "$TARGET"
+
+      - name: 📤 Upload the re-recorded pact
+        if: github.event_name == 'workflow_dispatch' && inputs.record
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: capability-pact-${{ matrix.target }}
+          path: tests/fixtures/capabilities/${{ matrix.target }}.*
+          if-no-files-found: error

--- a/.github/workflows/capability-pact.yml
+++ b/.github/workflows/capability-pact.yml
@@ -59,8 +59,8 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
-      # Only the scheduled run upserts the drift issue; one per target, so three runners
-      # failing together cannot race each other into duplicates.
+      # Only the scheduled run files an issue; one per target, so three runners failing
+      # together cannot race each other into duplicates.
       issues: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -77,30 +77,42 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TARGET: ${{ matrix.target }}
+        # Every run: here is bash. windows-latest defaults to pwsh, where `$TARGET` is not an
+        # env var (`$env:TARGET` is) and would expand to empty, silently un-pinning --target.
+        shell: bash
         run: bun .github/scripts/record-capability-pacts.ts --from-release --target "$TARGET" --check
 
-      - name: 📣 Report drift (scheduled only)
+      - name: 📣 Report an unverified pact (scheduled only)
         if: github.event_name == 'schedule' && steps.verify.outcome == 'failure'
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           TARGET: ${{ matrix.target }}
+        shell: bash
         run: |
           {
-            echo "## $TARGET's capability pact no longer matches the published engine"
+            echo "## $TARGET's capability pact was not confirmed against the published engine"
             echo
-            echo "\`tests/fixtures/capabilities/$TARGET.json\` was recorded from an engine that"
-            echo "no longer matches what \`kesha install\` downloads, so every per-PR assertion"
-            echo "derived from it is now gating against a binary nobody has."
+            echo "Read the run log before acting — the step fails for two different reasons:"
             echo
-            echo "Re-record per the header of \`.github/workflows/capability-pact.yml\`."
+            echo "- **The shape drifted.** The log shows a \`--- committed\` / \`+++\` diff, a"
+            echo "  sha256 mismatch, or an engine-version mismatch. Every per-PR assertion"
+            echo "  derived from \`tests/fixtures/capabilities/$TARGET.json\` is now gating"
+            echo "  against a binary nobody has. Re-record per the header of"
+            echo "  \`.github/workflows/capability-pact.yml\`."
+            echo "- **Verification could not run.** The log ends at the \`gh release download\`"
+            echo "  or \`--capabilities-json\` step. The pact is not implicated; the run proved"
+            echo "  nothing either way. Common causes: a network or API failure, or the window"
+            echo "  between a release merge and its tag, where \`keshaEngine.version\` names a"
+            echo "  release that does not exist yet."
             echo
             echo "Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           } > /tmp/pact-body.md
-          bash .github/scripts/upsert-audit-issue.sh /tmp/pact-body.md "Capability pact drift: $TARGET" ci
+          bash .github/scripts/upsert-audit-issue.sh /tmp/pact-body.md "Capability pact unverified: $TARGET" pact-drift
 
-      - name: ❌ Fail on drift
+      - name: ❌ Fail an unverified pact
         if: steps.verify.outcome == 'failure'
+        shell: bash
         run: exit 1
 
       - name: 📝 Re-record ${{ matrix.target }}
@@ -108,6 +120,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TARGET: ${{ matrix.target }}
+        shell: bash
         run: bun .github/scripts/record-capability-pacts.ts --from-release --target "$TARGET"
 
       - name: 📤 Upload the re-recorded pact

--- a/src/engine-install.ts
+++ b/src/engine-install.ts
@@ -525,7 +525,7 @@ function validateBackend(backend: string, caps: EngineCapabilities | null): void
  * Nix sandbox forbids it. Without this guard, `kesha-engine install
  * --diarize` would fail with clap's generic "unexpected argument" error.
  */
-function validateDiarize(caps: EngineCapabilities | null): void {
+export function validateDiarize(caps: EngineCapabilities | null): void {
   // null = pre-capabilities-JSON engine; forwarding --diarize would surface as clap's "unexpected argument".
   if (!caps || !caps.features.includes(TRANSCRIBE_DIARIZE_FEATURE)) {
     throw new Error(

--- a/src/engine-targets.ts
+++ b/src/engine-targets.ts
@@ -31,6 +31,10 @@ const ENGINE_TARGETS: Record<string, EngineTarget> = {
   },
 };
 
+export function targetKey(platform: string = process.platform, arch: string = process.arch): string {
+  return `${platform}-${arch}`;
+}
+
 /** Returns null for a platform with no published engine — callers choose how loudly to fail. */
 export function engineTarget(
   platform: string = process.platform,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -241,11 +241,7 @@ function assertVadModelInstalled(): void {
  * supports the pass — so a missing capability means the installed engine is
  * older than the CLI asking for it.
  */
-export async function preflightTranscribeEngineItn(
-  opts: TranscribeEngineOptions = {},
-): Promise<void> {
-  if (!opts.itn) return;
-  const caps = await getEngineCapabilities();
+export function assertItnSupported(caps: EngineCapabilities | null): void {
   if (!caps?.features.includes(TRANSCRIBE_ITN_FEATURE)) {
     throw new Error(
       "--itn requires a newer kesha-engine: the installed engine does not advertise " +
@@ -255,6 +251,13 @@ export async function preflightTranscribeEngineItn(
         `    ${installHint()}`,
     );
   }
+}
+
+export async function preflightTranscribeEngineItn(
+  opts: TranscribeEngineOptions = {},
+): Promise<void> {
+  if (!opts.itn) return;
+  assertItnSupported(await getEngineCapabilities());
 }
 
 export async function preflightTranscribeEngineWithSegments(
@@ -271,15 +274,18 @@ export async function preflightTranscribeEngineWithSegments(
 
   if (!opts.speakers) return;
 
-  if (!caps.features.includes(TRANSCRIBE_DIARIZE_FEATURE)) {
+  assertSpeakersSupported(caps);
+  assertDiarizeModelInstalled();
+  assertVadModelInstalled();
+}
+
+export function assertSpeakersSupported(caps: EngineCapabilities | null): void {
+  if (!caps?.features.includes(TRANSCRIBE_DIARIZE_FEATURE)) {
     throw new Error(
       "speaker diarization is currently darwin-arm64 only " +
         "(see https://github.com/drakulavich/kesha-voice-kit/issues/199)",
     );
   }
-
-  assertDiarizeModelInstalled();
-  assertVadModelInstalled();
 }
 
 function vadArg(vad: VadMode | undefined): string[] {
@@ -288,8 +294,16 @@ function vadArg(vad: VadMode | undefined): string[] {
   return [];
 }
 
-function itnArg(itn: boolean | undefined): string[] {
-  return itn ? ["--itn"] : [];
+/** Build the argv passed to `kesha-engine transcribe` (pure, unit-testable). */
+export function buildTranscribeArgs(
+  audioPath: string,
+  opts: TranscribeEngineOptions,
+  json = false,
+): string[] {
+  const args = ["transcribe", audioPath, ...(json ? ["--json"] : []), ...vadArg(opts.vad)];
+  if (opts.itn) args.push("--itn");
+  if (json && opts.speakers) args.push("--speakers");
+  return args;
 }
 
 export async function transcribeEngine(
@@ -298,7 +312,7 @@ export async function transcribeEngine(
 ): Promise<string> {
   await preflightTranscribeEngineItn(opts);
 
-  const args = ["transcribe", audioPath, ...vadArg(opts.vad), ...itnArg(opts.itn)];
+  const args = buildTranscribeArgs(audioPath, opts);
   const { stdout, stderr, exitCode } = await runEngine(args, { signal: opts.signal });
   if (exitCode !== 0) {
     throw new Error(stderr || `kesha-engine exited with code ${exitCode}`);
@@ -336,8 +350,7 @@ export async function transcribeEngineWithSegments(
   await preflightTranscribeEngineItn(opts);
   await preflightTranscribeEngineWithSegments(opts);
 
-  const args = ["transcribe", audioPath, "--json", ...vadArg(opts.vad), ...itnArg(opts.itn)];
-  if (opts.speakers) args.push("--speakers");
+  const args = buildTranscribeArgs(audioPath, opts, true);
   const { stdout, stderr, exitCode } = await runEngine(args, { signal: opts.signal });
   if (exitCode !== 0) {
     throw new Error(stderr || `kesha-engine exited with code ${exitCode}`);

--- a/tests/fixtures/capabilities/darwin-arm64.json
+++ b/tests/fixtures/capabilities/darwin-arm64.json
@@ -1,0 +1,75 @@
+{
+  "protocolVersion": 3,
+  "backend": "coreml",
+  "features": [
+    "transcribe",
+    "transcribe.segments",
+    "detect-lang",
+    "vad",
+    "detect-text-lang",
+    "tts",
+    "tts.ru_acronym_expansion",
+    "tts.en_acronym_expansion",
+    "tts.ru_emphasis_marker",
+    "tts.prosody_rate",
+    "transcribe.diarize"
+  ],
+  "tts": {
+    "languages": [
+      {
+        "code": "en",
+        "engines": [
+          "kokoro"
+        ]
+      },
+      {
+        "code": "es",
+        "engines": [
+          "kokoro"
+        ]
+      },
+      {
+        "code": "fr",
+        "engines": [
+          "kokoro"
+        ]
+      },
+      {
+        "code": "hi",
+        "engines": [
+          "kokoro"
+        ]
+      },
+      {
+        "code": "it",
+        "engines": [
+          "kokoro"
+        ]
+      },
+      {
+        "code": "ja",
+        "engines": [
+          "kokoro"
+        ]
+      },
+      {
+        "code": "pt",
+        "engines": [
+          "kokoro"
+        ]
+      },
+      {
+        "code": "zh",
+        "engines": [
+          "kokoro"
+        ]
+      },
+      {
+        "code": "ru",
+        "engines": [
+          "vosk"
+        ]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/capabilities/darwin-arm64.provenance.json
+++ b/tests/fixtures/capabilities/darwin-arm64.provenance.json
@@ -1,0 +1,6 @@
+{
+  "engineVersion": "1.24.9",
+  "assetName": "kesha-engine-darwin-arm64",
+  "sha256": "96635497a69d247f041a29ba1e34d3abf632e7eaaf4d4e7a9e7d171c1dd87859",
+  "recordedFrom": "kesha-engine-darwin-arm64 downloaded from release v1.24.9 with `gh release download` and executed locally"
+}

--- a/tests/fixtures/capabilities/linux-x64.json
+++ b/tests/fixtures/capabilities/linux-x64.json
@@ -1,0 +1,55 @@
+{
+  "protocolVersion": 3,
+  "backend": "onnx",
+  "features": [
+    "transcribe",
+    "transcribe.segments",
+    "detect-lang",
+    "vad",
+    "tts",
+    "tts.ru_acronym_expansion",
+    "tts.en_acronym_expansion",
+    "tts.ru_emphasis_marker",
+    "tts.prosody_rate"
+  ],
+  "tts": {
+    "languages": [
+      {
+        "code": "en",
+        "engines": [
+          "kokoro"
+        ]
+      },
+      {
+        "code": "es",
+        "engines": [
+          "kokoro"
+        ]
+      },
+      {
+        "code": "fr",
+        "engines": [
+          "kokoro"
+        ]
+      },
+      {
+        "code": "it",
+        "engines": [
+          "kokoro"
+        ]
+      },
+      {
+        "code": "pt",
+        "engines": [
+          "kokoro"
+        ]
+      },
+      {
+        "code": "ru",
+        "engines": [
+          "vosk"
+        ]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/capabilities/linux-x64.provenance.json
+++ b/tests/fixtures/capabilities/linux-x64.provenance.json
@@ -1,0 +1,6 @@
+{
+  "engineVersion": "1.24.9",
+  "assetName": "kesha-engine-linux-x64",
+  "sha256": "32298e355135d7a0ae468bb934ca14d179b31d54d6ba8e3b3c127074a26966bf",
+  "recordedFrom": "kesha-engine-linux-x64 smoke-tested pre-upload in build-engine run 31274041934 job 93144639950 (tag v1.24.9); sha256 from the release SHA256SUMS"
+}

--- a/tests/fixtures/capabilities/win32-x64.json
+++ b/tests/fixtures/capabilities/win32-x64.json
@@ -1,0 +1,55 @@
+{
+  "protocolVersion": 3,
+  "backend": "onnx",
+  "features": [
+    "transcribe",
+    "transcribe.segments",
+    "detect-lang",
+    "vad",
+    "tts",
+    "tts.ru_acronym_expansion",
+    "tts.en_acronym_expansion",
+    "tts.ru_emphasis_marker",
+    "tts.prosody_rate"
+  ],
+  "tts": {
+    "languages": [
+      {
+        "code": "en",
+        "engines": [
+          "kokoro"
+        ]
+      },
+      {
+        "code": "es",
+        "engines": [
+          "kokoro"
+        ]
+      },
+      {
+        "code": "fr",
+        "engines": [
+          "kokoro"
+        ]
+      },
+      {
+        "code": "it",
+        "engines": [
+          "kokoro"
+        ]
+      },
+      {
+        "code": "pt",
+        "engines": [
+          "kokoro"
+        ]
+      },
+      {
+        "code": "ru",
+        "engines": [
+          "vosk"
+        ]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/capabilities/win32-x64.provenance.json
+++ b/tests/fixtures/capabilities/win32-x64.provenance.json
@@ -1,0 +1,6 @@
+{
+  "engineVersion": "1.24.9",
+  "assetName": "kesha-engine-windows-x64.exe",
+  "sha256": "c3c2b61f7e381c99b68b745e27f61cd04a151f65e0c936df9df6a05f346f8de3",
+  "recordedFrom": "kesha-engine-windows-x64.exe smoke-tested pre-upload in build-engine run 31274041934 job 93144639921 (tag v1.24.9); sha256 from the release SHA256SUMS"
+}

--- a/tests/unit/capabilities-pact.test.ts
+++ b/tests/unit/capabilities-pact.test.ts
@@ -67,10 +67,10 @@ for (const { platform, arch, target } of engineTargetEntries()) {
 }
 
 /**
- * Every engine flag the TS side can emit, and the capabilities that make a target accept it —
- * an empty list means clap defines it on every published build. A flag emitted by one of the
- * argv builders with no row here fails `classifies every flag the TS side can emit`, which is
- * what keeps this table honest as flags are added.
+ * Every flag the three pure argv builders emit, and the capabilities that make a target accept
+ * it — an empty list means clap defines it on every published build. A flag added to a builder
+ * with no row here fails `classifies every flag the say, install and transcribe builders emit`.
+ * Subcommands with no pure builder (`record`, `say --list-voices`) are outside this view.
  */
 const FLAG_CAPABILITIES: Record<string, string[]> = {
   "--voice": ["tts"],
@@ -161,7 +161,7 @@ describe("capability pact — recordings", () => {
 });
 
 describe("capability pact — flags the TS side emits", () => {
-  it("classifies every flag the TS side can emit", () => {
+  it("classifies every flag the say, install and transcribe builders emit", () => {
     const emitted = new Set([
       ...flagsIn(buildSayArgs(EVERY_SAY_OPTION, EVERY_CAPABILITY)),
       ...capabilityBlindFlags(),

--- a/tests/unit/capabilities-pact.test.ts
+++ b/tests/unit/capabilities-pact.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Consumer side of the capability pact (#798).
+ *
+ * `Capabilities` is derived entirely at compile time, so an in-process Rust test only ever
+ * sees the build running it. Nothing compared the darwin CoreML shape against the
+ * Linux/Windows ONNX shape, and nothing checked that the flags the TS side emits are accepted
+ * by the target it emits them at — that matrix is observable only from the real binaries,
+ * which until now only the model-downloading lanes ever saw.
+ *
+ * These tests read `tests/fixtures/capabilities/<target>.json` — recordings of
+ * `--capabilities-json` from the published binaries — and drive the production seams against
+ * them. No engine, no models, no network. `.github/workflows/capability-pact.yml` re-records
+ * from the real artifacts and fails on drift, which is what stops a pact from rotting into a
+ * false green; it also owns the pinned-version check, which cannot live here because a release
+ * PR bumps `keshaEngine.version` before the tag it names exists.
+ */
+import { describe, expect, it } from "bun:test";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import {
+  pactPath,
+  provenancePath,
+  type PactProvenance,
+} from "../../.github/scripts/record-capability-pacts";
+import {
+  assertItnSupported,
+  assertSpeakersSupported,
+  buildTranscribeArgs,
+  RECORD_LIVE_FEATURE,
+  TRANSCRIBE_DIARIZE_FEATURE,
+  TRANSCRIBE_ITN_FEATURE,
+  TRANSCRIBE_SEGMENTS_FEATURE,
+  textLangFailureWarning,
+  type EngineCapabilities,
+} from "../../src/engine";
+import { buildEngineInstallArgs, validateDiarize } from "../../src/engine-install";
+import { engineTargetEntries, targetKey } from "../../src/engine-targets";
+import { buildSayArgs, type SayOptions } from "../../src/synth";
+import { pickVoiceForLang } from "../../src/voice-routing";
+import { readRepoFile, repoPath } from "../helpers/repo";
+
+interface PactTarget {
+  key: string;
+  platform: NodeJS.Platform;
+  arch: NodeJS.Architecture;
+  backend: "coreml" | "onnx";
+  pact: EngineCapabilities;
+  provenance: PactProvenance;
+}
+
+const unrecorded: string[] = [];
+const TARGETS: PactTarget[] = [];
+for (const { platform, arch, target } of engineTargetEntries()) {
+  const key = targetKey(platform, arch);
+  if (!existsSync(repoPath(pactPath(key))) || !existsSync(repoPath(provenancePath(key)))) {
+    unrecorded.push(key);
+    continue;
+  }
+  TARGETS.push({
+    key,
+    platform: platform as NodeJS.Platform,
+    arch: arch as NodeJS.Architecture,
+    backend: target.backend,
+    pact: JSON.parse(readRepoFile(pactPath(key))) as EngineCapabilities,
+    provenance: JSON.parse(readRepoFile(provenancePath(key))) as PactProvenance,
+  });
+}
+
+/**
+ * Every engine flag the TS side can emit, and the capabilities that make a target accept it —
+ * an empty list means clap defines it on every published build. A flag emitted by one of the
+ * argv builders with no row here fails `classifies every flag the TS side can emit`, which is
+ * what keeps this table honest as flags are added.
+ */
+const FLAG_CAPABILITIES: Record<string, string[]> = {
+  "--voice": ["tts"],
+  "--lang": ["tts"],
+  "--out": ["tts"],
+  "--rate": ["tts"],
+  "--ssml": ["tts"],
+  "--format": ["tts"],
+  "--bitrate": ["tts"],
+  "--sample-rate": ["tts"],
+  "--no-expand-abbrev": ["tts.ru_acronym_expansion", "tts.en_acronym_expansion"],
+  "--no-cache": [],
+  "--tts": ["tts"],
+  "--vad": ["vad"],
+  "--no-vad": ["vad"],
+  "--diarize": [TRANSCRIBE_DIARIZE_FEATURE],
+  "--json": [TRANSCRIBE_SEGMENTS_FEATURE],
+  "--itn": [TRANSCRIBE_ITN_FEATURE],
+  "--speakers": [TRANSCRIBE_DIARIZE_FEATURE],
+};
+
+/**
+ * Guards that must refuse a flag before it reaches an engine whose pact lacks its capability.
+ * `buildSayArgs` guards itself by taking capabilities and dropping the flag; the transcribe
+ * and install builders are capability-blind, so their gated flags need an entry here.
+ */
+const FLAG_GUARDS: Record<string, (caps: EngineCapabilities) => void> = {
+  "--diarize": validateDiarize,
+  "--speakers": assertSpeakersSupported,
+  "--itn": assertItnSupported,
+};
+
+/** Maximal option sets, so the builders emit every flag they are capable of emitting. */
+const EVERY_SAY_OPTION: SayOptions = {
+  text: "hello",
+  voice: "en-am_michael",
+  lang: "en",
+  out: "out.wav",
+  rate: 1.5,
+  ssml: true,
+  format: "ogg-opus",
+  bitrate: 32_000,
+  sampleRate: 24_000,
+  noExpandAbbrev: true,
+};
+const EVERY_INSTALL_OPTION = { noCache: true, ttsLangs: ["en"], vad: true, diarize: true };
+
+/** A hypothetical engine advertising everything, so a builder emits every flag it can. */
+const EVERY_CAPABILITY: EngineCapabilities = {
+  protocolVersion: 3,
+  backend: "onnx",
+  features: Object.values(FLAG_CAPABILITIES).flat(),
+};
+
+const flagsIn = (argv: string[]): string[] => argv.filter((arg) => arg.startsWith("--"));
+
+const satisfies = (pact: EngineCapabilities, capabilities: string[]): boolean =>
+  capabilities.length === 0 || capabilities.some((c) => pact.features.includes(c));
+
+/** Everything the TS side can put on the wire that no capability check filters first. */
+const capabilityBlindFlags = (): string[] => [
+  ...flagsIn(buildEngineInstallArgs(EVERY_INSTALL_OPTION)),
+  ...flagsIn(buildTranscribeArgs("a.wav", { vad: "on", itn: true, speakers: true }, true)),
+  ...flagsIn(buildTranscribeArgs("a.wav", { vad: "off" })),
+];
+
+describe("capability pact — recordings", () => {
+  it("records a pact for every published engine target", () => {
+    expect(unrecorded).toEqual([]);
+  });
+
+  it("records every target from the same engine release", () => {
+    // Mixed versions would gate one platform's flags against another platform's binary.
+    expect([...new Set(TARGETS.map((t) => t.provenance.engineVersion))]).toHaveLength(1);
+  });
+
+  for (const { key, backend, pact } of TARGETS) {
+    it(`${key} reports the backend src/engine-targets.ts claims it ships`, () => {
+      expect(pact.backend).toBe(backend);
+    });
+  }
+
+  // Point 4 of #798: an in-process test structurally cannot see a bump that lands on one
+  // target only, and the wire format the TS parser reads is shared across all of them.
+  it("speaks one protocol version across every target", () => {
+    expect([...new Set(TARGETS.map((t) => t.pact.protocolVersion))]).toHaveLength(1);
+  });
+});
+
+describe("capability pact — flags the TS side emits", () => {
+  it("classifies every flag the TS side can emit", () => {
+    const emitted = new Set([
+      ...flagsIn(buildSayArgs(EVERY_SAY_OPTION, EVERY_CAPABILITY)),
+      ...capabilityBlindFlags(),
+    ]);
+    expect([...emitted].filter((flag) => FLAG_CAPABILITIES[flag] === undefined)).toEqual([]);
+  });
+
+  for (const { key, pact } of TARGETS) {
+    it(`emits no say flag ${key}'s engine would reject`, () => {
+      // buildSayArgs takes the target's own capabilities, exactly as say() passes the
+      // installed engine's — so this is its drop decision held against the real binary.
+      const unsupported = flagsIn(buildSayArgs(EVERY_SAY_OPTION, pact)).filter(
+        (flag) => !satisfies(pact, FLAG_CAPABILITIES[flag] ?? []),
+      );
+      expect(unsupported).toEqual([]);
+    });
+
+    it(`refuses every capability-blind flag ${key}'s engine would reject`, () => {
+      for (const flag of new Set(capabilityBlindFlags())) {
+        const guard = FLAG_GUARDS[flag];
+        if (satisfies(pact, FLAG_CAPABILITIES[flag] ?? [])) {
+          if (guard) expect(() => guard(pact), `${flag} is supported on ${key}`).not.toThrow();
+          continue;
+        }
+        expect(guard, `${flag} is unsupported on ${key} and has no guard to refuse it`).toBeDefined();
+        expect(() => guard!(pact), `${flag} reaches ${key}'s engine unrefused`).toThrow();
+      }
+    });
+  }
+});
+
+describe("capability pact — platform behaviour derived from the recordings", () => {
+  // "darwin-arm64 only" is repeated in five user-facing strings; this is the one place the
+  // claim meets the binaries, so a Linux diarize build turns it red instead of shipping a lie.
+  it("advertises diarization on darwin-arm64 alone", () => {
+    const advertising = TARGETS.filter((t) => t.pact.features.includes(TRANSCRIBE_DIARIZE_FEATURE));
+    expect(advertising.map((t) => t.key).sort()).toEqual(["darwin-arm64"]);
+  });
+
+  for (const { key, platform, arch, pact } of TARGETS) {
+    it(`warns on failed text detection exactly where ${key} advertises detect-text-lang`, () => {
+      // #770: swallowing the failure off darwin is deliberate, warning on it is deliberate on
+      // darwin — both follow from whether that build carries the sidecar at all.
+      const advertised = pact.features.includes("detect-text-lang");
+      expect(textLangFailureWarning("boom", platform) !== null).toBe(advertised);
+    });
+
+    it(`routes only voices ${key}'s engine can synthesise`, () => {
+      const advertised = new Set(pact.tts?.languages.map((l) => l.code) ?? []);
+      const everyLanguage = new Set(
+        TARGETS.flatMap((t) => t.pact.tts?.languages.map((l) => l.code) ?? []),
+      );
+      const unsupported: string[] = [];
+      for (const lang of everyLanguage) {
+        const voice = pickVoiceForLang(lang, 0.95, platform, arch);
+        // `macos-*` is the AVSpeech sidecar, which serves no downloadable engine language.
+        if (!voice || voice.startsWith("macos-")) continue;
+        const code = voice.split("-", 1)[0]!;
+        if (!advertised.has(code)) unsupported.push(`${lang} -> ${voice}`);
+      }
+      expect(unsupported).toEqual([]);
+    });
+  }
+});
+
+describe("capability pact — gate strings", () => {
+  /**
+   * A gate on a capability string no build emits refuses forever. The pacts cannot be the
+   * authority here: a capability released after the pinned engine legitimately appears in no
+   * pact (`transcribe.itn` and `record.live` are both in that state today), so the Rust source
+   * answers "does this string exist" and the pacts answer "on which targets".
+   */
+  it("gates on capability strings the engine can emit", () => {
+    const rust = ["capabilities.rs", "transcribe/mod.rs", "record.rs"]
+      .map((file) => readRepoFile(join("rust", "src", file)))
+      .join("\n");
+    const gated = [
+      TRANSCRIBE_SEGMENTS_FEATURE,
+      TRANSCRIBE_DIARIZE_FEATURE,
+      TRANSCRIBE_ITN_FEATURE,
+      RECORD_LIVE_FEATURE,
+      ...Object.values(FLAG_CAPABILITIES).flat(),
+    ];
+    expect(gated.filter((capability) => !rust.includes(`"${capability}"`))).toEqual([]);
+  });
+});

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -3,6 +3,7 @@ import {
   forbidLinuxPackaging,
   requireDarwinSmokeCoversBothEngines,
   requireNpmPublishAfterPackaging,
+  requirePactVerificationCoversEveryTarget,
   requirePreUploadSynthesisSmoke,
   requireTestedScriptsInCodeFilter,
 } from "../../.github/scripts/check-workflows";
@@ -11,6 +12,7 @@ import { parseRepoYaml, readRepoFile } from "../helpers/repo";
 const PATH = ".github/workflows/build-engine.yml";
 const CI = ".github/workflows/ci.yml";
 const RELEASE_CLI = ".github/workflows/release-cli.yml";
+const PACT = ".github/workflows/capability-pact.yml";
 
 function job(name: string, steps: unknown[]) {
   return { jobs: { [name]: { steps } } };
@@ -242,5 +244,31 @@ describe("requireTestedScriptsInCodeFilter", () => {
 
   test("fails when the changes job has no inline filters", () => {
     expect(requireTestedScriptsInCodeFilter(CI, { jobs: { changes: {} } }, [])[0]).toContain("expected a `changes` job");
+  });
+});
+
+describe("requirePactVerificationCoversEveryTarget", () => {
+  const matrix = (targets: string[]) => ({
+    jobs: { pact: { strategy: { matrix: { include: targets.map((target) => ({ os: "ubuntu-latest", target })) } } } },
+  });
+
+  test("passes on the real capability-pact.yml", () => {
+    expect(requirePactVerificationCoversEveryTarget(PACT, parseRepoYaml(PACT))).toEqual([]);
+  });
+
+  test("ignores every other workflow", () => {
+    expect(requirePactVerificationCoversEveryTarget(CI, matrix([]))).toEqual([]);
+  });
+
+  test("fails when a published target has no runner", () => {
+    const errors = requirePactVerificationCoversEveryTarget(PACT, matrix(["darwin-arm64"]));
+    expect(errors).toHaveLength(2);
+    expect(errors.join("\n")).toContain("no runner verifies linux-x64's pact");
+  });
+
+  test("fails when the matrix is gone", () => {
+    expect(requirePactVerificationCoversEveryTarget(PACT, { jobs: { pact: {} } })[0]).toContain(
+      "strategy.matrix.include",
+    );
   });
 });


### PR DESCRIPTION
Closes #798. C1 of the accepted #741 ≤2 GB plan — the record-then-provider-verify pattern the later stages reuse.

## What it does

`rust/src/capabilities.rs` derives everything at compile time, so `caps_tests` only ever sees the build running it. Nothing compared the darwin CoreML shape against the Linux/Windows ONNX shape, and nothing checked that the flags the TS side emits are accepted by the target it emits them at.

Per PR, with **no engine and no models**, `tests/unit/capabilities-pact.test.ts` now drives the existing seams against recorded pacts:

| seam | what the pact decides |
| --- | --- |
| `buildSayArgs` | `--no-expand-abbrev` is dropped exactly where the target lacks the acronym capability |
| `validateDiarize` / `assertSpeakersSupported` / `assertItnSupported` | a capability-blind flag reaches an engine only if a guard refuses it first |
| `pickVoiceForLang` | no target is routed a voice for a language its `tts.languages` does not advertise |
| `textLangFailureWarning` | warns exactly where the pact advertises `detect-text-lang` |

Platform refusals are **derived** from the recordings rather than hardcoded a second time: `transcribe.diarize` present on darwin-arm64 alone, `detect-text-lang` from the pact rather than a `platform === "darwin"` literal.

## Pact provenance, per target

Engine v1.24.9, the version `keshaEngine.version` pins. Only three targets are published — there is no `darwin-x64` binary in the release, contrary to the issue body.

| target | recorded from | binary sha256 |
| --- | --- | --- |
| `darwin-arm64` | `gh release download v1.24.9` → run locally on Apple Silicon | `96635497…7859` |
| `linux-x64` | build-engine run [31274041934](https://github.com/drakulavich/kesha-voice-kit/actions/runs/31274041934) job 93144639950, the pre-upload `--capabilities-json` smoke on tag v1.24.9 | `32298e35…66bf` |
| `win32-x64` | same run, job 93144639921 | `c3c2b61f…8de3` |

The darwin recording was obtained both ways and the two agree byte-for-byte, which is what cross-validates the log-extraction used for the two targets that cannot execute locally. Hashes are the release's own `SHA256SUMS`; `--check` re-hashes what it downloads and compares.

Worth knowing: **no published binary advertises `transcribe.itn` or `record.live`**. Both landed on `main` after v1.24.9 (`b757517` #756, `50511a0` #757; `git tag --contains` returns nothing for either). That is legitimate — an engine feature ships on the next engine release — and it is what gives the `--itn` guard live, firing coverage across all three targets today.

## Red-first

Each demonstrated by breaking it, then reverted:

- routing `zh` at ONNX targets → `routes only voices linux-x64's engine can synthesise` fails with `zh -> zh-zm_050`
- dropping `validateDiarize` from the guard table → `--diarize is unsupported on linux-x64 and has no guard to refuse it`
- neutering `assertItnSupported` → `--itn reaches darwin-arm64's engine unrefused`, on all three targets
- corrupting a provenance sha256 + version → `--check` reports both, exit 1

## Provider verification

`.github/workflows/capability-pact.yml`, weekly + `workflow_dispatch`, one runner per target. Downloads the published binary (~65 MB, no models), re-derives, fails on drift, and upserts a per-target issue so a scheduled failure is not something nobody reads. `record: true` re-records and uploads artifacts scoped to one target each, so committing all three cannot clobber. `matrix.target` is passed to the recorder, which refuses a row whose runner and target disagree — `check-workflows` asserts every published target has a row.

**The pinned-version check lives in the scheduled job, not the PR lane.** A release PR bumps `keshaEngine.version` in the same commit the tag will later point at, so asserting `pact version === pinned version` per-PR would turn that PR red with no way to fix it — the binary is not published until after the merge. Circular, and it would have blocked shipping #756/#757.

## Production changes

Three, all small and behaviour-preserving:

- `validateDiarize` exported (it was already the pattern `buildEngineInstallArgs` follows).
- `buildTranscribeArgs` extracted — `--itn`/`--speakers`/`--vad` were built inline inside the async transcribe functions, out of reach of any pure test.
- `assertItnSupported` / `assertSpeakersSupported` extracted from their preflights, same shape as `validateDiarize`. The gates move; they do not loosen.

`upsert-audit-issue.sh` takes an optional label so pact drift does not land under `security`.

## Verification

- `bunx tsc --noEmit` — clean
- `bun test` — 1128 pass, 5 skip, 0 fail (main is 1108; +25 tests, and the 5 skips are the pre-existing model-gated ones)
- `bun run coverage:check:ts` — 79.99% total, every floor held (`src/engine.ts` 89.64% vs 80%)
- `bun run check:workflows` — clean, including the new pact-matrix guard
- `bash -n .github/scripts/upsert-audit-issue.sh` — clean
- `bun .github/scripts/record-capability-pacts.ts --from-release --check` run against the real published darwin-arm64 binary — matches

No Rust changed, so no cargo gate applies.

## Not in scope

Per #741's amendment, C3 fixture-recording of `TranscribeResult` shapes was absorbed into a later stage — this is flags and capabilities only. `FLAG_CAPABILITIES` covers the three pure argv builders; a new flag with no row there fails `classifies every flag the TS side can emit` rather than escaping silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBTpJjqyYFW6W8LHJ2nwy