### PR TITLE
fix(tts): say where --no-expand-abbrev actually applies, and warn where it does not

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -196,7 +196,7 @@ Format is also inferred from `--out` extension (`.ogg` / `.opus` / `.oga` → OG
 
 **Russian abbreviations** (`ru-vosk-*`): all-uppercase Cyrillic 2-5-char tokens auto-expand letter-by-letter when not pronounceable as a Russian syllable (ФСБ → "эф-эс-бэ", ВОЗ → "воз"). Disable with `--no-expand-abbrev`. See [docs/tts.md#russian-abbreviation-auto-expansion](docs/tts.md#russian-abbreviation-auto-expansion).
 
-**English acronyms** (`en-*`, Kokoro): three-table mechanism (letter-spell rule + STOP_LIST + IPA_LEXICON) auto-expands FBI → "ef bee eye" and gives EPAM/JSON/Anthropic the right IPA. Disable letter-spell with `--no-expand-abbrev`. See [docs/tts.md#english-acronym-auto-expansion](docs/tts.md#english-acronym-auto-expansion).
+**English acronyms** (`en-*`, Kokoro): three-table mechanism (letter-spell rule + STOP_LIST + IPA_LEXICON) auto-expands FBI → "ef bee eye" and gives EPAM/JSON/Anthropic the right IPA. Disable letter-spell with `--no-expand-abbrev` — honored on ONNX builds only; the released darwin-arm64 binary spells initialisms inside FluidAudio's own G2P and warns that the flag is a no-op ([#842](https://github.com/drakulavich/kesha-voice-kit/issues/842)). See [docs/tts.md#english-acronym-auto-expansion](docs/tts.md#english-acronym-auto-expansion).
 
 **Russian word stress** (`ru-vosk-*` only): `<emphasis>сл+ово</emphasis>` shifts stress to the vowel marked with `+`. `<emphasis level="none">сл+ово</emphasis>` strips the `+` (cancel inherited emphasis). Other voices (`en-*`, `macos-*`) silently strip the `+` and warn once per process. Auto-stress dictionary not provided — caller writes the `+` manually. Closes [#233](https://github.com/drakulavich/kesha-voice-kit/issues/233).
 

--- a/completions/kesha.fish
+++ b/completions/kesha.fish
@@ -80,7 +80,7 @@ complete -c kesha -n '__fish_seen_subcommand_from say' -l ssml -d 'Parse input a
 complete -c kesha -n '__fish_seen_subcommand_from say' -l format -r -d 'Output format: wav (default), ogg-opus (Telegram-ready voice note), or flac (lossless, plays in all browsers incl. Safari). Inferred from --out extension when omitted.'
 complete -c kesha -n '__fish_seen_subcommand_from say' -l bitrate -r -d 'Opus bitrate in bits/sec (e.g. 32000). Only with --format ogg-opus.'
 complete -c kesha -n '__fish_seen_subcommand_from say' -l sample-rate -r -d 'Opus encoder sample rate (8000/12000/16000/24000/48000). Only with --format ogg-opus.'
-complete -c kesha -n '__fish_seen_subcommand_from say' -l no-expand-abbrev -d 'Disable Russian acronym auto-expansion (ВОЗ → \'вэ о зэ\') for ru-vosk-* voices. <say-as interpret-as=\'characters\'> still works. Applies to Russian (ru-vosk-*) and English (en-*) voices.'
+complete -c kesha -n '__fish_seen_subcommand_from say' -l no-expand-abbrev -d 'Disable acronym auto-expansion on ru-vosk-* voices (ВОЗ → \'вэ о зэ\') and English on ONNX engine builds (FBI → \'ef bee eye\'). No effect on macOS arm64 FluidAudio, macos-* or non-English voices, which spell initialisms in their own G2P; the engine warns when the flag is ignored. <say-as interpret-as=\'characters\'> still works.'
 complete -c kesha -n '__fish_seen_subcommand_from say' -l verbose -d 'Log TTS synthesis time to stderr'
 complete -c kesha -n '__fish_seen_subcommand_from say' -l debug -d 'Trace engine subprocess calls on stderr (or KESHA_DEBUG=1)'
 complete -c kesha -n '__fish_seen_subcommand_from stats' -l help -d 'Show help'

--- a/completions/kesha.zsh
+++ b/completions/kesha.zsh
@@ -112,7 +112,7 @@ _kesha() {
         '--format=[Output format: wav (default), ogg-opus (Telegram-ready voice note), or flac (lossless, plays in all browsers incl. Safari). Inferred from --out extension when omitted.]:format:' \
         '--bitrate=[Opus bitrate in bits/sec (e.g. 32000). Only with --format ogg-opus.]:bitrate:' \
         '--sample-rate=[Opus encoder sample rate (8000/12000/16000/24000/48000). Only with --format ogg-opus.]:sample rate:' \
-        '--no-expand-abbrev[Disable Russian acronym auto-expansion (ВОЗ → '\''вэ о зэ'\'') for ru-vosk-* voices. <say-as interpret-as='\''characters'\''> still works. Applies to Russian (ru-vosk-*) and English (en-*) voices.]' \
+        '--no-expand-abbrev[Disable acronym auto-expansion on ru-vosk-* voices (ВОЗ → '\''вэ о зэ'\'') and English on ONNX engine builds (FBI → '\''ef bee eye'\''). No effect on macOS arm64 FluidAudio, macos-* or non-English voices, which spell initialisms in their own G2P; the engine warns when the flag is ignored. <say-as interpret-as='\''characters'\''> still works.]' \
         '--verbose[Log TTS synthesis time to stderr]' \
         '--debug[Trace engine subprocess calls on stderr (or KESHA_DEBUG=1)]'
       ;;

--- a/docs/tts.md
+++ b/docs/tts.md
@@ -101,6 +101,21 @@ kesha say --voice en-am_michael --no-expand-abbrev 'EPAM ...'
 
 `<say-as interpret-as="characters">…</say-as>` always wins — letter-spells via the embedded table regardless of `--no-expand-abbrev`. Engine reports `tts.en_acronym_expansion: true` in `--capabilities-json`. Closes [#244](https://github.com/drakulavich/kesha-voice-kit/issues/244).
 
+### Where `--no-expand-abbrev` actually applies
+
+The flag is accepted on every voice, but only two paths can act on it — the rest spell initialisms inside an engine-owned G2P with no opt-out, and warn on stderr instead of ignoring the request in silence ([#842](https://github.com/drakulavich/kesha-voice-kit/issues/842)).
+
+| Voice | Engine | `--no-expand-abbrev` |
+| --- | --- | --- |
+| `ru-vosk-*` (every build) | Vosk-TTS | **honored** — suppresses the Cyrillic letter-spell rule ([#232](https://github.com/drakulavich/kesha-voice-kit/issues/232)) |
+| `en-*` on ONNX builds (Linux, Windows, macOS without `system_kokoro`) | ONNX Kokoro | **honored** — suppresses the letter-spell rule; `IPA_LEXICON` hits still fire |
+| `en-*` on the released darwin-arm64 build | FluidAudio Kokoro (ANE) | no-op — upstream `EnglishInitialisms` spells `FBI`/`IBM` in its own G2P and exposes no suppression knob. Per-word overrides go through the lexicon binding ([#818](https://github.com/drakulavich/kesha-voice-kit/issues/818)), which wins ahead of the initialism rule |
+| `es`/`fr`/`it`/`pt` on ONNX builds | ONNX Kokoro + CharsiuG2P | no-op — the Romance normalizer runs unconditionally inside G2P, before the segment pipeline that reads the flag |
+| `es`/`fr`/`it`/`pt`/`hi`/`ja`/`zh` on darwin-arm64 | FluidAudio Kokoro | no-op |
+| `macos-*` | AVSpeech | no-op — the Swift sidecar owns normalization |
+
+Because the released macOS binary compiles `system_kokoro`, the same `kesha say --voice en-am_michael --no-expand-abbrev` suppresses spelling on Linux and does not on an Apple Silicon Mac. The engine says so on stderr; audio is byte-identical either way there.
+
 ## Russian abbreviation auto-expansion
 
 For `ru-vosk-*` voices, `kesha say` detects all-uppercase Cyrillic acronyms (length 2–5) and reads them letter-by-letter when the token cannot be pronounced as a natural Russian syllable:

--- a/man/kesha.1
+++ b/man/kesha.1
@@ -194,7 +194,7 @@ Opus bitrate in bits/sec (e.g. 32000). Only with \-\-format ogg\-opus.
 Opus encoder sample rate (8000/12000/16000/24000/48000). Only with \-\-format ogg\-opus.
 .TP
 .B \-\-no\-expand\-abbrev
-Disable Russian acronym auto\-expansion (ВОЗ → 'вэ о зэ') for ru\-vosk\-* voices. <say\-as interpret\-as='characters'> still works. Applies to Russian (ru\-vosk\-*) and English (en\-*) voices.
+Disable acronym auto\-expansion on ru\-vosk\-* voices (ВОЗ → 'вэ о зэ') and English on ONNX engine builds (FBI → 'ef bee eye'). No effect on macOS arm64 FluidAudio, macos\-* or non\-English voices, which spell initialisms in their own G2P; the engine warns when the flag is ignored. <say\-as interpret\-as='characters'> still works.
 .TP
 .B \-\-verbose
 Log TTS synthesis time to stderr

--- a/openspec/specs/tts-synthesis/spec.md
+++ b/openspec/specs/tts-synthesis/spec.md
@@ -382,8 +382,12 @@ and are not on the Russian stop-list. Spanish/French/Italian/Portuguese:
 integers 0–999,999 are expanded to words and 2–5-character uppercase acronyms
 are letter-spelled with that language's letter names, with per-language
 stop-lists exempting word-acronyms. `--no-expand-abbrev` SHALL disable the
-automatic letter-spelling for English and Russian — but the English IPA lexicon
-still fires, and `<say-as interpret-as="characters">` still works.
+automatic letter-spelling for Russian and for English on ONNX Kokoro builds —
+but the English IPA lexicon still fires, and `<say-as interpret-as="characters">`
+still works. On every other path — FluidAudio Kokoro, `macos-*` AVSpeech, and
+the Romance normalizer that runs inside CharsiuG2P — expansion belongs to an
+engine that offers no suppression knob, and the Engine SHALL warn on stderr
+rather than accept the flag silently.
 
 #### Scenario: English initialism is letter-spelled, lexicon word is not
 
@@ -415,6 +419,15 @@ still fires, and `<say-as interpret-as="characters">` still works.
 - WHEN Sona runs `kesha say --no-expand-abbrev "EPAM hired IBM"`
 - THEN `IBM` passes through unspelled
 - AND `EPAM` still uses its IPA lexicon pronunciation
+
+#### Scenario: --no-expand-abbrev on an engine that cannot honor it warns
+
+- GIVEN the released darwin-arm64 build, whose `en-*` voices run on FluidAudio
+- WHEN Sona runs `kesha say --voice en-am_michael --no-expand-abbrev "IBM"`
+- THEN `IBM` is still spelled letter by letter, because the initialism rule
+  lives inside FluidAudio's G2P
+- AND the Engine warns on stderr that the flag has no effect on this voice,
+  naming where it does apply
 
 #### Scenario: --no-expand-abbrev on an old engine warns instead of lying
 

--- a/rust/src/cli/say.rs
+++ b/rust/src/cli/say.rs
@@ -49,9 +49,11 @@ pub struct SayArgs {
     /// on stdout. See `docs/tts-stdin-loop.md`. Issue #213.
     #[arg(long = "stdin-loop", hide = true)]
     pub stdin_loop: bool,
-    /// Disable auto-expansion of Russian acronyms (e.g. ВОЗ → "вэ о зэ").
+    /// Disable acronym auto-expansion on `ru-vosk-*` voices (ВОЗ → "вэ о зэ")
+    /// and English on ONNX Kokoro builds (FBI → "ef bee eye"). No effect on
+    /// FluidAudio Kokoro, `macos-*` or non-English voices, which spell
+    /// initialisms in their own G2P; those paths warn on stderr instead (#842).
     /// `<say-as interpret-as="characters">` in SSML remains honored.
-    /// No effect for non-`ru-vosk-*` voices.
     #[arg(long = "no-expand-abbrev", default_value_t = false)]
     pub no_expand_abbrev: bool,
 }

--- a/rust/src/say_loop.rs
+++ b/rust/src/say_loop.rs
@@ -28,8 +28,9 @@
 //!
 //! All fields except `text` and `voice` are optional. `format` /
 //! `bitrate` / `sample_rate` mirror the CLI flags. `expand_abbrev`
-//! defaults to `true`; set to `false` to suppress Cyrillic acronym
-//! expansion for `ru-vosk-*` voices (mirrors `--no-expand-abbrev`).
+//! defaults to `true`; set to `false` to suppress acronym expansion on
+//! `ru-vosk-*` voices and English ONNX Kokoro (mirrors `--no-expand-abbrev`,
+//! including its per-engine no-ops — see `tts::say`).
 //!
 //! ## What this is NOT
 //!
@@ -83,9 +84,10 @@ struct LoopRequest {
     #[serde(default)]
     ssml: bool,
     /// Auto-expand all-uppercase acronyms before synth: Cyrillic on `ru-vosk-*`
-    /// (#232), Latin on `en-*` (#244). Defaults to `true` when absent so legacy
-    /// clients keep current behavior. Mirrors the CLI `--no-expand-abbrev` flag
-    /// (inverted). No effect for `macos-*` voices.
+    /// (#232), Latin on `en-*` ONNX Kokoro (#244). Defaults to `true` when
+    /// absent so legacy clients keep current behavior. Mirrors the CLI
+    /// `--no-expand-abbrev` flag (inverted); `false` is a no-op on FluidAudio
+    /// Kokoro, `macos-*` and non-English voices, which warn instead (#842).
     #[serde(default = "default_expand_abbrev")]
     expand_abbrev: bool,
 }

--- a/rust/src/tts/say.rs
+++ b/rust/src/tts/say.rs
@@ -67,6 +67,22 @@ fn compose_rate(cli_rate: f32, ssml_rate: f32) -> f32 {
     clamped
 }
 
+pub(crate) const WARN_EXPAND_ABBREV_IGNORED: &str = "no-expand-abbrev-ignored";
+
+/// `--no-expand-abbrev` is accepted on every voice but only Vosk and the
+/// English Kokoro path can act on it; the rest spell initialisms inside their
+/// own G2P with no opt-out, so the request is announced rather than dropped (#842).
+fn warn_expand_abbrev_ignored(engine: &str) {
+    crate::tts::warn::warn_once(
+        WARN_EXPAND_ABBREV_IGNORED,
+        &format!(
+            "--no-expand-abbrev has no effect with {engine}: acronym expansion is suppressible \
+             only for ru-vosk-* voices and English on ONNX Kokoro builds. Synthesizing with the \
+             engine's own initialism handling instead."
+        ),
+    );
+}
+
 /// Synthesize speech and return WAV bytes (mono float32; sample rate depends on engine).
 ///
 /// Loads the ONNX session fresh on each call (~100-800ms); callers that synthesize
@@ -96,10 +112,16 @@ pub fn say(opts: SayOptions) -> Result<Vec<u8>, TtsError> {
             target_arch = "aarch64"
         ))]
         EngineChoice::FluidKokoro { voice_id, speed } => {
+            if !opts.expand_abbrev {
+                warn_expand_abbrev_ignored("FluidAudio Kokoro voices");
+            }
             say_fluid_kokoro(opts.text, voice_id, speed, opts.format, opts.ssml)
         }
         #[cfg(all(feature = "system_tts", target_os = "macos"))]
         EngineChoice::AVSpeech { voice_id, speed } => {
+            if !opts.expand_abbrev {
+                warn_expand_abbrev_ignored("macos-* AVSpeech voices");
+            }
             say_avspeech(opts.text, voice_id, speed, opts.format, opts.ssml)
         }
         EngineChoice::Vosk {
@@ -244,6 +266,11 @@ pub(crate) fn say_kokoro(
     ssml: bool,
     expand_abbrev: bool,
 ) -> Result<Vec<u8>, TtsError> {
+    // Non-English Kokoro goes straight to CharsiuG2P, which never sees the
+    // segment normalizer that would honor the flag.
+    if !expand_abbrev && !en::is_en(lang) {
+        warn_expand_abbrev_ignored("non-English Kokoro voices");
+    }
     let segments = if ssml {
         let segments = ssml::parse(text).map_err(|e| TtsError::Coded {
             code: crate::errors::code_of(&e),
@@ -794,6 +821,47 @@ mod tests {
         // Idempotent: a second clamp doesn't change set membership.
         let _ = super::compose_rate(0.1, 0.1); // 0.01 → 0.5 (clamp low)
         assert!(crate::tts::warn::was_warned("compose-rate-clamped"));
+    }
+
+    /// #842: `--no-expand-abbrev` reaches the engine on every voice, but only
+    /// Vosk and the English Kokoro path can act on it. Ignoring it in silence
+    /// is what made `--help` unfalsifiable, so the ignored case must warn.
+    #[test]
+    fn no_expand_abbrev_warns_when_kokoro_cannot_honor_it() {
+        let _ = say_kokoro(
+            &mut sessions::TtsSessions::default(),
+            "hola",
+            "es",
+            Path::new("/nonexistent/kokoro/model.onnx"),
+            Path::new("/nonexistent/kokoro/voice.bin"),
+            1.0,
+            OutputFormat::Wav,
+            false,
+            false,
+        );
+        assert!(
+            crate::tts::warn::was_warned(WARN_EXPAND_ABBREV_IGNORED),
+            "a non-English Kokoro voice cannot suppress expansion and must say so"
+        );
+    }
+
+    #[test]
+    fn no_expand_abbrev_stays_quiet_on_the_english_kokoro_path() {
+        let _ = say_kokoro(
+            &mut sessions::TtsSessions::default(),
+            "FBI",
+            "en",
+            Path::new("/nonexistent/kokoro/model.onnx"),
+            Path::new("/nonexistent/kokoro/voice.bin"),
+            1.0,
+            OutputFormat::Wav,
+            false,
+            false,
+        );
+        assert!(
+            !crate::tts::warn::was_warned(WARN_EXPAND_ABBREV_IGNORED),
+            "English on Kokoro honors the flag; warning there would be the opposite lie"
+        );
     }
 
     /// Records every synthesized utterance and returns one sentinel sample

--- a/src/cli/say.ts
+++ b/src/cli/say.ts
@@ -288,8 +288,10 @@ export const sayCommand = defineCommand({
     "no-expand-abbrev": {
       type: "boolean",
       description:
-        "Disable Russian acronym auto-expansion (ВОЗ → 'вэ о зэ') for ru-vosk-* voices. " +
-        "<say-as interpret-as='characters'> still works. Applies to Russian (ru-vosk-*) and English (en-*) voices.",
+        "Disable acronym auto-expansion on ru-vosk-* voices (ВОЗ → 'вэ о зэ') and English on ONNX engine builds " +
+        "(FBI → 'ef bee eye'). No effect on macOS arm64 FluidAudio, macos-* or non-English voices, which spell " +
+        "initialisms in their own G2P; the engine warns when the flag is ignored. " +
+        "<say-as interpret-as='characters'> still works.",
     },
     verbose: {
       type: "boolean",

--- a/src/synth.ts
+++ b/src/synth.ts
@@ -44,7 +44,10 @@ export interface SayOptions {
   /** Only valid with `format: "ogg-opus"`. Must be one of 8000, 12000, 16000, 24000, 48000. Default 24000. */
   sampleRate?: number;
   /**
-   * Disable acronym auto-expansion for `ru-vosk-*` and `en-*` voices.
+   * Disable acronym auto-expansion. Honored for `ru-vosk-*` voices and for
+   * `en-*` on ONNX engine builds; a no-op on FluidAudio Kokoro (the released
+   * darwin-arm64 binary), `macos-*` and non-English voices, where the engine
+   * owns initialism handling and warns on stderr instead (#842).
    * When true, passes `--no-expand-abbrev` to the engine (requires engine
    * capability `tts.ru_acronym_expansion` or `tts.en_acronym_expansion`).
    * On older engines that don't advertise the capability, the flag is

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -325,7 +325,7 @@ OPTIONS
             --format=<format>    Output format: wav (default), ogg-opus (Telegram-ready voice note), or flac (lossless, plays in all browsers incl. Safari). Inferred from --out extension when omitted.
           --bitrate=<bitrate>    Opus bitrate in bits/sec (e.g. 32000). Only with --format ogg-opus.
   --sample-rate=<sample_rate>    Opus encoder sample rate (8000/12000/16000/24000/48000). Only with --format ogg-opus.
-           --no-expand-abbrev    Disable Russian acronym auto-expansion (ВОЗ → 'вэ о зэ') for ru-vosk-* voices. <say-as interpret-as='characters'> still works. Applies to Russian (ru-vosk-*) and English (en-*) voices.
+           --no-expand-abbrev    Disable acronym auto-expansion on ru-vosk-* voices (ВОЗ → 'вэ о зэ') and English on ONNX engine builds (FBI → 'ef bee eye'). No effect on macOS arm64 FluidAudio, macos-* or non-English voices, which spell initialisms in their own G2P; the engine warns when the flag is ignored. <say-as interpret-as='characters'> still works.
                     --verbose    Log TTS synthesis time to stderr (Default: false)
                       --debug    Trace engine subprocess calls on stderr (or KESHA_DEBUG=1) (Default: false)`);
   });


### PR DESCRIPTION
Closes #842

## The two inconsistencies

`--no-expand-abbrev` was accepted on every voice but acted on by only two paths, and `--help` described a third, wrong scope ("No effect for non-`ru-vosk-*` voices") while the flag demonstrably affects English on ONNX.

## Truth table (read out of the code, not the docs)

| Voice | Engine | `--no-expand-abbrev` today |
| --- | --- | --- |
| `ru-vosk-*`, every build | Vosk-TTS | **honored** — `ru::normalize_segments(segments, expand_abbrev)` (#232) |
| `en-*` on ONNX builds (Linux, Windows, macOS without `system_kokoro`) | ONNX Kokoro | **honored** — gates the letter-spell rule in `en::acronym::process_token`; `IPA_LEXICON` hits still fire |
| `en-*` on the released darwin-arm64 build | FluidAudio Kokoro | **no-op** — `EngineChoice::FluidKokoro` never receives `expand_abbrev`; upstream `EnglishInitialisms` (FluidAudio 0.15.5) spells `FBI`/`IBM` with no knob. Byte-identical WAV both ways, verified in #835 |
| `es`/`fr`/`it`/`pt` on ONNX builds | ONNX Kokoro + CharsiuG2P | **no-op** — `normalize::normalize` runs unconditionally inside `g2p::charsiu_ipa`, upstream of the segment pipeline that reads the flag. This one was not in the issue; it is a real second no-op |
| `es`/`fr`/`it`/`pt`/`hi`/`ja`/`zh` on darwin-arm64 | FluidAudio Kokoro | **no-op** |
| `macos-*` | AVSpeech | **no-op** — Swift sidecar owns normalization |

Because the released macOS binary compiles `system_kokoro`, the same command suppresses spelling on Linux and does not on an Apple Silicon Mac. The scope is platform-dependent, not voice-dependent — which is why the old one-line `--help` claim could not be made true by rewording alone.

## Decision, and why not the alternatives

**Chosen: honest docs + a runtime warning where the flag is a no-op.** The engine knows exactly which arm it took, so it now emits one `warn_once` line naming the voice class and where the flag does apply. That is the same mechanism already used for `spell-fluid-kokoro` and `ipa-fluid-kokoro` — "this feature is not honored on this engine" is an existing, precedented warning class here, and it satisfies the ERROR HANDLING rule against silently swallowing an explicit user request.

**Rejected — implement suppression on ANE.** There is no upstream knob: `KokoroAneEnglishPhonemizer` consults `customLexicon` first (line 116), then applies `EnglishInitialisms.letterNameOverrides` / `isCandidate` (lines 126, 152) with no flag between them. Adding one means forking **FluidAudio itself** — currently an upstream SwiftPM pin at 0.15.5, not the already-forked `fluidaudio-rs` — then threading a new FFI symbol through three layers for a niche flag. Not a small fork gate. The #818 lexicon binding is the wrong tool: it wins ahead of the initialism rule, so it already gives a per-word escape hatch (add the word to `IPA_LEXICON`), but you cannot enumerate every uppercase token a user might type, and we have no IPA to supply for arbitrary ones.

**Rejected — reject the flag with exit 2.** The no-op set is platform-dependent, so a script that works on Linux would exit 2 on macOS for the identical command. That trades a silent no-op for a loud break in working scripts; a warning gets the honesty without the breakage.

**Deliberately not changed: the capability strings.** `tts.en_acronym_expansion` remains truthful — the expansion happens on ANE, it is the *opt-out* that is missing. Narrowing it would fail the #798 pacts until a released engine re-records them, so a capability change is engine-release-gated regardless.

Suppressing the Romance normalizer for `es`/`fr`/`it`/`pt` is a plausible follow-up, but the spec deliberately scopes the flag to English and Russian, so widening it is a feature decision rather than part of making the current contract honest.

## Changes

- `rust/src/tts/say.rs` — `warn_expand_abbrev_ignored` plus three call sites: the `FluidKokoro` and `AVSpeech` dispatch arms, and the non-English branch of `say_kokoro` (which also covers the `--stdin-loop` entry point, since the loop calls `say_kokoro` directly).
- `--help` on both sides, regenerated completions and man page, `docs/tts.md` (new truth-table section), `SKILL.md`, `openspec/specs/tts-synthesis/spec.md` (scope + a scenario for the warning), `src/synth.ts` and `say_loop.rs` doc contracts.

## Tests

TDD, red first: `no_expand_abbrev_warns_when_kokoro_cannot_honor_it` and `no_expand_abbrev_stays_quiet_on_the_english_kokoro_path` in `rust/src/tts/say.rs` failed to compile against the missing warn key, then passed. The `--help` golden in `tests/unit/cli.test.ts` was updated first and observed failing before the source strings changed.

## Verification

- `bun test` — 1135 pass, 5 skip, 0 fail
- `bunx tsc --noEmit` — clean
- `make rust-test` — 516 passed, 0 skipped
- `cargo fmt --check` clean; `cargo clippy --all-targets -- -D warnings` clean on `tts` and on `tts,system_kokoro,system_tts`
- `cargo check --features coreml --no-default-features` clean
- `bun run generate:shell-artifacts` re-run, artifacts committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBTpJjqyYFW6W8LHJ2nwy