### PR TITLE
ci: hold windows run: steps to an explicit shell

### DIFF
--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -39,7 +39,7 @@ function requirePinnedActions(path: string, contents: string): string[] {
   return errors;
 }
 
-type Step = { run?: unknown; uses?: unknown; if?: unknown; with?: { filters?: unknown } };
+type Step = { name?: unknown; run?: unknown; uses?: unknown; if?: unknown; shell?: unknown; with?: { filters?: unknown } };
 
 function jobSteps(document: unknown, job: string): Step[] | undefined {
   const steps = (document as { jobs?: Record<string, { steps?: unknown[] }> })?.jobs?.[job]?.steps;
@@ -220,6 +220,71 @@ export function requirePactVerificationCoversEveryTarget(path: string, document:
 }
 
 /**
+ * Fails when a job that lands on a Windows runner leaves a `run:` step on the runner default.
+ *
+ * That default is pwsh, where a brace block fails loudly but `"$TARGET"` expands to the empty
+ * string in silence — bash written into a pwsh step keeps running and reports success on nothing
+ * (#849, #850). Cron-only workflows never execute in PR CI, so this file is the only lane that
+ * sees them. An explicit `shell:` of any kind is a decision and passes; so does a `# pwsh-ok`
+ * marker in the script, for the step that means the default.
+ */
+type Job = {
+  "runs-on"?: unknown;
+  steps?: unknown[];
+  strategy?: { matrix?: unknown };
+  defaults?: { run?: { shell?: unknown } };
+};
+
+/** Every scalar reachable at `path`, descending into matrix lists on the way. */
+function valuesAt(node: unknown, path: string[]): string[] {
+  if (node === null || node === undefined) return [];
+  if (Array.isArray(node)) return node.flatMap((item) => valuesAt(item, path));
+  if (path.length === 0) return typeof node === "object" ? [] : [String(node)];
+  if (typeof node !== "object") return [];
+  return valuesAt((node as Record<string, unknown>)[path[0]], path.slice(1));
+}
+
+/** The concrete labels a `runs-on` can resolve to, substituting the matrix keys it names. */
+function runnerLabels(job: Job): string[] {
+  const runsOn = job["runs-on"];
+  const literals = [...valuesAt(runsOn, []), ...valuesAt((runsOn as { labels?: unknown })?.labels, [])];
+  return literals.flatMap((label) => {
+    const references = [...label.matchAll(/\$\{\{\s*matrix\.([\w.]+)\s*\}\}/g)];
+    if (references.length === 0) return [label];
+    const matrix = job.strategy?.matrix;
+    return references.flatMap((reference) => {
+      const key = reference[1].split(".");
+      return [...valuesAt(matrix, key), ...valuesAt((matrix as { include?: unknown })?.include, key)];
+    });
+  });
+}
+
+export function requireBashOnWindowsRunSteps(path: string, document: unknown): string[] {
+  const jobs = (document as { jobs?: Record<string, Job> })?.jobs;
+  if (!jobs || typeof jobs !== "object") return [];
+
+  const workflowShell = (document as { defaults?: { run?: { shell?: unknown } } })?.defaults?.run?.shell;
+  const errors: string[] = [];
+
+  for (const [name, job] of Object.entries(jobs)) {
+    if (!Array.isArray(job?.steps)) continue;
+    if (!runnerLabels(job).some((label) => /windows/i.test(label))) continue;
+    if (typeof (job.defaults?.run?.shell ?? workflowShell) === "string") continue;
+
+    for (const [at, step] of (job.steps as Step[]).entries()) {
+      if (typeof step?.run !== "string" || typeof step.shell === "string") continue;
+      if (/(^|\n)\s*#\s*pwsh-ok\b/.test(step.run)) continue;
+      const label = typeof step.name === "string" ? `\`${step.name}\`` : `${at + 1}`;
+      errors.push(
+        `${path}: \`${name}\` step ${label} runs on windows without \`shell:\`; the default there is pwsh, where "$VAR" expands to empty in silence — set \`shell: bash\`, or \`# pwsh-ok\` in the script if it means pwsh (#850)`,
+      );
+    }
+  }
+
+  return errors;
+}
+
+/**
  * Fails when a script covered by a unit test sits outside ci.yml's `code` filter.
  * `check:versions` and the unit tests run inside `unit-tests`, which that filter gates,
  * so an uncovered script means edits to a gate skip the tests that prove it works.
@@ -282,6 +347,7 @@ function checkFile(path: string, testedScripts: string[]): string[] {
       ...forbidLinuxPackaging(path, contents),
       ...requireNpmPublishAfterPackaging(path, document),
       ...requirePactVerificationCoversEveryTarget(path, document),
+      ...requireBashOnWindowsRunSteps(path, document),
       ...requireTestedScriptsInCodeFilter(path, document, testedScripts),
     ];
   } catch (err) {

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -181,6 +181,7 @@ jobs:
         run: node .github/scripts/set-cargo-version.mjs "${TAG_NAME#v}"
 
       - name: Build release binary
+        shell: bash
         run: cd rust && cargo build --release --target ${{ matrix.target }} --features ${{ matrix.features }} --no-default-features
       - name: Prepare artifact
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,13 +237,16 @@ jobs:
 
       - name: 🔍 Type check
         if: matrix.os == 'ubuntu-latest'
+        shell: bash
         run: bunx tsc --noEmit
 
       - name: 🔢 Check version drift (package.json + Cargo.toml)
         if: matrix.os == 'ubuntu-latest'
+        shell: bash
         run: bun run check:versions
 
       - name: 🧪 Unit tests
+        shell: bash
         run: mkdir -p test-results && bun run test:unit --reporter=junit --reporter-outfile=test-results/unit-${{ matrix.os }}.xml
 
       - name: 📊 Test summary
@@ -628,6 +631,7 @@ jobs:
 
       - name: 🎧 Install system audio deps
         if: runner.os == 'Linux'
+        shell: bash
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends libopus-dev pkg-config

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -182,6 +182,7 @@ jobs:
       # coreml code because no PR CI job ever tried to build it.
       - name: Check coreml feature
         if: matrix.os == 'macos-14'
+        shell: bash
         # --all-targets so the `#[cfg(feature = "coreml")]` tests compile here too (#708).
         run: cd rust && cargo check --features coreml --no-default-features --all-targets
 
@@ -196,6 +197,7 @@ jobs:
       # darwin-only break is caught before a release tag builds it.
       - name: Lint darwin release feature set (incl. system_kokoro)
         if: matrix.os == 'macos-14'
+        shell: bash
         run: |
           cd rust
           cargo clippy --all-targets \

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -1,13 +1,15 @@
+import { readdirSync } from "node:fs";
 import { describe, expect, test } from "bun:test";
 import {
   forbidLinuxPackaging,
+  requireBashOnWindowsRunSteps,
   requireDarwinSmokeCoversBothEngines,
   requireNpmPublishAfterPackaging,
   requirePactVerificationCoversEveryTarget,
   requirePreUploadSynthesisSmoke,
   requireTestedScriptsInCodeFilter,
 } from "../../.github/scripts/check-workflows";
-import { parseRepoYaml, readRepoFile } from "../helpers/repo";
+import { parseRepoYaml, readRepoFile, repoPath } from "../helpers/repo";
 
 const PATH = ".github/workflows/build-engine.yml";
 const CI = ".github/workflows/ci.yml";
@@ -270,5 +272,87 @@ describe("requirePactVerificationCoversEveryTarget", () => {
     expect(requirePactVerificationCoversEveryTarget(PACT, { jobs: { pact: {} } })[0]).toContain(
       "strategy.matrix.include",
     );
+  });
+});
+
+describe("requireBashOnWindowsRunSteps", () => {
+  const BARE = { name: "report", run: 'echo "target=$TARGET"' };
+  const smoke = (job: Record<string, unknown>, top: Record<string, unknown> = {}) => ({
+    ...top,
+    jobs: { smoke: { "runs-on": "windows-latest", steps: [BARE], ...job } },
+  });
+  const errorsFor = (document: unknown) => requireBashOnWindowsRunSteps(CI, document);
+
+  test("passes on every workflow in the repo", () => {
+    for (const file of readdirSync(repoPath(".github/workflows"))) {
+      const path = `.github/workflows/${file}`;
+      expect([path, requireBashOnWindowsRunSteps(path, parseRepoYaml(path))]).toEqual([path, []]);
+    }
+  });
+
+  test("fails when a windows job leaves a run step on the default shell", () => {
+    const errors = errorsFor(smoke({}));
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("`smoke` step `report` runs on windows without `shell:`");
+  });
+
+  test("names an unnamed step by position", () => {
+    expect(errorsFor(smoke({ steps: [{ run: "ls" }] }))[0]).toContain("step 1");
+  });
+
+  test("passes when the step sets shell: bash", () => {
+    expect(errorsFor(smoke({ steps: [{ ...BARE, shell: "bash" }] }))).toEqual([]);
+  });
+
+  // An explicit non-bash shell is a decision; the trap this closes is the implicit pwsh default.
+  test("passes when the step opts into pwsh explicitly", () => {
+    expect(errorsFor(smoke({ steps: [{ name: "report", run: "Write-Host $env:TARGET", shell: "pwsh" }] }))).toEqual([]);
+  });
+
+  test("passes when the job defaults every run step to bash", () => {
+    expect(errorsFor(smoke({ defaults: { run: { shell: "bash" } } }))).toEqual([]);
+  });
+
+  test("passes when the workflow defaults every run step to bash", () => {
+    expect(errorsFor(smoke({}, { defaults: { run: { shell: "bash" } } }))).toEqual([]);
+  });
+
+  test("passes when the step carries the pwsh-ok marker", () => {
+    const run = "# pwsh-ok: this one really is PowerShell\nWrite-Host $env:TARGET";
+    expect(errorsFor(smoke({ steps: [{ name: "report", run }] }))).toEqual([]);
+  });
+
+  test("ignores steps that only `uses` an action", () => {
+    expect(errorsFor(smoke({ steps: [{ uses: "actions/checkout@3d3c42e" }] }))).toEqual([]);
+  });
+
+  test("passes when the job never touches windows", () => {
+    expect(errorsFor({ jobs: { smoke: { "runs-on": "ubuntu-latest", steps: [BARE] } } })).toEqual([]);
+  });
+
+  test("fails when a self-hosted label set names windows", () => {
+    expect(errorsFor(smoke({ "runs-on": ["self-hosted", "windows", "x64"] }))).toHaveLength(1);
+  });
+
+  const matrixJob = (matrix: unknown, runsOn = "${{ matrix.os }}") =>
+    smoke({ "runs-on": runsOn, strategy: { matrix } });
+
+  test("fails when a matrix list puts the job on windows", () => {
+    expect(errorsFor(matrixJob({ os: ["ubuntu-latest", "windows-latest"] }))).toHaveLength(1);
+  });
+
+  test("fails when a matrix include row puts the job on windows", () => {
+    const matrix = { include: [{ os: "ubuntu-latest" }, { os: "windows-latest", target: "win32-x64" }] };
+    expect(errorsFor(matrixJob(matrix))).toHaveLength(1);
+  });
+
+  // A cross-compile target naming windows does not move the job off its Linux runner.
+  test("resolves the key runs-on actually names", () => {
+    const matrix = { os: ["ubuntu-latest"], target: ["x86_64-pc-windows-gnu"] };
+    expect(errorsFor(matrixJob(matrix))).toEqual([]);
+  });
+
+  test("a matrix it cannot resolve is not treated as windows", () => {
+    expect(errorsFor(matrixJob({ os: "${{ fromJSON(needs.plan.outputs.os) }}" }))).toEqual([]);
   });
 });


### PR DESCRIPTION
`runs-on: windows-*` means `pwsh`, and bash written into a pwsh step does not fail the way you would hope. A brace block errors loudly, but `"$TARGET"` expands to the empty string in silence — the step keeps running, exits 0, and reports success on nothing. #849 nearly shipped exactly that in a scheduled workflow, where it would have silently un-pinned the matrix target. No existing lint could see it: `check:workflows`, `workflow-lint` and PR CI never execute a cron-only workflow.

`check-workflows.ts` gains `requireBashOnWindowsRunSteps`. It resolves each job's `runs-on` — literal label, label list, `labels:` object, and `${{ matrix.<key> }}` against both the matrix lists and its `include:` rows — and requires an explicit `shell:` on every `run:` step of a job that can land on Windows.

What satisfies it:

- `shell: bash` on the step, or `defaults.run.shell` at job or workflow level
- an explicit `shell: pwsh` — naming the shell is a decision; the trap this closes is the default nobody chose
- a `# pwsh-ok` line in the script, for a step that means the default

Matrix resolution follows the key `runs-on` actually names, so a Linux job cross-compiling to `x86_64-pc-windows-gnu` is not mistaken for a Windows runner.

## Sweep

Seven steps were violating; all now carry `shell: bash`, following `build-engine.yml`'s existing `Prepare artifact` precedent.

| Workflow | Job | Step |
| --- | --- | --- |
| `build-engine.yml` | `build` | `Build release binary` |
| `ci.yml` | `unit-tests` | `🔍 Type check` |
| `ci.yml` | `unit-tests` | `🔢 Check version drift (package.json + Cargo.toml)` |
| `ci.yml` | `unit-tests` | `🧪 Unit tests` |
| `ci.yml` | `release-branch-engine-smoke` | `🎧 Install system audio deps` |
| `rust-test.yml` | `test` | `Check coreml feature` |
| `rust-test.yml` | `test` | `Lint darwin release feature set (incl. system_kokoro)` |

`🧪 Unit tests` is the one that was genuinely executing under pwsh: `mkdir -p test-results && …` survives only because pwsh's `mkdir` binds `-p` as a prefix of `-Path`. The other six are gated off Windows by an `if:` today — the rule cannot evaluate those expressions, and pinning the shell now means loosening the gate later does not reintroduce the trap.

## Coverage

Rule tests are red-first in `tests/unit/check-workflows.test.ts` (14 cases: bare run fails, `shell: bash` passes, explicit pwsh passes, job- and workflow-level defaults pass, `# pwsh-ok` passes, `uses:`-only steps ignored, non-Windows jobs pass, self-hosted `windows` label fails, matrix list and `include` row both fail, cross-compile target does not false-positive, unresolvable matrix is not treated as Windows). One case walks every workflow in `.github/workflows` so the sweep cannot silently regress.

A workflow-only PR skips `unit-tests` (the `code` filter names only `ci.yml`), but `workflow-lint` fires on `.github/workflows/**` and runs `check:workflows`, so the rule gates those PRs regardless.

## Verification

- `bunx tsc --noEmit` — clean
- `bun test` — 1150 pass, 5 skip, 0 fail
- `bun run check:workflows` — clean after the sweep

Closes #850

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBTpJjqyYFW6W8LHJ2nwy