### PR TITLE
test: close the gaps mutation testing found in the plan and the capabilities wire

### DIFF
--- a/rust/src/capabilities.rs
+++ b/rust/src/capabilities.rs
@@ -116,7 +116,18 @@ mod caps_tests {
         for f in &caps.features {
             assert!(seen.insert(f), "duplicate feature entry {f:?}");
         }
-        assert!(!caps.backend.is_empty(), "backend name must be reported");
+    }
+
+    /// The name must be the backend actually compiled in, not merely non-empty:
+    /// the CLI routes on this string and the two backends never coexist.
+    #[test]
+    fn backend_names_the_compiled_asr_path() {
+        let expected = if cfg!(feature = "coreml") {
+            "coreml"
+        } else {
+            "onnx"
+        };
+        assert_eq!(get_capabilities().backend, expected);
     }
 
     /// The flag must track the compiled streaming path, not the OS alone —

--- a/rust/src/tts/voices.rs
+++ b/rust/src/tts/voices.rs
@@ -523,6 +523,21 @@ mod tests {
         assert_eq!(r.espeak_lang(), "");
     }
 
+    /// Through the accessor rather than the variant field: `say` hands this tag to
+    /// G2P, so an empty string phonemises an English voice as the default language.
+    #[test]
+    fn espeak_lang_reports_the_kokoro_language_tag() {
+        let tmp = tempfile::tempdir().unwrap();
+        #[cfg(not(all(
+            feature = "system_kokoro",
+            target_os = "macos",
+            target_arch = "aarch64"
+        )))]
+        populate_cache(tmp.path());
+        let r = resolve_voice(tmp.path(), "en-am_michael").unwrap();
+        assert_eq!(r.espeak_lang(), "en-us");
+    }
+
     #[test]
     fn resolve_vosk_ru_all_speaker_ids() {
         let tmp = tempfile::tempdir().unwrap();

--- a/tests/unit/install-plan.test.ts
+++ b/tests/unit/install-plan.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
-import { join } from "path";
+import { dirname, join } from "path";
 import { tmpdir } from "os";
 import { renderInstallPlan } from "../../src/install-plan";
 import { engineVersion } from "../../src/package-info";
+import modelPlan from "../../model-plan.json" with { type: "json" };
 
 const savedEnv = {
   HOME: process.env.HOME,
@@ -164,6 +165,110 @@ describe("renderInstallPlan", () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("the plan's download economics", () => {
+  function withCache<T>(slug: string, run: (cacheRoot: string) => Promise<T>): Promise<T> {
+    const dir = mkdtempSync(join(tmpdir(), `kesha-install-plan-${slug}-`));
+    process.env.HOME = dir;
+    process.env.KESHA_CACHE_DIR = join(dir, "cache");
+    process.env.KESHA_ENGINE_BIN = join(dir, "engine", "bin", "kesha-engine");
+    return run(join(dir, "cache")).finally(() => rmSync(dir, { recursive: true, force: true }));
+  }
+
+  function seed(cacheRoot: string, relPath: string, contents: string) {
+    const path = join(cacheRoot, relPath);
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, contents);
+  }
+
+  const langIdBytes = modelPlan.langId.reduce((sum, f) => sum + f.sizeBytes, 0);
+  const status = (plan: string, component: string) =>
+    new RegExp(`${component}: [^(]+\\([^,]+, (\\w+),`).exec(plan)?.[1];
+  const total = (plan: string, label: string) => new RegExp(`${label}: (.+)`).exec(plan)?.[1];
+
+  // Explicit --coreml/--onnx must beat the probe, or the plan quotes 2.43 GB nobody downloads (#684).
+  test("the requested backend decides which ASR component is planned", async () => {
+    await withCache("backend", async () => {
+      const coreml = await renderInstallPlan({ backend: "coreml" });
+      expect(coreml).toContain("ASR Parakeet TDT v3 (CoreML): ~");
+      expect(coreml).toContain("FluidAudio cache");
+      expect(coreml).not.toMatch(/ASR Parakeet TDT v3: /);
+
+      const onnx = await renderInstallPlan({ backend: "onnx" });
+      expect(onnx).toMatch(/ASR Parakeet TDT v3: [^(]+\(\d+ bytes,/);
+      expect(onnx).not.toContain("(CoreML)");
+      expect(onnx).not.toContain("FluidAudio cache");
+    });
+  });
+
+  test("a component is cached only once every file is present and non-empty", async () => {
+    await withCache("cached", async (cacheRoot) => {
+      expect(status(await renderInstallPlan({ backend: "onnx" }), "Audio language ID ECAPA")).toBe(
+        "needed",
+      );
+
+      for (const file of modelPlan.langId) seed(cacheRoot, file.relPath, "x");
+      expect(status(await renderInstallPlan({ backend: "onnx" }), "Audio language ID ECAPA")).toBe(
+        "cached",
+      );
+
+      seed(cacheRoot, modelPlan.langId[0].relPath, "");
+      expect(status(await renderInstallPlan({ backend: "onnx" }), "Audio language ID ECAPA")).toBe(
+        "needed",
+      );
+    });
+  });
+
+  test("a component quotes the sum of the files it covers", async () => {
+    await withCache("sizes", async () => {
+      const plan = await renderInstallPlan({ backend: "onnx" });
+      expect(plan).toContain(`Audio language ID ECAPA: `);
+      expect(plan).toContain(`(${langIdBytes} bytes,`);
+    });
+  });
+
+  test("the run total drops only for cache hits the run will actually reuse", async () => {
+    await withCache("totals", async (cacheRoot) => {
+      const cold = "Cold-cache Kesha-managed download";
+      const run = "Expected Kesha-managed network for this run";
+
+      const empty = await renderInstallPlan({ backend: "onnx" });
+      expect(total(empty, run)).toBe(total(empty, cold));
+
+      for (const file of modelPlan.langId) seed(cacheRoot, file.relPath, "x");
+      const warm = await renderInstallPlan({ backend: "onnx" });
+      expect(total(warm, cold)).toBe(total(empty, cold));
+      expect(total(warm, run)).not.toBe(total(warm, cold));
+
+      // --no-cache re-downloads the hit, so it counts against this run again.
+      const refresh = await renderInstallPlan({ backend: "onnx", noCache: true });
+      expect(total(refresh, run)).toBe(total(refresh, cold));
+    });
+  });
+
+  test("a bare plan promises nothing the flags did not ask for", async () => {
+    await withCache("bare", async () => {
+      const plan = await renderInstallPlan({ backend: "onnx" });
+      expect(plan).not.toContain("VAD Silero v5");
+      expect(plan).not.toContain("Diarization Sortformer");
+      expect(plan).not.toContain("TTS");
+      expect(plan).not.toContain("Warm-ups:");
+    });
+  });
+
+  // FluidAudio fetches its own bundle, so it cannot sit under a "Kesha-managed" total (#684).
+  test("a backend-fetched bundle is quoted apart from the managed totals", async () => {
+    await withCache("external", async () => {
+      const coreml = await renderInstallPlan({ backend: "coreml" });
+      const onnx = await renderInstallPlan({ backend: "onnx" });
+      const cold = "Cold-cache Kesha-managed download";
+
+      expect(coreml).toContain("Additionally fetched by the backend into its own cache: ~473 MB");
+      expect(onnx).not.toContain("Additionally fetched by the backend");
+      expect(total(coreml, cold)).not.toBe(total(onnx, cold));
+    });
   });
 });
 


### PR DESCRIPTION
Follow-up to the tooling #792 added: I pointed it at the rest of the codebase and fixed what it found. Three surfaces were executed by tests but not asserted by them.

## What survived, and why it mattered

| mutation | consequence had it been real |
|---|---|
| `capabilities.backend` → `"xyzzy"` | the string the CLI routes on, at 100% line coverage — only `!is_empty()` was asserted |
| `ResolvedVoice::espeak_lang()` → `""` | the tag `say` hands to G2P; the accessor was only ever called on a Vosk voice, which expects `""` |
| `install-plan`: `backend === "coreml"` → `!==` | `--onnx` planned as CoreML: 473 MB quoted instead of 2.43 GB |
| `install-plan`: `filesCached` → `true`/`false` | every component reads "cached" (or none does) — the plan's whole point is what it will download |
| `install-plan`: `sum + file.sizeBytes` → `sum -` | negative download sizes |

## Numbers

`install-plan.ts` mutation score **49.8% → 66.0%**, survivors 112 → 69, at 87% line coverage throughout — the coverage number never moved because the lines always ran.

The Rust side was already healthy: `voices.rs` + `ru/acronym.rs` scored 61 caught / 2 missed / 5 unviable before this. Both misses are addressed here — `espeak_lang` by a test, and `resolve_fluid_kokoro` not at all, because it is `cfg`-disabled under `--features tts` and cargo-mutants reports no-op mutations in dead cfg branches as MISSED.

Verified by re-running cargo-mutants on the same files: `1 missed, 43 caught, 6 unviable`, the miss being that cfg artifact.

## What is left in install-plan.ts, deliberately

Of the 69 remaining, 44 sit in branches only reachable off darwin-arm64 (the multilingual test returns early there, so this is a local-measurement artifact — CI's Linux lane kills most of them) and 32 are render strings, which want a golden rather than more assertions.

## Notes for the next person

- `cargo mutants -- -E 'not test(seam_long_form)'` drops the per-mutant cost from ~73 s to ~24 s. Those two tests take 60-120 s each and only exercise the transcribe path, so nothing outside `transcribe/` loses kill power.
- Stryker takes its config as a *positional* argument; `-c` means `concurrency`. Run it from the repo root or `ignorePatterns: ["rust/target"]` stops matching and the sandbox copy dies on a fluidaudio unix socket.

## Verification

`bun run test` 1156 pass / 5 skip · `bunx tsc --noEmit` · `cargo nextest run --features tts` 518 pass · `cargo fmt --check` · `cargo clippy --all-targets --features tts -- -D warnings`