### PR TITLE
refactor(diagnostic-log): drop a redaction arm that cannot fire

### DIFF
--- a/src/diagnostic-log.ts
+++ b/src/diagnostic-log.ts
@@ -27,8 +27,9 @@ const SAFE_STRING_VALUE = /^[A-Za-z0-9_.@+-]{1,120}$/;
 const SAFE_EVENT = /^[a-z][a-z0-9]*(?:\.[a-z][a-z0-9]*)*$/;
 const DISALLOWED_FIELD_NAME =
   /(?:path|file|filename|basename|message|text|transcript|stdout|stderr|env|token|secret|password|key|url|prompt|content|raw)/i;
+// Only sees values SAFE_STRING_VALUE accepted, so a URI-scheme arm here could never fire (#900).
 const UNSAFE_STRING_VALUE =
-  /(?:[\\/]|^[A-Za-z][A-Za-z0-9+.-]*:|[A-Za-z0-9_-][A-Za-z0-9_.-]*\.(?:aac|aiff?|caf|flac|m4a|m4v|mov|mp3|mp4|ogg|opus|wav|webm|wma)\b|(?:[A-Za-z0-9-]+\.)+[A-Za-z]{2,}\b)/i;
+  /(?:[\\/]|[A-Za-z0-9_-][A-Za-z0-9_.-]*\.(?:aac|aiff?|caf|flac|m4a|m4v|mov|mp3|mp4|ogg|opus|wav|webm|wma)\b|(?:[A-Za-z0-9-]+\.)+[A-Za-z]{2,}\b)/i;
 const RESERVED_FIELD_NAMES = new Set(["ts", "level", "event", "app_version", "pid"]);
 
 export type DiagnosticLogValue = string | number | boolean | null;

--- a/tests/unit/diagnostic-log.test.ts
+++ b/tests/unit/diagnostic-log.test.ts
@@ -400,3 +400,21 @@ describe("a buffered session only spends the disk it has to", () => {
     expect(existsSync(resolveDiagnosticLogPath())).toBe(false);
   });
 });
+
+// Pins the behaviour that made the URI-scheme arm of UNSAFE_STRING_VALUE unreachable: a colon
+// never survives SAFE_STRING_VALUE, so a scheme is rejected one condition earlier (#897 review).
+describe("a scheme-shaped value is refused whatever matches it", () => {
+  for (const value of ["mailto:alice", "data:abc", "file:notes", "x:y", "custom+scheme:1", "a:"]) {
+    test(`"${value}" is refused`, () => {
+      expect(() => buildDiagnosticLogLine("privacy.scheme", { endpoint: value })).toThrow(
+        "unsafe diagnostic string field",
+      );
+    });
+  }
+
+  test("the colon is what disqualifies it, not the word before it", () => {
+    expect(() =>
+      buildDiagnosticLogLine("privacy.scheme", { endpoint: "mailto" }),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
Follow-up to the finding flagged in #894: nine of that file's surviving mutants were all edits to one arm of `UNSAFE_STRING_VALUE` — the URI-scheme matcher `^[A-Za-z][A-Za-z0-9+.-]*:`.

They survived because **no input can reach it**. `validateField` evaluates `UNSAFE_STRING_VALUE` only after `SAFE_STRING_VALUE` has accepted the value:

```ts
if (!SAFE_STRING_VALUE.test(value) || UNSAFE_STRING_VALUE.test(value)) throw …
```

and `SAFE_STRING_VALUE` is `^[A-Za-z0-9_.@+-]{1,120}$` — an alphabet with no colon. Anything scheme-shaped is rejected one condition earlier, so the arm is dead code guarding nothing.

## Behaviour is unchanged, and checked rather than argued

A differential run over **every string up to length three** from an alphabet including `:`, `/`, `\`, `.`, `@`, `+`, `-` and a space — 4379 inputs, plus targeted shapes like `mailto:alice@example.com`, `data:text/plain;base64,…`, `urn:uuid:…`, `custom+scheme-1:v` — gives an identical accept/reject decision before and after:

```
inputs checked: 4379
divergent decisions: 0
```

A characterization test pins what actually matters: a scheme-shaped value is still refused, by the earlier condition. It passes on both sides of the change, which is the point — it would have caught the removal if the two arms had not overlapped.

## Numbers

Measured on this commit with the same tests, source change stashed and unstashed:

| | mutation score | survivors |
|---|---|---|
| before | 74.42% | 50 |
| after | **75.88%** | **44** |

The six that disappear are the unreachable ones. Five mutations of the remaining arms still survive — those are shadowed by *each other* (a media filename like `meeting.mp3` also matches the domain arm), which is a different kind of overlap and not addressed here.

## On removing a privacy guard

Worth stating plainly, since this is a redaction filter: the arm is not defence in depth today, it is unreachable. If `SAFE_STRING_VALUE` ever gains `:`, the scheme case needs handling again — and the comment left in its place says so, so the next person changing that alphabet is told what it used to buy.

## Verification

`bun run test` 1234 pass / 6 skip · `bunx tsc --noEmit`