### PR TITLE
fix(models): bound the download body by silence, not by elapsed time

### DIFF
--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -3094,10 +3094,12 @@ const BODY_STALL_BUDGET: Duration = Duration::from_secs(30);
 /// deadline and nothing else bounds it, so deleting that line would silently
 /// unbound the header wait (#893).
 ///
-/// `stall_budget` is meant to abort a body that has gone silent, but
-/// `timeout_recv_response` is stamped at headers-received and `RecvBody`
-/// inherits it, so today it caps the *whole body* instead — which is what makes
-/// a 654MB artifact unreachable on a slow link (#776).
+/// `stall_budget` is a *rolling* window: `RecvBody` inherits only
+/// `RecvResponse`, so leaving the latter unset re-arms the deadline on every
+/// read and the body aborts on silence rather than on elapsed time. Setting
+/// `timeout_recv_response` again would cap the whole body instead — ureq takes
+/// the minimum — which is what put a 654MB artifact out of reach on a slow link
+/// (#776, #893).
 ///
 /// Status is inspected by the caller rather than raised by ureq so a 429's
 /// `Retry-After` header survives into the backoff decision (#724). `identity`
@@ -3120,7 +3122,7 @@ fn download_request(
         .timeout_resolve(Some(header_budget))
         .timeout_connect(Some(header_budget))
         .timeout_send_request(Some(header_budget))
-        .timeout_recv_response(Some(stall_budget))
+        .timeout_recv_body(Some(stall_budget))
         .build()
 }
 
@@ -4605,7 +4607,11 @@ mod retry_tests {
     /// per-attempt cap, which is why five retries from byte 0 could never
     /// finish a 654MB file (#776). The second arm pins the other half: ureq
     /// takes the *minimum* of the two deadlines, so a generous
-    /// `timeout_recv_body` cannot loosen the cap, which is why it stays unset.
+    /// `timeout_recv_body` cannot loosen the cap.
+    ///
+    /// `download_request` dropped `timeout_recv_response` for exactly this
+    /// reason (#893), so this now characterizes a config we no longer ship —
+    /// which is the point. It is what goes red if anyone puts that knob back.
     ///
     /// Unix only, and that is itself the finding: this same probe on
     /// windows-latest received the whole body well past the deadline, which is

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -3082,6 +3082,48 @@ fn model_download_error(message: String) -> anyhow::Error {
     })
 }
 
+const HEADER_BUDGET: Duration = Duration::from_secs(10);
+const BODY_STALL_BUDGET: Duration = Duration::from_secs(30);
+
+/// The request policy every download attempt runs under. ureq ships no timeouts
+/// at all, so without these a host that accepts the connection and then goes
+/// quiet hangs the install forever.
+///
+/// `header_budget` is what bounds the wait for response headers, and it rides on
+/// `timeout_send_request`: `RecvResponse` inherits `SendRequest`'s absolute
+/// deadline and nothing else bounds it, so deleting that line would silently
+/// unbound the header wait (#893).
+///
+/// `stall_budget` is meant to abort a body that has gone silent, but
+/// `timeout_recv_response` is stamped at headers-received and `RecvBody`
+/// inherits it, so today it caps the *whole body* instead — which is what makes
+/// a 654MB artifact unreachable on a slow link (#776).
+///
+/// Status is inspected by the caller rather than raised by ureq so a 429's
+/// `Retry-After` header survives into the backoff decision (#724). `identity`
+/// because a `Range` addresses the encoded representation: mixing a decompressed
+/// prefix with an encoded remainder would corrupt the assembly, and ureq strips
+/// `content-encoding` after decoding so the response cannot be inspected for it
+/// afterwards.
+///
+/// Both budgets are parameters so tests can drive the real policy at a scaled
+/// deadline instead of waiting out the production one.
+fn download_request(
+    url: &str,
+    header_budget: Duration,
+    stall_budget: Duration,
+) -> ureq::RequestBuilder<ureq::typestate::WithoutBody> {
+    ureq::get(url)
+        .config()
+        .http_status_as_error(false)
+        .accept_encoding("identity")
+        .timeout_resolve(Some(header_budget))
+        .timeout_connect(Some(header_budget))
+        .timeout_send_request(Some(header_budget))
+        .timeout_recv_response(Some(stall_budget))
+        .build()
+}
+
 /// One GET plus its verified stream to disk. Every failure path reports whether
 /// it is worth retrying; the caller owns the backoff.
 ///
