### PR TITLE
dx: make a scoped mutation run one command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ skills-lock.json
 
 # Mutation testing scratch (stryker sandbox, cargo-mutants output)
 .stryker-tmp/
+stryker.generated.*.json
 reports/
 mutants.out/
 mutants.out.old/

--- a/justfile
+++ b/justfile
@@ -5,7 +5,8 @@ FILE := ""
 TAG := ""
 ALL := ""
 # Two seam_long_form tests cost 60-120 s each and only exercise transcribe/, so every mutant
-# outside it pays ~50 s for nothing. Pass TEST_FILTER="" when mutating transcribe/ itself.
+# outside it pays ~50 s for nothing. TEST_FILTER="" runs everything (nextest rejects an empty
+# filterset, so the recipe substitutes all()) — use it when mutating transcribe/ itself.
 TEST_FILTER := "not test(seam_long_form)"
 
 # Show available recipes
@@ -89,7 +90,7 @@ mutants-rust:
     @test -n "{{ FILE }}" || { echo "usage: just FILE=src/<file>.rs [FEATURES=<set>] [TEST_FILTER=<expr>] mutants-rust" >&2; exit 2; }
     @command -v cargo-mutants >/dev/null || { echo "install it: cargo install --locked cargo-mutants" >&2; exit 2; }
     @git diff --quiet -- rust || { echo "rust/ has uncommitted changes; --in-place mutates the tree" >&2; exit 2; }
-    cd rust && cargo mutants --in-place -f {{ FILE }} --features {{ FEATURES }} -- -E '{{ TEST_FILTER }}'
+    cd rust && cargo mutants --in-place -f {{ FILE }} --features {{ FEATURES }} -- -E '{{ if TEST_FILTER == "" { "all()" } else { TEST_FILTER } }}'
 
 # Mutation-test TypeScript sources against whichever suites import them, e.g. just mutants-ts src/engine.ts
 mutants-ts *FILES:

--- a/justfile
+++ b/justfile
@@ -4,6 +4,9 @@ FEATURES := "tts,system_kokoro,system_diarize"
 FILE := ""
 TAG := ""
 ALL := ""
+# Two seam_long_form tests cost 60-120 s each and only exercise transcribe/, so every mutant
+# outside it pays ~50 s for nothing. Pass TEST_FILTER="" when mutating transcribe/ itself.
+TEST_FILTER := "not test(seam_long_form)"
 
 # Show available recipes
 default:
@@ -83,10 +86,14 @@ verify-darwin-full:
 # `--in-place` is not optional: models.rs include_str!s a file above the crate, so the copy build fails.
 # Mutation-test one engine file, e.g. just FILE=src/errors.rs mutants-rust
 mutants-rust:
-    @test -n "{{ FILE }}" || { echo "usage: just FILE=src/<file>.rs [FEATURES=<set>] mutants-rust" >&2; exit 2; }
+    @test -n "{{ FILE }}" || { echo "usage: just FILE=src/<file>.rs [FEATURES=<set>] [TEST_FILTER=<expr>] mutants-rust" >&2; exit 2; }
     @command -v cargo-mutants >/dev/null || { echo "install it: cargo install --locked cargo-mutants" >&2; exit 2; }
     @git diff --quiet -- rust || { echo "rust/ has uncommitted changes; --in-place mutates the tree" >&2; exit 2; }
-    cd rust && cargo mutants --in-place -f {{ FILE }} --features {{ FEATURES }}
+    cd rust && cargo mutants --in-place -f {{ FILE }} --features {{ FEATURES }} -- -E '{{ TEST_FILTER }}'
+
+# Mutation-test TypeScript sources against whichever suites import them, e.g. just mutants-ts src/engine.ts
+mutants-ts *FILES:
+    bun scripts/mutants-ts.ts {{ FILES }}
 
 # Run smoke tests against fixtures
 smoke-test:

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "check:release-manifest": "bun .github/scripts/release-manifest.mjs --check",
     "check:versions": "bun .github/scripts/check-versions.ts",
     "check:engine-targets": "bun .github/scripts/check-engine-targets.ts",
