### PR TITLE
ci(coreml): make #841's warm-hit flake diagnose itself

### DIFF
--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -43,6 +43,8 @@ jobs:
             # lands here even though it's a git-branch dep.
             coreml:
               - 'rust/src/backend/fluidaudio.rs'
+              # The lane's diagnostics ride KESHA_DEBUG's sink selection (#841).
+              - 'rust/src/fluid_stdout.rs'
               - 'rust/build.rs'
               - 'rust/Cargo.toml'
               - 'rust/Cargo.lock'
@@ -404,9 +406,14 @@ jobs:
   # Runs only when the regression surface changes (the `coreml` paths-filter:
   # the FluidAudio backend, the coreml feature wiring, or the fluidaudio-rs pin
   # in Cargo.lock) — not on every PR and not nightly. The CoreML Parakeet
-  # bundle is large but cached, so the fetch is a once-per-key seed. macos-14 is
-  # GitHub-hosted Apple Silicon with a real ANE, so no self-hosted runner is
-  # required.
+  # bundle is large but cached, so the fetch is a once-per-key seed.
+  #
+  # macos-14 is GitHub-hosted Apple Silicon, but it is an `Apple M1 (Virtual)` VM
+  # with **no** Neural Engine (#742 measured `ioreg -c AppleARMIODevice | grep -ci
+  # ane` at 0 there against 32 on a real M2), so the ANE-converted Parakeet chain
+  # actually executes through BNNS on the CPU. The guard still catches a
+  # fluidaudio-rs bump that drops the stateless-reset fix, which is what #592
+  # asked of it; it just does not exercise the ANE.
   coreml-regression:
     needs: changes
     if: github.event_name == 'pull_request' && needs.changes.outputs.coreml == 'true'
@@ -415,6 +422,11 @@ jobs:
     env:
       MACOSX_DEPLOYMENT_TARGET: "14.0"
       NEXTEST_PROFILE: ci
+      # The Swift bridge collapses every transcribe throw to "Transcription
+      # failed" and prints the real error with `print`, i.e. onto the stdout the
+      # backend silences. Debug routes that sink to stderr so #841's warm-cache
+      # failure names its own cause (#678 does the same for darwin synthesis).
+      KESHA_DEBUG: "1"
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -460,13 +472,13 @@ jobs:
           restore-keys: |
             parakeet-coreml-models-v2-${{ runner.os }}-
 
-      - name: 🧪 CoreML decoder-state regression (ANE)
+      - name: 🧪 CoreML decoder-state regression
         run: |
           cd rust
           cargo nextest run \
             --no-default-features --features coreml \
             --run-ignored all \
-            -E 'test(transcribe_samples_is_stateless_across_calls)'
+            -E 'test(transcribe_samples_is_stateless_across_calls) + test(debug_routes_silenced_chatter_to_stderr)'
 
       - name: 📤 Upload JUnit
         if: always()

--- a/rust/src/backend/fluidaudio.rs
+++ b/rust/src/backend/fluidaudio.rs
@@ -18,9 +18,9 @@ const MIN_SAMPLES: usize = 16_000 + 16_000 / 2; // 1.5 s @ 16 kHz
 
 pub struct FluidAudioBackend {
     audio: FluidAudio,
-    /// Pre-opened /dev/null reused across `transcribe_samples` calls to skip
-    /// the open syscall on the per-segment hot path (~10K saved on a 1 h meeting).
-    devnull: Option<OwnedFd>,
+    /// Pre-opened sink reused across `transcribe_samples` calls to skip the open
+    /// syscall on the per-segment hot path (~10K saved on a 1 h meeting).
+    sink: Option<OwnedFd>,
 }
 
 impl FluidAudioBackend {
@@ -30,12 +30,10 @@ impl FluidAudioBackend {
         audio
             .init_asr()
             .context("failed to initialize FluidAudio ASR (first run compiles models for ANE)")?;
-        let devnull = std::fs::OpenOptions::new()
-            .write(true)
-            .open("/dev/null")
-            .ok()
-            .map(OwnedFd::from);
-        Ok(Self { audio, devnull })
+        Ok(Self {
+            audio,
+            sink: crate::fluid_stdout::oneshot_sink(),
+        })
     }
 }
 