@@ -3102,31 +3144,7 @@ fn download_attempt(
     let part = staging_path(target);
     let staged = fs::metadata(&part).map(|m| m.len()).unwrap_or(0);
 
-    // Status is inspected here rather than raised by ureq so a 429's
-    // `Retry-After` header survives into the backoff decision (#724).
-    //
-    // ureq ships no timeouts by default, so without these a host that accepts
-    // the connection and then goes quiet hangs the install forever. Measured on
-    // ureq 3.3 (#889): `timeout_recv_response` is anchored at headers-received
-    // and `RecvBody` inherits it, so it caps the *whole body* at 30s per
-    // attempt rather than detecting a stall. `timeout_recv_body` stays unset
-    // because ureq takes the minimum of the two — setting it can only tighten
-    // that cap, never lift it. Range-resume is what makes the cap survivable:
-    // every attempt keeps the bytes it did receive.
-    //
-    // `identity` because a `Range` addresses the encoded representation: mixing
-    // a decompressed prefix with an encoded remainder would corrupt the
-    // assembly, and ureq strips `content-encoding` after decoding so the
-    // response cannot be inspected for it afterwards.
-    let mut request = ureq::get(url)
-        .config()
-        .http_status_as_error(false)
-        .accept_encoding("identity")
-        .timeout_resolve(Some(Duration::from_secs(10)))
-        .timeout_connect(Some(Duration::from_secs(10)))
-        .timeout_send_request(Some(Duration::from_secs(10)))
-        .timeout_recv_response(Some(Duration::from_secs(30)))
-        .build();
+    let mut request = download_request(url, HEADER_BUDGET, BODY_STALL_BUDGET);
     if staged > 0 {
         request = request.header("range", format!("bytes={staged}-"));
     }
@@ -4413,9 +4431,22 @@ mod retry_tests {
         );
     }
 
+    /// Reads the request line and headers off `stream`, returning false if the
+    /// peer hung up first.
+    fn read_request(stream: &mut std::net::TcpStream) -> bool {
+        let mut request = Vec::new();
+        let mut buf = [0u8; 512];
+        while !request.windows(4).any(|w| w == b"\r\n\r\n") {
+            match stream.read(&mut buf) {
+                Ok(0) | Err(_) => return false,
+                Ok(n) => request.extend_from_slice(&buf[..n]),
+            }
+        }
+        true
+    }
+
     /// Streams a complete `chunk * chunks` body, `gap_ms` apart, then closes.
     /// The socket never goes quiet before the last byte.