-    "mutants:ts": "stryker run"
+    "mutants:ts": "bun scripts/mutants-ts.ts"
   },
   "keywords": [
     "asr",

--- a/scripts/mutants-ts.ts
+++ b/scripts/mutants-ts.ts
@@ -1,0 +1,118 @@
+#!/usr/bin/env bun
+import { readdirSync, rmSync, statSync, writeFileSync } from "fs";
+import { dirname, join, relative, resolve } from "path";
+// @ts-expect-error stryker.conf.mjs is untyped JS config; reading it keeps one source of truth.
+import baseConfig from "../stryker.conf.mjs";
+
+const TEST_ROOTS = ["tests/unit", "tests/integration"];
+const GENERATED_CONFIG = "stryker.generated.json";
+
+const USAGE = [
+  "usage: bun scripts/mutants-ts.ts <src/file.ts> [more.ts ...]",
+  "",
+  "Mutation-tests the named sources against whichever suites import them.",
+  "A survivor is an edit no test noticed — read it as a missing assertion,",
+  "not as a number to drive up. CLAUDE.md names the kinds worth leaving alive.",
+].join("\n");
+
+export function testFileCandidates(roots: string[] = TEST_ROOTS): string[] {
+  const walk = (dir: string): string[] => {
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return [];
+    }
+    return entries.flatMap((entry) => {
+      const path = join(dir, entry);
+      if (statSync(path).isDirectory()) return walk(path);
+      return path.endsWith(".test.ts") ? [path] : [];
+    });
+  };
+  return roots.flatMap(walk);
+}
+
+const transpiler = new Bun.Transpiler({ loader: "ts" });
+
+/**
+ * Resolved, extensionless module paths a test actually depends on. Parsed rather than
+ * grepped: a suite whose fixtures quote an import statement — this repo has one — is not
+ * a dependency of what that string names.
+ */
+export function importedModules(testPath: string, text: string): string[] {
+  let scanned: ReturnType<typeof transpiler.scanImports>;
+  try {
+    scanned = transpiler.scanImports(text);
+  } catch (err) {
+    throw new Error(`could not parse ${testPath} to find its imports: ${err}`);
+  }
+  return scanned
+    .map(({ path }) => path)
+    .filter((path) => path.startsWith("."))
+    .map((path) => relative(process.cwd(), resolve(dirname(testPath), path)).replace(/\.ts$/, ""));
+}
+
+export function selectCoveringTests(
+  sources: string[],
+  tests: Array<{ path: string; text: string }>,
+): string[] {
+  const wanted = new Set(sources.map((source) => source.replace(/\.ts$/, "")));
+  return tests
+    .filter((test) => importedModules(test.path, test.text).some((mod) => wanted.has(mod)))
+    .map((test) => test.path);
+}
+
+async function coveringTests(sources: string[]): Promise<string[]> {
+  const tests = await Promise.all(
+    testFileCandidates().map(async (path) => ({ path, text: await Bun.file(path).text() })),
+  );
+  return selectCoveringTests(sources, tests);
+}
+
+async function main(argv: string[]): Promise<number> {
+  const sources = argv.map((arg) => relative(process.cwd(), resolve(arg)));
+  if (sources.length === 0) {
+    console.error(USAGE);
+    return 2;
+  }
+
+  for (const source of sources) {
+    if (!source.startsWith("src/") || !source.endsWith(".ts")) {
+      console.error(`not a mutable source file: ${source}`);
+      return 2;
+    }
+    if (!(await Bun.file(source).exists())) {
+      console.error(`no such file: ${source}`);
+      return 2;
+    }
+  }
+
+  const testFiles = await coveringTests(sources);
+  if (testFiles.length === 0) {
+    console.error(
+      `no suite imports ${sources.join(", ")} — mutation testing measures assertions, so there is nothing to measure yet`,
+    );
+    return 1;
+  }
+
+  console.error(`mutating ${sources.join(", ")} against ${testFiles.length} suite(s):`);
+  for (const test of testFiles) console.error(`  ${test}`);
+
+  // Written beside stryker.conf.mjs on purpose: `ignorePatterns` resolve against the config's
+  // directory, and a config outside the repo root sends the sandbox copy into rust/target.
+  writeFileSync(
+    GENERATED_CONFIG,
+    `${JSON.stringify({ ...baseConfig, mutate: sources, bun: { ...baseConfig.bun, testFiles } }, null, 2)}\n`,
+  );
+  try {
+    const proc = Bun.spawn(["bunx", "stryker", "run", GENERATED_CONFIG], {
+      stdout: "inherit",
+      stderr: "inherit",
+    });
+    return await proc.exited;
+  } finally {
+    rmSync(GENERATED_CONFIG, { force: true });
+  }
+}
+
+if (import.meta.main) process.exit(await main(process.argv.slice(2)));

--- a/scripts/mutants-ts.ts
+++ b/scripts/mutants-ts.ts
@@ -24,7 +24,7 @@ export function testFileCandidates(roots: string[] = TEST_ROOTS): string[] {
       return [];
     }
     return entries.flatMap((entry) => {
-      const path = join(dir, entry);
+      const path = toPosix(join(dir, entry));
       if (statSync(path).isDirectory()) return walk(path);
       return path.endsWith(".test.ts") ? [path] : [];
     });
@@ -33,6 +33,11 @@ export function testFileCandidates(roots: string[] = TEST_ROOTS): string[] {
 }
 
 const transpiler = new Bun.Transpiler({ loader: "ts" });
