### PR TITLE
docs: make every docs/superpowers citation self-contained

### DIFF
--- a/.claude/skills/tts-internals/SKILL.md
+++ b/.claude/skills/tts-internals/SKILL.md
@@ -59,8 +59,17 @@ script-g U+0261, NFD base+combining-tilde); locked by a zero-residual-OOV regres
 in es, etc.) via `tts::normalize::{numbers,acronyms}`. CharsiuG2P collapses raw digits;
 the normalizer runs first so digit sentences produce longer, correctly-paced audio.
 
-**IO contract and latency reference:** `docs/superpowers/specs/2026-04-22-onnx-g2p-spike.md`
-(PR #185) — verified ~36 ms/word on M2, byte-identical Rust↔Python IPA for es/fr/it/pt.
+**IO contract** (PR #185, verified against the pinned export). `encoder_model`: in
+`input_ids` int64 `[B,S]` + `attention_mask` int64 `[B,S]`, out `last_hidden_state`
+f32 `[B,S,256]`. `decoder_model` (step 0): in `input_ids` + `encoder_attention_mask`
++ `encoder_hidden_states`, out `logits` f32 `[B,S,384]` + 16 `present.{0..3}.{decoder,encoder}.{key,value}`
+f32 `[B,6,S,64]`. `decoder_with_past_model` (steps 1..N): in `input_ids` `[B,1]` +
+`encoder_attention_mask` + the 16 `past_key_values.*`, out `logits` `[B,1,384]` + only
+the 8 **decoder** presents — the encoder K/V are seeded once at step 0 and re-fed
+verbatim every step. Decode is greedy, stops on EOS, capped at 128 steps.
+Model is ByT5-tiny: `vocab_size` 384, `d_model` 256, 12 encoder / 4 decoder layers,
+6 heads. Measured ~36 ms/word single-thread on M2, byte-identical to the Python
+reference for es/fr/it/pt.
 
 ### Multilingual G2P (#511)
 
@@ -91,4 +100,4 @@ acceptably). The `.mandarin` variant fetches its own `ANE-zh/` bundle (nested
 
 ## History
 
-Original spec assumed Silero TTS; pivoted to Piper during M3 spike (Silero ships PyTorch-only, no public ONNX). See `docs/superpowers/specs/2026-04-16-bidirectional-voice-design.md`.
+Original spec assumed Silero TTS; pivoted to Piper during the M3 spike (Silero ships PyTorch-only, no public ONNX), and Piper was later dropped for the current Kokoro/Vosk/AVSpeech split. The lesson that stuck is CLAUDE.md's "verify third-party model formats with a spike".

--- a/.clawhubignore
+++ b/.clawhubignore
@@ -1,7 +1,7 @@
 # Clawhub skill bundle — publish only skill-facing files.
 #
-# Without this, `clawhub publish .` ships all 96 text files in the repo
-# (CLAUDE.md, docs/superpowers/, src/**, tests/**, rust/**, etc.) as one
+# Without this, `clawhub publish .` ships every text file in the repo
+# (CLAUDE.md, docs/**, src/**, tests/**, rust/**, etc.) as one
 # skill package. Peer skills (tg-voice-whisper, voice-transcribe) ship
 # just SKILL.md.
 

--- a/.github/scripts/upload-flakiness.ts
+++ b/.github/scripts/upload-flakiness.ts
@@ -8,7 +8,9 @@
  * `macos-latest` produced five environments in 90 days (15.7.4, 15.7.5, 15.7.7,
  * 26.4, 26.5.2), each starting from empty history — which makes rare-flake
  * detection impossible. Truncating to major.minor before upload stops the
- * patch-level forks. Design: docs/superpowers/specs/2026-08-04-flakiness-signal-landing-design.md
+ * patch-level forks. Forward-only: `26.5` is a *new* environment, so the
+ * existing `26.5.2` rows do not migrate into it. Ubuntu and Windows are left
+ * alone because their reported versions have not drifted.
  *
  * Usage: bun .github/scripts/upload-flakiness.ts <junit-path> <category> [project]
  */

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,8 +1,9 @@
 # Architecture
 
 A contributor's map of kesha-voice-kit: where code lives, what the boundaries
-are, and where to make changes. For the **why** behind specific designs, see the
-spec docs under [`docs/superpowers/specs/`](superpowers/specs/).
+are, and where to make changes. For what each capability is contracted to *do*,
+see the baseline specs under [`openspec/specs/`](../openspec/specs/); for the
+**why** behind specific designs, see [`docs/decision-log.md`](decision-log.md).
 
 ## Two-process model
 

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -85,8 +85,7 @@ issue/PR that drove it). Newest concerns first within each section.
   spike because Silero ships PyTorch-only with no public ONNX export. Piper was adopted
   as the interim path and later removed in favor of the current Kokoro/Vosk/AVSpeech split.
 - **Rationale / lesson:** verify third-party model formats with a throwaway end-to-end
-  spike *before* committing a plan to them. See
-  `docs/superpowers/specs/2026-04-16-bidirectional-voice-design.md`.
+  spike *before* committing a plan to them — now a standing rule in CLAUDE.md.
 - **Status:** superseded by the three-engine split.
 
 ### Web-playable output: FLAC over MP3/AAC; OGG/Opus for messengers

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -1,5 +1,6 @@
 # cargo-deny policy. Run `cd rust && cargo deny check` locally before pushing.
-# See docs/superpowers/specs/2026-05-25-security-ci-gates-design.md.
+# Enforced by the `cargo-deny` job in .github/workflows/security.yml; every
+# policy choice below carries its reason inline.
 
 [advisories]
 # RUSTSEC advisory DB. Unfixable transitive CVEs go in `ignore` below, each

--- a/rust/src/errors.rs
+++ b/rust/src/errors.rs
@@ -3,8 +3,9 @@
 //! A leaf failure attaches a code via [`coded_bail!`] or [`CodedContext::coded`].
 //! The code rides in the `anyhow` chain inside a [`CodedError`]; the top-level
 //! [`report`] walks the chain, prints `error [CODE]: <message>` to stderr, and
-//! returns the process exit code. See
-//! `docs/superpowers/specs/2026-05-30-structured-error-taxonomy-design.md`.
+//! returns the process exit code. An uncoded error falls back to `E_INTERNAL`,
+//! so the `error [CODE]:` contract holds even on paths not individually coded.
+//! User-facing registry: `docs/errors.md`.
 
 use serde::Serialize;
 

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -1613,8 +1613,9 @@ pub fn incomplete_ane_bundle_names() -> Vec<String> {
 }
 
 /// Vosk-TTS multi-speaker Russian model, mirrored to HF at
-/// `drakulavich/vosk-tts-ru-0.9-multi`. Replaces Piper-ru per
-/// `docs/superpowers/specs/2026-04-27-vosk-ru-replacement-design.md`.
+/// `drakulavich/vosk-tts-ru-0.9-multi` (upstream ships a zip on alphacephei.com;
+/// the mirror is what the pinned hashes below are taken against). Replaced
+/// Piper-ru, which needed espeak-ng as a system dependency.
 /// SHA-256 pins computed from the HF mirror — see CLAUDE.md MODEL HASHES
 /// ARE PINNED rule.
 #[cfg(feature = "tts")]

--- a/rust/src/tts/en/acronym.rs
+++ b/rust/src/tts/en/acronym.rs
@@ -8,9 +8,8 @@
 //! - **Letter-spell rule** — uppercase 2..=5 tokens NOT on `STOP_LIST` and
 //!   NOT in `IPA_LEXICON` get expanded letter-by-letter; gated by `auto_expand`.
 //! - **`STOP_LIST`** — natural-English caps words Kokoro handles via training;
-//!   passed through unchanged.
-//!
-//! Spec: `docs/superpowers/specs/2026-05-07-kokoro-en-acronym-expansion-design.md`.
+//!   passed through unchanged. Deliberately excludes AM/PM/TV/DC/CD/DVD, which
+//!   read better letter-by-letter; extend it when a mispronunciation is reported.
 
 use super::letter_table::expand_chars;
 use crate::tts::ssml::Segment;

--- a/src/error-codes.ts
+++ b/src/error-codes.ts
@@ -1,8 +1,8 @@
 /**
  * Error-code taxonomy bridge. The engine is the source of truth for engine
  * codes (see `kesha-engine --error-codes-json`); these are the codes that
- * originate in TS, before/around the engine. See
- * `docs/superpowers/specs/2026-05-30-structured-error-taxonomy-design.md`.
+ * originate in TS, before/around the engine. User-facing registry:
+ * `docs/errors.md`.
  */
 
 /** Matches the engine's `error [CODE]:` line; CODE charset is constrained. */


### PR DESCRIPTION
Stage 1 of #867. Repoints or absorbs all 11 references into `docs/superpowers/specs/` so nothing dangles when stage 2 deletes the directory. **No `openspec/specs/` changes** — see the triage below for why.

## The headline: nothing was extracted

The issue predicted "already covered — delete" as the majority outcome. It is the outcome for **all 32 files**. I read every one against the current `openspec/specs/` corpus (4 319 lines, 12 capabilities) and against the current code, and found no requirement worth adding. Two things drove that:

1. **The baseline corpus is already thorough.** `tts-synthesis` alone documents voice routing precedence with the full platform table, the male-default rule and both exceptions, SSML tag behaviour, the Russian/English/Romance normalization rules with their stop-lists, script gates, and the exit-code map — each traced to `file:line`. `engine-contract` carries the complete 19-code taxonomy, the capability-flag table, and the `KESHA_*` table.
2. **Group B needed no runbook either.** The two CI docs' durable content is already inline in the config it governs — and the inline versions are *better*, because they record lessons learned after the docs were written (see below).

Adding a requirement to justify a deletion would be addition wearing subtraction's clothes, so I didn't.

## Triage — all 32 files

`2026-05-30-ci-fast-heavy-test-lanes-design.md` was already removed by #861/PR #864, so the corpus is 32, not the 33 the issue counted.

### A. Covered by an existing capability spec (23)

| spec | verdict |
|---|---|
| `2026-04-06-lib-split-design` | Delete. Describes `@drakulavich/parakeet-cli`, `beamWidth`/`modelDir` options, and a `translate-voice` refactor in another repo. Superseded by `programmatic-api`. |
| `2026-04-07-coreml-backend-design` | Delete. The `parakeet-coreml` Swift sidecar it specifies no longer exists (collapsed into `fluidaudio-rs`). |
| `2026-04-09-cli-help-design` | Delete. citty adoption + multi-file + `--json` shape; all in `cli-shell-integration` and `transcription`. |
| `2026-04-09-dx-improvements-design` | Delete. `status`, progress bar, actionable errors — in `diagnostics` and `installation`. Its ffmpeg and CoreML-fallback items describe code that no longer exists. |
| `2026-04-09-ffmpeg-error-dx-design` | Delete. Wholly obsolete: ffmpeg is no longer a dependency (symphonia + rubato), and `src/audio.ts::assertFfmpegExists` is gone. |
| `2026-04-09-lang-detection-design` | Delete. Specifies `tinyld` as the primary detector; today it is the confidence-0 fallback behind ECAPA-TDNN and `NLLanguageRecognizer`. `language-detection` is current. |
| `2026-04-12-coreml-lang-detection-design` | Delete. Same, plus `onnxruntime-node` and `parakeet-coreml` subcommands that no longer exist. |
| `2026-04-14-rust-engine-design` | Delete. `parakeet-engine`, `~/.cache/parakeet/`, `protocolVersion: 2`, "TTS — not planned". `engine-contract` is current. |
| `2026-04-16-bidirectional-voice-design` **(cited ×2)** | Delete. Reversed at the root: Silero never shipped, and its default-voice table is all-female (`af_heart`, `ef_dora`…), contradicting the male-default brand rule. Also specifies exit code 3, `kesha uninstall`, `--all`, `manifest.json`, `$KESHA_MODELS_DIR` — none exist. The clearest case of a doc that would inject unhonoured contracts. |
| `2026-04-27-vosk-ru-replacement-design` **(cited)** | Delete. Speaker map and hashes live in `rust/src/models.rs`; routing in `tts-synthesis`. |
| `2026-05-03-vosk-ru-acronym-expansion-design` | Delete. Rules, stop-list, `<say-as>` precedence, `--no-expand-abbrev` semantics all in `tts-synthesis`; letter table in `rust/src/tts/ru/letter_table.rs`. |
| `2026-05-05-vosk-ru-emphasis-marker-design` | Delete. `+`-marker, `level="none"`, warn-once, `<say-as>`-wins nesting all in `tts-synthesis`. |
| `2026-05-07-kokoro-en-acronym-expansion-design` **(cited)** | Delete. Drifted: it declares `KNOWN_PRONUNCIATIONS` out of scope as YAGNI, but `IPA_LEXICON` shipped. Its one durable idea — which words are *deliberately* not stop-listed — moved into `acronym.rs`. |
| `2026-05-09-darwin-diarization-poc-design` | Delete. Its spike **failed** (`FluidAudio.Diarizer` not exported at 0.1.0) and it recommends pivoting to ONNX; what shipped is neither. `speaker-diarization` is current. |
| `2026-05-10-prosody-rate-design` | Delete. The behaviour contract — whole-utterance-only, multiply-then-clamp against `--rate`, relative-percent rejected — is in `tts-synthesis`. The numeric named-rate map (`x-slow` 0.5 … `x-fast` 1.5) lives in `rust/src/tts/ssml/rate.rs:19-24`, documented on the function and locked by its own unit tests, which is where a lookup table belongs rather than in a behaviour spec. |
| `2026-05-20-fluidaudio-sidecar-collapse-design` | Delete. Covered by `speaker-diarization` + `tts-synthesis`; the stdout-shield and `.balancedV2` constraints live in the code. |
| `2026-05-21-diarize-compile-cache-design` | Delete — and it is actively wrong. It concludes the ANE cache is "keyed to the compiled model's path"; `installation` records the corrected finding ("keyed by compiled bundle identity, not path", #444). |
| `2026-05-26-kesha-mcp-server-design` | Delete. Specifies 3 tools; 4 shipped (`list_languages` added), and `list_voices` returns a richer record than designed. `mcp-server` is current. |
| `2026-05-30-structured-error-taxonomy-design` **(cited ×2)** | Delete. Its catalogue is stale: 18 codes with no `E_SCRIPT_UNSUPPORTED`, in neither the `ErrorCode` enum sketch (`:46`) nor the code table (`:102-122`), against the 19 the engine ships today. The mechanism it describes (`coded_bail!`, chain downcast, `error [CODE]:`, `--error-codes-json`) is intact and lives in `engine-contract` plus `docs/errors.md`, which is where both citations now point. |
| `2026-06-01-ja-fluidaudio-kokoro-design` | Delete. Self-superseding: a REVISION section retracts the entire premise (no `.japanese` variant exists; shipped zh instead), and even the corrected default voice `zh-zm_yunjian` is not what shipped (`zh-zm_050`). |
| `2026-06-01-multilingual-g2p-polish-design` | Delete. Stop-lists and Castilian degrade in `tts-synthesis`; its seed lists still include `UNESCO`, which the shipped 2–5-char rule handles instead. |
| `2026-06-01-onnx-kokoro-multilang-trackB-implementation-design` | Delete. Covered by `tts-synthesis`; its "predecessor spike" reference is *already* dangling (`2026-05-31-onnx-kokoro-multilang-g2p-spike-design.md` is not in the repo). |
| `2026-06-01-tts-install-languages-design` | Delete. Language-scoped install, additive semantics, capabilities `tts.languages`, protocol 3 — all in `installation` + `engine-contract`. |

### B. Engineering knowledge → judged on read (6)

I expected runbooks here. On reading the current config, **none is warranted** — the knowledge is already inline where a reader would look, and the inline copies are more current than the docs.

| spec | verdict |
|---|---|
| `2026-04-22-onnx-g2p-spike` **(cited)** | Delete; **facts absorbed into the `tts-internals` skill.** The full encoder / decoder / decoder-with-past IO tables, the encoder-K/V-constant detail, the ByT5 dimensions and the ~36 ms/word figure now live in `SKILL.md` itself rather than behind a pointer. |
| `2026-05-25-security-ci-gates-design` **(cited)** | Delete, no runbook. `rust/deny.toml` carries a reason per advisory-ignore, per license exception and per git-source allowance. And the doc is out of date: it specifies path-filtered `pull_request` triggers, whereas `security.yml` deliberately runs on every PR behind a `changes` gate — plus a `concurrency` group keyed on ref — because path-filtered required checks never report and block PRs forever (#597). Both lessons postdate the doc. |
| `2026-08-04-flakiness-signal-landing-design` **(cited)** | Delete, no runbook. `upload-flakiness.ts`'s header already carries the environment-identity finding and the five-environments-in-90-days evidence; `rust-test.yml:351-354` carries the `rust-push-gate` rationale, and `:357` the trap verbatim ("A job-level block replaces the inherited grant, so omitting this breaks checkout"). The upload consolidation shipped — seven call sites, one script. |
| `2026-04-14-benchmark-design` | Delete. A rewrite spec for `scripts/benchmark.ts`; the script is self-describing and `BENCHMARK.md` holds the results. |
| `2026-05-12-debug-signals-audit` | Delete. An audit checklist whose findings were actioned or superseded (D3, the silent `--no-expand-abbrev` drop, was just fixed in #842; D9's `KESHA_DEBUG` grammar divergence is resolved and the aligned grammar is documented in `engine-contract`). |
| `2026-04-07-scripts-ts-rewrite-design` | Delete. Names the `parakeet` binary and `test-reports.yml`; both gone, and its "ci.yml PR-only" decision has since been reversed. |

### C. Shipped meta-work (3)

`2026-04-24-readme-trim-design`, `2026-05-31-readme-optimization-design`, `2026-05-31-slim-claudemd-design` — records of completed one-off refactors. The last one is measurably stale: it targets `docs/runbooks/release.md`, `tts-internals.md` and `jj-git-lfs.md`, none of which exist (that content became skills).

## Citation repoints (11 sites, 3 more than the issue listed)

The issue named 8. Three more turned up: `.clawhubignore`, `docs/decision-log.md`, `docs/architecture.md`. `CLAUDE.md:82` was already cleaned by #861.

| site | treatment |
|---|---|
| `rust/deny.toml` | Points at `security.yml` as the enforcer; the policy reasons were already inline. |
| `.github/scripts/upload-flakiness.ts` | Absorbs the forward-only consequence (`26.5` is a new bucket; `26.5.2` history does not migrate) — verified against the script's own `truncateToMajorMinor` + `osVersionFull` dual-write. |
| `rust/src/errors.rs` | Repointed to `docs/errors.md`; absorbs the `E_INTERNAL` fallback guarantee. |
| `src/error-codes.ts` | Repointed to `docs/errors.md`. |
| `rust/src/models.rs` | Self-contained: says why the HF mirror exists and that the pins are taken against it. |
| `rust/src/tts/en/acronym.rs` | Reference dropped (the doc no longer describes this module); absorbs the deliberate stop-list exclusions. |
| `.claude/skills/tts-internals/SKILL.md` ×2 | IO contract + latency inlined; the Silero→Piper history made self-contained. |
| `docs/decision-log.md` | Lesson stated inline; it is a standing CLAUDE.md rule. |
| `docs/architecture.md` | Repointed at `openspec/specs/` for contracts and `docs/decision-log.md` for rationale. |
| `.clawhubignore` | Illustrative path list generalised. |

## Disagreements found — filed, not resolved

- **#870** — `tts-synthesis:498` says zh voices are "not staged in `rust/src/models.rs`", but #823's `stage_fluidaudio_kokoro_assets` stages them. The darwin-arm64 ANE staging and the `missing_kokoro_assets` pre-check that actually upholds the Never-auto-download rule are both unspecified.
- **#871** — `SKILL.md:22` and `docs/decision-log.md` both say CharsiuG2P was "retired"; it serves es/fr/it/pt today. `SKILL.md` contradicts itself 20 lines later.

Neither is touched here — both predate this work and deserve their own fix.

## Verification

- `bun test` → **1157 pass, 5 skip, 0 fail** (86 files)
- `bunx tsc --noEmit` → clean
- `bun run check:specs` → **12 passed, 0 failed**
- `cargo fmt -- --check` → clean; `cargo clippy --all-targets --features tts -- -D warnings` → clean
- `grep -rn superpowers` outside `docs/superpowers/` → **no matches**

## Next

Stage 2 deletes `docs/superpowers/` (32 files, 5 849 lines) once this merges. Held back deliberately so a reviewer can still open any doc named above and check the verdict against it.

Refs #867