-    #[cfg(unix)]
     fn streaming_server(chunk: usize, chunks: usize, gap_ms: u64) -> String {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind streaming server");
         let base = format!("http://{}", listener.local_addr().expect("stub addr"));
@@ -4423,13 +4454,8 @@ mod retry_tests {
             let Ok((mut stream, _)) = listener.accept() else {
                 return;
             };
-            let mut request = Vec::new();
-            let mut buf = [0u8; 512];
-            while !request.windows(4).any(|w| w == b"\r\n\r\n") {
-                match stream.read(&mut buf) {
-                    Ok(0) | Err(_) => return,
-                    Ok(n) => request.extend_from_slice(&buf[..n]),
-                }
+            if !read_request(&mut stream) {
+                return;
             }
             let head = format!(
                 "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
@@ -4447,6 +4473,129 @@ mod retry_tests {
             }
         });
         base
+    }
+
+    /// Promises `promised` bytes, sends `sent` of them, then holds the socket
+    /// open and quiet for `silence_ms` without ever closing it.
+    fn stalling_server(sent: usize, promised: usize, silence_ms: u64) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind stalling server");
+        let base = format!("http://{}", listener.local_addr().expect("stub addr"));
+        std::thread::spawn(move || {
+            let Ok((mut stream, _)) = listener.accept() else {
+                return;
+            };
+            if !read_request(&mut stream) {
+                return;
+            }
+            let head = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {promised}\r\nConnection: close\r\n\r\n"
+            );
+            if stream.write_all(head.as_bytes()).is_err() {
+                return;
+            }
+            if stream.write_all(&vec![b'k'; sent]).is_err() {
+                return;
+            }
+            let _ = stream.flush();
+            std::thread::sleep(Duration::from_millis(silence_ms));
+        });
+        base
+    }
+
+    /// Accepts the connection, reads the request, and never answers it.
+    fn silent_server(silence_ms: u64) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind silent server");
+        let base = format!("http://{}", listener.local_addr().expect("stub addr"));
+        std::thread::spawn(move || {
+            let Ok((mut stream, _)) = listener.accept() else {
+                return;
+            };
+            let _ = read_request(&mut stream);
+            std::thread::sleep(Duration::from_millis(silence_ms));
+        });
+        base
+    }
+
+    /// The regression #893 exists for: a link slower than the receive window was
+    /// cut mid-stream no matter how many times it retried, which is what put a
+    /// 654MB artifact out of reach on ubuntu and macOS (#776). The stall budget
+    /// is rolling, so a body that keeps arriving keeps its window alive.
+    #[test]
+    fn a_steady_body_outlasting_the_stall_budget_completes() {
+        const BUDGET: Duration = Duration::from_millis(500);
+        const CHUNK: usize = 64;
+        const CHUNKS: usize = 60;
+
+        let base = streaming_server(CHUNK, CHUNKS, 20);
+        let started = std::time::Instant::now();
+        let response = download_request(&format!("{base}/payload.bin"), BUDGET, BUDGET)
+            .call()
+            .expect("headers arrive promptly");
+
+        let mut sink = Vec::new();
+        io::copy(&mut response.into_body().into_reader(), &mut sink)
+            .expect("a body that never goes silent must not be cut");
+
+        assert_eq!(sink.len(), CHUNK * CHUNKS);
+        assert!(
+            started.elapsed() > BUDGET,
+            "the body finished inside the budget, so nothing was proven"
+        );
+    }
+
+    /// The other half of the swap: the budget must still fire on a body that
+    /// really has stopped, and leave the prefix behind for #889's resume.
+    #[test]
+    fn a_body_that_goes_silent_is_cut_at_the_stall_budget() {
+        const BUDGET: Duration = Duration::from_millis(500);
+        const SENT: usize = 64;
+
+        let base = stalling_server(SENT, SENT * 4, 5_000);
+        let started = std::time::Instant::now();
+        let response = download_request(&format!("{base}/payload.bin"), BUDGET, BUDGET)
+            .call()
+            .expect("headers arrive promptly");
+
+        let mut sink = Vec::new();
+        let err = io::copy(&mut response.into_body().into_reader(), &mut sink)
+            .expect_err("a body that stopped arriving must be cut");
+        let elapsed = started.elapsed();
+
+        assert_eq!(sink.len(), SENT, "the prefix must survive for resume");
+        assert!(
+            (BUDGET..BUDGET * 4).contains(&elapsed),
+            "aborted after {elapsed:?}, budget {BUDGET:?}"
+        );
+        assert!(err.to_string().to_lowercase().contains("timeout"), "{err}");
+    }
+
+    /// The coupling the swap rests on. With the body budget generous, the only
+    /// thing that can still cut a host which accepts and never answers is
+    /// `timeout_send_request`; without this test, dropping that line would
+    /// reintroduce an unbounded hang with nothing going red (#893).
+    #[test]
+    fn a_host_that_never_answers_is_cut_by_the_header_budget() {
+        const BUDGET: Duration = Duration::from_millis(500);
+
+        let base = silent_server(5_000);
+        let started = std::time::Instant::now();
+        let err = download_request(
+            &format!("{base}/payload.bin"),
+            BUDGET,
+            Duration::from_secs(30),
+        )
+        .call()
+        .expect_err("a host that never answers must be cut");
+        let elapsed = started.elapsed();
+
+        assert!(
+            (BUDGET..BUDGET * 4).contains(&elapsed),
+            "aborted after {elapsed:?}, budget {BUDGET:?}"
+        );
+        assert!(
+            matches!(err, ureq::Error::Timeout(ureq::Timeout::SendRequest)),
+            "{err}"
+        );
     }
 
     /// #780 inferred that the receive deadline detects a stall; #889 asked for


### PR DESCRIPTION
Closes #893

## What changed