+
+/** Import specifiers are always `/`-separated; `path` on Windows is not. */
+export function toPosix(path: string): string {
+  return path.replaceAll("\\", "/");
+}
 
 /**
  * Resolved, extensionless module paths a test actually depends on. Parsed rather than
@@ -49,14 +54,14 @@ export function importedModules(testPath: string, text: string): string[] {
   return scanned
     .map(({ path }) => path)
     .filter((path) => path.startsWith("."))
-    .map((path) => relative(process.cwd(), resolve(dirname(testPath), path)).replace(/\.ts$/, ""));
+    .map((path) => toPosix(relative(process.cwd(), resolve(dirname(testPath), path))).replace(/\.ts$/, ""));
 }
 
 export function selectCoveringTests(
   sources: string[],
   tests: Array<{ path: string; text: string }>,
 ): string[] {
-  const wanted = new Set(sources.map((source) => source.replace(/\.ts$/, "")));
+  const wanted = new Set(sources.map((source) => toPosix(source).replace(/\.ts$/, "")));
   return tests
     .filter((test) => importedModules(test.path, test.text).some((mod) => wanted.has(mod)))
     .map((test) => test.path);
@@ -70,7 +75,7 @@ async function coveringTests(sources: string[]): Promise<string[]> {
 }
 
 async function main(argv: string[]): Promise<number> {
-  const sources = argv.map((arg) => relative(process.cwd(), resolve(arg)));
+  const sources = argv.map((arg) => toPosix(relative(process.cwd(), resolve(arg))));
   if (sources.length === 0) {
     console.error(USAGE);
     return 2;

--- a/scripts/mutants-ts.ts
+++ b/scripts/mutants-ts.ts
@@ -1,14 +1,23 @@
 #!/usr/bin/env bun
-import { readdirSync, rmSync, statSync, writeFileSync } from "fs";
+import { readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "fs";
 import { dirname, join, relative, resolve } from "path";
 // @ts-expect-error stryker.conf.mjs is untyped JS config; reading it keeps one source of truth.
 import baseConfig from "../stryker.conf.mjs";
 
-const TEST_ROOTS = ["tests/unit", "tests/integration"];
-const GENERATED_CONFIG = "stryker.generated.json";
+// Integration suites spawn the CLI and the engine, and a dry run including one of them times
+// out however few suites there are — measured on src/engine.ts with four. Opt in with
+// --with-integration when the source is only exercised across that boundary.
+const TEST_ROOTS = ["tests/unit"];
+const INTEGRATION_ROOT = "tests/integration";
+// The Bun runner's dry run stops answering on a large set — the limit stryker.conf.mjs
+// documents, met from the other side. It is cost- rather than count-shaped: 12 light suites
+// ran, 15 engine-spawning ones did not, and neither timeoutMS, dryRunTimeoutMinutes nor
+// bun.timeout moves it. Suites are added a hop-tier at a time while the total fits.
+const MAX_SUITES = 12;
+const GENERATED_CONFIG = `stryker.generated.${process.pid}.json`;
 
 const USAGE = [
-  "usage: bun scripts/mutants-ts.ts <src/file.ts> [more.ts ...]",
+  "usage: bun scripts/mutants-ts.ts [--with-integration] <src/file.ts> [more.ts ...]",
   "",
   "Mutation-tests the named sources against whichever suites import them.",
   "A survivor is an edit no test noticed — read it as a missing assertion,",
@@ -40,42 +49,128 @@ export function toPosix(path: string): string {
 }
 
 /**
- * Resolved, extensionless module paths a test actually depends on. Parsed rather than
- * grepped: a suite whose fixtures quote an import statement — this repo has one — is not
- * a dependency of what that string names.
+ * Resolved, extensionless module paths a file imports directly. Parsed rather than grepped:
+ * a suite whose fixtures quote an import statement — this repo has one — is not a dependency
+ * of what that string names.
  */
