### PR TITLE
ci(cache): move Vosk to a weekly canary and land the 2 GB target

### DIFF
--- a/.github/actions/setup-kokoro-models/action.yml
+++ b/.github/actions/setup-kokoro-models/action.yml
@@ -1,8 +1,8 @@
 name: Setup Kokoro TTS models
 description: >
-  Restore-or-download the TTS models that have no stand-in: CharsiuG2P always, and
-  Vosk-RU when `vosk` is set. Kokoro itself is served by the committed mini, so this
-  action is now called by the Linux coverage lane alone (#741).
+  Restore-or-download CharsiuG2P, the only TTS weights left on the PR path that have
+  no stand-in. Kokoro is served by the committed mini and Vosk-RU moved to the weekly
+  real-model canary, so the Linux coverage lane is this action's only caller (#741).
 
   Restore-only by design: writing is the job of cache-seed.yml on main. GitHub
   scopes a cache written during a pull_request run to that PR's merge ref, so only
@@ -19,13 +19,6 @@ inputs:
     description: Model cache directory (also used as KOKORO_CACHE by callers).
     required: false
     default: ${{ github.workspace }}/.kokoro-spike
-  vosk:
-    description: >
-      Also stage the ~935 MB Vosk-TTS-RU bundle. Only the one lane that runs
-      `tts::vosk::tests::synth_short_phrase_produces_audio` needs it; every other
-      caller leaves this false and keeps its cache entry ~935 MB smaller (#741).
-    required: false
-    default: "false"
 
 runs:
   using: composite
@@ -49,9 +42,9 @@ runs:
       uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ inputs.cache-dir }}
-        key: kokoro-models-v3-${{ runner.os }}-vosk${{ inputs.vosk }}-${{ hashFiles('rust/ci/download-kokoro.sh') }}
+        key: kokoro-models-v4-${{ runner.os }}-${{ hashFiles('rust/ci/download-kokoro.sh') }}
         restore-keys: |
-          kokoro-models-v3-${{ runner.os }}-vosk${{ inputs.vosk }}
+          kokoro-models-v4-${{ runner.os }}
 
     # Idempotent: downloads only the files the restore didn't provide, so a cold
     # cache still works (just slower) and a warm one costs nothing.
@@ -59,5 +52,4 @@ runs:
       shell: bash
       env:
         KOKORO_CACHE_DIR: ${{ inputs.cache-dir }}
-        WITH_VOSK: ${{ inputs.vosk == 'true' && '1' || '0' }}
       run: bash rust/ci/download-kokoro.sh "$KOKORO_CACHE_DIR"

--- a/.github/actions/setup-kokoro-models/action.yml
+++ b/.github/actions/setup-kokoro-models/action.yml
@@ -2,7 +2,8 @@ name: Setup Kokoro TTS models
 description: >
   Restore-or-download CharsiuG2P, the only TTS weights left on the PR path that have
   no stand-in. Kokoro is served by the committed mini and Vosk-RU moved to the weekly
-  real-model canary, so the Linux coverage lane is this action's only caller (#741).
+  real-model canary, so the callers are down to two: rust-test.yml's Linux coverage
+  lane, which reads the entry, and cache-seed.yml, which writes it (#741).
 
   Restore-only by design: writing is the job of cache-seed.yml on main. GitHub
   scopes a cache written during a pull_request run to that PR's merge ref, so only

--- a/.github/workflows/cache-seed.yml
+++ b/.github/workflows/cache-seed.yml
@@ -75,7 +75,7 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ env.KOKORO_CACHE }}
-          key: kokoro-models-v3-${{ runner.os }}-vosk${{ runner.os == 'Linux' }}-${{ hashFiles('rust/ci/download-kokoro.sh') }}
+          key: kokoro-models-v4-${{ runner.os }}-${{ hashFiles('rust/ci/download-kokoro.sh') }}
           lookup-only: true
 
       # Restores through the prefix key (so a model-set change tops up the delta
@@ -85,15 +85,14 @@ jobs:
         uses: ./.github/actions/setup-kokoro-models
         with:
           cache-dir: ${{ env.KOKORO_CACHE }}
