### PR TITLE
ci(cache): give macOS-kesha-models-tts-v1 the writer it never had

### DIFF
--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -39,7 +39,14 @@ function requirePinnedActions(path: string, contents: string): string[] {
   return errors;
 }
 
-type Step = { name?: unknown; run?: unknown; uses?: unknown; if?: unknown; shell?: unknown; with?: { filters?: unknown } };
+type Step = {
+  name?: unknown;
+  run?: unknown;
+  uses?: unknown;
+  if?: unknown;
+  shell?: unknown;
+  with?: { filters?: unknown } & Record<string, unknown>;
+};
 
 function jobSteps(document: unknown, job: string): Step[] | undefined {
   const steps = (document as { jobs?: Record<string, { steps?: unknown[] }> })?.jobs?.[job]?.steps;
@@ -285,6 +292,81 @@ export function requireBashOnWindowsRunSteps(path: string, document: unknown): s
 }
 
 /**
+ * Fails when a restore-only model cache has no writer, or has one that disagrees about the entry.
+ *
+ * `cache-write: "false"` hands the whole responsibility for an entry to cache-seed.yml (#661). Nothing
+ * connected the two halves, so `macOS-kesha-models-tts-v1` was restored by the release-gating darwin
+ * smoke for months while no job ever wrote it — a silent cold download, not a failure (#877). The path
+ * set and archive mode are compared too: a reader whose path set differs from the writer's misses every
+ * time and looks exactly the same from the outside (#860).
+ */
+type CacheEntry = { key: string; paths: string[]; crossOs: boolean };
+
+const cachePaths = (value: unknown): string[] =>
+  String(value ?? "")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+const describeEntry = (entry: CacheEntry) =>
+  `path ${JSON.stringify(entry.paths)}${entry.crossOs ? " (cross-OS)" : ""}`;
+
+/** Every exact key cache-seed.yml saves, with the path set and archive mode it saves under. */
+export function collectCacheWriters(document: unknown): CacheEntry[] {
+  const jobs = (document as { jobs?: Record<string, { steps?: unknown[] }> })?.jobs ?? {};
+  return Object.values(jobs).flatMap((job) =>
+    (Array.isArray(job?.steps) ? (job.steps as Step[]) : [])
+      .filter((step) => typeof step?.uses === "string" && step.uses.startsWith("actions/cache/save"))
+      .map((step) => ({
+        key: String(step.with?.key ?? ""),
+        paths: cachePaths(step.with?.path),
+        crossOs: String(step.with?.enableCrossOsArchive ?? false) === "true",
+      })),
+  );
+}
+
+export function requireRestoreOnlyCachesHaveAWriter(
+  path: string,
+  document: unknown,
+  writers: CacheEntry[],
+): string[] {
+  const jobs = (document as { jobs?: Record<string, { steps?: unknown[] }> })?.jobs;
+  if (!jobs || typeof jobs !== "object") return [];
+
+  const errors: string[] = [];
+  for (const [name, job] of Object.entries(jobs)) {
+    if (!Array.isArray(job?.steps)) continue;
+    for (const step of job.steps as Step[]) {
+      if (step?.uses !== "./.github/actions/install-kesha-backend") continue;
+      if (String(step.with?.["cache-write"] ?? "true") !== "false") continue;
+
+      const reader: CacheEntry = {
+        key: String(step.with?.["cache-key"] ?? ""),
+        paths: cachePaths(step.with?.["cache-path"]),
+        crossOs: String(step.with?.["cache-cross-os"] ?? false) === "true",
+      };
+      const writer = writers.find((entry) => entry.key === reader.key);
+      if (!writer) {
+        errors.push(
+          `${path}: \`${name}\` restores \`${reader.key}\` with cache-write false, but no cache-seed.yml job saves that key — it can only ever cold-download (#877)`,
+        );
+        continue;
+      }
+      if (
+        writer.paths.join("\n") !== reader.paths.join("\n") ||
+        writer.crossOs !== reader.crossOs
+      ) {
+        errors.push(
+          `${path}: \`${name}\` restores \`${reader.key}\` at ${describeEntry(reader)}, but cache-seed.yml saves it at ${describeEntry(writer)}; a restore that disagrees with its writer never hits (#877)`,
+        );
+      }
+    }
+  }
+
+  return errors;
+}
+
+/**
  * Fails when a script covered by a unit test sits outside ci.yml's `code` filter.
  * `check:versions` and the unit tests run inside `unit-tests`, which that filter gates,
  * so an uncovered script means edits to a gate skip the tests that prove it works.
@@ -336,7 +418,7 @@ function describeUnreadable(path: string, err: unknown): string {
   return `${path}: ${err instanceof Error ? err.message : String(err)}`;
 }
 
-function checkFile(path: string, testedScripts: string[]): string[] {
+function checkFile(path: string, testedScripts: string[], cacheWriters: CacheEntry[]): string[] {
   try {
     const contents = readFileSync(path, "utf8");
     const document = parse(contents);
@@ -348,12 +430,15 @@ function checkFile(path: string, testedScripts: string[]): string[] {
       ...requireNpmPublishAfterPackaging(path, document),
       ...requirePactVerificationCoversEveryTarget(path, document),
       ...requireBashOnWindowsRunSteps(path, document),
+      ...requireRestoreOnlyCachesHaveAWriter(path, document, cacheWriters),
       ...requireTestedScriptsInCodeFilter(path, document, testedScripts),
     ];
   } catch (err) {
     return [describeUnreadable(path, err)];
   }
 }
+
+const SEED_WORKFLOW = ".github/workflows/cache-seed.yml";
 
 function main(): void {
   const files = dirs.flatMap((dir) => collectYamlFiles(dir)).sort();
@@ -363,7 +448,11 @@ function main(): void {
   }
 
   const testedScripts = collectTestedScripts();
-  const errors = files.flatMap((path) => checkFile(path, testedScripts));
+  // A missing seed workflow leaves every restore-only lane unwritten, which is the failure to report.
+  const cacheWriters = existsSync(SEED_WORKFLOW)
+    ? collectCacheWriters(parse(readFileSync(SEED_WORKFLOW, "utf8")))
+    : [];
+  const errors = files.flatMap((path) => checkFile(path, testedScripts, cacheWriters));
   for (const error of errors) console.error(error);
 
   if (errors.length > 0) {

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -403,8 +403,9 @@ jobs:
       # FluidAudio owns `~/.cache/fluidaudio` — the ANE voice packs install stages, plus the bundle it self-fetches.
       # Left out of the `kesha-models-tts-v3` share on purpose: this row caches a second path the other
       # lanes do not, so it cannot read their entry. Staying per-OS also keeps it off the cross-OS rules —
-      # a same-OS archive restores to the home dir it was saved from. `macOS-kesha-models-tts-*` has never
-      # been written by anything, so this row has always cold-downloaded and still does (#860).
+      # a same-OS archive restores to the home dir it was saved from. cache-seed.yml's `kesha-models-darwin`
+      # is the only writer of this key; path, key and archive mode must stay identical on both sides or
+      # the restore silently misses, which is how it went a year cold-downloading (#877).
       - name: 🔊 Install English TTS models
         uses: ./.github/actions/install-kesha-backend
         with:

--- a/.github/workflows/cache-seed.yml
+++ b/.github/workflows/cache-seed.yml
@@ -217,3 +217,77 @@ jobs:
           path: .kesha-ci-cache
           key: kesha-models-tts-v3
           enableCrossOsArchive: true
+
+  kesha-models-darwin:
+    name: Kesha models (darwin TTS)
+    # The writer `macOS-kesha-models-tts-v1` never had. `darwin-synthesis-smoke` restores that key
+    # restore-only and gates every engine tag (#819), so without this job it cold-downloaded the whole
+    # model set from Hugging Face on each tag build — 23 of 29 historical failures on that lane were HF
+    # network errors at exactly the fetch step (#877). The schedule above is what keeps it warm between
+    # releases; a release-only lane would otherwise be evicted long before the next tag.
+    #
+    # A separate entry from `kesha-models-tts-v3`, not an oversight: a darwin build stages FluidAudio
+    # ANE bundles the ONNX lanes never fetch, and Kokoro's G2P assets live under `~/.cache/fluidaudio`,
+    # a path upstream pins and `KESHA_CACHE_DIR` cannot move (#688). So this entry is home-relative and
+    # same-OS by construction — no `enableCrossOsArchive`, and none of the #860 remap rules apply,
+    # because a same-OS archive restores to the home directory it was saved from.
+    #
+    # Runner matched to the consumer's `macos-15`: the payload is data, but the smoke below runs the
+    # same CoreML path that lane does, and only there is it evidence.
+    runs-on: macos-15
+    timeout-minutes: 40
+    env:
+      # FluidAudio reports CoreML failures on stdout, which the bridge guard discards (#678).
+      KESHA_DEBUG: "1"
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Probe cache
+        id: probe
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cache/kesha
+            ~/.cache/fluidaudio
+          key: ${{ runner.os }}-kesha-models-tts-v1
+          lookup-only: true
+
+      - name: 🍞 Setup Bun workspace
+        if: steps.probe.outputs.cache-hit != 'true'
+        uses: ./.github/actions/setup-bun
+
+      # No cache inputs: the probe above already decided, and the save below is this job's own step.
+      - name: Populate models
+        if: steps.probe.outputs.cache-hit != 'true'
+        uses: ./.github/actions/install-kesha-backend
+        with:
+          ffmpeg-provider: skip
+          install-args: --tts en
+
+      # `install` exits 0 on a failed warm-up and the exact key is immutable, so a partial save would
+      # poison every later tag build instead of being repaired (#675). Synthesising is the consumer's
+      # own check, run before the bytes are archived. The short sentence is load-bearing: a hosted
+      # runner has no ANE, and its CPU CoreML takes SIGBUS on longer shapes (#742).
+      - name: Verify the bundle synthesises before saving
+        if: steps.probe.outputs.cache-hit != 'true'
+        shell: bash
+        run: bun .github/scripts/smoke-synthesis.ts --no-roundtrip --text "Kesha speaks." synthesis-smoke
+
+      # The consumer stages its freshly built engine and sidecar from the build artifacts, so a
+      # published binary here is dead weight — and at tag time, the previous version's.
+      - name: Drop the engine before saving
+        if: steps.probe.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          rm -rf ~/.cache/kesha/engine
+          test ! -e ~/.cache/kesha/engine
+
+      - name: Save models
+        if: steps.probe.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cache/kesha
+            ~/.cache/fluidaudio
+          key: ${{ runner.os }}-kesha-models-tts-v1

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -1,8 +1,10 @@
 import { readdirSync } from "node:fs";
 import { describe, expect, test } from "bun:test";
 import {
+  collectCacheWriters,
   forbidLinuxPackaging,
   requireBashOnWindowsRunSteps,
+  requireRestoreOnlyCachesHaveAWriter,
   requireDarwinSmokeCoversBothEngines,
   requireNpmPublishAfterPackaging,
   requirePactVerificationCoversEveryTarget,
@@ -354,5 +356,68 @@ describe("requireBashOnWindowsRunSteps", () => {
 
   test("a matrix it cannot resolve is not treated as windows", () => {
     expect(errorsFor(matrixJob({ os: "${{ fromJSON(needs.plan.outputs.os) }}" }))).toEqual([]);
+  });
+});
+
+describe("requireRestoreOnlyCachesHaveAWriter", () => {
+  const SEED = ".github/workflows/cache-seed.yml";
+  const writers = collectCacheWriters(parseRepoYaml(SEED));
+
+  const reader = (inputs: Record<string, string>) =>
+    job("smoke", [
+      { name: "install", uses: "./.github/actions/install-kesha-backend", with: { "cache-write": "false", ...inputs } },
+    ]);
+  const MODELS = { "cache-key": "models-v1", "cache-path": "~/.cache/kesha\n~/.cache/fluidaudio\n" };
+  const seeded = [{ key: "models-v1", paths: ["~/.cache/kesha", "~/.cache/fluidaudio"], crossOs: false }];
+  const errorsFor = (document: unknown, entries = seeded) =>
+    requireRestoreOnlyCachesHaveAWriter(CI, document, entries);
+
+  test("every restore-only lane in the repo has a matching writer", () => {
+    for (const file of readdirSync(repoPath(".github/workflows"))) {
+      const path = `.github/workflows/${file}`;
+      const errors = requireRestoreOnlyCachesHaveAWriter(path, parseRepoYaml(path), writers);
+      expect([path, errors]).toEqual([path, []]);
+    }
+  });
+
+  test("passes when the reader and the seed agree", () => {
+    expect(errorsFor(reader(MODELS))).toEqual([]);
+  });
+
+  test("fails when no seed job writes the key it restores", () => {
+    const errors = errorsFor(reader({ ...MODELS, "cache-key": "models-v2" }));
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("no cache-seed.yml job saves that key");
+  });
+
+  test("fails when the seed saves a different path set", () => {
+    const errors = errorsFor(reader({ ...MODELS, "cache-path": "~/.cache/kesha" }));
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("never hits");
+  });
+
+  test("fails when the two halves disagree about the cross-OS archive", () => {
+    expect(errorsFor(reader({ ...MODELS, "cache-cross-os": "true" }))).toHaveLength(1);
+  });
+
+  // A lane that seeds itself owns its entry; the rule is about handing that job to cache-seed.yml.
+  test("ignores a lane that still writes its own cache", () => {
+    const document = reader({ ...MODELS, "cache-write": "${{ github.event_name != 'pull_request' }}" });
+    expect(errorsFor(document)).toEqual([]);
+  });
+
+  test("collectCacheWriters reads a multi-line path block and the cross-OS flag", () => {
+    const save = job("seed", [
+      {
+        uses: "actions/cache/save@55cc834",
+        with: { path: ".kesha-ci-cache\n", key: "models-v3", enableCrossOsArchive: true },
+      },
+    ]);
+    expect(collectCacheWriters(save)).toEqual([{ key: "models-v3", paths: [".kesha-ci-cache"], crossOs: true }]);
+  });
+
+  test("a restore step is not a writer", () => {
+    const restore = job("seed", [{ uses: "actions/cache/restore@55cc834", with: { path: "x", key: "models-v3" } }]);
+    expect(collectCacheWriters(restore)).toEqual([]);
   });
 });


### PR DESCRIPTION
Closes #877

Per the owner decision on #877 — option (a): add macos to the cache-seed matrix so the release-critical `darwin-synthesis-smoke` lane stops cold-downloading its model set from Hugging Face on every tag build.

## Writer / reader agreement

The bug was never a wrong key — it was a reader with no writer at all. Both halves now derive the entry identically:

| | writer — `cache-seed.yml` job `kesha-models-darwin` | reader — `build-engine.yml` job `darwin-synthesis-smoke` |
|---|---|---|
| key | `${{ runner.os }}-kesha-models-tts-v1` | `${{ runner.os }}-kesha-models-tts-v1` |
| path | `~/.cache/kesha` + `~/.cache/fluidaudio` | `~/.cache/kesha` + `~/.cache/fluidaudio` |
| archive | same-OS (no `enableCrossOsArchive`) | same-OS (no `enableCrossOsArchive`) |
| runner | `macos-15` | `macos-15` |
| mode | `actions/cache/save` after a `lookup-only` probe | `cache-write: "false"` (restore only) |

**No key bump.** The path derivation is unchanged, and `v1` has never been written by anything, so there is no stale content the reader could pick up. The reader's `cache-restore-keys: ${{ runner.os }}-kesha-models-tts-` prefix stays as the fallback for a future bump.

**Not the shared `kesha-models-tts-v3` entry, and not workspace-relative.** A darwin build stages FluidAudio ANE bundles the ONNX lanes never fetch, and Kokoro's G2P assets live under `~/.cache/fluidaudio` — a path upstream pins, which `KESHA_CACHE_DIR` cannot move (#688). The entry is therefore home-relative by necessity; the workspace-relative `.kesha-ci-cache` pattern exists to make *cross-OS* archives remap correctly (#860), and nothing here crosses an OS. A same-OS archive restores to the home directory it was saved from, which the `parakeet-coreml-models-v2` seed already relies on.

## The regression guard lands first

`check-workflows.ts` gains `requireRestoreOnlyCachesHaveAWriter`: every `install-kesha-backend` step with `cache-write: "false"` must have a `cache-seed.yml` job saving that exact key, at the same path set and archive mode. Commit 1 is red on `build-engine.yml` with precisely the #877 message; commit 2 turns it green. This is the class of bug the issue is about — a writer and a reader that do not agree are worse than no writer, because the miss is silent.

The existing `kesha-models-tts-v3` pairing already satisfies the rule, so it locks in today's agreement too.

## Anti-poison gate

An exact cache key is immutable, and `kesha install` exits 0 on a failed warm-up — a partial bundle saved here would be restored by every later tag build rather than repaired (#675, the shape that bit the ASR seed). The seed therefore synthesises through Kokoro/CoreML before saving, using the same short sentence the consumer uses; a hosted runner has no ANE and its CPU CoreML takes SIGBUS on longer shapes (#742). If that fails, nothing is saved and the entry stays absent — status quo, not poison. The published engine binary is dropped before the save, mirroring the linux seed's `engine/` purge: the smoke lane stages its own freshly built engine and sidecar from the build artifacts.

## Cap budget

~2.6 GB steady state, taking the repo to ~77% of cap on the post-#860 baseline of 5.13 GB / 51.3%. The weekly `schedule:` is what makes this worth holding — a release-only lane's entry would otherwise be evicted by LRU long before the next tag. Roughly 450 MB of the entry duplicates the `parakeet-coreml-models-v2` FluidAudio ASR bundle, because `kesha install`'s warm-up fetches it and the consumer restores `~/.cache/kesha` wholesale; purging it before the save would put an HF download back on the release path, which is the thing this PR removes.

## Verification

YAML-only in effect — this environment downloads no engine or models, so the real proof is the first seed run on `main`.

Local gates, all green at `3c31f48`:
- `bun run check:workflows` — clean (includes the #850 shell rule, the pinned-SHA rule, and the new writer rule)
- `just preflight` — 1235 pass / 0 fail across 87 files, `bunx tsc --noEmit` clean; Rust and CoreML gates correctly skipped (no `rust/` changes)
- `bun run check` — 1097 pass / 0 fail
- Every `${{ }}` stays out of `run:` (#291); the two new `run:` steps use only literals and `shell: bash`.

Post-merge plan, in order:
1. `gh workflow run cache-seed.yml --ref main`, watch `Kesha models (darwin TTS)`: expect a probe miss, a populate, a green synthesis smoke, then the save.
2. Confirm `macOS-kesha-models-tts-v1` appears in `gh cache list` with a non-trivial size, and record the actual size against the ~2.6 GB estimate.
3. Dispatch or wait for a `build-engine.yml` run and confirm `darwin-synthesis-smoke` reports a cache **hit** on that key and skips the HF fetches — that is the only thing that proves the two halves agree in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBTpJjqyYFW6W8LHJ2nwy