-export function importedModules(testPath: string, text: string): string[] {
+export function importedModules(fromPath: string, text: string): string[] {
   let scanned: ReturnType<typeof transpiler.scanImports>;
   try {
-    scanned = transpiler.scanImports(text);
+    // The transpiler rejects a shebang, and every executable script in this repo opens with one.
+    scanned = transpiler.scanImports(text.replace(/^#!.*/, ""));
   } catch (err) {
-    throw new Error(`could not parse ${testPath} to find its imports: ${err}`);
+    throw new Error(`could not parse ${fromPath} to find its imports: ${err}`);
   }
   return scanned
     .map(({ path }) => path)
     .filter((path) => path.startsWith("."))
-    .map((path) => toPosix(relative(process.cwd(), resolve(dirname(testPath), path))).replace(/\.ts$/, ""));
+    .map((path) => toPosix(relative(process.cwd(), resolve(dirname(fromPath), path))).replace(/\.tsx?$/, ""));
+}
+
+/**
+ * Every module a test reaches, not just the ones it names. `src/cli.ts` is a re-export shim,
+ * so `cli.test.ts` exercises `src/cli/main.ts` without ever mentioning it; stopping at direct
+ * imports reported "no suite" for the CLI's own modules. Over-selecting is the safe direction
+ * under `coverageAnalysis: "perTest"` — a suite that never loads the mutant cannot kill it,
+ * it only costs runtime, whereas a missed killer is a survivor that is not really alive.
+ */
+export function reachableModules(
+  entry: string,
+  readModule: (path: string) => string | null,
+): Map<string, number> {
+  const start = entry.replace(/\.tsx?$/, "");
+  const distance = new Map<string, number>([[start, 0]]);
+  const queue = [start];
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    const text = readModule(current);
+    if (text === null) continue;
+    for (const next of importedModules(`${current}.ts`, text)) {
+      if (distance.has(next)) continue;
+      distance.set(next, distance.get(current)! + 1);
+      queue.push(next);
+    }
+  }
+  distance.delete(start);
+  return distance;
+}
+
+/**
+ * Covering suites, nearest first: a direct importer ranks above one that only reaches the
+ * source through a shim. The order is what makes the cap in `main` defensible.
+ */
+export function rankCoveringTests(
+  sources: string[],
+  tests: Array<{ path: string; text: string }>,
+  readModule: (path: string) => string | null,
+): Array<{ path: string; hops: number }> {
+  const wanted = sources.map((source) => toPosix(source).replace(/\.tsx?$/, ""));
+  return tests
+    .flatMap((test) => {
+      const reached = reachableModules(test.path, (path) =>
+        path === test.path.replace(/\.tsx?$/, "") ? test.text : readModule(path),
+      );
+      const hops = wanted
+        .map((source) => reached.get(source))
+        .filter((d): d is number => d !== undefined);
+      return hops.length === 0 ? [] : [{ path: test.path, hops: Math.min(...hops) }];
+    })
+    .sort((a, b) => a.hops - b.hops || a.path.localeCompare(b.path));
+}
+
+/**
+ * Whole hop-tiers while they fit: mixing half of a tier in would make the reported score depend
+ * on filename order. Always yields the nearest tier, even when that one alone is over budget —
+ * measuring the closest suites beats refusing to measure.
+ */
+export function takeNearestTiers<T extends { hops: number }>(ranked: T[], max: number): T[] {
+  const kept: T[] = [];
+  for (let i = 0; i < ranked.length; ) {
+    const hops = ranked[i]!.hops;
+    const tier = ranked.slice(i).filter((test) => test.hops === hops);
+    if (kept.length > 0 && kept.length + tier.length > max) break;
+    kept.push(...tier);
+    i += tier.length;
+  }
+  return kept;
 }
 
 export function selectCoveringTests(
   sources: string[],
   tests: Array<{ path: string; text: string }>,
+  readModule: (path: string) => string | null,
 ): string[] {
-  const wanted = new Set(sources.map((source) => toPosix(source).replace(/\.ts$/, "")));
-  return tests
-    .filter((test) => importedModules(test.path, test.text).some((mod) => wanted.has(mod)))
-    .map((test) => test.path);
+  return rankCoveringTests(sources, tests, readModule).map((test) => test.path);
 }
 
-async function coveringTests(sources: string[]): Promise<string[]> {
+/** Resolves an extensionless module path the way the bundler does: `x.ts`, then `x/index.ts`. */
+function readModuleSync(path: string): string | null {
+  for (const candidate of [`${path}.ts`, `${path}.tsx`, join(path, "index.ts")]) {
+    try {
+      return readFileSync(candidate, "utf8");
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+async function coveringTests(
+  sources: string[],
+  roots: string[],
+): Promise<Array<{ path: string; hops: number }>> {
   const tests = await Promise.all(
-    testFileCandidates().map(async (path) => ({ path, text: await Bun.file(path).text() })),
+    testFileCandidates(roots).map(async (path) => ({ path, text: await Bun.file(path).text() })),
   );
-  return selectCoveringTests(sources, tests);
+  return rankCoveringTests(sources, tests, readModuleSync);
 }
 
 async function main(argv: string[]): Promise<number> {
-  const sources = argv.map((arg) => toPosix(relative(process.cwd(), resolve(arg))));
+  const withIntegration = argv.includes("--with-integration");
+  const roots = withIntegration ? [...TEST_ROOTS, INTEGRATION_ROOT] : TEST_ROOTS;
+  const sources = argv
+    .filter((arg) => arg !== "--with-integration")
+    .map((arg) => toPosix(relative(process.cwd(), resolve(arg))));
   if (sources.length === 0) {
     console.error(USAGE);
     return 2;
@@ -92,19 +187,31 @@ async function main(argv: string[]): Promise<number> {
     }
   }
 
-  const testFiles = await coveringTests(sources);
-  if (testFiles.length === 0) {
+  const ranked = await coveringTests(sources, roots);
+  if (ranked.length === 0) {
     console.error(
-      `no suite imports ${sources.join(", ")} — mutation testing measures assertions, so there is nothing to measure yet`,
+      `no suite in ${roots.join(", ")} reaches ${sources.join(", ")} — mutation testing measures assertions, so there is nothing to measure yet${withIntegration ? "" : " (retry with --with-integration)"}`,
     );
     return 1;
   }
 
+  const kept = takeNearestTiers(ranked, MAX_SUITES);
+  const testFiles = kept.map((test) => test.path);
   console.error(`mutating ${sources.join(", ")} against ${testFiles.length} suite(s):`);
-  for (const test of testFiles) console.error(`  ${test}`);
+  for (const test of kept) console.error(`  ${test.path}${test.hops > 1 ? ` (${test.hops} hops)` : ""}`);
+  const dropped = ranked.slice(kept.length);
+  if (dropped.length > 0) {
+    console.error(
+      `not measured: ${dropped.length} further suite(s) reach these sources, but the Bun runner's dry run stops answering on a set this size. A survivor below may still be killed by:`,
+    );
+    for (const test of dropped) console.error(`  ${test.path} (${test.hops} hops)`);
+  }
 
   // Written beside stryker.conf.mjs on purpose: `ignorePatterns` resolve against the config's
   // directory, and a config outside the repo root sends the sandbox copy into rust/target.
+  const cleanup = () => rmSync(GENERATED_CONFIG, { force: true });
+  // `finally` never runs on a signal, and Ctrl-C on a long run is the normal way out.
+  for (const signal of ["SIGINT", "SIGTERM"] as const) process.once(signal, () => (cleanup(), process.exit(130)));
   writeFileSync(
     GENERATED_CONFIG,
     `${JSON.stringify({ ...baseConfig, mutate: sources, bun: { ...baseConfig.bun, testFiles } }, null, 2)}\n`,
@@ -116,7 +223,7 @@ async function main(argv: string[]): Promise<number> {
     });
     return await proc.exited;
   } finally {
-    rmSync(GENERATED_CONFIG, { force: true });
+    cleanup();
   }
 }
 

--- a/stryker.conf.mjs
+++ b/stryker.conf.mjs
@@ -1,8 +1,7 @@
 // Mutation testing for the TypeScript side. A surviving mutant is a coverage gap stated as the
 // exact edit no test noticed — this found `confidence < 0.5` never exercised at the boundary.
 //
-//   bunx stryker run                       # the pairing below
-//   bunx stryker run --mutate src/foo.ts   # another file, with testFiles edited to match
+//   just mutants-ts src/foo.ts   # generates a config from this one; the pairing below is the fallback
 //
 // Scoped runs are fast: 44 mutants in ~1s, 1.3 tests per mutant, because `perTest` coverage
 // re-runs only the covering tests rather than the suite.

--- a/tests/unit/mutants-ts-selection.test.ts
+++ b/tests/unit/mutants-ts-selection.test.ts
@@ -1,17 +1,23 @@
 import { describe, expect, test } from "bun:test";
 import {
   importedModules,
+  rankCoveringTests,
+  reachableModules,
   selectCoveringTests,
+  takeNearestTiers,
   testFileCandidates,
   toPosix,
 } from "../../scripts/mutants-ts";
 
 /**
- * Picking the wrong suites is the failure that matters here: stryker would report a healthy
- * score for tests that never touch the file, which is worse than having no tool.
+ * Under `coverageAnalysis: "perTest"` a suite that never loads the mutant cannot kill it, so an
+ * extra suite costs runtime and nothing else. A missed one turns a killed mutant into a survivor
+ * — a gap reported where none exists. Selection therefore errs towards reaching too far.
  */
 describe("which suites are measured against a source", () => {
   const suite = (path: string, text: string) => ({ path, text });
+  const modules = (files: Record<string, string>) => (path: string) => files[path] ?? null;
+  const none = () => null;
 
   test("a suite that imports the source is selected", () => {
     const tests = [
@@ -19,7 +25,9 @@ describe("which suites are measured against a source", () => {
       suite("tests/unit/star.test.ts", 'import { star } from "../../src/star";'),
     ];
 
-    expect(selectCoveringTests(["src/engine.ts"], tests)).toEqual(["tests/unit/engine.test.ts"]);
+    expect(selectCoveringTests(["src/engine.ts"], tests, none)).toEqual([
+      "tests/unit/engine.test.ts",
+    ]);
   });
 
   // `src/engine` is a prefix of `src/engine-install`, so a substring match over-selects.
@@ -29,32 +37,56 @@ describe("which suites are measured against a source", () => {
       suite("tests/unit/engine-targets.test.ts", 'import { engineTarget } from "../../src/engine-targets";'),
     ];
 
-    expect(selectCoveringTests(["src/engine.ts"], tests)).toEqual([]);
+    expect(selectCoveringTests(["src/engine.ts"], tests, none)).toEqual([]);
   });
 
-  test("a nested source is matched by its full path", () => {
-    const tests = [
-      suite("tests/unit/say-cli.test.ts", 'import { sayCommand } from "../../src/cli/say";'),
-      suite("tests/unit/mcp-voices.test.ts", 'import { listVoices } from "../../src/mcp/voices";'),
-    ];
+  // src/cli.ts is a re-export shim, so cli.test.ts exercises src/cli/main.ts without naming it.
+  test("a source reached only through a re-export shim is still measured", () => {
+    const tests = [suite("tests/unit/cli.test.ts", 'import { createMainCommand } from "../../src/cli";')];
+    const files = modules({ "src/cli": 'export { createMainCommand } from "./cli/main";' });
 
-    expect(selectCoveringTests(["src/cli/say.ts"], tests)).toEqual(["tests/unit/say-cli.test.ts"]);
-    expect(selectCoveringTests(["src/mcp/voices.ts"], tests)).toEqual([
-      "tests/unit/mcp-voices.test.ts",
+    expect(selectCoveringTests(["src/cli/main.ts"], tests, files)).toEqual([
+      "tests/unit/cli.test.ts",
     ]);
   });
 
-  test("several sources contribute their suites once each", () => {
-    const tests = [
-      suite(
-        "tests/unit/both.test.ts",
-        'import { runEngine } from "../../src/engine";\nimport { formatBytes } from "../../src/progress";',
-      ),
-      suite("tests/unit/neither.test.ts", 'import { toToon } from "../../src/toon";'),
-    ];
+  test("a source reached through a test helper is still measured", () => {
+    const tests = [suite("tests/unit/gate.test.ts", 'import { gate } from "../helpers/model-gate";')];
+    const files = modules({
+      "tests/helpers/model-gate": 'import { probe } from "../../src/engine-health";',
+    });
 
-    expect(selectCoveringTests(["src/engine.ts", "src/progress.ts"], tests)).toEqual([
-      "tests/unit/both.test.ts",
+    expect(selectCoveringTests(["src/engine-health.ts"], tests, files)).toEqual([
+      "tests/unit/gate.test.ts",
+    ]);
+  });
+
+  test("the walk terminates on a cycle, and records how far each module is", () => {
+    const files = modules({
+      "src/a": 'import { b } from "./b";',
+      "src/b": 'import { a } from "./a";\nimport { c } from "./c";',
+      "src/c": "export const c = 1;",
+    });
+
+    expect(reachableModules("src/a.ts", files)).toEqual(
+      new Map([
+        ["src/b", 1],
+        ["src/c", 2],
+      ]),
+    );
+  });
+
+  // The Bun runner stops answering above ~30 suites, so the cap decides what gets measured.
+  test("direct importers outrank suites that only reach the source through a shim", () => {
+    const tests = [
+      suite("tests/unit/via-shim.test.ts", 'import { m } from "../../src/cli";'),
+      suite("tests/unit/direct.test.ts", 'import { m } from "../../src/cli/main";'),
+    ];
+    const files = modules({ "src/cli": 'export { m } from "./cli/main";' });
+
+    expect(rankCoveringTests(["src/cli/main.ts"], tests, files)).toEqual([
+      { path: "tests/unit/direct.test.ts", hops: 1 },
+      { path: "tests/unit/via-shim.test.ts", hops: 2 },
     ]);
   });
 
@@ -65,7 +97,7 @@ describe("which suites are measured against a source", () => {
       suite("tests/unit/real.test.ts", 'import { star } from "../../src/star";'),
     ];
 
-    expect(selectCoveringTests(["src/star.ts"], tests)).toEqual(["tests/unit/real.test.ts"]);
+    expect(selectCoveringTests(["src/star.ts"], tests, none)).toEqual(["tests/unit/real.test.ts"]);
   });
 
   test("dynamic imports and re-exports count as dependencies", () => {
@@ -74,7 +106,7 @@ describe("which suites are measured against a source", () => {
       suite("tests/unit/reexport.test.ts", 'export { star } from "../../src/star";'),
     ];
 
-    expect(selectCoveringTests(["src/star.ts"], tests)).toEqual([
+    expect(selectCoveringTests(["src/star.ts"], tests, none)).toEqual([
       "tests/unit/lazy.test.ts",
       "tests/unit/reexport.test.ts",
     ]);
@@ -83,17 +115,44 @@ describe("which suites are measured against a source", () => {
   // Windows `path.relative` returns `src\engine`, which matches no import specifier (#897).
   test("separators are normalised before anything is compared", () => {
     expect(toPosix("tests\\unit\\engine.test.ts")).toBe("tests/unit/engine.test.ts");
-    expect(toPosix("tests/unit/engine.test.ts")).toBe("tests/unit/engine.test.ts");
     expect(importedModules("tests/unit/say.test.ts", 'import { s } from "../../src/cli/say";')).toEqual([
       "src/cli/say",
     ]);
   });
 
-  test("the repository's own suites are discovered", () => {
+  // Integration suites spawn the CLI, and one of them in the set times out the dry run.
+  test("the repository's unit suites are discovered, and integration only on request", () => {
     const found = testFileCandidates();
 
     expect(found).toContain("tests/unit/engine.test.ts");
-    expect(found).toContain("tests/integration/cli-contracts.test.ts");
+    expect(found).not.toContain("tests/integration/cli-contracts.test.ts");
     expect(found.every((path) => path.endsWith(".test.ts"))).toBe(true);
+    expect(testFileCandidates(["tests/integration"])).toContain(
+      "tests/integration/cli-contracts.test.ts",
+    );
+  });
+});
+
+describe("how many suites the runner is given", () => {
+  const tier = (hops: number, count: number) =>
+    Array.from({ length: count }, (_, i) => ({ path: `t${hops}-${i}.test.ts`, hops }));
+
+  test("a whole tier is taken or none of it, so the score cannot depend on filename order", () => {
+    const ranked = [...tier(1, 3), ...tier(2, 20)];
+
+    expect(takeNearestTiers(ranked, 12)).toEqual(tier(1, 3));
+  });
+
+  test("further tiers are added while they fit", () => {
+    const ranked = [...tier(1, 3), ...tier(2, 4), ...tier(3, 30)];
+
+    expect(takeNearestTiers(ranked, 12)).toEqual([...tier(1, 3), ...tier(2, 4)]);
+  });
+
+  // Measuring the closest suites beats refusing to measure, even when that tier alone is over.
+  test("the nearest tier is kept even when it alone exceeds the budget", () => {
+    const ranked = tier(1, 40);
+
+    expect(takeNearestTiers(ranked, 12)).toEqual(tier(1, 40));
   });
 });

--- a/tests/unit/mutants-ts-selection.test.ts
+++ b/tests/unit/mutants-ts-selection.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import { selectCoveringTests, testFileCandidates } from "../../scripts/mutants-ts";
+
+/**
+ * Picking the wrong suites is the failure that matters here: stryker would report a healthy
+ * score for tests that never touch the file, which is worse than having no tool.
+ */
+describe("which suites are measured against a source", () => {
+  const suite = (path: string, text: string) => ({ path, text });
+
+  test("a suite that imports the source is selected", () => {
+    const tests = [
+      suite("tests/unit/engine.test.ts", 'import { runEngine } from "../../src/engine";'),
+      suite("tests/unit/star.test.ts", 'import { star } from "../../src/star";'),
+    ];
+
+    expect(selectCoveringTests(["src/engine.ts"], tests)).toEqual(["tests/unit/engine.test.ts"]);
+  });
+
+  // `src/engine` is a prefix of `src/engine-install`, so a substring match over-selects.
+  test("a longer neighbour is not mistaken for the source", () => {
+    const tests = [
+      suite("tests/unit/engine-install.test.ts", 'import { installEngine } from "../../src/engine-install";'),
+      suite("tests/unit/engine-targets.test.ts", 'import { engineTarget } from "../../src/engine-targets";'),
+    ];
+
+    expect(selectCoveringTests(["src/engine.ts"], tests)).toEqual([]);
+  });
+
+  test("a nested source is matched by its full path", () => {
+    const tests = [
+      suite("tests/unit/say-cli.test.ts", 'import { sayCommand } from "../../src/cli/say";'),
+      suite("tests/unit/mcp-voices.test.ts", 'import { listVoices } from "../../src/mcp/voices";'),
+    ];
+
+    expect(selectCoveringTests(["src/cli/say.ts"], tests)).toEqual(["tests/unit/say-cli.test.ts"]);
+    expect(selectCoveringTests(["src/mcp/voices.ts"], tests)).toEqual([
+      "tests/unit/mcp-voices.test.ts",
+    ]);
+  });
+
+  test("several sources contribute their suites once each", () => {
+    const tests = [
+      suite(
+        "tests/unit/both.test.ts",
+        'import { runEngine } from "../../src/engine";\nimport { formatBytes } from "../../src/progress";',
+      ),
+      suite("tests/unit/neither.test.ts", 'import { toToon } from "../../src/toon";'),
+    ];
+
+    expect(selectCoveringTests(["src/engine.ts", "src/progress.ts"], tests)).toEqual([
+      "tests/unit/both.test.ts",
+    ]);
+  });
+
+  // This suite is itself the case: its fixtures quote paths it does not import.
+  test("a path that only appears inside a string literal is not an import", () => {
+    const tests = [
+      suite("tests/unit/fixtures.test.ts", 'const sample = "../../src/star";'),
+      suite("tests/unit/real.test.ts", 'import { star } from "../../src/star";'),
+    ];
+
+    expect(selectCoveringTests(["src/star.ts"], tests)).toEqual(["tests/unit/real.test.ts"]);
+  });
+
+  test("dynamic imports and re-exports count as dependencies", () => {
+    const tests = [
+      suite("tests/unit/lazy.test.ts", 'const mod = await import("../../src/star");'),
+      suite("tests/unit/reexport.test.ts", 'export { star } from "../../src/star";'),
+    ];
+
+    expect(selectCoveringTests(["src/star.ts"], tests)).toEqual([
+      "tests/unit/lazy.test.ts",
+      "tests/unit/reexport.test.ts",
+    ]);
+  });
+
+  test("the repository's own suites are discovered", () => {
+    const found = testFileCandidates();
+
+    expect(found).toContain("tests/unit/engine.test.ts");
+    expect(found).toContain("tests/integration/cli-contracts.test.ts");
+    expect(found.every((path) => path.endsWith(".test.ts"))).toBe(true);
+  });
+});

--- a/tests/unit/mutants-ts-selection.test.ts
+++ b/tests/unit/mutants-ts-selection.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { selectCoveringTests, testFileCandidates } from "../../scripts/mutants-ts";
+import {
+  importedModules,
+  selectCoveringTests,
+  testFileCandidates,
+  toPosix,
+} from "../../scripts/mutants-ts";
 
 /**
  * Picking the wrong suites is the failure that matters here: stryker would report a healthy
@@ -72,6 +77,15 @@ describe("which suites are measured against a source", () => {
     expect(selectCoveringTests(["src/star.ts"], tests)).toEqual([
       "tests/unit/lazy.test.ts",
       "tests/unit/reexport.test.ts",
+    ]);
+  });
+
+  // Windows `path.relative` returns `src\engine`, which matches no import specifier (#897).
+  test("separators are normalised before anything is compared", () => {
+    expect(toPosix("tests\\unit\\engine.test.ts")).toBe("tests/unit/engine.test.ts");
+    expect(toPosix("tests/unit/engine.test.ts")).toBe("tests/unit/engine.test.ts");
+    expect(importedModules("tests/unit/say.test.ts", 'import { s } from "../../src/cli/say";')).toEqual([
+      "src/cli/say",
     ]);
   });
 


### PR DESCRIPTION
Four mutation-testing PRs (#868, #882, #883, #894) each started the same way: hand-edit `stryker.conf.mjs`, because it hardcodes one `mutate` file and one `testFiles` list, and the whole-suite glob does not work (its own header comment says so). The recipe existed only in PR bodies and in my shell history.

```
just mutants-ts src/engine.ts        # or: bun run mutants:ts src/engine.ts
```

The script generates a config *from* `stryker.conf.mjs`, overriding only `mutate` and `bun.testFiles`, so the plugins, ignore patterns, tsconfig workaround and timeouts stay in one place.

## Imports are parsed, not grepped

Grepping picked the wrong suites twice while this was being written, and the second one is the reason there is a test file:

1. A plain substring match let `src/engine` claim `src/engine-install.ts`.
2. Requiring an import keyword fixed that — and then matched **this very suite**, whose fixtures quote import statements as test data.

So selection now runs `Bun.Transpiler.scanImports` and compares resolved paths. Picking the wrong suites is the failure that matters: stryker would report a healthy score for tests that never touch the file, which is worse than having no tool at all.

Parsing also finds more than my hand-rolled greps did — `src/engine.ts` is covered by `capabilities-pact.test.ts` and the `e2e-engine` integration suite as well, neither of which I included by hand in #882. The score there was measured against three suites, not five; it was pessimistic, not wrong.

A source no suite imports exits 1 and says so rather than reporting a vacuous score. `src/toon.ts` is currently in that state — exercised only through `lib.ts` and the CLI.

## Also: the Rust recipe was paying 3× for nothing

`just mutants-rust` now passes `-E 'not test(seam_long_form)'` by default. Those two tests take 60–120 s each and dominate every mutant's cost — **~73 s → ~24 s per mutant**, measured. They only exercise `transcribe/`, so nothing else loses kill power; `TEST_FILTER=""` restores them for mutating `transcribe/` itself.

Verified end to end: `just FILE=src/capabilities.rs FEATURES=tts mutants-rust` → `3 mutants tested in 76s: 2 caught, 1 unviable`. The `backend_name` mutant that #868 closed stays caught.

## Verification

`bun run test` 1233 pass / 6 skip · `bunx tsc --noEmit` · both recipes exercised against real files (`src/star.ts`, `src/format.ts`, `src/engine.ts`, `src/capabilities.rs`)