-          # Only the Linux lane runs the Vosk synth test, so only Linux carries the bundle.
-          vosk: ${{ runner.os == 'Linux' }}
+
 
       - name: Save TTS models
         if: steps.probe.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ env.KOKORO_CACHE }}
-          key: kokoro-models-v3-${{ runner.os }}-vosk${{ runner.os == 'Linux' }}-${{ hashFiles('rust/ci/download-kokoro.sh') }}
+          key: kokoro-models-v4-${{ runner.os }}-${{ hashFiles('rust/ci/download-kokoro.sh') }}
 
   parakeet:
     name: Parakeet CoreML models

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,13 +410,18 @@ jobs:
       - name: 🔊 Setup integration backend
         uses: ./.github/actions/install-kesha-backend
         with:
+          # Just the engine tree, not the whole cache root. #820 rooted the ~450 MB
+          # FluidAudio bundle under `~/.cache/kesha`, so archiving that root would
+          # re-mint this entry at ~550 MB on the first main-side miss — no key bump
+          # needed, and the budget would move without anyone deciding to. Narrowing
+          # the path bounds the entry by construction instead of by discipline.
+          #
+          # `engine/` is what is worth keeping: the binary, its sidecars and the
+          # `.version` marker that gates re-download. The model bundles under
+          # `models/` and `fluidaudio/` are not in this entry today and are fetched
+          # per run regardless (#741).
           cache-path: |
-            ~/.cache/kesha
-          # 94 MB because this key predates #820, so the entry archives the ONNX
-          # layout only. Do NOT rotate it casually: the same key today would
-          # re-archive the ~450 MB FluidAudio bundle now rooted under that tree,
-          # and this lane's entry is the one the whole budget is measured against
-          # (#741).
+            ~/.cache/kesha/engine
           cache-key: ${{ runner.os }}-kesha-engine-v1
           # The last cache a pull request could still write. It never does in
           # practice — the restore hits main's entry, so the save is skipped — but

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -412,11 +412,18 @@ jobs:
         with:
           cache-path: |
             ~/.cache/kesha
-          # 94 MB today because this key predates #820, so the entry archives the
-          # ONNX layout only. Rotating it re-archives the ~450 MB FluidAudio
-          # bundle now rooted under the same tree — check the budget before you
-          # bump it, or move this lane off the PR path first (#741).
+          # 94 MB because this key predates #820, so the entry archives the ONNX
+          # layout only. Do NOT rotate it casually: the same key today would
+          # re-archive the ~450 MB FluidAudio bundle now rooted under that tree,
+          # and this lane's entry is the one the whole budget is measured against
+          # (#741).
           cache-key: ${{ runner.os }}-kesha-engine-v1
+          # The last cache a pull request could still write. It never does in
+          # practice — the restore hits main's entry, so the save is skipped — but
+          # on a miss a PR would mint its own ~550 MB copy under its merge ref,
+          # which is the eviction pressure #843 removed everywhere else. This lane
+          # also runs nightly on main, so it seeds itself and needs no seed job.
+          cache-write: ${{ github.event_name != 'pull_request' }}
           cache-restore-keys: ${{ runner.os }}-kesha-engine-
       - name: 🧪 Integration tests (real engine)
         run: mkdir -p test-results && bun run test:integration --reporter=junit --reporter-outfile=test-results/integration-full.xml

