### PR TITLE
fix(dx): raise the stryker child ceiling so a whole-suite pairing can run

### DIFF
--- a/stryker.conf.mjs
+++ b/stryker.conf.mjs
@@ -5,11 +5,6 @@
 //
 // Scoped runs are fast: 44 mutants in ~1s, 1.3 tests per mutant, because `perTest` coverage
 // re-runs only the covering tests rather than the suite.
-//
-// KNOWN LIMIT — `testFiles` cannot be a whole-suite glob. Measured: either 30-file half of
-// tests/unit passes; all 60 together wait out the full inspectorTimeout and fail with "Failed to
-// get inspector URL", so the process is alive and the URL never arrives. Cause unconfirmed;
-// NO_COLOR/FORCE_COLOR (shell and bun.env) and a 60s timeout were tried and change nothing.
 export default {
   testRunner: "bun",
   // Stryker auto-loads only @stryker-mutator/*; this runner lives under another scope.
@@ -19,6 +14,8 @@ export default {
   mutate: ["src/voice-routing.ts"],
   bun: {
     testFiles: ["tests/unit/voice-routing.test.ts"],
+    // Child ceiling (dry run gets it +30s); a mutant this kills scores as detected, so 10s inflates.
+    timeout: 180_000,
   },
   // TS 7 removed ts.parseConfigFileTextToJson, which Stryker's sandbox rewriter calls; point it away.
   tsconfigFile: "tsconfig.stryker-none.json",

--- a/tests/unit/stryker-config.test.ts
+++ b/tests/unit/stryker-config.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+
+// Below this the whole-suite dry run is killed mid-flight and slow mutant runs score as detected.
+const CHILD_CEILING_FLOOR_MS = 120_000;
+
+interface StrykerConfig {
+  bun?: { timeout?: number };
+}
+
+async function loadStrykerConfig(): Promise<StrykerConfig> {
+  const href = new URL("../../stryker.conf.mjs", import.meta.url).href;
+  const module_ = (await import(href)) as { default: StrykerConfig };
+  return module_.default;
+}
+
+describe("stryker config", () => {
+  test("pins the bun child-process ceiling above the suite's own runtime", async () => {
+    const config = await loadStrykerConfig();
+
+    expect(config.bun?.timeout).toBeGreaterThanOrEqual(CHILD_CEILING_FLOOR_MS);
+  });
+});


### PR DESCRIPTION
## The blocker

`stryker.conf.mjs` documented a limit it had misdiagnosed:

> KNOWN LIMIT — `testFiles` cannot be a whole-suite glob. […] all 60 together wait out the full inspectorTimeout and fail with "Failed to get inspector URL" […] Cause unconfirmed.

The inspector is fine. It connects and streams 807 events. What actually happens is a child-process kill.

## Root cause

`bun.timeout` was never set, so the runner fell back to its 10 s default. That one value is the child-process ceiling for **both** kinds of run:

| run | ceiling |
|---|---|
| dry run | `bun.timeout` + `DRAIN_ACK_ABSOLUTE_CEILING_MS` (30 s) = **40 s** |
| each mutant run | `bun.timeout` flat = **10 s** |

`tests/unit` takes 47–52 s. The dry run was killed at 40 s, every time, and the failure surfaced as `Dry run timed out` — not as the inspector error the comment named.

## It was never about file count

The six slowest unit files — six, against a note claiming 30 work — total 39.6 s and sit right on the ceiling. Same config, two consecutive runs: one dry run succeeded at 39.6 s, the next was killed. The boundary is wall-clock, and it is flaky by construction.

## The quieter half

`mutation-testing-metrics` scores `totalDetected = timeout + killed`. A mutant killed by the 10 s child ceiling is therefore reported as **caught**. Running six slow suites at the default gave `0 survived, 8 timed out` on a file whose true result is one survivor — the score did not fail loudly, it went up.

## Fix

`bun.timeout: 180_000`. Stryker's own `TimeoutDecorator` still enforces the real per-mutant limit (`timeoutFactor × netTime + timeoutMS + overhead`), so this is a hard backstop, not the working limit.

## Verification

| set | dry run | result |
|---|---|---|
| 67 unit suites | succeeded, 1055 tests, 52 s | 97.73%, 1 survivor, **0 timeouts** |
| 70 suites incl. `tests/integration/e2e-engine.test.ts` | succeeded, 1099 tests, 64 s | 97.73%, 1 survivor, 0 timeouts |

97.73% / 1 survivor is exactly what the hand-paired scoped run reports, so the whole-suite pairing agrees with the narrow one.

`just preflight` — 1228 pass / 6 skip / 0 fail, `tsc --noEmit` clean.

## Follow-up, not in this PR

`scripts/mutants-ts.ts` (#897) caps selection at `MAX_SUITES = 12` and states the cause as "neither timeoutMS, dryRunTimeoutMinutes nor bun.timeout moves it". The runs above disprove that. Today `bun run mutants:ts src/engine.ts` measures 4 of 32 covering suites and prints "not measured: 28 further suite(s)" — so engine.ts scores are pessimistic by an unknown margin. Removing that cap depends on this PR and follows in its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZwnEPwLkVUyfMLNfX9JcW
