### PR TITLE
chore(coverage): raise the engine-install floor from 15% to 60%

### DIFF
--- a/.github/scripts/check-coverage.ts
+++ b/.github/scripts/check-coverage.ts
@@ -35,7 +35,8 @@ const presets: Record<PresetName, CoveragePreset> = {
     minFileLines: {
       "src/cli/main.ts": 35,
       "src/cli/say.ts": 50,
-      "src/engine-install.ts": 15,
+      // Sat at 15 while the file measured 65.9%, so a fourfold collapse would still pass (#847 audit).
+      "src/engine-install.ts": 60,
       "src/engine.ts": 80,
     },
   },


### PR DESCRIPTION
Found while auditing whether the coverage floors are risk-based or historical.

### The gap

| File | Actual (CI) | Floor | Headroom |
|---|---:|---:|---:|
| `src/engine-install.ts` | 65.89% | **15%** | +51 |
| `src/engine.ts` | 89.64% | 80% | +10 |
| `src/cli/main.ts` | 39.62% | 35% | +4.6 |
| `src/cli/say.ts` | 51.75% | 50% | +1.75 |

I expected `engine-install.ts` at 15% to be a floor frozen at whatever the file measured when it was set. It is the reverse: the file is covered to 66% and the floor guards nothing — coverage could fall fourfold and the gate would still pass. That is on the surface where #770, #796 and #801 clustered.

Numbers are from the `ts-coverage` job of run `31425179661` on main, not from a local run.

### The change

One line, 15 → 60. Roughly 6 points of headroom against the CI figure, so ordinary work doesn't trip it but a real regression does.

Local `bun run coverage:check:ts` reports **91.63%** for this file rather than 65.89%, because an installed engine walks more of the install path. The CI figure is the binding one and is what 60 is chosen against — worth knowing before anyone reads a local run and thinks the headroom is larger.

### Not changed

`src/cli/say.ts` has only 1.75 points of headroom, which is the mirror problem: it will fire on refactors unrelated to risk. Left alone deliberately — tightening or loosening it is a judgement call about that file, not a mechanical fix, and it belongs in its own change.