--- a/.github/workflows/real-model-canary.yml
+++ b/.github/workflows/real-model-canary.yml
@@ -1,0 +1,122 @@
+name: "🐤 Real-Model Canary"
+
+# The counterweight to the stand-ins (#741).
+#
+# Every per-PR lane now runs Kokoro through a 1 KB stand-in, and the Vosk synth test
+# is off the PR path entirely. That trade is only honest if something still exercises
+# the real weights, and this is that something: the full nextest suite against real
+# Kokoro, real Vosk-RU and real CharsiuG2P, weekly.
+#
+# `KESHA_REQUIRE_MODEL_TESTS: real` is the point. Every gate that a PR lane satisfies
+# with a stand-in must here resolve to genuine weights or fail — this is the only lane
+# where the `real` tier is exercised, and it is what stops the stand-ins from quietly
+# becoming the only thing anyone runs.
+#
+# Distinct from `mini-model-pact.yml` on purpose: that job asks whether the stand-in
+# still *matches* the real model's signature, this one asks whether the real model
+# still *works*. Same weakness would fail them differently, and a shared job would
+# blur which.
+#
+# Detection latency is up to a week, deliberately: real Kokoro audio through a
+# from-source build was previously asserted on every PR that touched TTS, and this is
+# the price of the ~2.6 GB the stand-ins took out of the cache budget.
+
+on:
+  schedule:
+    # Weekly, clear of both the capability pact (05:00) and the mini-model pact (08:00)
+    # so three model-downloading jobs never contend.
+    - cron: "0 11 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  canary:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      issues: write
+    env:
+      KOKORO_CACHE: ${{ github.workspace }}/.kokoro-real
+      NEXTEST_PROFILE: ci
+      # Real weights or fail: a stand-in satisfying a gate here would defeat the lane.
+      KESHA_REQUIRE_MODEL_TESTS: real
+      KESHA_REQUIRE_VOSK_TESTS: "1"
+      KESHA_REQUIRE_G2P_TESTS: "1"
+      # tts::vosk's synth test is CI-only, and this is now the lane that runs it.
+      CI: "true"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with:
+          toolchain: stable
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: rust
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - uses: taiki-e/install-action@1beb33eee6d086258184383af9a538940be190ed # v2.85.6
+        with:
+          tool: nextest
+
+      - name: 🎧 Install system audio deps
+        shell: bash
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends libopus-dev pkg-config
+
+      # Deliberately uncached: this runs weekly, and a ~1.4 GB entry to save one
+      # download a week is exactly the trade #741 exists to refuse.
+      - name: ⬇️ Download the real TTS weights
+        id: models
+        continue-on-error: true
+        shell: bash
+        env:
+          WITH_REAL_KOKORO: "1"
+          WITH_VOSK: "1"
+        run: bash rust/ci/download-kokoro.sh "$KOKORO_CACHE"
+
+      - name: 🧪 Run the suite against real weights
+        id: suite
+        if: steps.models.outcome == 'success'
+        continue-on-error: true
+        shell: bash
+        run: bash rust/ci/run-cargo-test.sh "$KOKORO_CACHE" Linux
+
+      - name: 📣 Report a failed canary (scheduled only)
+        if: github.event_name == 'schedule' && (steps.models.outcome == 'failure' || steps.suite.outcome == 'failure')
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          {
+            echo "## The real-model canary failed"
+            echo
+            echo "Read the run log before acting — this fails for three different reasons:"
+            echo
+            echo "- **A real model regressed.** The suite ran and a test failed. Every per-PR"
+            echo "  lane is on stand-ins, so this is the only place that signal exists, and"
+            echo "  the regression may be up to a week old. Do not dismiss it as flake."
+            echo "- **A gate resolved to a stand-in.** The failure names"
+            echo "  \`KESHA_REQUIRE_MODEL_TESTS asks for Real\`. The staging is wrong, not the"
+            echo "  model — this lane must never run on the committed mini."
+            echo "- **The download could not run.** The log ends in the download step. The"
+            echo "  models are not implicated; the run proved nothing either way."
+            echo
+            echo "Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          } > /tmp/canary-body.md
+          bash .github/scripts/upsert-audit-issue.sh /tmp/canary-body.md "Real-model canary failing" pact-drift
+
+      - name: ❌ Fail the canary
+        if: steps.models.outcome == 'failure' || steps.suite.outcome == 'failure'
+        shell: bash
+        run: exit 1

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -252,9 +252,10 @@ jobs:
       KOKORO_CACHE: ${{ github.workspace }}/.kokoro-spike
       NEXTEST_PROFILE: ci
       KESHA_REQUIRE_MODEL_TESTS: mini
-      # Separate flags because this is the only lane staging either bundle; the
-      # macOS/Windows lanes promise the Kokoro stand-in and nothing more.
-      KESHA_REQUIRE_VOSK_TESTS: "1"
+      # CharsiuG2P has no stand-in and its IPA goldens own phoneme fidelity, so this
+      # lane still promises it. Vosk-RU moved to real-model-canary.yml: one synth test
+      # was not worth ~935 MB of per-PR cache, and it needs real weights either way
+      # (#741).
       KESHA_REQUIRE_G2P_TESTS: "1"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -289,12 +290,10 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends libopus-dev pkg-config
 
-      # The only lane carrying weights nothing can stand in for: CharsiuG2P for the
-      # multilingual phonemiser, and Vosk-RU for its one synth test (#741).
+      # The only weights left on the PR path that nothing can stand in for:
+      # CharsiuG2P, whose phonemiser the Kokoro mini does not replace (#741).
       - name: 🎚️ Setup real TTS models
         uses: ./.github/actions/setup-kokoro-models
-        with:
-          vosk: "true"
 
       # After the restore, never before: an archive written under an older key still
       # carries a real model.onnx, and unpacking it over a staged stand-in would put

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -200,9 +200,9 @@ jobs:
             --features coreml,tts,system_tts,system_kokoro,system_diarize,system_text_lang \
             --no-default-features -- -D warnings
 
-      # No model cache on this lane at all: the Kokoro stand-in is committed, and
-      # the bundles that have no stand-in (CharsiuG2P, Vosk-RU) are covered once on
-      # the Linux coverage lane rather than three times (#741).
+      # No model cache on this lane at all: the Kokoro stand-in is committed,
+      # CharsiuG2P is covered once on the Linux coverage lane rather than three
+      # times, and Vosk-RU left the PR path entirely for the weekly canary (#741).
       - name: 🎚️ Stage Kokoro stand-ins
         shell: bash
         run: bash rust/ci/stage-mini-models.sh "$KOKORO_CACHE"

--- a/rust/ci/download-kokoro.sh
+++ b/rust/ci/download-kokoro.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Download the TTS models that have no stand-in: CharsiuG2P always, Vosk-RU when
-# the caller asks. Kokoro is served by the committed mini instead (#741).
+# Download the TTS models the caller asks for. CharsiuG2P always; Vosk-RU and the
+# real Kokoro weights only behind their flags, which only the weekly canary sets.
+# The PR lanes run on the committed Kokoro stand-in instead (#741).
 # Called by rust-test.yml; cache warms on subsequent runs.
 set -euo pipefail
 
@@ -22,10 +23,39 @@ fetch() {
   mv "$dest.part" "$dest"
 }
 
-# Kokoro's graph and voice packs are no longer fetched: the committed stand-in in
-# tests/fixtures/mini-models/kokoro carries the same I/O signature for ~1 KB, and
-# rust/ci/stage-mini-models.sh lays it out (#741). Only weights nothing can stand
-# in for are downloaded here.
+# Kokoro's graph and voice packs are not fetched for the PR lanes: the committed
+# stand-in in tests/fixtures/mini-models/kokoro carries the same I/O signature for
+# ~1 KB, and rust/ci/stage-mini-models.sh lays it out (#741).
+#
+# WITH_REAL_KOKORO is the canary's opt-in. Weekly, real-model-canary.yml runs the
+# same suites against these weights, which is the only place real Kokoro audio is
+# asserted at all now — so this arm is the counterweight to the stand-ins, not a
+# leftover.
+if [[ "${WITH_REAL_KOKORO:-0}" == "1" ]]; then
+  if [[ ! -f "$DEST/model.onnx" ]]; then
+    echo "Downloading Kokoro model.onnx (kokoro-onnx official release)..."
+    # Mirrors rust/src/models.rs::kokoro_manifest URL — see #207 for why we
+    # switched off the HF onnx-community variant.
+    fetch "$DEST/model.onnx" \
+      https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0/kokoro-v1.0.onnx
+  fi
+  KOKORO_DIR="$DEST/models/kokoro-82m"
+  mkdir -p "$KOKORO_DIR/voices"
+  ln -f "$DEST/model.onnx" "$KOKORO_DIR/model.onnx" 2>/dev/null \
+    || cp "$DEST/model.onnx" "$KOKORO_DIR/model.onnx"
+  # am_michael is the male brand default (CLAUDE.md); the rest carry the multilang
+  # corpus. ff_siwis is the documented French exception.
+  VOICE_BASE="https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices"
+  for v in am_michael em_alex ff_siwis im_nicola pm_alex; do
+    if [[ ! -f "$KOKORO_DIR/voices/$v.bin" ]]; then
+      echo "Downloading Kokoro voice $v.bin..."
+      fetch "$KOKORO_DIR/voices/$v.bin" "$VOICE_BASE/$v.bin"
+    fi
+  done
+  ln -f "$KOKORO_DIR/voices/am_michael.bin" "$DEST/am_michael.bin" 2>/dev/null \
+    || cp "$KOKORO_DIR/voices/am_michael.bin" "$DEST/am_michael.bin"
+  ls -lh "$KOKORO_DIR/voices"
+fi
 
 # Vosk-TTS Russian, ~935 MB. Exactly one consumer:
 # `tts::vosk::tests::synth_short_phrase_produces_audio`, which needs real weights


### PR DESCRIPTION
Stage 5 of the ≤2 GB plan — [design](https://github.com/drakulavich/kesha-voice-kit/issues/741#issuecomment-5239888431), [correction](https://github.com/drakulavich/kesha-voice-kit/issues/741#issuecomment-5240471297). **This is the one that lands the target.**

## The PR-path budget, entry by entry

Every cache a pull request can restore, after this stage:

| entry | MB | why it stays |
|---|---:|---|
| `parakeet-coreml-models-v2-macOS` | 446 | the #592 ANE decoder-state guard; real weights, not stand-in-able |
| `v0-rust-linux` | 387 | Rust build artifacts, written on main only (#843) |
| `v0-rust-xcode-16.2-tts-e2e-Darwin` | 291 | same |
| `kokoro-models-v4-Linux` | ~106 | CharsiuG2P alone — no stand-in, and its IPA goldens own phoneme fidelity |
| `macOS-kesha-engine-v1` | 94 | engine binary for the heavy lane; nightly-seeded, PR-read-only as of this PR |
| `bun-*` ×6 | 160 | dependency caches |
| `node-cache-Linux` | 48 | raycast extension |
| `determinatesystem-nix-installer` ×2 | 79 | nix lane |
| **total** | **1611** | **79% of the 2048 MB target, 16% of the 10 GB cap** |

Starting point when this ticket opened: **10857 MB against a 10240 MB cap, actively evicting.**

The `*-kesha-models-tts-v1` pair (5277 MB) and the superseded `kokoro-models-v1/v2/v3` entries are dead — nothing restores them — and stage 6 deletes them. They are excluded above because no PR reads them.

## Vosk moves, and the canary becomes more than its new home

The Vosk-RU synth test was the last ~935 MB on the PR path, held there by one assertion that needs real weights and behaves identically on every OS. `KESHA_REQUIRE_VOSK_TESTS` moves with it; the coverage lane keeps CharsiuG2P and nothing else.

But stage 4's loss accounting named something real — *no per-PR lane synthesises through real Kokoro any more* — and a lane that only ran Vosk would leave that standing. So `real-model-canary.yml` runs **the whole suite against real Kokoro, real Vosk-RU and real CharsiuG2P**, weekly, with `KESHA_REQUIRE_MODEL_TESTS: real`.

That flag is the point. Every gate a PR satisfies with a stand-in must here resolve to genuine weights or fail. It is the **first user of the `real` tier**, and it is what stops the stand-ins from quietly becoming the only thing anyone runs.

Verified by simulating the lane locally:

```
514 tests run: 514 passed, 0 skipped
  tts_e2e kokoro_ssml_with_break_produces_wav      14.633s   (real Kokoro)
  tts_multilang_audio  es/fr/it/pt                            (real Kokoro + real G2P)
  tts::vosk synth_short_phrase_produces_audio      33.326s   (real Vosk)
```

**The guard caught my own mistake while I did that.** My first simulation staged only `am_michael`, and `multilang_audio_regression_es` failed in 0.017 s rather than skipping — the tier refusing an incomplete real staging. That is the exact failure mode the canary's issue text calls out, demonstrated before it could ever fire in anger.

Kept separate from `mini-model-pact.yml` deliberately: that job asks whether the stand-in still *matches* the real signature, this one whether the real model still *works*. The same weakness fails them differently, and one job would blur which.

## The last pull request that could write a cache

`integration-tests-full` still defaulted to `cache-write: true` — the residual grok flagged in #843's round. It never writes in practice, because its restore hits main's entry and the save is skipped. But on a miss a PR would mint its own copy under its merge ref, and since #820 rooted the FluidAudio bundle under the tree that key archives, that copy is **~550 MB** — the exact eviction pressure #843 removed everywhere else.

Closed with the same discipline: `cache-write: ${{ github.event_name != 'pull_request' }}`. The lane already runs nightly on main, so it seeds itself and needs no new seed job.

### The deferred rotation, resolved properly

My first answer was "do not rotate", which prevented the *deliberate* cost and left the accidental one live. Grok was right to push: on the first main-side **miss**, the save step re-archives whatever `cache-path` names — no key bump needed — and #820 rooted the ~450 MB FluidAudio bundle under the cache root that entry pointed at. The ledger would have gone 1611 → ~2067 MB without anyone deciding to.

So the entry is now bounded by **path** rather than by discipline: `cache-path` names `~/.cache/kesha/engine` — the binary, its sidecars and the `.version` marker that gates re-download. The model bundles under `models/` and `fluidaudio/` are not in this entry today and are fetched per run either way, so nothing is lost and no key is safe-or-unsafe to rotate any more; the bound holds under any key.

One honest caveat on timing: this PR's own CI cannot exercise the narrowing. PRs no longer write this cache, so the save path only runs on the next main-side miss. The current entry is already 94 MB, so there is no exposure in the meantime — but the narrowing is verified by construction and by reading the action's inputs, not by a green check.

## Loss accounting

**Weekly-only from here**, at up to 7 days' detection latency:

- real Kokoro synthesis through the CLI and library paths (`tts_e2e`, `tts_smoke`, `tts_stdin_loop`)
- real Kokoro rendering of real CharsiuG2P phonemes (`tts_multilang_audio` — its IPA goldens stay per-PR, so *phoneme* fidelity is unaffected; what moves is whether those phonemes become good audio)
- real Russian synthesis (`tts::vosk`)

**Still per-PR**: every structural assertion, on stand-ins; the CharsiuG2P IPA goldens on real weights; the ANE decoder-state guard on real weights; `smoke-synthesis.ts` round-tripping real weights on the published-engine lanes.

I chose to add the from-source real-Kokoro canary **in this stage** rather than defer it to stage 6 or its own ticket. Deferring would have left stage 4's named loss open across two more merges, and the lane had to exist for Vosk anyway — the marginal cost was one download flag.

## What this PR's CI proves, and the one thing it cannot

On the real coverage runner: **zero** Vosk downloads, `tts::vosk` skipping in 0.014 s (against 33 s when it runs), and the CharsiuG2P goldens and multilang corpus still executing at 0.651 s and 2.490 s. The move is real, not just configured.

**The canary itself has not run in CI, and cannot before merge.** GitHub resolves `workflow_dispatch` against the default branch, so a workflow that exists only on a feature branch returns `HTTP 404: not found on the default branch`. Its logic is verified locally — the full suite against real weights, plus the tier guard catching an incomplete staging — but the workflow file itself is unexercised until it lands.

That is the same shape as the mini-model pact in stage 3, and worth treating the same way: **dispatch it once immediately after merge** rather than waiting a week for the cron to find a typo. I would rather say that plainly than let "green CI" imply more than it does.

## Verification

- `cargo fmt --check`; `cargo clippy --all-targets --features tts -- -D warnings` — clean
- `CI=true make rust-test` — 514 passed, 0 skipped
- coverage lane simulated without Vosk — 514 passed, 0 skipped
- canary lane simulated with real weights and `KESHA_REQUIRE_MODEL_TESTS=real` — 514 passed, 0 skipped
- `bun test` 1133 tests, 0 fail; `bunx tsc --noEmit`; `bun run check:workflows`; every workflow parses

Refs #741 (stage 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBTpJjqyYFW6W8LHJ2nwy
