### PR TITLE
fix(install): let the engine children see the cache dir the parent resolved

### DIFF
--- a/src/engine-health.ts
+++ b/src/engine-health.ts
@@ -32,6 +32,9 @@ export async function probeExecutable(
       stdin: "ignore",
       stdout: "ignore",
       stderr: "ignore",
+      // Nothing this probe runs reads a `KESHA_*` today; it is passed so every engine spawn
+      // resolves env the same way and the #874/#876 class cannot come back here (#876).
+      env: process.env,
     });
   } catch (err) {
     return { status: "unusable", detail: errorMessage(err) };

--- a/src/engine-install.ts
+++ b/src/engine-install.ts
@@ -12,6 +12,7 @@ import { engineFunctionalHealth, probeExecutable } from "./engine-health";
 import { engineTarget, isDarwinArm64 } from "./engine-targets";
 import { log } from "./log";
 import { engineVersion } from "./package-info";
+import { keshaCacheDir } from "./paths";
 import { streamResponseToFile } from "./progress";
 import {
   readInstalledEngineVersion,
@@ -234,6 +235,9 @@ async function warmDarwinKokoro(binPath: string): Promise<void> {
     {
       stdout: "ignore",
       stderr: "pipe",
+      // Resolves the voice from the Model cache, so it needs the same runtime
+      // `KESHA_CACHE_DIR` the install itself was given (#876).
+      env: process.env,
     },
   );
 
@@ -554,9 +558,13 @@ function runEngineModelInstall(
     diarize: options.diarize,
   });
   // #680: piping buffers the child until exit, so multi-GB downloads looked hung.
+  // `env` is load-bearing, not tidiness: this child resolves the model destination from
+  // `KESHA_CACHE_DIR`, and without it Bun's startup snapshot sends a redirected install
+  // to the real `~/.cache/kesha` anyway (#876).
   const proc = Bun.spawnSync([binPath, ...installArgs], {
     stdout: "inherit",
     stderr: "inherit",
+    env: process.env,
   });
 
   if (proc.exitCode !== 0) {
@@ -572,18 +580,33 @@ function runEngineModelInstall(
  *
  * Redirecting `KESHA_ENGINE_BIN`/`KESHA_CACHE_DIR` is opt-in per test, so a suite that forgets
  * it overwrites a real multi-GB install with a stub — and does it silently. Bun sets
- * `NODE_ENV=test` only under `bun test`, so this fires exactly there and nowhere else; it is
- * checked against `homedir()` rather than `keshaCacheDir()` so an isolated cache never trips it.
+ * `NODE_ENV=test` only under `bun test`, so this fires exactly there and nowhere else; the
+ * refused location is always derived from `homedir()`, so an isolated cache never trips it.
+ *
+ * Both destinations are checked because different variables redirect them: an isolated
+ * `KESHA_ENGINE_BIN` satisfied the binary half on its own while the models still downloaded
+ * into the real cache (#876).
  */
 export function assertNotRealCacheUnderTest(binPath: string): void {
   if (process.env.NODE_ENV !== "test") return;
   const realCache = resolve(join(homedir(), ".cache", "kesha"));
-  if (!resolve(binPath).startsWith(realCache + sep)) return;
+  const insideRealCache = (path: string): boolean => {
+    const resolved = resolve(path);
+    return resolved === realCache || resolved.startsWith(realCache + sep);
+  };
+
+  const offender = insideRealCache(binPath)
+    ? { what: `install the engine into ${binPath}`, fix: "KESHA_ENGINE_BIN to a temp path" }
+    : insideRealCache(keshaCacheDir())
+      ? { what: `download models into ${keshaCacheDir()}`, fix: "KESHA_CACHE_DIR to a temp dir" }
+      : null;
+  if (!offender) return;
+
   throw new Error(
-    `Refusing to install the engine into ${binPath} during a test run: that is the real ` +
+    `Refusing to ${offender.what} during a test run: that is the real ` +
       "per-user cache, and writing there destroys the developer's install (#796).\n" +
       "  Fix: call isolateEngineCache() from tests/helpers/fake-engine.ts in beforeEach, or set " +
-      "KESHA_ENGINE_BIN to a temp path.\n" +
+      `${offender.fix}.\n` +
       "  If this is not a test run, unset NODE_ENV — Bun sets NODE_ENV=test under `bun test`.",
   );
 }

--- a/tests/unit/engine-install-decisions.test.ts
+++ b/tests/unit/engine-install-decisions.test.ts
@@ -41,11 +41,11 @@ function shQuote(value: string): string {
 /**
  * A shell stub answering the three things `installEngine` asks of a real engine:
  * `--capabilities-json`, `install`, and `say` (the Kokoro warmup). Each invocation appends
- * its argv to `argvLog`, so a test can state what the engine was asked to do.
+ * its argv to `argvLog` and the cache dir it was handed to `envLog`, so a test can state
+ * both what the engine was asked to do and which cache it would have acted on.
  *
- * The log path is baked into the script rather than read from the environment: Bun.spawn
- * snapshots the environment at process start, so a `process.env` key set inside a test never
- * reaches the child.
+ * Both log paths are baked into the script rather than read from the environment, so the
+ * stub never depends on the env-forwarding it is used to verify (#876).
  */
 function engineScript({ caps = PLAIN_CAPS, installExit = 0, sayExit = 0 }: EngineStub = {}): string {
   const capsCase = caps
@@ -54,6 +54,7 @@ function engineScript({ caps = PLAIN_CAPS, installExit = 0, sayExit = 0 }: Engin
   return (
     `#!/bin/sh\n` +
     `echo "$*" >> ${shQuote(argvLog)}\n` +
+    `echo "$1 KESHA_CACHE_DIR=\${KESHA_CACHE_DIR:-UNSET}" >> ${shQuote(envLog)}\n` +
     `case "$1" in\n` +
     capsCase +
     `  install) exit ${installExit} ;;\n` +
@@ -67,6 +68,7 @@ const savedFetch = globalThis.fetch;
 const tempDirs: string[] = [];
 let releaseCacheIsolation: () => void = () => {};
 let argvLog = "";
+let envLog = "";
 
 const posixTest = process.platform === "win32" ? test.skip : test;
 /** The Kokoro warmup and the sidecars only ever run on darwin-arm64. */
@@ -77,6 +79,7 @@ beforeEach(() => {
   const dir = mkdtempSync(join(tmpdir(), "kesha-argv-log-"));
   tempDirs.push(dir);
   argvLog = join(dir, "argv.log");
+  envLog = join(dir, "env.log");
 });
 
 afterEach(() => {
@@ -96,6 +99,12 @@ afterEach(() => {
 function engineInvocations(): string[] {
   if (!existsSync(argvLog)) return [];
   return readFileSync(argvLog, "utf8").split("\n").filter(Boolean);
+}
+
+/** The cache dir each stub invocation was actually handed, as `<subcommand> KESHA_CACHE_DIR=<value>`. */
+function engineCacheSightings(): string[] {
+  if (!existsSync(envLog)) return [];
+  return readFileSync(envLog, "utf8").split("\n").filter(Boolean);
 }
 
 /** Stages a cache-valid install: right version, runnable engine, healthy sidecars. */
@@ -181,6 +190,20 @@ describe("an install only ever writes where it was pointed (#796)", () => {
     ).not.toThrow();
   });
 
+  // The half the binary-path check could not see: isolating only KESHA_ENGINE_BIN satisfied
+  // the guard while `kesha-engine install` still wrote models to the real cache (#876).
+  posixTest("an isolated binary with a real model cache is refused too", () => {
+    const saved = process.env.KESHA_CACHE_DIR;
+    delete process.env.KESHA_CACHE_DIR;
+    try {
+      const isolatedBin = join(tmpdir(), "kesha-isolated-bin", "kesha-engine");
+      expect(() => assertNotRealCacheUnderTest(isolatedBin)).toThrow(/download models into/);
+    } finally {
+      if (saved === undefined) delete process.env.KESHA_CACHE_DIR;
+      else process.env.KESHA_CACHE_DIR = saved;
+    }
+  });
+
   // The guard must not cost a real user their install: outside `bun test` it is inert, even
   // for the very path it refuses under one.
   posixTest("outside a test run the real cache is allowed", () => {
@@ -193,6 +216,36 @@ describe("an install only ever writes where it was pointed (#796)", () => {
       else process.env.NODE_ENV = saved;
     }
   });
+});
+
+/**
+ * `Bun.spawnSync`/`Bun.spawn` snapshot the environment at process start unless an `env` is
+ * passed, and `kesha-engine install` is the child that decides where multi-GB model
+ * downloads land — it resolves them from `KESHA_CACHE_DIR` (`rust/src/models.rs`).
+ *
+ * `isolateEngineCache()` sets that variable *after* startup, so under snapshot semantics a
+ * test believed it was isolated while the model half of that isolation silently did not
+ * reach the child. The #796 guard did not catch it either: it checks the resolved binary
+ * path, which an isolated `KESHA_ENGINE_BIN` satisfies on its own (#876).
+ */
+describe("the engine children see the cache dir the parent resolved (#876)", () => {
+  posixTest("the model install is handed the cache dir set after startup", async () => {
+    stageInstalledEngine("kesha-install-env-");
+
+    await installEngine();
+
+    expect(engineCacheSightings()).toContain(
+      `install KESHA_CACHE_DIR=${process.env.KESHA_CACHE_DIR}`,
+    );
+  }, 30_000);
+
+  darwinArmTest("the Kokoro warm-up is handed the same cache dir", async () => {
+    stageInstalledEngine("kesha-warmup-env-");
+
+    await installEngine({ ttsLangs: ["en"] });
+
+    expect(engineCacheSightings()).toContain(`say KESHA_CACHE_DIR=${process.env.KESHA_CACHE_DIR}`);
+  }, 30_000);
 });
 
 describe("capabilities gate the flags forwarded to the engine (#772)", () => {


### PR DESCRIPTION
`Bun.spawn`/`spawnSync` snapshot the environment at process start unless an `env` is passed. #875 fixed that for `spawnEngineProcess`; the three other sites that spawn the engine still took the snapshot.

## Per-site decision

| site | spawns | decision | why |
|---|---|---|---|
| `engine-install.ts:557` `kesha-engine install` | `spawnSync` | **fixed — mandatory** | this child resolves the model destination from `KESHA_CACHE_DIR` (`rust/src/models.rs`). A runtime-set cache dir never reached it, so a redirected install downloaded models into the real `~/.cache/kesha`. |
| `engine-install.ts:224` Kokoro warm-up (`say`) | `spawn` | **fixed** | resolves the voice out of the Model cache, so it needs the same runtime cache dir the install itself was given. Proven by a red test on darwin-arm64, not assumed from the table. |
| `engine-health.ts:31` `probeExecutable` | `spawn` | **fixed — consistency** | nothing it runs reads a `KESHA_*` today, so this is a no-op in behaviour. Taken anyway: it is the identical latent trap, it costs nothing, and uniformity across all four engine spawns is what stops the class coming back one site at a time. |
| `engine-install.ts:118` `codesign`/`xattr` | `spawnSync` | **left alone** | not the engine, and no `KESHA_*` semantics — matches the issue's table. |

## The measurement that made the mechanism unambiguous

The red run produced a differential *inside a single test*, which is better evidence than the snapshot theory on its own — two children spawned moments apart, one through the site #875 already fixed and one through `:557`:

```
"--capabilities-json KESHA_CACHE_DIR=/var/…/kesha-cache-isolated-rJEyXC",   ← spawnEngineProcess (fixed in #875)
"install KESHA_CACHE_DIR=UNSET"                                             ← spawnSync at :557
```

The capabilities probe reaches the engine through `getEngineCapabilities` → `runEngine` → `spawnEngineProcess`, which is why it already saw the isolated dir. `probeExecutable` never ran here — `engineFunctionalHealth` only falls back to it when capabilities fail.

## Blast radius

Full suite, this branch vs `origin/main` at `fc1a1c3`, same machine:

| | tests | pass | fail | skip |
|---|---:|---:|---:|---:|
| `origin/main` | 1170 | 1164 | 0 | 6 |
| this branch | 1173 | 1167 | 0 | 6 |

`+3` is exactly the three tests added here. No existing test changed outcome.

Fifteen test files mutate `KESHA_CACHE_DIR` or call `isolateEngineCache()`, and the ones that transitively reach these three sites are `engine-install-decisions`, `engine-repair`, `engine-version-override` (all via `installEngine`), plus `doctor` and `status` (via `probeExecutable`). Their children now see the isolated cache dir where they previously saw the startup snapshot.

**Latent-liar check — did any test rely on the child seeing real paths?** No. Every stub in those suites is a fake binary that ignores the environment; the only consumer of `KESHA_CACHE_DIR` in a child is a real engine, and no test spawns one. I checked the risky direction specifically: `grep` for `installEngine`/`downloadEngine`/`downloadModel` across `tests/integration/` returns nothing, so no suite drives a real model install whose destination this could move. That matches the issue's "not observed failing today" — the hazard was latent, and this closes it before a test arrives to trip it.

The one stub that *did* encode the old behaviour was the shared `engineScript` helper, whose comment explained that the argv-log path is baked in "because Bun.spawn snapshots the environment". That reason expires with this change, so the comment now says the paths are baked so the stub never depends on the env-forwarding it is used to verify.

## Guard hardening (issue's item 4) — taken, because it turned out free

`assertNotRealCacheUnderTest` checked the resolved binary path only, so an isolated `KESHA_ENGINE_BIN` satisfied it while the models still went home. It now refuses either destination and names which one tripped, since different variables redirect them. One predicate, applied to two paths.

Cost measured rather than assumed: the full suite is unchanged with it in place, so it widens no scope in practice. It is covered by its own test that is red without the widening.

## Verification

- `bunx tsc --noEmit` → clean
- `bun run test` → **1167 pass, 0 fail, 6 skip** (1173 across 87 files)
- `bun run coverage:check:ts` → total **80.22%** (≥70%); `src/engine-install.ts` 91.84% (≥60%), `src/engine.ts` 89.64% (≥80%), `src/cli/say.ts` 51.92% (≥50%), `src/cli/main.ts` 39.62% (≥35%)
- All three new tests verified **red first**: the two env tests fail on unmodified source with `install KESHA_CACHE_DIR=UNSET`, and the guard test fails with the binary-path-only predicate stashed back in.

**Windows:** the two env tests are `posixTest`, consistent with every other stub-driven case in this file. The #875 `envEchoEngine` trick — making the interpreter the binary and the script its argument — needs test-controlled argv, and this seam spawns `binPath` with argv the engine owns (`buildEngineInstallArgs`), so it does not apply here. The `darwinArmTest` warm-up case is gated the same way its siblings are. No new Windows gap: this whole suite was already POSIX-only.

Closes #876

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBTpJjqyYFW6W8LHJ2nwy
