### PR TITLE
docs(openspec): spec the darwin-arm64 Kokoro staging and its pre-synthesis check

### DIFF
--- a/openspec/specs/GLOSSARY.md
+++ b/openspec/specs/GLOSSARY.md
@@ -37,7 +37,7 @@ verbatim; if you need a new term, add it here first.
 | **TOON** | Token-oriented object notation (`@toon-format/toon`): compact tabular encoding of the same data as `--json`, losslessly decodable. |
 | **Output format (TTS)** | One of **wav** (default, IEEE-float mono), **ogg-opus**, **flac**. |
 | **Install plan** | The dry-run preview (`--plan`) listing components, sizes, and cache status before any download. |
-| **Never-auto-download rule** | The Engine and models download only during explicit `kesha install` / `kesha init`; every other command fails with an actionable hint when something is missing. |
+| **Never-auto-download rule** | The Engine and models download only during explicit `kesha install` / `kesha init`; every other command fails with an actionable hint when something is missing. Where a third-party runtime would fetch on its own — FluidAudio Kokoro on darwin-arm64 — the rule is upheld by checking the assets are on disk before that runtime is handed anything. |
 | **Diagnostic log** | Privacy-safe local NDJSON event log managed by `kesha logs` (modes: off / on / retain-on-failure). No transcript content or file paths. |
 | **Stats DB** | Local SQLite database of anonymous performance metrics managed by `kesha stats`. |
 | **Support bundle** | Redacted `.tar.gz` diagnostics archive produced by `kesha support-bundle`. |

--- a/openspec/specs/installation/spec.md
+++ b/openspec/specs/installation/spec.md
@@ -302,6 +302,11 @@ additive and idempotent: an asset already present and matching its Pinned hash
 is not downloaded again. Russian is unaffected — Vosk-TTS installs into the
 Model cache on every platform.
 
+One asset group is deliberately excluded: the Mandarin jieba HMM tables, which
+upstream never published. Segmentation falls back to FMM without them, so their
+absence degrades quality rather than blocking synthesis, and the pre-synthesis
+asset check SHALL NOT require them.
+
 #### Scenario: Maks installs Mandarin TTS on Apple Silicon
 
 - GIVEN the machine is darwin-arm64
@@ -338,10 +343,12 @@ Model cache on every platform.
 > pinned because `G2PModel.shared` resolves it itself (fluidaudio-rs 4e488d7,
 > still true at upstream 0.15.5). `ANE_ZH_FILES` carries `g2pw/g2pw.mlmodelc`
 > because upstream's `requiredModelsZh` checks the whole set before loading
