### PR TITLE
test(progress): assert what the progress surface promises the user

### DIFF
--- a/src/progress.ts
+++ b/src/progress.ts
@@ -25,7 +25,11 @@ export function formatPercentProgress(label: string, percent: number): string {
   return `${label}  [${bar(pct)}] ${pct}%`;
 }
 
-function estimatePercent(elapsedMs: number, estimatedTotalMs: number): number {
+/**
+ * Time-based estimate for work that reports no progress of its own: 0 before it starts,
+ * then 1..99 — never 100, which only `finish` may claim. Exported for the test.
+ */
+export function estimatePercent(elapsedMs: number, estimatedTotalMs: number): number {
   if (elapsedMs <= 0) return 0;
   const targetMs = Math.max(1, estimatedTotalMs);
   return Math.max(1, Math.min(99, Math.floor((elapsedMs / targetMs) * 99)));

--- a/tests/unit/progress-stream.test.ts
+++ b/tests/unit/progress-stream.test.ts
@@ -277,3 +277,56 @@ describe("applyBackpressure honours the FileSink contract (#669)", () => {
     expect(sink.flushes).toBe(0);
   });
 });
+
+describe("the sweep only claims its own destination's staging", () => {
+  // One `kesha install` downloads the engine and both sidecars into the same bin dir, so a
+  // sweep keyed on the directory rather than the destination would eat a sibling's staging.
+  posixTest("a stale staging file belonging to another download is left alone", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-stream-sibling-"));
+    try {
+      const dest = join(dir, "kesha-engine");
+      const sibling = join(dir, "kesha-textlang.part.4242.0");
+      const dayAgo = new Date(Date.now() - 25 * 60 * 60 * 1000);
+      writeFileSync(sibling, "another asset's orphan");
+      utimesSync(sibling, dayAgo, dayAgo);
+
+      await streamResponseToFile(responseOf("engine bytes"), dest, "payload");
+
+      expect(readFileSync(sibling, "utf8")).toBe("another asset's orphan");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  posixTest("an unrelated stale file next to the destination is left alone", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-stream-unrelated-"));
+    try {
+      const dest = join(dir, "kesha-engine");
+      const bystander = join(dir, "kesha-engine.version");
+      const dayAgo = new Date(Date.now() - 25 * 60 * 60 * 1000);
+      writeFileSync(bystander, "1.24.9\n");
+      utimesSync(bystander, dayAgo, dayAgo);
+
+      await streamResponseToFile(responseOf("engine bytes"), dest, "payload");
+
+      expect(readFileSync(bystander, "utf8")).toBe("1.24.9\n");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("a download with nothing to stream fails with a fix", () => {
+  test("an empty response body names the label and what to do", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-stream-empty-"));
+    try {
+      const dest = join(dir, "kesha-engine");
+      const promise = streamResponseToFile(new Response(null), dest, "kesha-engine binary");
+      await expect(promise).rejects.toThrow("empty response for kesha-engine binary");
+      await expect(promise).rejects.toThrow("Try again");
+      expect(readdirSync(dir)).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/progress.test.ts
+++ b/tests/unit/progress.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect } from "bun:test";
 import {
   createPercentProgress,
   createProgressBar,
+  estimatePercent,
   formatPercentProgress,
   formatProgressBar,
   formatBytes,
@@ -226,5 +227,115 @@ describe("createProgressBar", () => {
       Object.defineProperty(process.stderr, "isTTY", { value: originalIsTTY, configurable: true });
       process.stderr.write = originalWrite;
     }
+  });
+});
+
+describe("estimatePercent", () => {
+  test("stays silent until the clock has actually moved", () => {
+    expect(estimatePercent(0, 1000)).toBe(0);
+    expect(estimatePercent(-5, 1000)).toBe(0);
+  });
+
+  // A bar that reads 0% while work is under way is indistinguishable from a hang.
+  test("never reads 0% once the work is running", () => {
+    expect(estimatePercent(1, 30 * 60 * 1000)).toBe(1);
+    expect(estimatePercent(0.5, 30 * 60 * 1000)).toBe(1);
+  });
+
+  // 100% belongs to finish(); an estimate reaching it would announce a completion it cannot know.
+  test("never reaches 100%, however far past the estimate it runs", () => {
+    expect(estimatePercent(1000, 1000)).toBe(99);
+    expect(estimatePercent(100_000, 1000)).toBe(99);
+  });
+
+  test("a zero or negative estimate does not divide by zero", () => {
+    expect(estimatePercent(10, 0)).toBe(99);
+    expect(estimatePercent(10, -1000)).toBe(99);
+  });
+
+  test("tracks the fraction elapsed in between", () => {
+    expect(estimatePercent(500, 1000)).toBe(49);
+    expect(estimatePercent(250, 1000)).toBe(24);
+  });
+});
+
+function withCapturedStderr(isTTY: boolean, fn: () => void): string {
+  const originalIsTTY = process.stderr.isTTY;
+  const originalWrite = process.stderr.write;
+  const writes: string[] = [];
+  try {
+    Object.defineProperty(process.stderr, "isTTY", { value: isTTY, configurable: true });
+    process.stderr.write = ((chunk: string) => {
+      writes.push(chunk);
+      return true;
+    }) as typeof process.stderr.write;
+    fn();
+  } finally {
+    process.stderr.write = originalWrite;
+    Object.defineProperty(process.stderr, "isTTY", { value: originalIsTTY, configurable: true });
+  }
+  return writes.join("");
+}
+
+describe("the live bar cleans up after itself", () => {
+  const label = "Transcribing a-rather-long-file-name.wav";
+  const liveLine = `${label}  [░░░░░░░░░░░░░░░░░░░░] 0%`;
+
+  // A shorter final line drawn over a longer one leaves the tail of the old line on screen.
+  test("finishing blanks the whole live line before the final one", () => {
+    const out = withCapturedStderr(true, () => {
+      const progress = createPercentProgress(label, { intervalMs: 10_000 });
+      progress.finish("Done");
+    });
+
+    expect(out).toContain(`\r${" ".repeat(liveLine.length)}\r`);
+    expect(out.endsWith("Done  [████████████████████] 100%\n")).toBe(true);
+  });
+
+  test("stopping blanks the line and says nothing further", () => {
+    const out = withCapturedStderr(true, () => {
+      const progress = createPercentProgress(label, { intervalMs: 10_000 });
+      progress.stop();
+    });
+
+    expect(out).toBe(`\r${liveLine}\r${" ".repeat(liveLine.length)}\r`);
+  });
+});
+
+/** The sizeless fallback reports through `log`, which splits across console.log/error. */
+function withCapturedLog(fn: () => void): string {
+  const saved = { log: console.log, error: console.error, isTTY: process.stderr.isTTY };
+  const lines: string[] = [];
+  const collect = (...args: unknown[]) => void lines.push(args.join(" "));
+  try {
+    Object.defineProperty(process.stderr, "isTTY", { value: false, configurable: true });
+    console.log = collect;
+    console.error = collect;
+    fn();
+  } finally {
+    console.log = saved.log;
+    console.error = saved.error;
+    Object.defineProperty(process.stderr, "isTTY", { value: saved.isTTY, configurable: true });
+  }
+  return lines.join("\n");
+}
+
+describe("the download line reports the size it knows", () => {
+  test("a known Content-Length is quoted in the non-TTY line", () => {
+    const out = withCapturedLog(() => {
+      const bar = createProgressBar("model.onnx", 5 * 1024 * 1024);
+      bar.update(1024);
+      bar.finish();
+    });
+
+    expect(out).toContain("Downloading model.onnx (5.0MB)...");
+    expect(out).toContain("Downloaded model.onnx ✓");
+  });
+
+  test("an unknown size is left out rather than printed as zero", () => {
+    const out = withCapturedLog(() => createProgressBar("model.onnx", 0).finish());
+
+    expect(out).toContain("Downloading model.onnx...");
+    expect(out).not.toContain("0.0MB");
   });
 });


### PR DESCRIPTION
Third pass of the mutation sweep, after #868 and #882.

## First, a correction to my own ranking

The order I proposed earlier came off a stale checkout. Re-measured on current `main`, it looks quite different:

| file | mutation score | survivors |
|---|---|---|
| `progress.ts` | **53.9%** | 70 |
| `diagnostic-log.ts` | 54.7% | 85 |
| `synth.ts` | 51.1% | 28 (+65 uncovered) |
| `install-plan.ts` | 67.0% | 67 |
| `status.ts` | 84.9% | 28 |
| `stats.ts` | **86.2%** | 70 |

`stats.ts` was the file I expected to be worst; it is the healthiest of the set. Worth knowing before anyone spends time there — and worth re-measuring rather than trusting a ranking that is a few merges old.

## What survived in progress.ts

At **94% line coverage**, all of this passed:

- `estimatePercent` could return **0 while work is running** (indistinguishable from a hang), reach **100 before `finish`** claims it, or divide by a zero estimate. Exported for the test now, the way `applyBackpressure` already is.
- The staging sweep (#770) was tested only against its own `.part.` files. Widening the prefix so it eats a **sibling download's** staging survived — and the engine plus both sidecars land in one bin dir, so that is a live install eating a concurrent one.
- A download whose response has no body threw a message no test read.
- The live bar's erase was asserted as `toContain("\r")`, which says nothing about whether the blank run covers the line being overwritten. A shorter final line drawn over a longer one leaves the old tail on screen.

## Numbers

**53.9% → 69.8%** mutation score (covered 58.3% → 74.7%), survivors **70 → 43**.

## Left alive on purpose

The TTY timer internals and `update()`'s percent coalescing. The existing "ends with 100% and a newline" test already spells out why the cadence is not pinned (#161): asserting it means asserting write counts, and coalescing writes is a legitimate refactor.

## Verification

`bun run test` 1176 pass / 6 skip · `bunx tsc --noEmit` · `bun run coverage:check:ts` 80.21% total, all four floors met