### PR TITLE
fix(test): make the MCP synthesis case actually run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,8 @@ jobs:
               - 'bun.lock'
               - 'tests/fixtures/**'
               - 'tests/integration/say-e2e.test.ts'
+              - 'tests/integration/mcp-synthesis-e2e.test.ts'
+              - 'src/mcp/**'
               - 'src/engine.ts'
               - 'src/synth.ts'
               - 'src/voice-routing.ts'
@@ -772,9 +774,12 @@ jobs:
           KOKORO_VOICE: ${{ github.workspace }}/tests/fixtures/mini-models/kokoro/am_michael.bin
           KESHA_ENGINE_BIN: ${{ github.workspace }}/rust/target/release/kesha-engine
           DYLD_FALLBACK_LIBRARY_PATH: /opt/homebrew/lib
+          # This lane stages the stand-in, so a self-skip here would be a green run of
+          # nothing — which is exactly how the MCP synthesis case stayed dormant (#857).
+          KESHA_REQUIRE_MODEL_TESTS: mini
         run: |
           mkdir -p test-results
-          bun test tests/integration/say-e2e.test.ts \
+          bun test tests/integration/say-e2e.test.ts tests/integration/mcp-synthesis-e2e.test.ts \
             --reporter=junit --reporter-outfile=test-results/tts-e2e.xml
 
       - name: 📊 Test summary

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -101,7 +101,10 @@ export function spawnEngineProcess(
   stdio: ReturnType<typeof spawnStdioWithDebugFd>,
 ): ReturnType<typeof Bun.spawn> {
   try {
-    return Bun.spawn([binPath, ...args], { detached: true, stdio });
+    // Bun snapshots `process.env` at startup unless `env` is passed, so anything the CLI
+    // resolves at runtime — `NO_COLOR` from `--no-color`, a `KESHA_*` override — reached the
+    // parent and not the engine (#874).
+    return Bun.spawn([binPath, ...args], { detached: true, stdio, env: process.env });
   } catch (err) {
     throw new Error(
       `error [${TS_NATIVE_CODES.ENGINE_SPAWN}]: failed to launch kesha-engine at ${binPath}: ` +

--- a/tests/helpers/fake-engine.ts
+++ b/tests/helpers/fake-engine.ts
@@ -114,3 +114,22 @@ exit 2
   chmodSync(path, 0o755);
   return path;
 }
+
+/**
+ * A stub engine that echoes the environment it was handed, for asserting what a spawned
+ * child actually inherits (#874).
+ *
+ * Runs under `bun` instead of a shell script so it executes on Windows too: an
+ * extensionless `#!/bin/sh` file is not executable there, which is why the other
+ * stub-driven tests in this suite are win32-skipped. Returns the argv pair rather than a
+ * path, because the interpreter is the binary and the script is its argument.
+ */
+export function envEchoEngine(vars: string[]): { binPath: string; args: string[] } {
+  const dir = mkdtempSync(join(tmpdir(), "kesha-env-echo-"));
+  const script = join(dir, "echo-env.js");
+  writeFileSync(
+    script,
+    `for (const v of ${JSON.stringify(vars)}) console.log(v + "=" + (process.env[v] ?? "UNSET"));\n`,
+  );
+  return { binPath: process.execPath, args: [script] };
+}

--- a/tests/integration/mcp-e2e.test.ts
+++ b/tests/integration/mcp-e2e.test.ts
@@ -1,7 +1,6 @@
-import { describe, test, expect, beforeAll } from "bun:test";
+import { describe, test, expect } from "bun:test";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { existsSync, mkdirSync, symlinkSync } from "fs";
 import { createKeshaMcpServer } from "../../src/mcp/server";
 import { engineGate } from "../helpers/model-gate";
 
@@ -25,32 +24,8 @@ async function client() {
   return cl;
 }
 
-// TTS model availability — mirrors say-e2e.test.ts gating
-const SPIKE_MODEL = process.env.KOKORO_MODEL ?? "/tmp/kokoro-spike/model.onnx";
-const SPIKE_VOICE = process.env.KOKORO_VOICE ?? "/tmp/kokoro-spike/af_heart.bin";
-const G2P_SRC_DIR = process.env.KESHA_CACHE_DIR
-  ? `${process.env.KESHA_CACHE_DIR}/models/g2p/byt5-tiny`
-  : "";
-const G2P_AVAILABLE =
-  G2P_SRC_DIR !== "" && existsSync(`${G2P_SRC_DIR}/encoder_model.onnx`);
-const SPIKE_AVAILABLE = existsSync(SPIKE_MODEL) && existsSync(SPIKE_VOICE) && G2P_AVAILABLE;
-
-const TTS_CACHE_DIR = `/tmp/kesha-mcp-e2e-${Date.now()}`;
-const MODEL_DIR = `${TTS_CACHE_DIR}/models/kokoro-82m`;
-const G2P_DIR = `${TTS_CACHE_DIR}/models/g2p/byt5-tiny`;
-
-beforeAll(() => {
-  if (!SPIKE_AVAILABLE) return;
-  mkdirSync(`${MODEL_DIR}/voices`, { recursive: true });
-  symlinkSync(SPIKE_MODEL, `${MODEL_DIR}/model.onnx`);
-  symlinkSync(SPIKE_VOICE, `${MODEL_DIR}/voices/af_heart.bin`);
-  mkdirSync(G2P_DIR, { recursive: true });
-  for (const f of ["encoder_model.onnx", "decoder_model.onnx", "decoder_with_past_model.onnx"]) {
-    symlinkSync(`${G2P_SRC_DIR}/${f}`, `${G2P_DIR}/${f}`);
-  }
-  process.env.KESHA_CACHE_DIR = TTS_CACHE_DIR;
-});
-
+// Synthesis lives in mcp-synthesis-e2e.test.ts: it needs a Kokoro model this lane's
+// installed engine may not use at all, so gating it on the engine alone left it dormant (#857).
 describe.skipIf(!engineInstalled)("mcp e2e", () => {
   test("transcribe_audio returns non-empty text", async () => {
     const cl = await client();
@@ -59,28 +34,4 @@ describe.skipIf(!engineInstalled)("mcp e2e", () => {
     // Backend-stable word: CoreML and ONNX disagree on "сообщения"/"сообщение" for this clip.
     expect((res.content as Array<{ text: string }>)[0].text).toContain("транскрипцией");
   }, 60_000);
-
-  test.skipIf(!SPIKE_AVAILABLE)(
-    "synthesize_speech returns a readable resource_link to a valid file",
-    async () => {
-      const cl = await client();
-      const res = await cl.callTool({
-        name: "synthesize_speech",
-        arguments: { text: "Hello world", voice: "en-am_michael", format: "wav" },
-      });
-      expect(res.isError).toBeUndefined();
-      const link = (res.content as Array<{ type: string; uri: string }>).find((c) => c.type === "resource_link");
-      expect(link?.uri.startsWith("kesha-audio://")).toBe(true);
-      const sc = res.structuredContent as { uri: string; path: string; bytes: number };
-      const { existsSync, statSync } = await import("fs");
-      expect(existsSync(sc.path)).toBe(true);
-      expect((statSync(sc.path).mode & 0o777)).toBe(0o600);
-      expect(sc.bytes).toBeGreaterThan(1000);
-      const read = await cl.readResource({ uri: sc.uri });
-      const blob = (read.contents[0] as { blob?: string }).blob;
-      expect(typeof blob).toBe("string");
-      expect(Buffer.from(blob as string, "base64").length).toBe(sc.bytes);
-    },
-    60_000,
-  );
 });

--- a/tests/integration/mcp-synthesis-e2e.test.ts
+++ b/tests/integration/mcp-synthesis-e2e.test.ts
@@ -1,0 +1,115 @@
+import { describe, test, expect, beforeAll } from "bun:test";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { existsSync, mkdirSync, statSync, symlinkSync } from "fs";
+import { createKeshaMcpServer } from "../../src/mcp/server";
+import { modelsRequired } from "../helpers/model-gate";
+
+/**
+ * The MCP synthesis contract: a `synthesize_speech` call routes to the engine, and what
+ * comes back is a readable `kesha-audio://` resource. Everything asserted here is adapter
+ * plumbing — the resource_link, the `0600` mode, the byte count, the base64 read-back —
+ * so it runs against the committed Kokoro stand-in and downloads nothing (#741). Audio
+ * *quality* is the real-model canary's job, not this suite's.
+ *
+ * Split out of mcp-e2e.test.ts, which gates on the *installed* engine: on darwin-arm64
+ * that is the CoreML `system_kokoro` build, where `en-*` synthesises through FluidAudio's
+ * ANE assets rather than the ONNX `models/kokoro-82m` a stand-in can supply (#857).
+ *
+ * English Kokoro phonemises through the embedded misaki lexicon (#207), not the byt5
+ * CharsiuG2P pack — gating this on a G2P artifact is what kept the old case dormant.
+ */
+const SPIKE_MODEL = process.env.KOKORO_MODEL ?? "/tmp/kokoro-spike/model.onnx";
+const SPIKE_VOICE = process.env.KOKORO_VOICE ?? "/tmp/kokoro-spike/am_michael.bin";
+const BUILT_ENGINE =
+  process.env.KESHA_ENGINE_BIN ??
+  `${new URL("../..", import.meta.url).pathname}rust/target/release/kesha-engine`;
+
+const AVAILABLE = existsSync(SPIKE_MODEL) && existsSync(SPIKE_VOICE) && existsSync(BUILT_ENGINE);
+
+/**
+ * A lane that promised these models must not quietly cover nothing — the failure this
+ * suite exists to prevent was a skip nobody could tell apart from a pass (#857).
+ *
+ * Keyed on the lane naming `KOKORO_MODEL`, not on `KESHA_REQUIRE_MODEL_TESTS` alone:
+ * `integration-tests-full` sets that flag for the ASR weights it installs and stages no
+ * Kokoro at all, so the broader flag would fail a lane this suite was never part of.
+ */
+const LANE_PROMISED_KOKORO = modelsRequired() && process.env.KOKORO_MODEL !== undefined;
+if (!AVAILABLE && LANE_PROMISED_KOKORO) {
+  test("this lane must stage the Kokoro stand-in and a built engine (#857)", () => {
+    throw new Error(
+      `This lane names KOKORO_MODEL and sets KESHA_REQUIRE_MODEL_TESTS, but the synthesis ` +
+        `prerequisites are missing — model=${existsSync(SPIKE_MODEL)} ` +
+        `voice=${existsSync(SPIKE_VOICE)} engine=${existsSync(BUILT_ENGINE)}. ` +
+        `Skipping here would be a green run of nothing.`,
+    );
+  });
+}
+
+const CACHE_DIR = `/tmp/kesha-mcp-synth-${process.pid}-${Date.now()}`;
+const MODEL_DIR = `${CACHE_DIR}/models/kokoro-82m`;
+
+beforeAll(() => {
+  if (!AVAILABLE) return;
+  mkdirSync(`${MODEL_DIR}/voices`, { recursive: true });
+  symlinkSync(SPIKE_MODEL, `${MODEL_DIR}/model.onnx`);
+  // Staged under the brand-default name, because that is the voice the case requests.
+  symlinkSync(SPIKE_VOICE, `${MODEL_DIR}/voices/am_michael.bin`);
+  // Pin the engine before repointing the cache: `defaultEngineBinPath()` is rooted in
+  // KESHA_CACHE_DIR, so a bare cache override hides the engine from the CLI side (#857).
+  process.env.KESHA_ENGINE_BIN = BUILT_ENGINE;
+  process.env.KESHA_CACHE_DIR = CACHE_DIR;
+});
+
+async function client() {
+  const server = createKeshaMcpServer();
+  const [c, s] = InMemoryTransport.createLinkedPair();
+  await server.connect(s);
+  const cl = new Client({ name: "t", version: "0" });
+  await cl.connect(c);
+  return cl;
+}
+
+describe.skipIf(!AVAILABLE)("mcp synthesis e2e", () => {
+  test(
+    "synthesize_speech returns a readable resource_link to a valid file",
+    async () => {
+      const cl = await client();
+      const res = await cl.callTool({
+        name: "synthesize_speech",
+        arguments: { text: "Hello world", voice: "en-am_michael", format: "wav" },
+      });
+
+      expect(res.isError).toBeUndefined();
+      const link = (res.content as Array<{ type: string; uri: string }>).find(
+        (c) => c.type === "resource_link",
+      );
+      expect(link?.uri.startsWith("kesha-audio://")).toBe(true);
+
+      const sc = res.structuredContent as { uri: string; path: string; bytes: number };
+      expect(existsSync(sc.path)).toBe(true);
+      expect(statSync(sc.path).mode & 0o777).toBe(0o600);
+      expect(sc.bytes).toBeGreaterThan(1000);
+
+      const read = await cl.readResource({ uri: sc.uri });
+      const blob = (read.contents[0] as { blob?: string }).blob;
+      expect(typeof blob).toBe("string");
+      expect(Buffer.from(blob as string, "base64").length).toBe(sc.bytes);
+    },
+    60_000,
+  );
+
+  test(
+    "an unknown voice surfaces as a tool error, not a protocol throw",
+    async () => {
+      const cl = await client();
+      const res = await cl.callTool({
+        name: "synthesize_speech",
+        arguments: { text: "Hello world", voice: "xx-nonexistent", format: "wav" },
+      });
+      expect(res.isError).toBe(true);
+    },
+    60_000,
+  );
+});

--- a/tests/unit/engine.test.ts
+++ b/tests/unit/engine.test.ts
@@ -3,7 +3,7 @@ import { chmodSync, mkdtempSync, mkdirSync, writeFileSync } from "fs";
 import { homedir, tmpdir } from "os";
 import { join } from "path";
 import { waitForPidExit, waitForPidFile } from "../helpers/process";
-import { saveEngineEnv, writeTranscribingEngine } from "../helpers/fake-engine";
+import { envEchoEngine, saveEngineEnv, writeTranscribingEngine } from "../helpers/fake-engine";
 import { applyColorEnv } from "../../src/cli/context";
 import {
   detectTextLanguageEngine,
@@ -480,17 +480,9 @@ describe("text language detection degrades loudly (#770)", () => {
  * parent and not the engine (#874).
  */
 describe("engine subprocess env", () => {
-  const echoEngine = (vars: string[]) => {
-    const dir = mkdtempSync(join(tmpdir(), "kesha-env-echo-"));
-    const binPath = join(dir, "kesha-engine");
-    const body = vars.map((v) => `echo ${v}=\${${v}:-UNSET}`).join("\n");
-    writeFileSync(binPath, `#!/bin/sh\n${body}\n`);
-    chmodSync(binPath, 0o755);
-    return binPath;
-  };
-
-  const readStdout = async (binPath: string) => {
-    const proc = spawnEngineProcess(binPath, [], spawnStdioWithDebugFd(["ignore", "pipe", "pipe"]));
+  const readStdout = async (vars: string[]) => {
+    const { binPath, args } = envEchoEngine(vars);
+    const proc = spawnEngineProcess(binPath, args, spawnStdioWithDebugFd(["ignore", "pipe", "pipe"]));
     return (await new Response(proc.stdout as ReadableStream).text()).trim();
   };
 
@@ -500,7 +492,7 @@ describe("engine subprocess env", () => {
     try {
       process.env.KESHA_CACHE_DIR = "/tmp/kesha-env-probe-cache";
       applyColorEnv(true);
-      const out = await readStdout(echoEngine(["KESHA_CACHE_DIR", "NO_COLOR"]));
+      const out = await readStdout(["KESHA_CACHE_DIR", "NO_COLOR"]);
       expect(out).toContain("KESHA_CACHE_DIR=/tmp/kesha-env-probe-cache");
       expect(out).toContain("NO_COLOR=1");
     } finally {

--- a/tests/unit/engine.test.ts
+++ b/tests/unit/engine.test.ts
@@ -3,7 +3,8 @@ import { chmodSync, mkdtempSync, mkdirSync, writeFileSync } from "fs";
 import { homedir, tmpdir } from "os";
 import { join } from "path";
 import { waitForPidExit, waitForPidFile } from "../helpers/process";
-import { writeTranscribingEngine } from "../helpers/fake-engine";
+import { saveEngineEnv, writeTranscribingEngine } from "../helpers/fake-engine";
+import { applyColorEnv } from "../../src/cli/context";
 import {
   detectTextLanguageEngine,
   parseLangResult,
@@ -12,6 +13,7 @@ import {
   preflightTranscribeEngineItn,
   preflightTranscribeEngineWithSegments,
   recordEngine,
+  spawnEngineProcess,
   spawnStdioWithDebugFd,
   textLangFailureWarning,
   transcribeEngine,
@@ -468,5 +470,43 @@ describe("text language detection degrades loudly (#770)", () => {
 
     const warned = captured.some((line) => line.includes("Text language detection failed"));
     expect(warned).toBe(process.platform === "darwin");
+  });
+});
+
+/**
+ * `Bun.spawn` snapshots `process.env` at process start unless an `env` is passed,
+ * so a value the CLI resolves at runtime — `NO_COLOR` from `--no-color`
+ * (`src/cli/context.ts::applyColorEnv`), or a `KESHA_*` override — reached the
+ * parent and not the engine (#874).
+ */
+describe("engine subprocess env", () => {
+  const echoEngine = (vars: string[]) => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-env-echo-"));
+    const binPath = join(dir, "kesha-engine");
+    const body = vars.map((v) => `echo ${v}=\${${v}:-UNSET}`).join("\n");
+    writeFileSync(binPath, `#!/bin/sh\n${body}\n`);
+    chmodSync(binPath, 0o755);
+    return binPath;
+  };
+
+  const readStdout = async (binPath: string) => {
+    const proc = spawnEngineProcess(binPath, [], spawnStdioWithDebugFd(["ignore", "pipe", "pipe"]));
+    return (await new Response(proc.stdout as ReadableStream).text()).trim();
+  };
+
+  test("forwards env resolved after startup, not the startup snapshot", async () => {
+    const restore = saveEngineEnv();
+    const savedNoColor = process.env.NO_COLOR;
+    try {
+      process.env.KESHA_CACHE_DIR = "/tmp/kesha-env-probe-cache";
+      applyColorEnv(true);
+      const out = await readStdout(echoEngine(["KESHA_CACHE_DIR", "NO_COLOR"]));
+      expect(out).toContain("KESHA_CACHE_DIR=/tmp/kesha-env-probe-cache");
+      expect(out).toContain("NO_COLOR=1");
+    } finally {
+      restore();
+      if (savedNoColor === undefined) delete process.env.NO_COLOR;
+      else process.env.NO_COLOR = savedNoColor;
+    }
   });
 });


### PR DESCRIPTION
`mcp-e2e`'s `synthesize_speech` case has never executed in CI. This makes it run, and fixes the production defect that was underneath it.

## The contract decision

I read what the case actually asserts before changing anything: `isError` undefined, a `resource_link` carrying a `kesha-audio://` URI, the output file present at `structuredContent.path` with mode `0600`, `bytes > 1000`, and `readResource(uri)` returning a base64 blob that decodes to exactly `bytes`.

**Every assertion is MCP-adapter plumbing. None reads an audio property.** So this is a plumbing test and belongs on the **mini tier**, per-PR — real synthesis quality stays the canary's job.

It is not redundant with the seven `mcp-*` unit suites: those cover the *error* surfaces (rate range, missing-models install hint, stdout discipline, handshake, voice parsing). Nothing covered `synthesize_speech`'s **success** path or the resource read-back. That gap is why it was worth repairing rather than deleting.

## Four problems, not three

The three in #857, plus one underneath them:

1. **Gate never opened.** It required a CharsiuG2P pack at `$KESHA_CACHE_DIR/models/g2p/byt5-tiny`. English Kokoro phonemises through the embedded misaki lexicon (#207) and never touches that pack — `say-e2e`'s own header already says so. Worse, `G2P_SRC_DIR` was `""` whenever `KESHA_CACHE_DIR` was unset, which is the case in every lane, so the gate was closed by construction.
2. **Voice staging mismatch.** Staged `af_heart.bin`, requested `en-am_michael`.
3. **Cache/engine coupling.** `defaultEngineBinPath()` is rooted in `keshaCacheDir()`, so repointing `KESHA_CACHE_DIR` hid the engine from the CLI side.
4. **(new) `Bun.spawn` snapshots `process.env`.** Without an explicit `env`, a value set after process start never reaches the child. So `beforeAll`'s `process.env.KESHA_CACHE_DIR = …` reached the TypeScript side (live read → hid the engine) and *not* the engine (snapshot → read the real cache). Both halves broken, in opposite directions — which is why staging into the active cache "got past it" and then behaved unpredictably.

## The production bug (#874)

Problem 4 is not test-only. `src/cli/context.ts:97` sets `process.env.NO_COLOR = "1"`, and its own comment states the purpose: *"so engine subprocesses inherit the right value"*. They did not. Demonstrated through the real production functions:

```
parent process.env.NO_COLOR = "1"
child NO_COLOR=UNSET
```

So `kesha --no-color` never suppressed ANSI in the engine; only a `NO_COLOR` exported *before* launch worked, because that one is in the snapshot. Two specs assert the propagation works — `cli-shell-integration` ("so that Engine subprocesses spawned later in the same process also see it") and `engine-contract` ("the Engine SHALL read them at spawn time (inheriting `process.env` from the CLI)").

**The fix is one line** in `spawnEngineProcess`: pass `env: process.env`. It touches every engine spawn, so it is called out here rather than buried. It makes the code match both specs, and it is the root cause of the test's structural problem rather than a way around it.

## Where the case now lives

`integration-tests-full` runs `mcp-e2e` on `macos-latest` against the **installed** engine. I checked that engine: `backend: "coreml"`, advertising `hi/ja/zh` — the darwin-arm64 `system_kokoro` build, where `en-*` synthesises through **FluidAudio ANE assets**, not the ONNX `models/kokoro-82m` a stand-in supplies. A mini stand-in there is a no-op, so that lane can never host this case.

`tts-e2e` already builds the ONNX engine from source, points `KESHA_ENGINE_BIN` at it, and stages the committed Kokoro stand-in — exactly what this case needs. So:

- **new `tests/integration/mcp-synthesis-e2e.test.ts`**, gated like `say-e2e` (model + voice + built engine), runs in `tts-e2e`.
- **`mcp-e2e.test.ts`** keeps `transcribe_audio`, which genuinely needs the installed engine and real ASR weights, and loses the dead staging scaffolding.

## Execution evidence (#838 — proving it runs, not that it is green)

Driving the exact `tts-e2e` invocation locally:

```
$ KOKORO_MODEL=…/mini-models/kokoro/model.onnx KOKORO_VOICE=…/am_michael.bin \
  KESHA_ENGINE_BIN=…/rust/target/release/kesha-engine KESHA_REQUIRE_MODEL_TESTS=mini \
  bun test tests/integration/say-e2e.test.ts tests/integration/mcp-synthesis-e2e.test.ts

 5 pass · 0 fail · 16 expect() calls · Ran 5 tests across 2 files
```

Assertions execute — a skip reports `0 pass / N skip` with no expects.

**Sabotage — reintroducing the original bug.** Staging the voice as `af_heart.bin` while requesting `am_michael`:

```
error: expect(received).toBeUndefined()   Received: true
(fail) synthesize_speech returns a readable resource_link to a valid file
```

The repaired test catches problem 2. Reverted afterwards.

**Gate behaviour, both directions:**

| lane shape | result |
|---|---|
| `tts-e2e` (names `KOKORO_MODEL`, artifacts present) | 2 pass |
| `tts-e2e` shape, artifact missing | **fails loudly**, naming which prerequisite |
| `integration-tests-full` (`KESHA_REQUIRE_MODEL_TESTS` set, no `KOKORO_MODEL`) | skips quietly |
| dev machine, nothing staged | skips quietly |

That third row matters: my first version keyed the loud failure on `KESHA_REQUIRE_MODEL_TESTS` alone, which **would have broken `integration-tests-full`** — that lane sets the flag for the ASR weights it installs and stages no Kokoro. Caught locally before pushing; the guard now also requires the lane to have named `KOKORO_MODEL`.

## A note on what I removed

I wrote a second env test ("a variable deleted after startup is not resurrected") and deleted it: it passed *before* the fix, vacuously, because it deleted a variable that was never in the snapshot. Shipping a test that looks like coverage and is not would have been the exact failure #857 is about.

## Verification

Baseline measured on the same machine with the diff stashed, so the comparison is like-for-like:

| | baseline (`origin/main`) | this PR |
|---|---|---|
| `bun test` | 1158 pass · 4 skip · 0 fail · 86 files · 2995 expects | **1159 pass · 5 skip · 0 fail · 87 files · 2997 expects** |

Delta reconciles exactly: +1 pass (net new engine test), +2 skip (new suite, bare), −1 skip (migrated case), +1 file, +2 expects.

- `bunx tsc --noEmit` → clean
- `bun .github/scripts/check-workflows.ts` → exit 0
- MCP suite (9 files) → 22 pass · 2 skip · 0 fail
- No Rust source changes (the engine was built only to drive the suite)

Closes #857, closes #874

## Blast radius of `env: process.env`

The one-line change flips spawn semantics from snapshot-at-start to live-at-spawn for every call through `spawnEngineProcess`. Enumerated rather than inferred from the green suite, because a test that passed *because* the child ignored its mutation would not show up as a failure.

### (a) Spawn call sites

| site | spawns the engine? | env before | env after |
|---|---|---|---|
| `src/engine.ts:107` `spawnEngineProcess` | yes — `runEngine`, `synth.ts:176`, `mcp/voices.ts:115`, `cli/say.ts:315`, `engine.ts:402` | snapshot | **live (changed)** |
| `src/engine-health.ts:31` | yes — capabilities probe | snapshot | snapshot |
| `src/engine-install.ts:224` | yes — darwin Kokoro warm-up | snapshot | snapshot |
| `src/engine-install.ts:557` | yes — `kesha-engine install` | snapshot | snapshot |
| `src/engine-install.ts:118` | no — `codesign`/`xattr` | snapshot | snapshot |
| `src/star.ts:75`, `src/process-tree.ts:70` | no | snapshot | snapshot |

Only `spawnEngineProcess` changed. The remaining inconsistency — in particular `engine-install.ts:557`, where a runtime `KESHA_CACHE_DIR` still cannot reach the child that decides where models are written — is filed as **#876** rather than widened into this PR: changing where a multi-GB download lands deserves its own verification.

### (b) Tests that mutate `process.env` and then spawn

18 files mutate `process.env` (`KESHA_*`, `HOME`, `NO_COLOR`, `NODE_ENV`). The set that matters is the **intersection**: mutates env *and* spawns through the one changed site.

| file | spawns via | child is | child's view before → after | assertion depended on old view? |
|---|---|---|---|---|
| `tests/unit/engine.test.ts` | `spawnEngineProcess` | stub | snapshot → mutated | no — stub reads no env |
| `tests/unit/mcp-list-voices.test.ts` | `spawnEngineProcess` | stub | snapshot → mutated | no — same |
| `tests/unit/lib.test.ts` | `spawnEngineProcess` | stub | snapshot → mutated | no — same |
| `tests/unit/status.test.ts` | `spawnEngineProcess` | stub | snapshot → mutated | no — same |
| `tests/integration/mcp-synthesis-e2e.test.ts` | `spawnEngineProcess` | **real** | n/a (new) | intentional — this is the fix |
| `tests/unit/engine-repair.test.ts` | `engine-health.ts` / `engine-install.ts` | real+stub | **unchanged** (those sites still snapshot) | n/a |
| `e2e-engine`, `say-e2e`, `mcp-e2e` | real engine | real | **unchanged** — none mutates `process.env` | n/a |

The load-bearing fact is that the four pre-existing intersection files all drive **stub** engines, and **no stub in the suite reads an environment variable**. Proof:

```
grep -rnoE '\$\{?(KESHA_[A-Z_]*|HOME|NO_COLOR|NODE_ENV|PATH|[A-Z][A-Z_]{2,})\}?' \
  tests/helpers/fake-engine.ts tests/unit/*.test.ts tests/integration/*.test.ts | grep -v 'process.env'
```

Every hit is a TypeScript template literal evaluated at test-authoring time (`${JSON…}`, `${MODEL_DIR}`, `${OVERRIDE}`, `${TRANSCRIBE_*_FEATURE}`) or a `$HOME` inside a comment. The stub bodies branch only on `$1`. A child that reads no env cannot behave differently when its env changes — so the latent-liar set is **empty**, not merely "passing".

Differential over all 18, toggling only the one line:

| | result |
|---|---|
| with `env: process.env` | **356 pass · 0 fail** · 1031 expects |
| without (snapshot) | 355 pass · **1 fail** · 1030 expects |

The single flip is the regression test added here, red without the fix by construction.

### (c) #796 guard direction

`assertNotRealCacheUnderTest` is parent-side — `process.env.NODE_ENV`, `homedir()`, and the resolved `binPath`, all read before any spawn — so child inheritance cannot touch it either way.

Isolation itself gets **stronger, never weaker**, and the reason is directional: the change can only move a child from *the developer's real values* (startup snapshot) to *the test's isolated values* (live). The reverse is unreachable, because the snapshot never contained a value the test set after startup.

The one direction that could theoretically weaken it — a test **deleting** an isolating var that *was* in the startup snapshot, dropping the child back to the `~/.cache/kesha` default — does not occur: `isolateEngineCache()` **sets** `KESHA_CACHE_DIR` and deletes only `KESHA_ENGINE_BIN`, which is resolved parent-side by `getEngineBinPath()` and never read by the child.

Stronger isolation stops at the changed site, though: `engine-install.ts:557` still snapshots, so a runtime `KESHA_CACHE_DIR` still cannot reach the child that decides where models are written — **#876**.

## Why the mini staging is scoped the way it is

`mcp-synthesis-e2e` pins `KESHA_ENGINE_BIN` at the source-built **ONNX** engine before repointing `KESHA_CACHE_DIR`, and does not reuse `mcp-e2e`'s installed engine. That is deliberate and load-bearing: on darwin-arm64 the installed engine is the CoreML `system_kokoro` build (`backend: "coreml"`, advertising `hi/ja/zh`), whose `en-*` voices synthesise through FluidAudio ANE assets rather than the ONNX `models/kokoro-82m` a stand-in can supply. Pointing this suite at the installed engine, or dropping the `KESHA_ENGINE_BIN` pin as a "simplification", puts the case straight back to dormant.