-> anything, even though the disambiguator cannot activate at this pin; the
-> jieba HMM tables are deliberately not staged and segmentation falls back to
-> FMM. `--plan` and `kesha doctor` render these sets from
-> `src/kokoro-ane.ts::kokoroAneComponents` (#823, #828, #831).*
+> anything, even though the disambiguator cannot activate at this pin.
+> `--plan` and `kesha doctor` preview only the English ANE chain and the
+> shared G2P set, via `src/kokoro-ane.ts::kokoroAneComponents`; the Mandarin
+> bundle is excluded there on purpose, since `--tts zh` is a separate opt-in
+> and its bytes already appear under the cache report's Kokoro ANE root
+> (#823, #828, #831).*
 
 ### Requirement: VAD and Diarize install are separate opt-in flags
 

--- a/openspec/specs/installation/spec.md
+++ b/openspec/specs/installation/spec.md
@@ -280,6 +280,69 @@ already installed leaves English in place.
 > `hi`, `ja`, `zh` on darwin-arm64 — so a bad code is rejected before anything downloads.
 > The Engine re-validates authoritatively at download time.*
 
+### Requirement: On darwin-arm64, `--tts` stages FluidAudio's Kokoro assets outside the Model cache
+
+On darwin-arm64 `kesha install --tts` SHALL stage every asset first synthesis
+would otherwise fetch, verified against the same Pinned hashes as any other
+model. The non-Russian voices there are served by FluidAudio's CoreML/ANE
+bundles, which upstream reads from directories of its own choosing rather than
+from the Model cache, so the assets are staged into those directories:
+
+- for any of `en`, `es`, `fr`, `hi`, `it`, `ja`, `pt` — the English ANE model
+  chain with its vocab and bundled voice pack, the requested languages' voice
+  packs, and the shared BART G2P bundle with the Misaki lexicon;
+- for `zh` — the Mandarin ANE bundle with its voice packs and its pinyin
+  dictionaries.
+
+The ANE chain and the Mandarin bundle SHALL follow whichever models root the
+Engine points FluidAudio at, so relocating the root relocates the staged
+assets. The shared G2P assets SHALL be staged to the fixed path upstream's
+singleton resolves for itself, which no models root can move. Staging SHALL be
+additive and idempotent: an asset already present and matching its Pinned hash
+is not downloaded again. Russian is unaffected — Vosk-TTS installs into the
+Model cache on every platform.
+
+#### Scenario: Maks installs Mandarin TTS on Apple Silicon
+
+- GIVEN the machine is darwin-arm64
+- WHEN Maks runs `kesha install --tts zh`
+- THEN the Mandarin ANE bundle, the `zh` voice packs, and the pinyin
+  dictionaries are downloaded, hash-verified, and staged into FluidAudio's
+  Mandarin bundle directory
+- AND the process exits 0
+- AND a later `kesha say --voice zh-zm_050` synthesizes without downloading
+  anything
+
+#### Scenario: A second language install leaves the first in place
+
+- GIVEN `kesha install --tts en` has already staged the English chain
+- WHEN Maks runs `kesha install --tts zh`
+- THEN the English assets are left in place and the Mandarin ones are added
+- AND the process exits 0
+
+#### Scenario: Russian-only install stages nothing into FluidAudio
+
+- GIVEN the machine is darwin-arm64
+- WHEN Ira runs `kesha install --tts ru`
+- THEN the Vosk-TTS files land in the Model cache
+- AND no FluidAudio Kokoro asset is downloaded or staged
+
+> *Technical Note — sources: `rust/src/models.rs::download_tts` calls
+> `stage_fluidaudio_kokoro_assets` (manifests `ANE_EN_FILES`,
+> `KOKORO_G2P_FILES`, `ANE_ZH_FILES`, `ANE_ZH_G2P_ASSETS`; the English variant
+> serves `ANE_ENGLISH_VARIANT_LANGS` = en/es/fr/hi/it/ja/pt) and
+> `stage_ane_kokoro_voices` (`ANE_KOKORO_VOICES`, #475), both under
+> `cfg(all(system_kokoro, macos, aarch64))`. Directories:
+> `fluidaudio_ane_kokoro_dir()` and `fluidaudio_ane_zh_kokoro_dir()`, which sit
+> under `fluidaudio_kokoro_location()`, and `fluidaudio_kokoro_g2p_dir()`,
+> pinned because `G2PModel.shared` resolves it itself (fluidaudio-rs 4e488d7,
+> still true at upstream 0.15.5). `ANE_ZH_FILES` carries `g2pw/g2pw.mlmodelc`
+> because upstream's `requiredModelsZh` checks the whole set before loading
+> anything, even though the disambiguator cannot activate at this pin; the
+> jieba HMM tables are deliberately not staged and segmentation falls back to
+> FMM. `--plan` and `kesha doctor` render these sets from
+> `src/kokoro-ane.ts::kokoroAneComponents` (#823, #828, #831).*
+
 ### Requirement: VAD and Diarize install are separate opt-in flags
 
 The CLI SHALL install the Silero VAD model only when `--vad` is passed (~2.3 MB).

--- a/openspec/specs/tts-synthesis/spec.md
+++ b/openspec/specs/tts-synthesis/spec.md
@@ -190,7 +190,8 @@ French voice exists.
 
 Synthesis SHALL fail loudly — never download — when the required TTS model is
 not in the Model cache. The failure carries Error code `E_MODEL_MISSING` and an
-actionable `kesha install --tts` hint, and exits 1.
+actionable `kesha install --tts` hint, and exits 1 — the voice is rejected
+while it is being resolved, before synthesis starts.
 
 On darwin-arm64 the FluidAudio Kokoro voices are not gated by the Model cache,
 so the guarantee rests on a check of its own: before the FluidAudio bridge is

--- a/openspec/specs/tts-synthesis/spec.md
+++ b/openspec/specs/tts-synthesis/spec.md
@@ -225,8 +225,9 @@ the first few missing paths so the gap is identifiable, and the refusal exits 4
   and hints `kesha install --tts zh`
 - AND the process exits 4 without downloading anything
 
-> *Technical Note — model presence gates: `rust/src/tts/voices.rs:192-204`
-> (ONNX Kokoro), `:307-313` (Vosk). `macos-*` voices need no model download.
+> *Technical Note — model presence gates:
+> `rust/src/tts/voices.rs::build_kokoro_voice` (ONNX Kokoro) and
+> `::resolve_vosk_ru` (Vosk). `macos-*` voices need no model download.
 > The darwin-arm64 pre-check is `rust/src/models.rs::missing_kokoro_assets`,
 > called from `tts/fluid_kokoro.rs::with_kokoro` alongside
 > `fluidaudio_rs::set_offline_mode(true)` — two defences because neither covers
@@ -561,11 +562,19 @@ still exit 0.
 
 ### Requirement: Exit codes distinguish failure classes
 
-`kesha say` SHALL exit 0 on success, 1 when the voice is unknown or its model
-is not installed, 2 for invalid input (bad flags, empty text, malformed
-flag combinations), 4 for synthesis/SSML/internal failures, and 5 when the
-text exceeds the length limit. The CLI SHALL propagate the Engine's exit code
-unchanged (`SayError.exitCode`); CLI-side pre-checks use the same map.
+`kesha say` SHALL exit 0 on success, 1 when voice resolution rejects the
+request, 2 for invalid input (bad flags, empty text, malformed flag
+combinations), 4 for synthesis-time failures, and 5 when the text exceeds the
+length limit. The CLI SHALL propagate the Engine's exit code unchanged
+(`SayError.exitCode`); CLI-side pre-checks use the same map.
+
+Exit 1 SHALL cover the checks that run while the Voice id is resolved: an
+unknown voice, and a model absent from the Model cache on the paths the cache
+gates (ONNX Kokoro, Vosk). Exit 4 SHALL cover every coded failure raised once
+resolution has succeeded, including the darwin-arm64 FluidAudio asset
+pre-check, which reports `E_MODEL_MISSING` from synthesis rather than from
+resolution. The Error code says what went wrong and the exit code says how far
+the run got, so the same `E_MODEL_MISSING` legitimately appears with either.
 
 #### Scenario: Exit-code contract in a script
 
@@ -580,15 +589,17 @@ unchanged (`SayError.exitCode`); CLI-side pre-checks use the same map.
 - THEN the CLI reports the stderr text and exits with the Engine's nonzero
   code, or 4 for non-SayError internal failures
 
-> *Technical Note — Engine map: `rust/src/cli/say.rs:132-138`
-> (`exit_code_for_tts_err`: `EmptyText` → 2, `TextTooLong` → 5,
-> `SynthesisFailed`/`Coded` → 4); voice resolution failures return 1 directly
-> (`rust/src/cli/say.rs:228-235`); format/flag errors return 2
-> (`:169-183`, `:220-226`). CLI side: `SayError` carries the Engine exit code
-> (`src/cli/say.ts:289-292`); pre-flight checks exit 2
-> (`src/cli/say.ts:62-101,204-207`) and 5 (`src/synth.ts:117-125`).
-> `E_SSML_INVALID`, `E_SSML_UNSUPPORTED`, and `E_SCRIPT_UNSUPPORTED` all
-> surface as `Coded` → exit 4.*
+> *Technical Note — Engine map: `rust/src/cli/say.rs::exit_code_for_tts_err`
+> (`EmptyText` → 2, `TextTooLong` → 5, `SynthesisFailed`/`Coded` → 4). Voice
+> resolution failures return 1 from `cli/say.rs::resolve_voice`, which is where
+> the `ModelMissing` bails in `tts/voices.rs::build_kokoro_voice` (ONNX Kokoro)
+> and `::resolve_vosk_ru` surface; `--model`/`--voice-file` and output-format
+> errors return 2 from `resolve_voice` and `cli/say.rs::run`.
+> `E_SSML_INVALID`, `E_SSML_UNSUPPORTED`, `E_SCRIPT_UNSUPPORTED`, and the
+> darwin-arm64 late `E_MODEL_MISSING` from `models::missing_kokoro_assets` all
+> reach the caller as `TtsError::Coded` → exit 4. CLI side: `SayError` carries
+> the Engine exit code, and `src/synth.ts::say` pre-checks empty text (2) and
+> the length limit (5).*
 
 ## Open Issues
 

--- a/openspec/specs/tts-synthesis/spec.md
+++ b/openspec/specs/tts-synthesis/spec.md
@@ -192,6 +192,17 @@ Synthesis SHALL fail loudly — never download — when the required TTS model i
 not in the Model cache. The failure carries Error code `E_MODEL_MISSING` and an
 actionable `kesha install --tts` hint, and exits 1.
 
+On darwin-arm64 the FluidAudio Kokoro voices are not gated by the Model cache,
+so the guarantee rests on a check of its own: before the FluidAudio bridge is
+initialized, synthesis SHALL confirm that every asset the requested voice needs
+— its bundle's model chain, that voice's own pack, and the variant's G2P assets
+— is already on disk, and refuse with `E_MODEL_MISSING` when any is absent.
+Refusing up front is what makes the rule hold there, because upstream's asset
+downloader consults no offline switch and would otherwise fetch a voice pack
+that `kesha install --tts <other-lang>` never staged. The message SHALL name
+the first few missing paths so the gap is identifiable, and the refusal exits 4
+(the `kesha say` code for a coded synthesis failure), not 1.
+
 #### Scenario: Synthesis with installed models stays offline
 
 - GIVEN the English Kokoro model is installed
@@ -206,9 +217,28 @@ actionable `kesha install --tts` hint, and exits 1.
   with Error code `E_MODEL_MISSING`
 - AND the process exits 1 without downloading anything
 
+#### Scenario: Mandarin voice on an English-only Apple Silicon install
+
+- GIVEN a darwin-arm64 machine where only `kesha install --tts en` has run
+- WHEN Maks runs `kesha say --voice zh-zm_050 "你好"`
+- THEN stderr carries Error code `E_MODEL_MISSING`, names missing asset paths,
+  and hints `kesha install --tts zh`
+- AND the process exits 4 without downloading anything
+
 > *Technical Note — model presence gates: `rust/src/tts/voices.rs:192-204`
-> (ONNX Kokoro), `:307-313` (Vosk). `macos-*` voices need no model download;
-> FluidAudio Kokoro voices are fetched only by `kesha install --tts`.*
+> (ONNX Kokoro), `:307-313` (Vosk). `macos-*` voices need no model download.
+> The darwin-arm64 pre-check is `rust/src/models.rs::missing_kokoro_assets`,
+> called from `tts/fluid_kokoro.rs::with_kokoro` alongside
+> `fluidaudio_rs::set_offline_mode(true)` — two defences because neither covers
+> the other: the flag stops upstream's repo downloads but not its
+> `AssetDownloader` (#823). Its required set is derived from the same staging
+> manifests the install uses, so a manifest change cannot leave the check
+> behind. The error is a `CodedError { ModelMissing }` that reaches the caller
+> as `TtsError::Coded`, hence exit 4 rather than the 1 a voice-resolution
+> failure returns; a file that exists but is truncated slips past and surfaces
+> as the same message from FluidAudio's `AssetsUnavailable`. What install
+> stages: installation spec, "On darwin-arm64, `--tts` stages FluidAudio's
+> Kokoro assets outside the Model cache".*
 
 ### Requirement: Output formats — wav, ogg-opus, flac
 
@@ -495,8 +525,10 @@ stderr note, because the upstream CharsiuG2P export has no Castilian θ tag.
 > degrade decision (#511 Phase-0 spike found no working θ tag in the klebster
 > CharsiuG2P export): `rust/src/tts/charsiu/mod.rs:46-110`; `es-ES` is detected
 > by `is_castilian_region` while `es`/`es-419`/`es-MX` use the LatAm tag
-> directly. zh voices are fetched by FluidAudio's own `ANE-zh/` bundle, not
-> staged in `rust/src/models.rs`.*
+> directly. zh runs off FluidAudio's separate Mandarin (`ANE-zh/`) bundle,
+> which `kesha install --tts zh` stages like every other model — voice packs
+> and pinyin dictionaries included (`rust/src/models.rs::ANE_ZH_FILES`,
+> `ANE_ZH_G2P_ASSETS`, #823).*
 
 ### Requirement: List installed voices
 


### PR DESCRIPTION
Closes #870

## The stale note

`openspec/specs/tts-synthesis/spec.md` (Script gates Technical Note) said:

> zh voices are fetched by FluidAudio's own `ANE-zh/` bundle, not staged in `rust/src/models.rs`.

It now says:

> zh runs off FluidAudio's separate Mandarin (`ANE-zh/`) bundle, which `kesha install --tts zh` stages like every other model — voice packs and pinyin dictionaries included (`rust/src/models.rs::ANE_ZH_FILES`, `ANE_ZH_G2P_ASSETS`, #823).

Verified against the code, not the issue text: `stage_fluidaudio_kokoro_assets` stages `ANE_ZH_FILES` **and** `ANE_ZH_G2P_ASSETS` into `fluidaudio_ane_zh_kokoro_dir()`, and `ANE_ZH_FILES` carries `voices/zf_001.bin` and `voices/zm_050.bin`, so the voices themselves are staged too — not only the chain.

## Where the new requirements went, and why

Split across both specs, because the two behaviours belong to two different commands:

- **`installation/spec.md`** — new requirement *"On darwin-arm64, `--tts` stages FluidAudio's Kokoro assets outside the Model cache"*, placed right after the existing `--tts` opt-in requirement whose scope it extends. It covers what is staged per language group (English ANE chain + vocab + bundled pack + requested voice packs + shared BART G2P/Misaki lexicon for `ANE_ENGLISH_VARIANT_LANGS` = en/es/fr/hi/it/ja/pt; Mandarin bundle + its voice packs + pinyin dictionaries for `zh`), that the ANE and Mandarin directories follow the models root while the G2P directory cannot, and that staging is additive, idempotent and hash-verified. Directories are named as the code derives them (`fluidaudio_ane_kokoro_dir()`, `fluidaudio_ane_zh_kokoro_dir()`, `fluidaudio_kokoro_g2p_dir()`), not as hardcoded paths.
- **`tts-synthesis/spec.md`** — the pre-synthesis check extends the existing *"TTS models are never auto-downloaded"* requirement rather than becoming a new one. It is the same guarantee that requirement already states, just for the one path the Model cache does not gate.

## Correction the issue did not anticipate

The existing requirement says a missing-model refusal `exits 1`. That holds for the cache-gated voices (`voices.rs` resolution failures return 1), but **not** for the FluidAudio pre-check: `missing_kokoro_assets` raises `CodedError { ModelMissing }`, which `tts/say.rs:191` wraps as `TtsError::Coded`, which `exit_code_for_tts_err` maps to **4**. `resolve_fluid_kokoro` takes no cache dir and gates nothing, so there is no earlier exit-1 path. The new paragraph and scenario state exit 4 explicitly, and the Technical Note records why.

## GLOSSARY

One clause added to **Never-auto-download rule**: where a third-party runtime would fetch on its own, the rule is upheld by checking assets are on disk before that runtime is handed anything. Kept to one sentence — the mechanism belongs in the specs, not the glossary.

## Not fixed here (follow-up candidate)

`rust/src/models.rs:492-497` carries the *same* stale claim in a code comment — "the FluidAudio 0.15.5 `.mandarin` KokoroAne variant fetches its own `ANE-zh/` bundle ... on first synth". Its actual point (zh ids are numbered, so a flat pack in `ANE_KOKORO_VOICES` would be unused) is still correct; only the "fetches on first synth" half is stale. Left alone deliberately to keep this PR docs-only rather than pulling the Rust CI lanes onto a spec change. Worth a one-line fix next time `models.rs` is touched.

## Validation

- `bun run check:specs` (`openspec validate --specs --strict`, the same command the `openspec-validate` CI job runs) → **12 passed, 0 failed**. The first draft failed with `requirements.6.text: Requirement must contain SHALL or MUST` — the validator reads only the requirement's **first line** for the keyword, so the opening paragraph was reordered to lead with the SHALL.
- `bunx tsc --noEmit` → clean.
- `bun test` → **1164 pass, 6 skip, 0 fail** (1170 across 87 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBTpJjqyYFW6W8LHJ2nwy