### PR TITLE
fix(tts): clip the padding a chunk join stacks into dead air

### DIFF
--- a/rust/src/tts/mod.rs
+++ b/rust/src/tts/mod.rs
@@ -16,6 +16,7 @@ pub mod kokoro;
 pub mod normalize;
 pub mod ru;
 pub mod say;
+pub mod seam;
 pub mod sessions;
 pub mod ssml;
 mod token;

--- a/rust/src/tts/seam.rs
+++ b/rust/src/tts/seam.rs
@@ -27,12 +27,44 @@ pub fn join_chunks(chunks: Vec<Vec<f32>>, sample_rate: u32) -> Vec<f32> {
     if chunks.len() < 2 {
         return chunks.into_iter().next().unwrap_or_default();
     }
+    let frame = (sample_rate as usize * FRAME_MS / 1000).max(1);
+    let keep = sample_rate as usize * SEAM_SILENCE_MS / 2000;
+    let last = chunks.len() - 1;
     let mut out = Vec::new();
-    for chunk in &chunks {
-        out.extend_from_slice(chunk);
+    for (i, chunk) in chunks.iter().enumerate() {
+        out.extend_from_slice(clip_edges(chunk, frame, keep, i > 0, i < last));
     }
-    let _ = sample_rate;
     out
+}
+
+/// Narrow `samples` to the span that keeps at most `keep` samples of silence
+/// on each requested edge. An edge not requested is returned in full.
+fn clip_edges(samples: &[f32], frame: usize, keep: usize, lead: bool, tail: bool) -> &[f32] {
+    let rms: Vec<f32> = samples
+        .chunks(frame)
+        .map(|f| (f.iter().map(|s| s * s).sum::<f32>() / f.len() as f32).sqrt())
+        .collect();
+    let floor = rms.iter().fold(0.0f32, |a, &b| a.max(b)) * SILENCE_FLOOR;
+    let Some(first) = rms.iter().position(|&r| r > floor) else {
+        let len = if lead || tail {
+            keep.min(samples.len())
+        } else {
+            samples.len()
+        };
+        return &samples[..len];
+    };
+    let voiced_end = rms.iter().rposition(|&r| r > floor).unwrap_or(first);
+    let start = if lead {
+        (first * frame).saturating_sub(keep)
+    } else {
+        0
+    };
+    let end = if tail {
+        ((voiced_end + 1) * frame + keep).min(samples.len())
+    } else {
+        samples.len()
+    };
+    &samples[start..end]
 }
 
 #[cfg(test)]
@@ -48,7 +80,7 @@ mod tests {
     /// Silence, then a tone, then silence — the shape Kokoro emits per chunk.
     fn padded(lead_ms: usize, tone_ms: usize, tail_ms: usize) -> Vec<f32> {
         let mut v = vec![0.0; ms(lead_ms)];
-        v.extend((0..ms(tone_ms)).map(|i| (i as f32 * 0.1).sin() * 0.5));
+        v.extend((0..ms(tone_ms)).map(|i| if i % 24 < 12 { 0.5 } else { -0.5 }));
         v.extend(vec![0.0; ms(tail_ms)]);
         v
     }

--- a/rust/src/tts/seam.rs
+++ b/rust/src/tts/seam.rs
@@ -1,0 +1,139 @@
+//! Joining the chunks a long utterance is split into.
+//!
+//! Kokoro pads every utterance it synthesizes with near-silence at both edges
+//! (~0.42 s lead, ~0.62 s tail on `am_michael`). Concatenating chunk samples
+//! raw therefore stacks both paddings into ~1 s of dead air at each join —
+//! 2.5x the median natural pause of the same clip, in a spot where the source
+//! text had only a space (#808).
+
+/// Silence a join may keep, split evenly between the two edges it trims.
+/// Sized to the inter-word gaps an unchunked utterance shows (60–135 ms
+/// measured on `en-am_michael`): the split consumed a space token, so the
+/// join should read as a word boundary.
+const SEAM_SILENCE_MS: usize = 120;
+
+/// Analysis frame for the silence scan.
+const FRAME_MS: usize = 5;
+
+/// Frame RMS at or below this fraction of the chunk's loudest frame (-45 dB)
+/// counts as silence. Kokoro's edge padding sits below -150 dB, so the value
+/// only has to stay under real speech.
+const SILENCE_FLOOR: f32 = 0.0056;
+
+/// Concatenate the rendered chunks of one utterance, clipping the padding each
+/// chunk carries at the joins back to [`SEAM_SILENCE_MS`]. The clip's own head
+/// and tail keep the model's padding, and a single chunk is returned untouched.
+pub fn join_chunks(chunks: Vec<Vec<f32>>, sample_rate: u32) -> Vec<f32> {
+    if chunks.len() < 2 {
+        return chunks.into_iter().next().unwrap_or_default();
+    }
+    let mut out = Vec::new();
+    for chunk in &chunks {
+        out.extend_from_slice(chunk);
+    }
+    let _ = sample_rate;
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SR: u32 = 24_000;
+
+    fn ms(n: usize) -> usize {
+        SR as usize * n / 1000
+    }
+
+    /// Silence, then a tone, then silence — the shape Kokoro emits per chunk.
+    fn padded(lead_ms: usize, tone_ms: usize, tail_ms: usize) -> Vec<f32> {
+        let mut v = vec![0.0; ms(lead_ms)];
+        v.extend((0..ms(tone_ms)).map(|i| (i as f32 * 0.1).sin() * 0.5));
+        v.extend(vec![0.0; ms(tail_ms)]);
+        v
+    }
+
+    /// Longest run of samples under the audible floor, ignoring the head and
+    /// tail of the clip — what a listener hears as a pause.
+    fn longest_interior_silence(samples: &[f32]) -> usize {
+        let voiced: Vec<usize> = samples
+            .iter()
+            .enumerate()
+            .filter(|(_, s)| s.abs() > 0.01)
+            .map(|(i, _)| i)
+            .collect();
+        voiced
+            .windows(2)
+            .map(|w| w[1] - w[0] - 1)
+            .max()
+            .unwrap_or(0)
+    }
+
+    #[test]
+    fn join_clips_the_padding_stacked_at_a_seam() {
+        let joined = join_chunks(vec![padded(400, 200, 600), padded(400, 200, 600)], SR);
+        assert!(
+            longest_interior_silence(&joined) <= ms(120),
+            "seam kept {} ms of silence",
+            longest_interior_silence(&joined) * 1000 / SR as usize
+        );
+    }
+
+    #[test]
+    fn join_keeps_the_clips_own_head_and_tail() {
+        let joined = join_chunks(vec![padded(400, 200, 600), padded(400, 200, 600)], SR);
+        let lead = joined.iter().take_while(|s| s.abs() <= 0.01).count();
+        let tail = joined.iter().rev().take_while(|s| s.abs() <= 0.01).count();
+        assert!(lead >= ms(390), "head padding lost: {lead} samples");
+        assert!(tail >= ms(590), "tail padding lost: {tail} samples");
+    }
+
+    #[test]
+    fn join_trims_both_edges_of_a_middle_chunk() {
+        let joined = join_chunks(
+            vec![
+                padded(400, 200, 600),
+                padded(400, 200, 600),
+                padded(400, 200, 600),
+            ],
+            SR,
+        );
+        assert!(
+            longest_interior_silence(&joined) <= ms(120),
+            "seam kept {} samples of silence",
+            longest_interior_silence(&joined)
+        );
+    }
+
+    #[test]
+    fn join_returns_a_single_chunk_verbatim() {
+        let one = padded(400, 200, 600);
+        assert_eq!(join_chunks(vec![one.clone()], SR), one);
+        assert!(join_chunks(vec![], SR).is_empty());
+    }
+
+    #[test]
+    fn join_leaves_a_gap_already_under_the_budget_alone() {
+        let a = padded(400, 200, 20);
+        let b = padded(20, 200, 600);
+        let joined = join_chunks(vec![a.clone(), b.clone()], SR);
+        assert_eq!(joined.len(), a.len() + b.len());
+    }
+
+    #[test]
+    fn join_bounds_an_all_silent_chunk() {
+        let joined = join_chunks(
+            vec![
+                padded(400, 200, 600),
+                vec![0.0; ms(2000)],
+                padded(400, 200, 600),
+            ],
+            SR,
+        );
+        assert!(
+            longest_interior_silence(&joined) <= ms(180),
+            "all-silent chunk contributed {} samples",
+            longest_interior_silence(&joined)
+        );
+    }
+}

--- a/rust/src/tts/sessions.rs
+++ b/rust/src/tts/sessions.rs
@@ -19,7 +19,8 @@ use std::path::{Path, PathBuf};
 
 use super::{
     charsiu::Charsiu,
-    kokoro::Kokoro,
+    kokoro::{self, Kokoro},
+    seam,
     tokenizer::{self, Tokenizer},
     voices,
     vosk::Vosk,
@@ -78,20 +79,29 @@ impl KokoroSession {
     /// silent skip (SSML segments).
     ///
     /// IPA past Kokoro's active-token cap is split with
-    /// [`tokenizer::chunk_ipa`] and the chunks' samples concatenated, so long
-    /// input synthesizes in full instead of being cut at the cap (#715).
+    /// [`tokenizer::chunk_ipa`] and the chunks' samples joined by
+    /// [`seam::join_chunks`], so long input synthesizes in full instead of
+    /// being cut at the cap (#715) without a dead-air join (#808).
     pub fn infer_ipa(
         &mut self,
         ipa: &str,
         voice_path: &Path,
         speed: f32,
     ) -> anyhow::Result<Vec<f32>> {
-        let mut samples = Vec::new();
+        let mut rendered = Vec::new();
         for chunk in tokenizer::chunk_ipa(ipa, tokenizer::KOKORO_MAX_ACTIVE) {
             let ids = self.tokenizer.encode(&chunk);
             if ids.is_empty() {
                 continue;
             }
+            // `pad_to_context` truncates past the cap, which is how #715 lost
+            // audio silently; fail loudly in debug if chunking stops holding.
+            debug_assert!(
+                ids.len() <= tokenizer::KOKORO_MAX_ACTIVE,
+                "chunk encoded to {} ids, past the {} cap",
+                ids.len(),
+                tokenizer::KOKORO_MAX_ACTIVE
+            );
             let active = ids.len();
             let padded = Tokenizer::pad_to_context(ids);
 
@@ -101,9 +111,9 @@ impl KokoroSession {
                 let voice = self.voice(voice_path)?;
                 voices::select_style(voice, active).to_vec()
             };
-            samples.extend(self.kokoro.infer(&padded, &style, speed)?);
+            rendered.push(self.kokoro.infer(&padded, &style, speed)?);
         }
-        Ok(samples)
+        Ok(seam::join_chunks(rendered, kokoro::SAMPLE_RATE))
     }
 }
 

--- a/rust/src/tts/tokenizer.rs
+++ b/rust/src/tts/tokenizer.rs
@@ -184,6 +184,65 @@ mod tests {
     }
 
     #[test]
+    fn chunk_splits_one_char_past_the_cap_and_not_at_it() {
+        let at_cap = "a".repeat(KOKORO_MAX_ACTIVE);
+        assert_eq!(chunk_ipa(&at_cap, KOKORO_MAX_ACTIVE), vec![at_cap.clone()]);
+
+        let past_cap = format!("{at_cap}a");
+        assert_eq!(
+            chunk_ipa(&past_cap, KOKORO_MAX_ACTIVE),
+            vec![at_cap, "a".to_string()]
+        );
+    }
+
+    #[test]
+    fn chunk_counts_characters_not_utf8_bytes() {
+        // ˈ is two bytes: a byte-counting cap would split this in half.
+        let ipa = "ˈ".repeat(KOKORO_MAX_ACTIVE);
+        assert_eq!(chunk_ipa(&ipa, KOKORO_MAX_ACTIVE), vec![ipa]);
+    }
+
+    #[test]
+    fn chunk_collapses_consecutive_whitespace_at_a_break() {
+        assert_eq!(chunk_ipa("aaa \t\n bbb ccc", 8), vec!["aaa", "bbb ccc"]);
+    }
+
+    #[test]
+    fn chunk_breaks_cleanly_on_whitespace_at_the_window_edge() {
+        assert_eq!(chunk_ipa("aaa bbb", 3), vec!["aaa", "bbb"]);
+        assert_eq!(chunk_ipa("aaa bbbb", 4), vec!["aaa", "bbbb"]);
+    }
+
+    #[test]
+    fn chunk_conserves_phonemes_across_punctuation_splits() {
+        let ipa = (0..200)
+            .map(|i| format!("wˈɜːrd{i},"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        let chunks = chunk_ipa(&ipa, KOKORO_MAX_ACTIVE);
+        assert!(chunks.len() > 1, "expected a split, got {}", chunks.len());
+        let strip = |s: &str| s.chars().filter(|c| !c.is_whitespace()).collect::<String>();
+        assert_eq!(
+            strip(&chunks.concat()),
+            strip(&ipa),
+            "chunking dropped or reordered phonemes"
+        );
+    }
+
+    #[test]
+    fn chunk_conserves_a_combining_mark_run() {
+        // e + U+0303 pairs with no boundary anywhere: every break is a hard
+        // split, and each half must still carry every character it was given.
+        let ipa = "e\u{0303}".repeat(400);
+        let chunks = chunk_ipa(&ipa, KOKORO_MAX_ACTIVE);
+        assert!(chunks.len() > 1, "expected a split, got {}", chunks.len());
+        for c in &chunks {
+            assert!(c.chars().count() <= KOKORO_MAX_ACTIVE);
+        }
+        assert_eq!(chunks.concat(), ipa);
+    }
+
+    #[test]
     fn truncates_beyond_max_active() {
         let ids: Vec<i64> = (1..=600).collect();
         let padded = Tokenizer::pad_to_context(ids);


### PR DESCRIPTION
Closes #808.

## The seam

Past the 510-phoneme cap (#807) a long utterance is split into chunks, each synthesized as its own utterance — so each carries Kokoro's edge padding, and the raw `samples.extend` join stacked chunk A's tail onto chunk B's lead. The text there had only a space.

`seam::join_chunks` clips each **interior** edge back to 60 ms of silence, sized to the inter-word gaps an unchunked utterance shows. The clip's own head and tail keep the model's padding, and a single chunk short-circuits the whole path, so every input under the cap stays byte-identical (verified: `cmp` of the control WAV before/after is clean).

## Before / after

138-word unpunctuated English input, `en-am_michael`, two chunks, local ONNX build. Silent runs measured as 5 ms frame RMS below -45 dB relative to the clip's loudest frame.

| | before | after |
|---|---|---|
| join at t=28.30 s | **1090 ms** | **120 ms** |
| longest interior gap in the clip | 1090 ms | 550 ms (a natural pause, present in both) |
| every other gap | — | unchanged, sample for sample |
| clip lead / tail | 420 / 615 ms | 420 / 615 ms |

Controls for "what is natural here": the same voice on an unpunctuated single-chunk control shows a 495 ms longest natural pause and 25 ms median; a punctuated control shows 260–335 ms after a period. The old 1090 ms join was 2.2x the longest natural pause; the new 120 ms lands in the 60–135 ms inter-word range, which is what a dropped space token should read as.

## No crossfade

The issue offered a 10–20 ms equal-power crossfade as the more ambitious fix, mainly for clicks on a hard-split mid-run. Measured instead of assumed: because every chunk is a separately-padded utterance, the splice always lands in silence on both sides. Within 10 ms of the join the largest sample is 3.9e-4 and the largest sample-to-sample step is 3.0e-4, against 0.198 during speech. A scan for steps >0.05 in low-energy context finds nothing at the join — neither in the whitespace-split clip nor in a 798-char boundary-less run that hard-splits mid-word (that clip's longest interior gap is 440 ms, all natural). A crossfade of silence with silence has nothing to fix, so it is not in this PR.

## Hardening and test gaps

`pad_to_context` still truncates past the cap as a backstop — the mode that lost 27% of a sentence silently in #715 — so `infer_ipa` now `debug_assert!`s the encode bound it relies on, making a future tokenizer change loud instead of quiet.

Six tokenizer split cases the #807 review named and the suite never exercised: exact 510/511 boundary, a cap-length multi-byte string (a byte-counting cap would halve it), consecutive whitespace at a break, whitespace on the window edge, phoneme conservation across a *punctuation* split (the existing test rejoins with `" "`, which only holds for whitespace splits), and a combining-mark run where every break is a hard split.

## Verification

- `cargo fmt --check` clean
- `cargo clippy --all-targets --features tts -- -D warnings` clean
- `make rust-test` — 507 passed, 0 failed
- `bun test` — 1129 pass, 4 skip, 0 fail; `bunx tsc --noEmit` clean
- `cargo check --features coreml --no-default-features` and `--features system_kokoro --no-default-features` both clean (neither reaches this path: FluidAudio does its own chunking)
- Red-first: the join was extracted with today's behaviour first and the tests reported `seam kept 1000 ms of silence` before the fix landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBTpJjqyYFW6W8LHJ2nwy