### PR TITLE
build(dx): add a justfile and reduce the Makefile to a shim (#797 Phase 0)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,73 +1,67 @@
-.PHONY: dev-setup install check cli-fast coverage-ts coverage-rust test unit integration rust-test lint versions smoke-test smoke-test-tts benchmark release release-preflight release-notes help
+# Compatibility shim over the justfile (#797 Phase 0) — `just` owns the logic now.
+# The one-line `bun run …` targets below were never more than bookmarks; they stay
+# here verbatim rather than round-tripping through a runner, and Phase 4 deletes them
+# along with this file. Everything else delegates, so `just --list` is the one index.
 
-help: ## Show available targets
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-15s %s\n", $$1, $$2}'
+.PHONY: dev-setup install check cli-fast coverage-ts coverage-rust test unit integration rust-test mutants-rust lint versions smoke-test smoke-test-tts benchmark release release-preflight release-notes help
 
-dev-setup: ## Bootstrap a contributor checkout (checks deps, runs safe local setup)
-	bash scripts/dev-setup.sh
+help:
+	@just --list
 
-install: ## Install dependencies
+dev-setup:
+	just dev-setup
+
+test:
+	just test
+
+check:
+	just check
+
+coverage-ts:
+	just coverage-ts
+
+coverage-rust:
+	just coverage-rust
+
+rust-test:
+	just rust-test
+
+mutants-rust:
+	just $(if $(FILE),FILE='$(FILE)') $(if $(FEATURES),FEATURES='$(FEATURES)') mutants-rust
+
+smoke-test:
+	just smoke-test
+
+smoke-test-tts:
+	just smoke-test-tts
+
+release-preflight:
+	just release-preflight
+
+release:
+	just release
+
+release-notes:
+	just $(if $(TAG),TAG='$(TAG)') release-notes
+
+# Direct package.json scripts — no justfile recipe exists for these on purpose.
+install:
 	bun install
 
-test: unit integration ## Run all tests
-
-check: lint versions test ## Run local checks that mirror the cheap CI gates
-
-cli-fast: ## Run deterministic CLI checks without engine-backed E2E lanes
+cli-fast:
 	bun run check
 
-coverage-ts: ## Run Bun coverage and enforce TS coverage gates
-	bun run coverage:ts
-	bun run coverage:check:ts
-
-coverage-rust: ## Run cargo llvm-cov and enforce Rust coverage gates
-	bun run coverage:rust
-	bun run coverage:check:rust
-
-unit: ## Run unit tests
+unit:
 	bun run test:unit
 
-integration: ## Run integration tests
+integration:
 	bun run test:integration
 
-rust-test: ## Run Rust tests via nextest (matches CI — rust-test.yml)
-	cd rust && cargo nextest run --features tts
-
-# The widened set measures the ANE + diarize surfaces; `system_kokoro` cfg-excludes the ONNX-Kokoro
-# ones, so those need a second pass with FEATURES=tts. No target measures both — they are exclusive.
-FEATURES ?= tts,system_kokoro,system_diarize
-
-# `--in-place` is not optional: models.rs include_str!s a file above the crate, so the copy build fails.
-mutants-rust: ## Mutation-test one engine file, e.g. make mutants-rust FILE=src/errors.rs [FEATURES=tts]
-	@test -n "$(FILE)" || { echo "usage: make mutants-rust FILE=src/<file>.rs [FEATURES=<set>]" >&2; exit 2; }
-	@command -v cargo-mutants >/dev/null || { echo "install it: cargo install --locked cargo-mutants" >&2; exit 2; }
-	@git diff --quiet -- rust || { echo "rust/ has uncommitted changes; --in-place mutates the tree" >&2; exit 2; }
-	cd rust && cargo mutants --in-place -f $(FILE) --features $(FEATURES)
-
-lint: ## Type-check with tsc
+lint:
 	bunx tsc --noEmit
 
-versions: ## Check version drift between package.json + Cargo.toml (#267 F16)
+versions:
 	bun .github/scripts/check-versions.ts
 
-smoke-test: ## Run smoke tests against fixtures
-	bun link @drakulavich/kesha-voice-kit
-	kesha install
-	bun scripts/smoke-test.ts
-
-smoke-test-tts: ## Run smoke tests with TTS
-	bun link @drakulavich/kesha-voice-kit
-	kesha install --tts
-	bun scripts/smoke-test.ts --tts
-
-benchmark: ## Run benchmark (openai-whisper vs faster-whisper vs Kesha)
+benchmark:
 	bun scripts/benchmark.ts
-
-release-preflight: check smoke-test ## Verify locally before cutting a GitHub release
-	@echo "Release preflight passed. Cut/publish via the GitHub release workflow, not npm publish."
-
-release: release-preflight ## Backward-compatible alias for release-preflight
-
-release-notes: ## Print an existing release body: make release-notes TAG=vX.Y.Z
-	@test -n "$(TAG)" || (echo "usage: make release-notes TAG=vX.Y.Z" >&2; exit 2)
-	gh release view "$(TAG)" --json body --jq .body

--- a/Makefile
+++ b/Makefile
@@ -3,45 +3,49 @@
 # here verbatim rather than round-tripping through a runner, and Phase 4 deletes them
 # along with this file. Everything else delegates, so `just --list` is the one index.
 
-.PHONY: dev-setup install check cli-fast coverage-ts coverage-rust test unit integration rust-test mutants-rust lint versions smoke-test smoke-test-tts benchmark release release-preflight release-notes help
+.PHONY: need-just dev-setup install check cli-fast coverage-ts coverage-rust test unit integration rust-test mutants-rust lint versions smoke-test smoke-test-tts benchmark release release-preflight release-notes help
 
-help:
+# Without this, a checkout lacking just gets a bare "make: just: No such file or directory".
+need-just:
+	@command -v just >/dev/null || { echo "just is required for this target: cargo install --locked just" >&2; exit 2; }
+
+help: need-just
 	@just --list
 
-dev-setup:
+dev-setup: need-just
 	just dev-setup
 
-test:
+test: need-just
 	just test
 
-check:
+check: need-just
 	just check
 
-coverage-ts:
+coverage-ts: need-just
 	just coverage-ts
 
-coverage-rust:
+coverage-rust: need-just
 	just coverage-rust
 
-rust-test:
+rust-test: need-just
 	just rust-test
 
-mutants-rust:
+mutants-rust: need-just
 	just $(if $(FILE),FILE='$(FILE)') $(if $(FEATURES),FEATURES='$(FEATURES)') mutants-rust
 
-smoke-test:
+smoke-test: need-just
 	just smoke-test
 
-smoke-test-tts:
+smoke-test-tts: need-just
 	just smoke-test-tts
 
-release-preflight:
+release-preflight: need-just
 	just release-preflight
 
-release:
+release: need-just
 	just release
 
-release-notes:
+release-notes: need-just
 	just $(if $(TAG),TAG='$(TAG)') release-notes
 
 # Direct package.json scripts — no justfile recipe exists for these on purpose.

--- a/justfile
+++ b/justfile
@@ -1,0 +1,69 @@
+# The widened set measures the ANE + diarize surfaces; `system_kokoro` cfg-excludes the ONNX-Kokoro
+# ones, so those need a second pass with FEATURES=tts. No recipe measures both — they are exclusive.
+FEATURES := "tts,system_kokoro,system_diarize"
+FILE := ""
+TAG := ""
+
+# Show available recipes
+default:
+    @just --list
+
+# Bootstrap a contributor checkout (checks deps, runs safe local setup)
+dev-setup:
+    bash scripts/dev-setup.sh
+
+# Run all tests
+test:
+    bun run test:unit
+    bun run test:integration
+
+# Run local checks that mirror the cheap CI gates
+check:
+    bun run lint
+    bun run check:versions
+    {{ just_executable() }} test
+
+# Run Bun coverage and enforce TS coverage gates
+coverage-ts:
+    bun run coverage:ts
+    bun run coverage:check:ts
+
+# Run cargo llvm-cov and enforce Rust coverage gates
+coverage-rust:
+    bun run coverage:rust
+    bun run coverage:check:rust
+
+# Run Rust tests via nextest (matches CI — rust-test.yml)
+rust-test:
+    cd rust && cargo nextest run --features tts
+
+# `--in-place` is not optional: models.rs include_str!s a file above the crate, so the copy build fails.
+# Mutation-test one engine file, e.g. just FILE=src/errors.rs mutants-rust
+mutants-rust:
+    @test -n "{{ FILE }}" || { echo "usage: just FILE=src/<file>.rs [FEATURES=<set>] mutants-rust" >&2; exit 2; }
+    @command -v cargo-mutants >/dev/null || { echo "install it: cargo install --locked cargo-mutants" >&2; exit 2; }
+    @git diff --quiet -- rust || { echo "rust/ has uncommitted changes; --in-place mutates the tree" >&2; exit 2; }
+    cd rust && cargo mutants --in-place -f {{ FILE }} --features {{ FEATURES }}
+
+# Run smoke tests against fixtures
+smoke-test:
+    bun link @drakulavich/kesha-voice-kit
+    kesha install
+    bun scripts/smoke-test.ts
+
+# Run smoke tests with TTS
+smoke-test-tts:
+    bun link @drakulavich/kesha-voice-kit
+    kesha install --tts
+    bun scripts/smoke-test.ts --tts
+
+# Verify locally before cutting a GitHub release
+release-preflight: check smoke-test
+    @echo "Release preflight passed. Cut/publish via the GitHub release workflow, not npm publish."
+
+alias release := release-preflight
+
+# Print an existing release body: just TAG=vX.Y.Z release-notes
+release-notes:
+    @test -n "{{ TAG }}" || { echo "usage: just TAG=vX.Y.Z release-notes" >&2; exit 2; }
+    gh release view "{{ TAG }}" --json body --jq .body

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -42,6 +42,15 @@ else
   missing_system=1
 fi
 
+# just: every `make` target now delegates to a justfile recipe (#797), so a
+# checkout without it can run the direct `bun run …` scripts and nothing else.
+if have just; then
+  ok "just ($(just --version | awk '{print $2}'))"
+else
+  todo "just missing — cargo install --locked just  (the task runner behind make/just recipes)"
+  missing_system=1
+fi
+
 # --- System libraries the Rust build needs (guide only) ---
 bold "System libraries (Rust build deps)"
 


### PR DESCRIPTION
Refs #797 — Phase 0 only (shim + bootstrap). Phases 1–4 are separate PRs.

Pure additive shim: no doc, workflow, `CLAUDE.md`, `.claude/**` or `docs/superpowers/**` file is touched. Every existing `make …` invocation keeps working; nothing yet *calls* `just`.

## Recipe inventory (12 recipes vs the Makefile's 20 targets)

| recipe | purpose |
| --- | --- |
| `default` | `just --list` — replaces the hand-rolled `grep \| awk` help target |
| `dev-setup` | contributor bootstrap via `scripts/dev-setup.sh` |
| `test` | unit + integration |
| `check` | the cheap CI gates locally: lint, version drift, tests |
| `coverage-ts` | Bun coverage + the TS coverage gate |
| `coverage-rust` | `cargo llvm-cov` + the Rust coverage gate |
| `rust-test` | nextest with `--features tts`, matching `rust-test.yml` |
| `mutants-rust` | mutation-test one engine file, guards intact |
| `smoke-test` | link + install + fixtures |
| `smoke-test-tts` | same, with TTS |
| `release-preflight` | `check` + `smoke-test` (+ `alias release`) |
| `release-notes` | print an existing release body |

**Alias-half disposition.** The seven one-line `bun run …` wrappers the issue names — `install`, `unit`, `integration`, `lint`, `versions`, `benchmark`, `cli-fast` — are **not** ported. They keep their existing one-line bodies in the Makefile (routing a one-liner through a second runner buys nothing) and become direct `bun run …` calls when Phase 4 deletes the file. `release` becomes a `just` alias rather than a recipe, so it costs nothing but still shows in `--list` as `[alias: release]`.

**Two judgement calls worth a reviewer's eye:**

1. **`dev-setup` is ported even though it is a one-liner.** It wraps a repo script, not a `package.json` script, and the issue's deleted set enumerates only `bun run` wrappers. Deleting it instead would land the count at 11.
2. **Count is 12, not the issue's "~8" / "≤10".** The gap is `coverage-ts`/`coverage-rust` (two-line recipes, not aliases, and the shim needs both names) and `smoke-test-tts`, which Phase 3 folds into `smoke-test` via `tts := ""`. The ≤10 target is reachable as an end-state, not at Phase 0 while behaviour must be preserved.

## Verification

`just 1.58.0` (`cargo install --locked just`).

**No workflow calls `make`** — confirmed. Every `make` hit under `.github/workflows/` is the substring in a `cmake` comment; there are zero `make <target>` invocations. Nothing in CI is affected by this PR.

Command-line parity, `just -n <recipe>` against the pre-change Makefile body:

| target | parity |
| --- | --- |
| `dev-setup`, `test`, `coverage-ts`, `coverage-rust`, `rust-test`, `smoke-test`, `smoke-test-tts` | identical command lines |
| `check` | `bun run lint` → `bun run check:versions` → `test`, the same order make's prerequisite list produced |
| `release-preflight` / `release` | expands to `check` then `smoke-test` then the echo, unchanged |
| `mutants-rust` | all three guards present; `--features` default `tts,system_kokoro,system_diarize` reproduced, and `FEATURES=tts` still overrides it |
| `release-notes` | guard + `gh release view` unchanged |

Executed for real, not dry-run:

- `just --list` / `make help` render all 12 recipes with their doc line.
- `make mutants-rust` (no `FILE`) → usage on stderr, **exit 2**, matching the old Makefile exactly.
- `make release-notes` (no `TAG`) → usage on stderr, **exit 2**.
- `make versions` → runs `check-versions.ts`, unchanged (non-delegated alias).
- All 10 `make <target>` strings referenced anywhere in the repo, and all six `Bash(make …)` allowlist entries (`test`, `lint`, `unit`, `integration`, `smoke-test`, `release`), resolve to a live target.
- `make test` with `just` masked off `PATH` → `just is required for this target: cargo install --locked just`, exit 2; `make lint` (a non-delegated alias) still runs, so the guard is scoped to the targets that need it.
- `bun test` → **1164 pass, 6 skip, 0 fail**; `bunx tsc --noEmit` → clean. No TS changed.

## Things that did not port cleanly

- **`just` is now a hard requirement, one phase early.** The shim means any delegated `make` target fails without it. The issue placed that in Phase 4; it is inherent to the shim shape Phase 0 mandates. `scripts/dev-setup.sh` gains a `just` check (hint: `cargo install --locked just`, no Hermit) that counts toward its TODO tally. Placed in **Toolchains** next to `cargo` rather than literally beside `cmake` — `just` is not a Rust build dep, and the hint depends on cargo being present. A single `need-just` prerequisite in the Makefile carries the same hint to anyone who reaches a delegated target without having run `dev-setup`, so the failure is actionable rather than `make: just: No such file or directory`.
- **Guard usage strings now name `just`.** `make mutants-rust` with no `FILE` prints `usage: just FILE=…` because the guard lives in the recipe. Exit code and stream are unchanged; only the suggested spelling moved to the canonical runner.
- **The `##` doc-comment convention is gone from the Makefile.** It existed only to feed the `grep | awk` help target. Keeping it would have made a second place to describe a target — the thing this issue exists to kill.
- **`mutants-rust` added to `.PHONY`.** It was missing, a live bug in a file being rewritten anyway. The issue notes the whole class disappears once `just` owns these.
- **Discoverability of the seven aliases.** `make help` now lists recipes, so `install`/`unit`/`lint`/… no longer appear. They are `package.json` scripts and remain visible through `bun run`.

## Next: Phase 1

`just preflight` — change detection against `origin/main…HEAD`, always the TS gate, the Rust gate when `rust/**` changed, the coreml check when `rust/src/backend/**` changed — plus `verify-darwin-full` holding the full darwin feature set, **called by `rust-test.yml`** so the flag list stops existing twice. `.claude/commands/preflight.md` collapses to a wrapper and `CLAUDE.md`'s VERIFY BEFORE PUSHING section points at the recipe. That is the phase where the prose layer actually shrinks; this one only makes it landable on its own.

One more thing to fold into whichever later phase touches `flake.nix`: the devShell ships `gnumake` but not `just`, so a Nix contributor hits the `need-just` message with no `just` in the shell. Out of Phase 0's file scope.