@@ -52,7 +50,7 @@ impl TranscribeBackend for FluidAudioBackend {
     /// would corrupt `--json` output (#259).
     fn transcribe_samples(&mut self, samples: &[f32]) -> Result<String> {
         let padded = pad_to_min(samples, MIN_SAMPLES);
-        let result = with_silenced_stdout(self.devnull.as_ref(), || {
+        let result = with_silenced_stdout(self.sink.as_ref(), || {
             self.audio.transcribe_samples(&padded)
         })
         .context("FluidAudio sample transcription failed")?;
@@ -75,6 +73,162 @@ fn pad_to_min(samples: &[f32], min_len: usize) -> std::borrow::Cow<'_, [f32]> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fmt::Write as _;
+    use std::path::Path;
+
+    /// #841: the warm-cache flake fails ~20 s in with a bare "Transcription
+    /// failed" on a cleanly restored bundle, and a same-SHA rerun goes green —
+    /// so the failing run is the only place the evidence will ever exist.
+    /// Renders on panic, silent on a passing run.
+    struct FailureDump {
+        first_call: Option<String>,
+    }
+
+    impl Drop for FailureDump {
+        fn drop(&mut self) {
+            if std::thread::panicking() {
+                eprintln!("{}", render_diagnostics(self.first_call.as_deref()));
+            }
+        }
+    }
+
+    fn render_diagnostics(first_call: Option<&str>) -> String {
+        let loc = crate::models::fluidaudio_asr_location();
+        let mut out = String::from("\n──── #841 coreml-regression diagnostics ────\n");
+        let _ = writeln!(out, "bundle dir : {}", loc.dir.display());
+        let _ = writeln!(
+            out,
+            "bundle root: {}",
+            loc.root.as_deref().map_or_else(
+                || "<FluidAudio default>".into(),
+                |r| r.display().to_string()
+            )
+        );
+        let _ = writeln!(
+            out,
+            "first call : {}",
+            match first_call {
+                Some(text) => format!("ok, {} chars {text:?}", text.chars().count()),
+                None => "never completed".into(),
+            }
+        );
+        let _ = writeln!(out, "host       : {}", probe("sysctl", &["-n", "hw.model"]));
+        let _ = writeln!(
+            out,
+            "virtualized: kern.hv_vmm_present={}",
+            probe("sysctl", &["-n", "kern.hv_vmm_present"])
+        );
+        let _ = writeln!(out, "os         : {}", one_line(&probe("sw_vers", &[])));
+        // Hosted macOS runners are `Apple M1 (Virtual)` VMs with no Neural
+        // Engine, so this reads 0 there and CoreML falls back to BNNS on the
+        // CPU (#742 measured it against 32 on a real M2).
+        let _ = writeln!(
+            out,
+            "ane        : AppleARMIODevice /ane/i lines = {}",
+            ane_lines()
+        );
+        let _ = writeln!(
+            out,
+            "thermal    : {}",
+            one_line(&probe("pmset", &["-g", "therm"]))
+        );
+        let _ = writeln!(out, "memory     : {}", one_line(&probe("vm_stat", &[])));
+        out.push_str(&fingerprint(&loc.dir));
+        out.push_str("──── end #841 diagnostics ────");
+        out
+    }
+
+    /// Hashing all 446 MB every run is too dear; the manifests, vocab and
+    /// `coremldata.bin` blobs are where a poisoned restore would show, and for
+    /// the weights the size alone separates a truncated restore from a whole one.
+    const HASH_MAX_BYTES: u64 = 1 << 20;
+
+    fn fingerprint(dir: &Path) -> String {
+        let mut rels = Vec::new();
+        collect_files(dir, dir, &mut rels);
+        rels.sort();
+
+        let mut out = format!("bundle contents ({} files):\n", rels.len());
+        let mut total = 0_u64;
+        for rel in &rels {
+            let path = dir.join(rel);
+            let Ok(meta) = std::fs::metadata(&path) else {
+                let _ = writeln!(out, "  {rel}  <stat failed>");
+                continue;
+            };
+            total += meta.len();
+            let mtime = meta
+                .modified()
+                .ok()
+                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                .map_or(0, |d| d.as_secs());
+            let digest = if meta.len() <= HASH_MAX_BYTES {
+                sha256_prefix(&path)
+            } else {
+                "-".into()
+            };
+            let _ = writeln!(out, "  {rel}  {}  mtime={mtime}  {digest}", meta.len());
+        }
+        let _ = writeln!(out, "  total: {total} bytes");
+        out
+    }
+
+    fn collect_files(root: &Path, dir: &Path, out: &mut Vec<String>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                collect_files(root, &path, out);
+            } else if let Ok(rel) = path.strip_prefix(root) {
+                out.push(rel.display().to_string());
+            }
+        }
+    }
+
+    fn sha256_prefix(path: &Path) -> String {
+        use sha2::{Digest, Sha256};
+        match std::fs::read(path) {
+            Ok(bytes) => {
+                let mut hex = format!("{:x}", Sha256::digest(&bytes));
+                hex.truncate(16);
+                hex
+            }
+            Err(err) => format!("<read failed: {err}>"),
+        }
+    }
+
+    fn probe(cmd: &str, args: &[&str]) -> String {
+        match std::process::Command::new(cmd).args(args).output() {
+            Ok(out) => {
+                let stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
+                if stdout.is_empty() {
+                    String::from_utf8_lossy(&out.stderr).trim().to_string()
+                } else {
+                    stdout
+                }
+            }
+            Err(err) => format!("<{cmd} unavailable: {err}>"),
+        }
+    }
+
+    /// Mirrors #742's `ioreg -c AppleARMIODevice | grep -ci ane` so the numbers
+    /// in that thread and this dump are comparable.
+    fn ane_lines() -> usize {
+        probe("ioreg", &["-c", "AppleARMIODevice"])
+            .lines()
+            .filter(|line| line.to_ascii_lowercase().contains("ane"))
+            .count()
+    }
+
+    fn one_line(text: &str) -> String {
+        text.lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+            .collect::<Vec<_>>()
+            .join(" | ")
+    }
 
     #[test]
     fn pad_to_min_borrows_when_already_long_enough() {
@@ -123,10 +277,13 @@ mod tests {
         );
         let samples = crate::audio::load_audio(wav).expect("decode sentence fixture");
 
+        // Declared first so it drops last — after the backend's CoreML teardown.
+        let mut dump = FailureDump { first_call: None };
         let mut be = FluidAudioBackend::new().expect("init FluidAudio CoreML backend");
         let first = be
             .transcribe_samples(&samples)
             .expect("first transcribe_samples");
+        dump.first_call = Some(first.clone());
         let second = be
             .transcribe_samples(&samples)
             .expect("second transcribe_samples");

--- a/rust/src/fluid_stdout.rs
+++ b/rust/src/fluid_stdout.rs
@@ -119,13 +119,16 @@ pub(crate) fn with_silenced_stdout<R>(devnull: Option<&OwnedFd>, f: impl FnOnce(
     f()
 }
 
-/// Where FluidAudio's stdout chatter goes for the duration of a one-shot call:
+/// Where FluidAudio's stdout chatter goes while a silencing guard is held:
 /// `/dev/null` normally, stderr under `KESHA_DEBUG`.
 ///
 /// CoreML reports real failures — the ANE-less prepare error and the E5RT
 /// exceptions behind it (#678) — on stdout, so discarding it unconditionally
 /// makes those failures unreadable exactly where they matter: a CI runner you
-/// cannot attach to.
+/// cannot attach to. The ASR path is the same story: the bridge collapses every
+/// `transcribeSamples` throw to a bare "Transcription failed" and prints the
+/// underlying error with Swift `print`, so /dev/null is where #841's warm-cache
+/// flake diagnosis went.
 ///
 /// Scope of what this changes, precisely: only where fd 1 points *while the
 /// guard is held*. Callers write their payload after it returns, so the
@@ -134,8 +137,12 @@ pub(crate) fn with_silenced_stdout<R>(devnull: Option<&OwnedFd>, f: impl FnOnce(
 /// background CoreML print landing on real stdout after the guard restores
 /// fd 1, which can still corrupt a streamed WAV. That is unchanged either way,
 /// since `/dev/null` does not catch a post-restore print either.
-#[cfg(any(feature = "system_kokoro", feature = "system_diarize"))]
-fn oneshot_sink() -> Option<OwnedFd> {
+#[cfg(any(
+    feature = "coreml",
+    feature = "system_kokoro",
+    feature = "system_diarize"
+))]
+pub(crate) fn oneshot_sink() -> Option<OwnedFd> {
     use std::os::fd::FromRawFd;
 
     if crate::debug::enabled() {
@@ -258,18 +265,60 @@ mod tests {
     use std::io::{Read, Seek};
     use std::os::fd::{AsRawFd, OwnedFd};
 
-    /// Restores the test's original fd 1 even when an assert panics — under a
+    /// Restores the test's original fd even when an assert panics — under a
     /// single-process `cargo test --lib` run a leaked redirect would misdirect
     /// other tests' output.
-    struct RestoreStdout(std::os::fd::RawFd);
-    impl Drop for RestoreStdout {
+    struct RestoreFd {
+        saved: std::os::fd::RawFd,
+        target: std::os::fd::RawFd,
+    }
+    impl Drop for RestoreFd {
         fn drop(&mut self) {
-            // SAFETY: self.0 is the dup of the original fd 1 we own.
+            // SAFETY: self.saved is the dup of the original fd we own.
             unsafe {
-                libc::dup2(self.0, libc::STDOUT_FILENO);
-                libc::close(self.0);
+                libc::dup2(self.saved, self.target);
+                libc::close(self.saved);
             }
         }
+    }
+
+    /// #841: the bridge collapses every transcribe throw to "Transcription
+    /// failed" and prints the real error with Swift `print`, so `KESHA_DEBUG`
+    /// has to land that stdout on stderr — the coreml-regression lane sets it
+    /// for exactly this, and /dev/null would keep the flake undiagnosable.
+    #[cfg(any(
+        feature = "coreml",
+        feature = "system_kokoro",
+        feature = "system_diarize"
+    ))]
+    #[test]
+    fn debug_routes_silenced_chatter_to_stderr() {
+        std::env::set_var("KESHA_DEBUG", "1");
+        let mut capture = tempfile::tempfile().expect("capture tempfile");
+        let saved_real = unsafe { libc::dup(libc::STDERR_FILENO) };
+        assert!(saved_real >= 0, "dup stderr failed");
+        let _restore = RestoreFd {
+            saved: saved_real,
+            target: libc::STDERR_FILENO,
+        };
+        assert!(unsafe { libc::dup2(capture.as_raw_fd(), libc::STDERR_FILENO) } >= 0);
+
+        // Taken after the redirect: the sink dups whatever fd 2 points at now.
+        let sink = oneshot_sink();
+        with_silenced_stdout(sink.as_ref(), || {
+            // SAFETY: NUL-terminated literal; printf buffers via C stdio,
+            // exactly like the Swift bridge's print.
+            unsafe { libc::printf(c"Transcribe samples error: simulated\n".as_ptr()) };
+        });
+        drop(_restore);
+
+        let mut contents = String::new();
+        capture.rewind().unwrap();
+        capture.read_to_string(&mut contents).unwrap();
+        assert!(
+            contents.contains("Transcribe samples error"),
+            "KESHA_DEBUG must route FluidAudio's stdout chatter to stderr, got {contents:?}"
+        );
     }
 
     /// #543: a C-stdio write buffered inside the guarded scope (a Swift
@@ -282,7 +331,10 @@ mod tests {
         let mut capture = tempfile::tempfile().expect("capture tempfile");
         let saved_real = unsafe { libc::dup(libc::STDOUT_FILENO) };
         assert!(saved_real >= 0, "dup stdout failed");
-        let _restore = RestoreStdout(saved_real);
+        let _restore = RestoreFd {
+            saved: saved_real,
+            target: libc::STDOUT_FILENO,
+        };
         assert!(unsafe { libc::dup2(capture.as_raw_fd(), libc::STDOUT_FILENO) } >= 0);
 
         let devnull = std::fs::OpenOptions::new()
@@ -328,7 +380,10 @@ mod tests {
         let mut capture = tempfile::tempfile().expect("capture tempfile");
         let saved_real = unsafe { libc::dup(libc::STDOUT_FILENO) };
         assert!(saved_real >= 0, "dup stdout failed");
-        let _restore = RestoreStdout(saved_real);
+        let _restore = RestoreFd {
+            saved: saved_real,
+            target: libc::STDOUT_FILENO,
+        };
         assert!(unsafe { libc::dup2(capture.as_raw_fd(), libc::STDOUT_FILENO) } >= 0);
 
         {


### PR DESCRIPTION
Instrumentation so #841's **warm-hit class** — clean v2 restore, entry present at 446 MB, `Swift bridge error: Transcription failed` ~20 s in, green on a same-SHA rerun — names its own cause the next time it fires. Not the fix: the issue stays open until a diagnosed warm-hit lands.

## What was throwing the evidence away

The fork's bridge collapses every `transcribeSamples` throw to a bare string and prints the real error separately:

```rust
// fluidaudio-rs src/ffi/bridge.rs
if result != 0 { return Err("Transcription failed".to_string()); }
```
```swift
// swift/FluidAudioBridge.swift
} catch { print("Transcribe samples error: \(error)"); return -1 }
```

That `print` goes to **stdout** — which `transcribe_samples` silences to `/dev/null`. So the underlying `NSError` was being discarded on our side, not swallowed by the fork, and no fork-side enrichment is needed to recover it.

`oneshot_sink()` already routes that stdout to stderr under `KESHA_DEBUG` for the Kokoro/diarize paths (#678); the ASR hot path now uses it too, and the lane sets `KESHA_DEBUG: "1"`.

## The dump

A `Drop` guard on `transcribe_samples_is_stateless_across_calls` renders on panic and is silent on a pass. Rendered by temporarily panicking after the first call (reverted):

```
──── #841 coreml-regression diagnostics ────
bundle dir : /Users/anton/Library/Application Support/FluidAudio/Models/parakeet-tdt-0.6b-v3
bundle root: <FluidAudio default>
first call : ok, 82 chars "I need you to review the pull request before we can merge it into the main branch."
host       : Mac14,2
virtualized: kern.hv_vmm_present=0
os         : ProductName:macOS | ProductVersion:26.6.1 | BuildVersion:25G76
ane        : AppleARMIODevice /ane/i lines = 23
thermal    : Note: No thermal warning level has been recorded | Note: No performance warning level has been recorded | …
memory     : Mach Virtual Memory Statistics: (page size of 16384 bytes) | Pages free: 41260. | Pages active: 317004. | … | Swapouts: 1038430.
bundle contents (23 files):
  Decoder.mlmodelc/analytics/coremldata.bin  243  mtime=1785908818  4238c4e81ecd0dc9
  Decoder.mlmodelc/coremldata.bin  554  mtime=1785908821  18647af085d87bd8
  Decoder.mlmodelc/metadata.json  3427  mtime=1785908821  a39e93cd8371b8de
  Decoder.mlmodelc/model.mil  13110  mtime=1785908822  ef2a0a281695398a
  Decoder.mlmodelc/weights/weight.bin  23604992  mtime=1785908821  -
  Encoder.mlmodelc/analytics/coremldata.bin  243  mtime=1785908822  42e638870d73f26b
  Encoder.mlmodelc/coremldata.bin  485  mtime=1785908997  d48034a167a82e88
  Encoder.mlmodelc/metadata.json  2921  mtime=1785908997  da24da9cca943fb2
  Encoder.mlmodelc/model.mil  959769  mtime=1785908997  ed7b19156ca29fa7
  Encoder.mlmodelc/weights/weight.bin  445187200  mtime=1785908996  -
  JointDecisionv3.mlmodelc/…  …
  Preprocessor.mlmodelc/weights/weight.bin  491072  mtime=1785909006  129b76e3aeafa8af
  config.json  2  mtime=1785909008  44136fa355b3678a
  parakeet_v3_vocab.json  151122  mtime=1785909008  7ec60e05f1b24480
  parakeet_vocab.json  151122  mtime=1785909008  7ec60e05f1b24480
  total: 483256769 bytes
──── end #841 diagnostics ────
```

`first call` is the field that splits the class outright: if the first transcript came back clean and the *second* call threw, hit-with-bad-content is dead and it is a runtime flake. Hashing is capped at 1 MiB per file — the manifests, vocab and `coremldata.bin` blobs are where a poisoned restore shows, and for the two big `weight.bin`s the size alone separates a truncated restore from a whole one, so a 446 MB rehash per run buys nothing.

## What this PR deliberately does not do

- **No retry.** A blind retry hides the class, and the issue asks for diagnosis first. Worth revisiting once a dump has been captured.
- **No pre-warm / load-split.** `FluidAudioBackend::new()` and the two calls already carry distinct `expect` messages, so the panic line names which half failed. Splitting them would not identify anything the current output doesn't, and would cost the #592 coverage of "two calls on one instance".

## Correction that fell out of this

The job comment claimed macos-14 gives it "a real ANE". #742 measured the opposite: hosted runners are `Apple M1 (Virtual)` VMs where `ioreg -c AppleARMIODevice | grep -ci ane` reads **0** against 32 on a real M2, so the ANE-converted Parakeet chain executes through BNNS on the CPU. The #592 guard still catches a fluidaudio-rs bump that drops the stateless-reset fix; it just never exercised the ANE. That is also a live hypothesis for the warm-hit class itself, given #742's BNNS-path SIGBUS on the neighbouring Kokoro chain — the dump's `ane` line records it per run rather than leaving it assumed.

`rust/src/fluid_stdout.rs` joins the `coreml` paths-filter, and `debug_routes_silenced_chatter_to_stderr` joins the lane's nextest filter, so the sink selection the dump rides on cannot rot unnoticed.

## Verification

| gate | result |
|---|---|
| `cargo fmt --check` | pass |
| `cargo clippy --all-targets --features tts -- -D warnings` | clean |
| `cargo clippy --all-targets --no-default-features --features coreml -- -D warnings` | clean |
| `cargo check --features coreml --no-default-features` | pass |
| `make rust-test` | 514/514 |
| `bun run test` | 1135 pass, 0 fail |
| `bunx tsc --noEmit` | pass |
| `bun run check:workflows` | pass |

The real lane command was run locally on Apple Silicon with the bundle staged: both tests pass in 1.4 s and **no dump is emitted** on success. Failure rendering was verified by temporarily panicking before the first call (`first call : never completed`) and after it (shown above), then reverting. `debug_routes_silenced_chatter_to_stderr` was verified non-vacuous by disabling the `debug::enabled()` branch — it fails with `got ""`.

Refs #841

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBTpJjqyYFW6W8LHJ2nwy
