### PR TITLE
docs: stop claiming nothing enforces the model-gate guard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,9 @@ Coverage is a merge gate, not a vanity metric. `bun run coverage:check:ts` holds
 
 Which suite runs where: the `integration-tests` (fast) and `integration-tests-full` (heavy) jobs in `ci.yml` are authoritative — every-PR runs never download the 2.4 GB model bundle. `docs/superpowers/specs/2026-05-30-ci-fast-heavy-test-lanes-design.md` explains why, but it is a design doc and has drifted; read it for intent, not for current fact.
 
-Model-dependent suites self-skip, and not uniformly: `e2e-engine` and `mcp-e2e` guard their outer `describe` on `!engineInstalled`, while `mcp-e2e`'s TTS cases and all of `say-e2e` guard on `!SPIKE_AVAILABLE` — an installed engine does not mean `mcp-e2e` runs in full. A new real-engine test without such a guard breaks the fast lane instead of skipping, which is the intended loud signal, though it may surface as a timeout rather than a clean assertion failure. Nothing enforces the guard: there is no meta-test and no `tests/integration/README`.
+Model-dependent suites self-skip, and not uniformly: `e2e-engine` and `mcp-e2e` guard their outer `describe` on `!engineInstalled`, while `mcp-e2e`'s TTS cases and all of `say-e2e` guard on `!SPIKE_AVAILABLE` — an installed engine does not mean `mcp-e2e` runs in full. A new real-engine test without such a guard breaks the fast lane instead of skipping, which is the intended loud signal, though it may surface as a timeout rather than a clean assertion failure. `say-e2e`'s gate also requires the source-built engine, not just a model — since the Kokoro stand-in is committed, a model-only gate would run it in lanes that never build the binary.
+
+On the Rust side the guard **is** enforced: `KESHA_REQUIRE_MODEL_TESTS` names which weights a lane promised (`mini` or real), every gate in `rust/tests/common/mod.rs` refuses the wrong tier, and `rust/tests/model_gate.rs` is the meta-test — including the exemptions it lists deliberately. `KESHA_REQUIRE_G2P_TESTS` and `KESHA_REQUIRE_VOSK_TESTS` do the same for the two bundles that have no stand-in. There is still no `tests/integration/README` and no equivalent meta-test on the TS side.
 
 ### PR ETIQUETTE
 

--- a/rust/tests/model_gate.rs
+++ b/rust/tests/model_gate.rs
@@ -11,10 +11,10 @@
 //! The rule is meant to be complete: every model-gated skip site either asserts
 //! the flag or is listed here as deliberately exempt. Exempt today:
 //! `kokoro_rate_e2e.rs` and `diarize_e2e.rs` (ANE/Sortformer bundles no lane
-//! stages), `vosk.rs`'s synth test (its own `KESHA_REQUIRE_VOSK_TESTS`, since
-//! only one lane carries that bundle), and the `KESHA_*` env skips inside
-//! `rust/src/tts/` — those sit behind integration gates that already fail loudly,
-//! so covering them is defense-in-depth for a later stage, not a hole today.
+//! stages), and `vosk.rs`'s synth test, which carries `KESHA_REQUIRE_VOSK_TESTS`
+//! because only the weekly canary stages that bundle. The CharsiuG2P skips in
+//! `rust/src/tts/` are no longer exempt: they gained `KESHA_REQUIRE_G2P_TESTS`
+//! when those IPA assertions became the named owner of phoneme fidelity.
 
 mod common;
 


### PR DESCRIPTION
Stage 6 tidy-up — the only file changes the close-out sweep turned up. Refs #741 (stage 6).

Two statements went stale as the stages landed, both in places a future agent reads *before* deciding what to build:

- **CLAUDE.md** still said "Nothing enforces the guard: there is no meta-test." `rust/tests/model_gate.rs` has been exactly that since #838, and now covers the tier, both refusal directions and the symlink staging shape. Left as-is it invites someone to rebuild what exists. The TS side genuinely still has no equivalent, so that half of the sentence stays — and I added the `say-e2e` engine-in-the-gate fact from #855, which is the kind of thing the paragraph exists to record.
- **`model_gate.rs`'s own exemption list** still counted the CharsiuG2P skips in `rust/src/tts/` as uncovered. They gained `KESHA_REQUIRE_G2P_TESTS` in #855's review round. An exemption list that lists covered sites is worse than no list.

Everything else in the sweep was clean: zero references anywhere in `.github/` or `rust/` to `kokoro-models-v1/v2/v3`, the `vosktrue`/`voskfalse` discriminators, or `parakeet-coreml-models-v1`; the surviving `restore-keys` prefix (`kokoro-models-v4-<os>`) matches the live key; and `KESHA_REQUIRE_VOSK_TESTS` is set by exactly one lane and read by exactly one test.

Docs only — no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBTpJjqyYFW6W8LHJ2nwy