### PR TITLE
build(dx): make `just preflight` the executable pre-push gate (#797 Phase 1)

### DIFF
--- a/.claude/commands/preflight.md
+++ b/.claude/commands/preflight.md
@@ -1,31 +1,14 @@
 ---
 description: Run the full pre-push verification gate (bun + rust) per CLAUDE.md's VERIFY BEFORE PUSHING rules.
-argument-hint: "[--all] (force the rust gate even if no rust changed)"
-allowed-tools: Bash(bun test:*), Bash(bunx tsc:*), Bash(make:*), Bash(cd:*), Bash(cargo fmt:*), Bash(cargo clippy:*), Bash(cargo nextest:*), Bash(cargo check:*), Bash(git status:*), Bash(git diff:*)
+argument-hint: "[--all] (run every gate even if no rust changed)"
+allowed-tools: Bash(just:*)
 ---
 
-Run this repo's mandatory pre-push verification gate and report pass/fail with the actual command output. Do **not** claim success on any failure — surface the failing output verbatim and stop.
+Run `just preflight` — or `just ALL=1 preflight` when `$ARGUMENTS` contains `--all` — and report a concise PASS/FAIL summary with the actual command output. Do **not** claim success on any failure: surface the failing output verbatim and stop.
 
-## Steps
+The recipe owns which gates run and with which flags; do not reconstruct the commands here or reach past it to raw `cargo`.
 
-1. Determine what changed: `git diff --name-only origin/main...HEAD` (and `git status --porcelain` for uncommitted work). Note whether anything under `rust/**` changed, and specifically whether `rust/src/backend/**` changed.
+- If `cargo fmt` reformatted anything, mention the whitespace diff to commit.
+- If clippy fails only because CI's rustc is newer, point at `gh run view <id> --log-failed`.
 
-2. **Always run the TypeScript/CLI gate:**
-   ```bash
-   bun test && bunx tsc --noEmit
-   ```
-
-3. **If `rust/**` changed (or `$ARGUMENTS` contains `--all`), run the Rust gate** — use the exact flags; `--all-targets` and `nextest` are mandatory (plain `cargo test` is NOT acceptable in this repo):
-   ```bash
-   cd rust && cargo fmt && cargo clippy --all-targets -- -D warnings && cargo nextest run --features tts
-   ```
-   (`make rust-test` wraps the nextest call if you prefer.)
-
-4. **If `rust/src/backend/**` changed, also run the CoreML build check:**
-   ```bash
-   cd rust && cargo check --features coreml --no-default-features
-   ```
-
-5. Report a concise PASS/FAIL summary per gate. If `cargo fmt` made changes, mention the whitespace diff to commit. If clippy fails only because CI rustc is newer, point at `gh run view <id> --log-failed`.
-
-Reference: CLAUDE.md "VERIFY BEFORE PUSHING".
+Reference: the `preflight` recipe in `justfile`, CLAUDE.md "VERIFY BEFORE PUSHING".

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -37,6 +37,7 @@
       "Bash(tail *)",
       "Bash(wc *)",
       "Bash(grep *)",
+      "Bash(just:*)",
       "Bash(make test)",
       "Bash(make lint)",
       "Bash(make unit)",

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -195,14 +195,16 @@ jobs:
       # release-smoke gate), but `--all-targets` clippy at least type-checks
       # and lints the test code + the install-time voice-pack staging so a
       # darwin-only break is caught before a release tag builds it.
+      # The feature set lives in the `verify-darwin-full` recipe, so CI and the local
+      # gate cannot drift apart (#797) — hence a `just` on PATH for this lane.
+      - uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2.85.10
+        if: matrix.os == 'macos-14'
+        with:
+          tool: just@1.58.0
       - name: Lint darwin release feature set (incl. system_kokoro)
         if: matrix.os == 'macos-14'
         shell: bash
-        run: |
-          cd rust
-          cargo clippy --all-targets \
-            --features coreml,tts,system_tts,system_kokoro,system_diarize,system_text_lang \
-            --no-default-features -- -D warnings
+        run: just verify-darwin-full
 
       # No model cache on this lane at all: the Kokoro stand-in is committed,
       # CharsiuG2P is covered once on the Linux coverage lane rather than three

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,9 +54,9 @@ git worktree remove .worktrees/<slug> && git worktree prune
 
 ### VERIFY BEFORE PUSHING
 
-- `just preflight` before every push. The recipe is the single executable definition of the gate — TS always, the Rust gate when `rust/**` changed, the CoreML check when `rust/src/backend/**` changed; `just ALL=1 preflight` runs every gate regardless of the diff. Read it rather than reconstructing the commands.
+- `just preflight` before every push — the executable definition of the default gate: TS always, the Rust gate when `rust/**` changed, the CoreML check when `rust/src/backend/**` changed; `just ALL=1 preflight` runs every gate regardless of the diff. Read it rather than reconstructing the commands.
 - Always nextest for the suite — the only sanctioned plain `cargo test` calls are `--doc` and the pin-bump's `models::manifest_tests`; always `--all-targets`, or CI catches `#[cfg(test)]` dead code you didn't.
-- Touching darwin-only code (`system_kokoro` / `system_diarize` / `system_text_lang`): `just verify-darwin-full`, the same recipe `rust-test.yml` runs. Nothing else compiles those paths locally, so a break there is otherwise invisible until CI.
+- `preflight` does **not** build the darwin feature set, so it goes green on code that never compiled: touching `rust/src/tts/**` or anything fluidaudio-rs-adjacent (`system_kokoro` / `system_diarize` / `system_text_lang`) also needs `just verify-darwin-full`, the recipe `rust-test.yml` runs.
 - Do NOT push broken code.
 
 Rust toolchain quirks (CI rustc drift, rustfmt, `protoc`) and language gotchas: `docs/runbooks/rust-gotchas.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,9 +54,9 @@ git worktree remove .worktrees/<slug> && git worktree prune
 
 ### VERIFY BEFORE PUSHING
 
-- `bun test && bunx tsc --noEmit` before every push.
-- Rust changes: `make rust-test` (wraps `cargo nextest run --features tts`) plus `cargo fmt` and `cargo clippy --all-targets -- -D warnings`. Always nextest for the suite — the only sanctioned plain `cargo test` calls are `--doc` and the pin-bump's `models::manifest_tests`; always `--all-targets`, or CI catches `#[cfg(test)]` dead code you didn't.
-- Backend module changes: also `cargo check --features coreml --no-default-features`.
+- `just preflight` before every push. The recipe is the single executable definition of the gate — TS always, the Rust gate when `rust/**` changed, the CoreML check when `rust/src/backend/**` changed; `just ALL=1 preflight` runs every gate regardless of the diff. Read it rather than reconstructing the commands.
+- Always nextest for the suite — the only sanctioned plain `cargo test` calls are `--doc` and the pin-bump's `models::manifest_tests`; always `--all-targets`, or CI catches `#[cfg(test)]` dead code you didn't.
+- Touching darwin-only code (`system_kokoro` / `system_diarize` / `system_text_lang`): `just verify-darwin-full`, the same recipe `rust-test.yml` runs. Nothing else compiles those paths locally, so a break there is otherwise invisible until CI.
 - Do NOT push broken code.
 
 Rust toolchain quirks (CI rustc drift, rustfmt, `protoc`) and language gotchas: `docs/runbooks/rust-gotchas.md`.

--- a/justfile
+++ b/justfile
@@ -3,6 +3,7 @@
 FEATURES := "tts,system_kokoro,system_diarize"
 FILE := ""
 TAG := ""
+ALL := ""
 
 # Show available recipes
 default:
@@ -36,6 +37,46 @@ coverage-rust:
 # Run Rust tests via nextest (matches CI — rust-test.yml)
 rust-test:
     cd rust && cargo nextest run --features tts
+
+# Gates are selected from what changed against origin/main...HEAD plus the working tree:
+# the Rust gate on rust/, the CoreML check on rust/src/backend/. just ALL=1 preflight forces both.
+# The pre-push gate — CLAUDE.md "VERIFY BEFORE PUSHING"
+preflight:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    git rev-parse --verify --quiet origin/main >/dev/null || { echo "preflight: no local origin/main to diff against — run: git fetch origin main" >&2; exit 2; }
+    changed="$( { git diff --name-only origin/main...HEAD; git diff --name-only HEAD; git ls-files --others --exclude-standard; } | sort -u )"
+    rust=""; backend=""
+    if [ -n "{{ ALL }}" ] || grep -q '^rust/' <<<"$changed"; then rust=1; fi
+    if [ -n "{{ ALL }}" ] || grep -q '^rust/src/backend/' <<<"$changed"; then backend=1; fi
+
+    echo "==> TS gate (always)"
+    bun run test
+    bun run lint
+
+    if [ -n "$rust" ]; then
+      echo "==> Rust gate"
+      # `cargo fmt` formats in place rather than checking, so this can leave a whitespace diff to commit.
+      (cd rust && cargo fmt && cargo clippy --all-targets -- -D warnings)
+      {{ just_executable() }} rust-test
+    else
+      echo "==> Rust gate skipped: no rust/ changes (force with just ALL=1 preflight)"
+    fi
+
+    if [ -n "$backend" ]; then
+      echo "==> CoreML build check"
+      (cd rust && cargo check --features coreml --no-default-features)
+    else
+      echo "==> CoreML check skipped: no rust/src/backend/ changes"
+    fi
+
+# The default nextest run builds only onnx,tts, so system_kokoro / system_diarize /
+# system_text_lang never compile locally; rust-test.yml calls this recipe rather than repeat the set.
+# Lint the full darwin release feature set (macOS 14+ arm64)
+verify-darwin-full:
+    cd rust && cargo clippy --all-targets \
+        --features coreml,tts,system_tts,system_kokoro,system_diarize,system_text_lang \
+        --no-default-features -- -D warnings
 
 # `--in-place` is not optional: models.rs include_str!s a file above the crate, so the copy build fails.
 # Mutation-test one engine file, e.g. just FILE=src/errors.rs mutants-rust

--- a/justfile
+++ b/justfile
@@ -45,7 +45,8 @@ preflight:
     #!/usr/bin/env bash
     set -euo pipefail
     git rev-parse --verify --quiet origin/main >/dev/null || { echo "preflight: no local origin/main to diff against — run: git fetch origin main" >&2; exit 2; }
-    changed="$( { git diff --name-only origin/main...HEAD; git diff --name-only HEAD; git ls-files --others --exclude-standard; } | sort -u )"
+    # --no-renames: with detection on, a file moved out of rust/ reports only its destination.
+    changed="$( { git diff --no-renames --name-only origin/main...HEAD; git diff --no-renames --name-only HEAD; git ls-files --others --exclude-standard; } | sort -u )"
     rust=""; backend=""
     if [ -n "{{ ALL }}" ] || grep -q '^rust/' <<<"$changed"; then rust=1; fi
     if [ -n "{{ ALL }}" ] || grep -q '^rust/src/backend/' <<<"$changed"; then backend=1; fi
@@ -65,7 +66,8 @@ preflight:
 
     if [ -n "$backend" ]; then
       echo "==> CoreML build check"
-      (cd rust && cargo check --features coreml --no-default-features)
+      # --all-targets matches rust-test.yml's check so the #[cfg(feature = "coreml")] tests compile too (#708).
+      (cd rust && cargo check --features coreml --no-default-features --all-targets)
     else
       echo "==> CoreML check skipped: no rust/src/backend/ changes"
     fi


### PR DESCRIPTION
Phase 1 of #797. Phase 0 (#890) added the justfile and the Makefile shim; this phase gives the pre-push gate an executable definition and deletes the prose that stood in for one.

## What got deleted, and from where

| Source of truth | Before | After |
| --- | --- | --- |
| `.claude/commands/preflight.md` | 31 lines: 5 numbered steps, 3 fenced shell blocks spelling out the whole gate | 14 lines wrapping `just preflight` — **17 lines gone, all 3 shell blocks gone** |
| its `allowed-tools` | 10 `Bash(...)` patterns (`bun test`, `bunx tsc`, `make`, `cd`, `cargo fmt`, `cargo clippy`, `cargo nextest`, `cargo check`, `git status`, `git diff`) | 1: `Bash(just:*)` |
| CLAUDE.md "VERIFY BEFORE PUSHING" | 3 bullets restating 5 command strings | 3 bullets, none restating a command; the recipe is named as the definition. The prose gotchas stay (nextest-only rule, rust-gotchas link, do-not-push-broken-code) |
| `rust-test.yml` darwin lint | 5-line inline `cargo clippy` with the six-feature list | 1 line: `run: just verify-darwin-full` |

The darwin feature set (`coreml,tts,system_tts,system_kokoro,system_diarize,system_text_lang`) now has **one executable copy**, in `verify-darwin-full`, consumed by both CI and local dev. Two non-executable copies remain and are deliberately out of Phase 1's scope:

- `build-engine.yml:98` — a **build** matrix row, not a lint. CLAUDE.md's "BUILD-ENGINE FEATURE MATRIX MIRRORS CARGO DEFAULTS" rule depends on the flags being literally in each row (it documents a `grep` for exactly that), so folding it into a recipe would break a different gate. Phase 5 territory.
- `rust/tests/kokoro_rate_e2e.rs:26` — a doc comment showing a `cargo nextest run … <filter>` invocation, a different command from the clippy lint. Phase 3's `rust-test *ARGS` is what makes that collapsible.

## Recipes added

- `preflight` — change detection over `origin/main...HEAD` plus the working tree (`git diff --name-only HEAD` + `git ls-files --others`, so uncommitted and untracked work counts; `--no-renames` so a file moved *out* of `rust/` still reports its old path). TS gate always; Rust gate (`cargo fmt`, `cargo clippy --all-targets -- -D warnings`, then the existing `rust-test` recipe) when `rust/` changed; `cargo check --features coreml --no-default-features --all-targets` when `rust/src/backend/` changed. `just ALL=1 preflight` runs everything regardless of the diff — that is the `--all` the command file's argument-hint already advertised.
- `verify-darwin-full` — the full darwin feature-set clippy, called by `rust-test.yml`.

Three deliberate choices worth a look in review:

- The recipe runs `bun run test` / `bun run lint` rather than the literal `bun test && bunx tsc --noEmit` from CLAUDE.md. Same commands, but `package.json`'s `test` script carries `--timeout 30000`; bare `bun test` caps at 5 s and fails scenarios that pass in CI.
- The CoreML check carries `--all-targets`, which the prose copies did **not** — a deliberate strengthening, not drift. `rust-test.yml`'s "Check coreml feature" step has passed `--all-targets` since #708 so the `#[cfg(feature = "coreml")]` tests compile; a local gate one flag weaker than CI is exactly the false-green this phase exists to remove.
- `cargo fmt` still formats in place rather than `--check`, matching what both prose copies said. Changing that is a behaviour change, not a de-duplication, so it is not in this PR.

## Verification

**`just preflight` on an untouched tree** (only these doc/config files changed) — TS gate only, exit 0:

```
==> TS gate (always)
$ bun test --timeout 30000
 1226 pass
 0 fail
 3126 expect() calls
Ran 1232 tests across 87 files. [144.36s]
==> Rust gate skipped: no rust/ changes (force with just ALL=1 preflight)
==> CoreML check skipped: no rust/src/backend/ changes
```

**Gate selection**, exercised through the real recipe with `bun`/`cargo` shimmed onto PATH so the branch taken and the exact argv are both visible (probe files created then removed; `git status` clean afterwards):

| Tree state | Rust gate | CoreML check |
| --- | --- | --- |
| no `rust/` changes | skipped | skipped |
| `rust/__probe.txt` | `cargo fmt` → `cargo clippy --all-targets -- -D warnings` → `just rust-test` → `cargo nextest run --features tts` | skipped |
| `rust/src/backend/__probe.rs` | as above | `cargo check --features coreml --no-default-features --all-targets` |
| `ALL=1`, no rust changes | forced | forced |
| `git mv rust/src/errors.rs errors_moved_probe.rs` | fires | skipped (correct — not a backend path) |

That last row is the `--no-renames` fix: with detection on, `git diff --name-only HEAD` reports only `errors_moved_probe.rs` and the Rust gate would have been skipped for a change that deletes a Rust source file. With `--no-renames` both sides appear and the gate fires.

**Other gates**: `bun run check:workflows` passes with the `rust-test.yml` edit (the pinned-SHA rule and #850's windows-shell rule both hold — the new step is a `uses:`, and the edited `run:` keeps its explicit `shell: bash`). `bun run check` and `bun run check:versions` pass. `just --fmt --check --unstable` passes. `just --list` renders a doc comment for both new recipes.

**Not run**: `make rust-test` / nextest. No Rust source changed — the workflow edit is YAML-only and the recipe reproduces the previous command verbatim.

`taiki-e/install-action` is the same action already installing nextest on this job, pinned to the same SHA (v2.85.10) and now to `just@1.58.0`; it is gated `if: matrix.os == 'macos-14'`, so the Windows leg of the matrix does not pay for it.

## Phase 2 preview

`.github/scripts/check-recipes.ts`, in the family of `check:workflows` / `check:versions`: parse `just --dump --dump-format json` and fail when a `just <recipe>` referenced in `README.md`, `CONTRIBUTING.md`, `CLAUDE.md`, `docs/architecture.md`, `.claude/**` or `.github/workflows/**` does not exist, or when a recipe carries no doc comment (`docs/superpowers/**` excluded). Test-first, and now with a CI caller to protect: this PR makes `rust-test.yml` break if `verify-darwin-full` is ever renamed. `CONTRIBUTING.md`'s own Rust command block is the next prose copy in line, and it goes in the Phase 4 sweep.

Refs #797

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBTpJjqyYFW6W8LHJ2nwy