`download_attempt` bounded the response body with `timeout_recv_response(30s)`. ureq stamps that deadline at headers-received and `RecvBody` inherits it (`Timeout::preceeding()` — `RecvBody`'s only predecessor is `RecvResponse`), so the 30s was an **absolute cap on the whole body**, not a stall detector: a fresh ONNX install needed ≥16 MB/s sustained or the encoder weights were unreachable at any number of retries (#776). This swaps the knob to `timeout_recv_body(30s)` and leaves `recv_response` unset. Because `RecvBody` then has no inherited term left, ureq re-arms the deadline before every socket read, so the same 30s constant changes meaning from "the body may not take longer than this" to "the body may not go silent for longer than this". `MAX_DOWNLOAD_ATTEMPTS`, the backoff and the #889 resume logic are untouched — they now fire on real stalls instead of on slow-but-healthy links.

The header wait was never bounded by `recv_response`: `RecvResponse` inherits `SendRequest`'s absolute deadline, and with `timeout_send_request(10s)` set that minimum always won. That coupling is now load-bearing, so it is both stated in the doc comment on `download_request` and pinned by a test — deleting the `timeout_send_request` line would otherwise silently unbound the header wait with nothing going red.

To make any of this testable without waiting out a 30s production deadline, the request policy moved into `download_request(url, header_budget, stall_budget)`. That is the only structural change; the call site passes the same 10s/30s values it always did.

## Test evidence

Red first (`0213398`), with production still on `recv_response`:

```
a_steady_body_outlasting_the_stall_budget_completes ... FAILED
  a body that never goes silent must not be cut:
  Custom { kind: Other, error: Timeout(RecvResponse) }
```

The server streams 60 × 64 B chunks 20 ms apart (1.2 s total, never quiet) against a 500 ms budget. Green after `f52050d`: full 3840 bytes, no error.

Three cases, all driving the real `download_request`:

| test | asserts |
|---|---|
| `a_steady_body_outlasting_the_stall_budget_completes` | a body that keeps arriving completes past the budget (**red before, green after**) |
| `a_body_that_goes_silent_is_cut_at_the_stall_budget` | a body that stops is cut within the budget, `timeout` error, and the prefix survives for resume |
| `a_host_that_never_answers_is_cut_by_the_header_budget` | with a 30 s body budget, a host that accepts and never answers is still cut at the header budget with `Timeout(SendRequest)` |

`models::retry_tests` 27/27 green, ~4 s; the three new ones repeated 10× locally with no flake. Full `just ALL=1 preflight` green.

None of the three carries `#[cfg(unix)]`, and **that settles #893's open prediction**. The issue argued that Windows ignores the absolute deadline but should still honour `SO_RCVTIMEO` on the *no-data-at-all* path, so the stall detector ought to work there and close a gap Windows has never had a bound for. It does — `test (windows-latest)` on `f52050d`:

```
PASS [0.555s] models::retry_tests::a_body_that_goes_silent_is_cut_at_the_stall_budget
PASS [0.559s] models::retry_tests::a_host_that_never_answers_is_cut_by_the_header_budget
PASS [1.221s] models::retry_tests::a_steady_body_outlasting_the_stall_budget_completes
```

Both timeout cases fired at ~0.55 s against a 500 ms budget, so the deadline really was enforced rather than passed through. Windows gains body-stall protection it did not have before this PR, and `#[cfg(unix)]` remains only on #892's absolute-cap characterization, where it belongs.

## #892's characterization test

`the_receive_deadline_caps_the_whole_body_not_just_a_stall` is kept, unchanged in body and name. It configures its own agent rather than production's, so it still passes. Its doc comment lost one stale clause ("which is why it stays unset") and gained two sentences saying it now characterizes a config we no longer ship — which is its remaining job: it is what goes red if anyone puts `timeout_recv_response` back.

## Residual: a trickle host is unbounded

Per the owner decision, nothing was added for this. A server sending a byte a second never trips a rolling window, so such a transfer now runs without an outer bound where the old absolute cap ended it by accident. It stays visible (progress bar) and interruptible (Ctrl-C), and the honest trade is that the same cap made a legitimate 2.4 GB download impossible. A sanity bound is one line — `timeout_global` / `timeout_per_call` are both unset and both absolute — if a "slow but alive forever" report ever arrives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBTpJjqyYFW6W8LHJ2nwy
