### PR TITLE
test(package): fail when a script names a file that no longer exists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,7 +317,7 @@ jobs:
     # (`e2e-engine`, `mcp-e2e`, `say-e2e`) self-skip via
     # `describe.skipIf(!engineInstalled)` when no engine is present, so this
     # lane exercises only the fake/stub-based contract suites
-    # (`cli-contracts`, `e2e-cli`, `say`). No `kesha install`, no cache, no
+    # (`cli-contracts`, `say`). No `kesha install`, no cache, no
     # download — so it's safe on every PR including release/* branches
     # (no published-engine 404 risk without an install step). Real-engine
     # coverage lives in `integration-tests-full` below, gated to engine/model

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "test": "bun test --timeout 30000",
     "test:watch": "bun test --timeout 30000 --watch",
     "test:unit": "bun test --timeout 30000 tests/unit/",
-    "test:cli-fast": "bun test --timeout 30000 tests/unit/ tests/integration/cli-contracts.test.ts tests/integration/e2e-cli.test.ts tests/integration/say.test.ts",
+    "test:cli-fast": "bun test --timeout 30000 tests/unit/ tests/integration/cli-contracts.test.ts tests/integration/say.test.ts",
     "test:integration": "bun test --timeout 30000 tests/integration/",
     "coverage:ts": "bun run test:cli-fast --coverage --coverage-reporter=text --coverage-reporter=lcov --coverage-dir=coverage/ts",
     "coverage:check:ts": "bun .github/scripts/check-coverage.ts --preset=ts --lcov=coverage/ts/lcov.info --summary=coverage/ts/summary.md",

--- a/tests/unit/package-metadata.test.ts
+++ b/tests/unit/package-metadata.test.ts
@@ -1,10 +1,19 @@
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 interface PackageJson {
   files?: string[];
   scripts?: Record<string, string>;
+}
+
+const REPO_DIRS = ["tests/", "src/", "scripts/", ".github/"];
+
+function repoPathsIn(script: string): string[] {
+  return script
+    .split(/\s+/)
+    .filter((token) => !token.startsWith("-") && !token.includes("="))
+    .filter((token) => REPO_DIRS.some((dir) => token.startsWith(dir)));
 }
 
 describe("package metadata", () => {
@@ -21,5 +30,21 @@ describe("package metadata", () => {
 
     expect(pkg.scripts?.postinstall).toBeUndefined();
     expect(pkg.files ?? []).not.toContain("scripts/postinstall.cjs");
+  });
+
+  // `bun test` exits 0 on a filter that matches nothing whenever another one does.
+  test("every repo path a script names still exists", () => {
+    const repoRoot = new URL("../../", import.meta.url);
+    const pkg = JSON.parse(
+      readFileSync(fileURLToPath(new URL("package.json", repoRoot)), "utf8"),
+    ) as PackageJson;
+
+    const missing = Object.entries(pkg.scripts ?? {}).flatMap(([name, script]) =>
+      repoPathsIn(script)
+        .filter((path) => !existsSync(fileURLToPath(new URL(path, repoRoot))))
+        .map((path) => `${name}: ${path}`),
+    );
+
+    expect(missing).toEqual([]);
   });
 });


### PR DESCRIPTION
## What

`test:cli-fast` filtered on `tests/integration/e2e-cli.test.ts`. #588 deleted that suite as redundant; the filter stayed.

## Why it matters

`bun test` exits 1 only when **no** filter matches. Verified on this branch:

```
$ bun test tests/integration/e2e-cli.test.ts        # sole filter, no match
exit=1
$ bun test tests/unit/ ... e2e-cli.test.ts ...      # one dead filter among live ones
738 pass, exit=0
```

So a stale path in a multi-filter script is dropped in silence and the lane reports green while running less than it advertises. Harmless in this instance — the suite was deliberately removed — but the failure mode is a CI gate that passes with a typo'd test path.

## Change

- regression test in `tests/unit/package-metadata.test.ts`: every token in a `scripts` entry that looks like a repo path (`tests/`, `src/`, `scripts/`, `.github/`) must resolve. Fails on the dangling filter before the fix lands.
- drop the dead filter from `test:cli-fast`.
- `ci.yml` fast-lane comment no longer lists `e2e-cli` among the suites it runs.

Found while auditing stale references left behind by the `docs/superpowers` deletion (#864, #873) — the removed spec was the last thing still pointing at this path.

## Verification

- `bun test` — 1233 pass / 6 skip / 0 fail
- `bunx tsc --noEmit` — clean
- `bun run check:workflows` — clean
- `bun run test:cli-fast` — 1089 pass across 69 files (unchanged; the dead filter contributed nothing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZwnEPwLkVUyfMLNfX9JcW
