### PR TITLE
build(dx): make the worktree ritual a recipe and parameterize the rest (#797 Phase 3)

### DIFF
--- a/.claude/commands/land.md
+++ b/.claude/commands/land.md
@@ -1,7 +1,7 @@
 ---
 description: Land a green PR — verify CI+Greptile on head SHA, confirm issue linkage, merge, and clean up the worktree.
 argument-hint: "[pr-number] (defaults to the current branch's PR)"
-allowed-tools: Bash(gh pr view:*), Bash(gh pr checks:*), Bash(gh pr merge:*), Bash(gh issue view:*), Bash(gh issue close:*), Bash(git worktree:*), Bash(git rev-parse:*)
+allowed-tools: Bash(gh pr view:*), Bash(gh pr checks:*), Bash(gh pr merge:*), Bash(gh issue view:*), Bash(gh issue close:*), Bash(just:*), Bash(git rev-parse:*)
 ---
 
 Finish and merge a PR safely, enforcing the repo's review gate, issue-linkage, and worktree-cleanup rules. **Do not merge** unless CI and Greptile are both green on the latest head SHA.
@@ -28,9 +28,9 @@ Arguments: `$ARGUMENTS` → optional PR number (defaults to the current branch's
    gh pr merge <PR_N> -R drakulavich/kesha-voice-kit --squash --delete-branch
    ```
 
-5. **Clean up the worktree** for the merged branch (from the root checkout):
+5. **Clean up the worktree** for the merged branch — from the root checkout, which the recipe enforces:
    ```bash
-   git worktree remove .worktrees/<slug> && git worktree prune
+   just worktree-rm <slug>
    ```
 
 6. **Verify the issue actually closed** (auto-close can lag for partial links). If it should be closed but isn't (`<ISSUE_N>` is the issue, `<PR_N>` is the PR that landed it):

--- a/.claude/commands/start-issue.md
+++ b/.claude/commands/start-issue.md
@@ -1,7 +1,7 @@
 ---
 description: Pick up a GitHub issue — tag it WIP and spin up a worktree off fresh origin/main.
 argument-hint: "<issue-number> [slug]"
-allowed-tools: Bash(gh issue view:*), Bash(gh issue edit:*), Bash(gh label create:*), Bash(gh label list:*), Bash(git fetch:*), Bash(git worktree:*)
+allowed-tools: Bash(gh issue view:*), Bash(gh issue edit:*), Bash(gh label create:*), Bash(gh label list:*), Bash(just:*)
 ---
 
 Start work on a GitHub issue, following the repo's "FLAG ACTIVE WORK WITH A WIP LABEL" and worktree rules in one step.
@@ -23,10 +23,9 @@ Arguments: `$ARGUMENTS` → first token is the issue number (required), optional
    gh issue edit <N> -R drakulavich/kesha-voice-kit --add-label WIP
    ```
 
-3. Create the worktree off **fresh** `origin/main` (never local main, never the root checkout):
+3. Create the worktree from the root checkout — the recipe fetches `origin/main` and branches off it, never off local main:
    ```bash
-   git fetch origin main
-   git worktree add .worktrees/<slug> -b fix/issue-<N> origin/main
+   just worktree <slug> fix/issue-<N>
    ```
    Pick a descriptive branch prefix (`fix/`, `feat/`, `chore/`) based on the issue type.
 

--- a/.claude/commands/worktree.md
+++ b/.claude/commands/worktree.md
@@ -1,33 +1,19 @@
 ---
 description: Create a gitignored worktree off fresh origin/main per CLAUDE.md's "MAIN STAYS IN ROOT" rule.
 argument-hint: "<slug> [branch-name]"
-allowed-tools: Bash(git fetch:*), Bash(git worktree:*), Bash(git branch:*), Bash(git rev-parse:*)
+allowed-tools: Bash(just:*)
 ---
 
-Create an isolated worktree for new work, strictly following the repo's "MAIN STAYS IN THE ROOT CHECKOUT — AGENTS EDIT ONLY IN WORKTREES" rule. **Never** switch the root checkout to a feature branch; **never** branch off the (possibly stale) local `main`.
+Run `just worktree <slug> [branch]` from the **root checkout** and report where the new tree landed.
 
-Arguments: `$ARGUMENTS` → first token is `<slug>` (required), optional second token is the branch name.
+Arguments: `$ARGUMENTS` → first token is `<slug>` (required), optional second token is the branch name. If the slug is missing, ask for it and stop.
 
-## Steps
+The recipe owns the ritual — fetching `origin/main`, branching off it rather than off the possibly-stale local `main`, and refusing to run from inside an existing worktree. Do not reconstruct the `git worktree` commands here or reach past it.
 
-1. Parse `<slug>` (required) and the optional branch. If no branch given, default to the slug (e.g. slug `vad-fix` → branch `vad-fix`). If the slug is missing, ask for it and stop.
+- The branch defaults to the slug (slug `vad-fix` → branch `vad-fix`).
+- If the recipe refuses because you are inside a worktree, `cd` to the root checkout and rerun; do **not** work around it.
+- If the branch already exists, `git worktree add -b` fails — report that rather than picking another name.
 
-2. Confirm you are in the **root checkout** (not already inside `.worktrees/`): `git rev-parse --show-toplevel`. If inside a worktree, cd to the root checkout first.
+Then tell the user to `cd .worktrees/<slug>`, and that edit/test/commit/PR all happen inside the worktree while cleanup (`just worktree-rm <slug>`) happens back in the root checkout.
 
-3. Branch off **fresh** `origin/main`:
-   ```bash
-   git fetch origin main
-   git worktree add .worktrees/<slug> -b <branch> origin/main
-   ```
-   If the branch already exists, stop and report rather than clobbering.
-
-4. Print the next step for the user:
-   ```
-   cd .worktrees/<slug>
-   ```
-   and remind that edit/test/commit/PR all happen inside the worktree, and cleanup after merge is:
-   ```
-   git worktree remove .worktrees/<slug> && git worktree prune
-   ```
-
-Reference: CLAUDE.md "MAIN STAYS IN THE ROOT CHECKOUT".
+Reference: the `worktree` recipe in `justfile`, CLAUDE.md "MAIN STAYS IN THE ROOT CHECKOUT".

--- a/.github/scripts/check-recipes.ts
+++ b/.github/scripts/check-recipes.ts
@@ -22,7 +22,12 @@
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
-type Recipe = { doc?: string | null; private?: boolean };
+type Recipe = {
+  doc?: string | null;
+  private?: boolean;
+  parameters?: { name?: string }[];
+  body?: unknown;
+};
 export type JustDump = { recipes?: Record<string, Recipe>; aliases?: Record<string, unknown> };
 
 const SWEPT_ROOT_FILES = ["README.md", "CONTRIBUTING.md", "CLAUDE.md"];
@@ -125,6 +130,33 @@ export function unknownReferences(path: string, contents: string, known: Set<str
     );
 }
 
+function interpolatedNames(body: unknown): string[] {
+  if (!Array.isArray(body)) return [];
+  if (body[0] === "variable" && typeof body[1] === "string") return [body[1]];
+  return body.flatMap(interpolatedNames);
+}
+
+/**
+ * `{{ slug }}` is substituted into the recipe *text*, which the shell then parses — so quoting it
+ * as `"{{ slug }}"` survives spaces and nothing else, and a caller passing `x"; rm -rf ~; #` gets
+ * their payload run. This is #291's GHA `run:` class one layer down. The fix is `[positional-arguments]`
+ * plus `"$1"`, where the shell receives the value as data it never re-parses.
+ */
+export function interpolatedParameters(dump: JustDump): string[] {
+  return Object.entries(dump.recipes ?? {}).flatMap(([name, recipe]) => {
+    const parameters = new Set((recipe.parameters ?? []).map((p) => p.name));
+    const offenders = [...new Set(interpolatedNames(recipe.body))]
+      .filter((used) => parameters.has(used))
+      .sort();
+    if (offenders.length === 0) return [];
+    return [
+      `justfile: recipe \`${name}\` interpolates ${offenders.map((o) => `{{ ${o} }}`).join(", ")} ` +
+        `into its body, so a caller's shell metacharacters are parsed as code — add ` +
+        `[positional-arguments] and read the value as "$1" instead (#907)`,
+    ];
+  });
+}
+
 export function undocumentedRecipes(dump: JustDump): string[] {
   return Object.entries(dump.recipes ?? {})
     .filter(([, recipe]) => !recipe.private && !recipe.doc)
@@ -163,6 +195,7 @@ function main(): void {
 
   const errors = [
     ...undocumentedRecipes(dump),
+    ...interpolatedParameters(dump),
     ...sweptFiles(root).flatMap((path) =>
       unknownReferences(path, readFileSync(join(root, path), "utf8"), known),
     ),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,15 +41,14 @@ The root checkout stays on `main`: shared coordination state, not an edit surfac
 
 Fixtures, benchmark audio, and `docs/assets/` are **Git LFS**-tracked (`.gitattributes`). Run `git lfs pull` in a fresh checkout — without it those files are pointer stubs, not audio, and tests fail in confusing ways.
 
-Branch off fresh `origin/main` (local `main` may be stale):
+Branch off fresh `origin/main` (local `main` may be stale) — the recipes do the fetch and refuse to run from anywhere but the root checkout, so cleanup cannot delete the tree it is standing in:
 
 ```bash
-git fetch origin main
-git worktree add .worktrees/<slug> -b <branch> origin/main
-cd .worktrees/<slug>          # edit, test, commit here
+just worktree <slug> [<branch>]   # branch defaults to the slug
+cd .worktrees/<slug>              # edit, test, commit here
 gh pr create --base main --head <branch>
-cd -                          # cleanup runs from the root checkout, not the worktree
-git worktree remove .worktrees/<slug> && git worktree prune
+cd -                              # cleanup runs from the root checkout, not the worktree
+just worktree-rm <slug>
 ```
 
 ### VERIFY BEFORE PUSHING

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ coverage-ts: need-just
 coverage-rust: need-just
 	just coverage-rust
 
+# make cannot forward a trailing filter (it reads one as another goal) — use `just rust-test <filter>`.
 rust-test: need-just
 	just rust-test
 

--- a/Makefile
+++ b/Makefile
@@ -31,13 +31,13 @@ rust-test: need-just
 	just rust-test
 
 mutants-rust: need-just
-	just $(if $(FILE),FILE='$(FILE)') $(if $(FEATURES),FEATURES='$(FEATURES)') mutants-rust
+	just $(if $(FEATURES),FEATURES='$(FEATURES)') mutants-rust $(FILE)
 
 smoke-test: need-just
 	just smoke-test
 
 smoke-test-tts: need-just
-	just smoke-test-tts
+	just TTS=1 smoke-test
 
 release-preflight: need-just
 	just release-preflight
@@ -46,7 +46,7 @@ release: need-just
 	just release
 
 release-notes: need-just
-	just $(if $(TAG),TAG='$(TAG)') release-notes
+	just release-notes $(TAG)
 
 # Direct package.json scripts — no justfile recipe exists for these on purpose.
 install:

--- a/justfile
+++ b/justfile
@@ -1,9 +1,9 @@
 # The widened set measures the ANE + diarize surfaces; `system_kokoro` cfg-excludes the ONNX-Kokoro
 # ones, so those need a second pass with FEATURES=tts. No recipe measures both — they are exclusive.
 FEATURES := "tts,system_kokoro,system_diarize"
-FILE := ""
-TAG := ""
 ALL := ""
+TTS := ""
+TTS_FLAG := if TTS == "" { "" } else { "--tts" }
 # Two seam_long_form tests cost 60-120 s each and only exercise transcribe/, so every mutant
 # outside it pays ~50 s for nothing. TEST_FILTER="" runs everything (nextest rejects an empty
 # filterset, so the recipe substitutes all()) — use it when mutating transcribe/ itself.
@@ -16,6 +16,31 @@ default:
 # Bootstrap a contributor checkout (checks deps, runs safe local setup)
 dev-setup:
     bash scripts/dev-setup.sh
+
+# Both worktree recipes act on the root checkout's worktree list, and `worktree-rm` in particular
+# must not run from the tree it is deleting. Only the main working tree has --git-dir equal to
+# --git-common-dir; every linked worktree's git dir is a subdirectory of it.
+[private]
+root-checkout-only:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    common="$(git rev-parse --path-format=absolute --git-common-dir)"
+    if [ "$(git rev-parse --path-format=absolute --git-dir)" != "$common" ]; then
+      echo "refusing: worktree recipes run from the root checkout, not from inside one — cd $(dirname "$common")" >&2
+      exit 2
+    fi
+
+# `git worktree add -b` refuses an existing branch on its own, so there is no clobber to guard.
+# Branch off fresh origin/main into .worktrees/<slug>: just worktree <slug> [branch]
+worktree slug branch=slug: root-checkout-only
+    git fetch origin main
+    git worktree add ".worktrees/{{ slug }}" -b "{{ branch }}" origin/main
+    @echo "==> cd .worktrees/{{ slug }} — edit, test, commit and open the PR from there"
+
+# Remove a merged worktree and prune its metadata: just worktree-rm <slug>
+worktree-rm slug: root-checkout-only
+    git worktree remove ".worktrees/{{ slug }}"
+    git worktree prune
 
 # Run all tests
 test:
@@ -39,9 +64,12 @@ coverage-rust:
     bun run coverage:rust
     bun run coverage:check:rust
 
-# Run Rust tests via nextest (matches CI — rust-test.yml)
-rust-test:
-    cd rust && cargo nextest run --features tts
+# "$@" rather than {{ ARGS }}: interpolation is textual, so a filterset's parens would reach sh
+# unquoted and be a syntax error — the one nextest argument worth forwarding.
+# Run Rust tests via nextest (matches CI — rust-test.yml); args are nextest filters: just rust-test ssml
+[positional-arguments]
+rust-test *ARGS:
+    cd rust && cargo nextest run --features tts "$@"
 
 # Gates are selected from what changed against origin/main...HEAD plus the working tree:
 # the Rust gate on rust/, the CoreML check on rust/src/backend/. just ALL=1 preflight forces both.
@@ -86,9 +114,8 @@ verify-darwin-full:
         --no-default-features -- -D warnings
 
 # `--in-place` is not optional: models.rs include_str!s a file above the crate, so the copy build fails.
-# Mutation-test one engine file, e.g. just FILE=src/errors.rs mutants-rust
-mutants-rust:
-    @test -n "{{ FILE }}" || { echo "usage: just FILE=src/<file>.rs [FEATURES=<set>] [TEST_FILTER=<expr>] mutants-rust" >&2; exit 2; }
+# Mutation-test one engine file, e.g. just mutants-rust src/errors.rs
+mutants-rust FILE:
     @command -v cargo-mutants >/dev/null || { echo "install it: cargo install --locked cargo-mutants" >&2; exit 2; }
     @git diff --quiet -- rust || { echo "rust/ has uncommitted changes; --in-place mutates the tree" >&2; exit 2; }
     cd rust && cargo mutants --in-place -f {{ FILE }} --features {{ FEATURES }} -- -E '{{ if TEST_FILTER == "" { "all()" } else { TEST_FILTER } }}'
@@ -97,17 +124,11 @@ mutants-rust:
 mutants-ts *FILES:
     bun scripts/mutants-ts.ts {{ FILES }}
 
-# Run smoke tests against fixtures
+# Run smoke tests against fixtures; just TTS=1 smoke-test covers the TTS fixtures too
 smoke-test:
     bun link @drakulavich/kesha-voice-kit
-    kesha install
-    bun scripts/smoke-test.ts
-
-# Run smoke tests with TTS
-smoke-test-tts:
-    bun link @drakulavich/kesha-voice-kit
-    kesha install --tts
-    bun scripts/smoke-test.ts --tts
+    kesha install {{ TTS_FLAG }}
+    bun scripts/smoke-test.ts {{ TTS_FLAG }}
 
 # Verify locally before cutting a GitHub release
 release-preflight: check smoke-test
@@ -115,7 +136,6 @@ release-preflight: check smoke-test
 
 alias release := release-preflight
 
-# Print an existing release body: just TAG=vX.Y.Z release-notes
-release-notes:
-    @test -n "{{ TAG }}" || { echo "usage: just TAG=vX.Y.Z release-notes" >&2; exit 2; }
+# Print an existing release body: just release-notes vX.Y.Z
+release-notes TAG:
     gh release view "{{ TAG }}" --json body --jq .body

--- a/justfile
+++ b/justfile
@@ -30,16 +30,30 @@ root-checkout-only:
       exit 2
     fi
 
+# Interpolating this pattern is safe where interpolating a slug is not: it is a justfile literal,
+# never a caller's value. It keeps the slug a single path component, so `../..` cannot escape
+# .worktrees/ and land an edit surface outside the rule this whole section exists to enforce.
+SLUG_PATTERN := "^[A-Za-z0-9][A-Za-z0-9._-]*$"
+
 # `git worktree add -b` refuses an existing branch on its own, so there is no clobber to guard.
+# The branch needs no pattern of its own — git rejects a malformed ref name.
 # Branch off fresh origin/main into .worktrees/<slug>: just worktree <slug> [branch]
+[positional-arguments]
 worktree slug branch=slug: root-checkout-only
+    #!/usr/bin/env bash
+    set -euo pipefail
+    [[ "$1" =~ {{ SLUG_PATTERN }} ]] || { echo "refusing: slug must match {{ SLUG_PATTERN }}, got: $1" >&2; exit 2; }
     git fetch origin main
-    git worktree add ".worktrees/{{ slug }}" -b "{{ branch }}" origin/main
-    @echo "==> cd .worktrees/{{ slug }} — edit, test, commit and open the PR from there"
+    git worktree add ".worktrees/$1" -b "$2" origin/main
+    echo "==> cd .worktrees/$1 — edit, test, commit and open the PR from there"
 
 # Remove a merged worktree and prune its metadata: just worktree-rm <slug>
+[positional-arguments]
 worktree-rm slug: root-checkout-only
-    git worktree remove ".worktrees/{{ slug }}"
+    #!/usr/bin/env bash
+    set -euo pipefail
+    [[ "$1" =~ {{ SLUG_PATTERN }} ]] || { echo "refusing: slug must match {{ SLUG_PATTERN }}, got: $1" >&2; exit 2; }
+    git worktree remove ".worktrees/$1"
     git worktree prune
 
 # Run all tests
@@ -114,15 +128,19 @@ verify-darwin-full:
         --no-default-features -- -D warnings
 
 # `--in-place` is not optional: models.rs include_str!s a file above the crate, so the copy build fails.
+# FEATURES and TEST_FILTER stay interpolated: they are set by whoever types the command, while
+# FILE is the argument a script or agent passes through.
 # Mutation-test one engine file, e.g. just mutants-rust src/errors.rs
+[positional-arguments]
 mutants-rust FILE:
     @command -v cargo-mutants >/dev/null || { echo "install it: cargo install --locked cargo-mutants" >&2; exit 2; }
     @git diff --quiet -- rust || { echo "rust/ has uncommitted changes; --in-place mutates the tree" >&2; exit 2; }
-    cd rust && cargo mutants --in-place -f {{ FILE }} --features {{ FEATURES }} -- -E '{{ if TEST_FILTER == "" { "all()" } else { TEST_FILTER } }}'
+    cd rust && cargo mutants --in-place -f "$1" --features {{ FEATURES }} -- -E '{{ if TEST_FILTER == "" { "all()" } else { TEST_FILTER } }}'
 
 # Mutation-test TypeScript sources against whichever suites import them, e.g. just mutants-ts src/engine.ts
+[positional-arguments]
 mutants-ts *FILES:
-    bun scripts/mutants-ts.ts {{ FILES }}
+    bun scripts/mutants-ts.ts "$@"
 
 # Run smoke tests against fixtures; just TTS=1 smoke-test covers the TTS fixtures too
 smoke-test:
@@ -137,5 +155,6 @@ release-preflight: check smoke-test
 alias release := release-preflight
 
 # Print an existing release body: just release-notes vX.Y.Z
+[positional-arguments]
 release-notes TAG:
-    gh release view "{{ TAG }}" --json body --jq .body
+    gh release view "$1" --json body --jq .body

--- a/tests/unit/check-recipes.test.ts
+++ b/tests/unit/check-recipes.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import {
   commandLines,
+  interpolatedParameters,
   isSwept,
+  type JustDump,
   knownRecipeNames,
   referencedRecipes,
   sweptFiles,
@@ -15,9 +17,9 @@ const YML = ".github/workflows/rust-test.yml";
 
 const recipe = (doc: string | null, isPrivate = false) => ({ doc, private: isPrivate });
 const dump = (
-  recipes: Record<string, ReturnType<typeof recipe>>,
+  recipes: NonNullable<JustDump["recipes"]>,
   aliases: Record<string, unknown> = {},
-) => ({ recipes, aliases });
+): JustDump => ({ recipes, aliases });
 
 const names = (path: string, contents: string) => referencedRecipes(path, contents).map((r) => r.recipe);
 
@@ -184,6 +186,45 @@ describe("sweptFiles", () => {
 
   test("every swept file is one isSwept accepts", () => {
     expect(files.filter((path) => !isSwept(path))).toEqual([]);
+  });
+});
+
+// `{{ slug }}` is substituted into the recipe text before the shell parses it, so a caller's
+// metacharacters run: `just worktree 'x"; rm -rf ~; #'` executed the payload until #907.
+describe("interpolatedParameters", () => {
+  const withBody = (parameters: string[], body: unknown[]) => ({
+    doc: "d",
+    parameters: parameters.map((name) => ({ name })),
+    body,
+  });
+  const addSlug = ['git worktree add ".worktrees/', [["variable", "slug"]], '"'];
+
+  test("flags a parameter substituted into the recipe body", () => {
+    const errors = interpolatedParameters(dump({ worktree: withBody(["slug"], [addSlug]) }));
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("`worktree` interpolates {{ slug }}");
+  });
+
+  test("passes when the body binds the parameter positionally instead", () => {
+    const positional = [['git worktree add ".worktrees/$1"']];
+    expect(interpolatedParameters(dump({ worktree: withBody(["slug"], positional) }))).toEqual([]);
+  });
+
+  test("a justfile variable is not a parameter, so interpolating it is not this bug", () => {
+    const body = [["kesha install ", [["variable", "TTS_FLAG"]]]];
+    expect(interpolatedParameters(dump({ "smoke-test": withBody([], body) }))).toEqual([]);
+  });
+
+  test("finds an interpolation nested anywhere in the body", () => {
+    const shebang = [["#!/usr/bin/env bash"], ["set -euo pipefail"], addSlug];
+    expect(interpolatedParameters(dump({ worktree: withBody(["slug"], shebang) }))).toHaveLength(1);
+  });
+
+  test("names every offending parameter once, however often it appears", () => {
+    const body = [addSlug, ["-b ", [["variable", "branch"]]], addSlug];
+    const errors = interpolatedParameters(dump({ worktree: withBody(["slug", "branch"], body) }));
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("{{ branch }}, {{ slug }}");
   });
 });
 

--- a/tests/unit/check-recipes.test.ts
+++ b/tests/unit/check-recipes.test.ts
@@ -189,9 +189,14 @@ describe("sweptFiles", () => {
 
 // The gate's own subject matter: the extractor must find the real references and no English ones.
 describe("the repository's own references", () => {
-  test("CLAUDE.md points at the recipes the pre-push gate is made of", () => {
+  test("CLAUDE.md spells its executable rituals as recipes, not as shell to copy", () => {
     const found = new Set(names("CLAUDE.md", readRepoFile("CLAUDE.md")));
-    expect([...found].sort()).toEqual(["preflight", "verify-darwin-full"]);
+    expect([...found].sort()).toEqual([
+      "preflight",
+      "verify-darwin-full",
+      "worktree",
+      "worktree-rm",
+    ]);
   });
 
   test("rust-test.yml calls verify-darwin-full rather than repeating its flags", () => {


### PR DESCRIPTION
> **Stacked on #905; merge that first.** Base is `feat/issue-720`, not `main`. #905 built the schema, the TS seam and `words_onto_segment`; this fills in the one platform that row was missing.

Closes #720 — with this the ticket's both arms are done, so the README matrix row stops being inverted from every other row in it.

## What was actually missing

Nothing in the model, and nothing in this repo's logic. `manager.transcribe` fills `ASRResult.tokenTimings` on every call at our pinned FluidAudio 0.15.5, and our bridge discarded them one line after receiving them (`swift/FluidAudioBridge.swift:122`). The spike measured the whole thing a year of `Refs #720` ago; this is the marshalling.

## Fork: `fluidaudio_transcribe_*_with_words`

`drakulavich/fluidaudio-rs`, branch `feat/offline-mode` (the branch the pin already tracks), extended per the #818 / #823 / #904 precedent:

- **[`1f4c99b`](https://github.com/drakulavich/fluidaudio-rs/commit/1f4c99b1f557308a54c2b19c42b054c3bf97edd1) → [`fcdf070`](https://github.com/drakulavich/fluidaudio-rs/commit/fcdf07023c8962d1ad880022b03cdb656b732877)**

Two design choices worth stating, because the issue left both open:

**Grouping runs on the Swift side**, through FluidAudio's own public `buildWordTimings(from:)` (`AsrTypes.swift:182`). Marshalling raw token timings and regrouping in Rust would mean reimplementing `▁`-boundary handling and then owning the drift when upstream changes it. Using the library's helper means our word boundaries *are* FluidAudio's, by construction.

**Parallel arrays, not a JSON string.** The spike suggested JSON as least-effort, but `fluidaudio-rs` has exactly one dependency (`thiserror`) and adding a JSON one to a binding crate to move three fields is the larger change. `fluidaudio_diarize_file` is the existing precedent for a variable-length array of records with a string field, and this copies it exactly: `outWords` (char\*\*) + `outWordStarts` + `outWordEnds` + `outWordCount`, freed together by `fluidaudio_free_word_timings`, collected Rust-side by a `collect_word_timings` modelled on `collect_diarization_segments`.

**Additive, no ABI break.** New `@_cdecl` symbols rather than wider out-param lists on the existing ones — an export's arity *is* its ABI. `nm` on the built static lib confirms all three new symbols alongside the old ones. Internally the two `transcribeFile`/`transcribeSamples` bridge methods now return `ASRResult` instead of a 5-tuple, with the scalar copy shared by an `emitAsrScalars` helper; that is internal Swift, not exported.

Fork gates: `cargo test` 24 passed / 10 ignored on `ffi_bindings`, 4 on `offline_mode`, 5 doc-tests. `cargo clippy --all-targets -- -D warnings` still fails on the **pre-existing** `needless_borrows_for_generic_args` in `build.rs` under rustc 1.94 — same one #904 reported, untouched here.

The fork's own model-backed test ran for real on this M2 (the ANE bundle is staged, nothing downloaded): `word_timings_line_up_with_the_transcript_they_came_from`, 20.37 s, pass.

## Engine

`backend/fluidaudio.rs` calls the `_with_words` siblings and hands the result to `chunk_from`, which keeps the words **only when they are the transcript's words** — same spelling, same order, one per whitespace-separated word. Both sides come out of one decode so they agree in practice, but the segmenting paths address words positionally (the fixed-window seam drops them by *count*) and nothing downstream re-verifies the correspondence. Absent beats misaligned, which is also why no timings at all reads as `None` rather than `Some(vec![])`.

**No second offset implementation.** `words_onto_segment` from #905 already moves slice-local times onto the file clock and clamps them into their segment; the CoreML backend returns slice-local times exactly like the ONNX one, so every segmenting path was already correct the moment the backend stopped returning `None`. The seam evidence below is that claim measured rather than asserted.

`transcribe.words` stops being ONNX-only: the gate goes from `all(onnx, not(coreml))` to `any(coreml, onnx)` — still backend-gated, since a build with no ASR backend must not advertise it, which is what the capabilities test now pins.

## Red first

The naive version — pass every timing through as `Some` — was written first and run:

```
test backend::fluidaudio::tests::words_reach_the_chunk_on_the_slice_clock ... ok
test backend::fluidaudio::tests::no_timings_at_all_is_absent_rather_than_empty ... FAILED
test backend::fluidaudio::tests::empty_transcript_carries_no_words ... FAILED
test backend::fluidaudio::tests::words_that_disagree_with_the_transcript_are_dropped ... FAILED

TranscriptionChunk { text: "Hello there world.", words: Some([WordTiming { word: "Hello", ...}, WordTiming { word: "world.", ...}]) }
TranscriptionChunk { text: "Hello world.", words: Some([]) }
```

Three failures, one per thing the guard owes. Green after adding it: 7 passed, 1 ignored.

## Real audio, this M2, CoreML engine built from this branch

`--capabilities-json` on the built binary reports `backend: "coreml"` with `transcribe.words` present.

`tests/fixtures/benchmark-en/01-check-email.ogg` — *"Please check your email and get back to me as soon as possible about the deployment."*

| word | start | end | | word | start | end |
|---|---|---|---|---|---|---|
| Please | 0.00 | 0.32 | | as | 2.32 | 2.56 |
| check | 0.32 | 0.48 | | possible | 2.56 | 3.04 |
| your | 0.48 | 0.64 | | about | 3.04 | 3.20 |
| email | 0.64 | 1.04 | | the | 3.20 | 3.36 |
| and | 1.04 | 1.28 | | deployment. | 3.36 | 4.00 |

Start-to-start gaps run 0.16 / 0.16 / 0.40 / 0.24 / 0.16 … — non-uniform, which is what separates real per-token durations from interpolation across the segment. The 0.40 before *"and"* and the 0.48 before *"about"* are the audible pauses.

Russian, `benchmark/01-ne-nuzhno-slat-soobshcheniya.ogg`, same binary, same model:

```
Не 0.08→0.40   нужно 0.40→0.72   слать 0.88→1.36   сообщения 1.44→2.08
с 2.08→2.24    транскрипцией, 2.24→3.20   сразу 3.20→3.68   выполняй 3.76→4.72
инструкцию, 4.72→5.52   которую 5.52→5.84   я 5.84→6.00   отправил 6.00→6.48
в 6.48→6.56    войсе. 6.56→7.04
```

### The seam, measured

A 10.23 s WAV of three `say`-generated utterances separated by 1.5 s of silence, through `--vad --json`. If the offset were missing every segment's words would restart near 0:

```
segment 0: 0.00 -> 2.56   The quick brown fox jumps over the lazy dog.
    The 0.00→0.08   quick 0.08→0.40  …  dog. 2.08→2.40
segment 1: 3.97 -> 6.40   Word timings must land on the file clock.
    Word 3.97→4.29  timings 4.29→4.77  …  clock. 5.81→6.29
segment 2: 7.84 -> 10.23  Not on the clock of the slice they came from.
    Not 7.84→8.08   on 8.08→8.16  …  from. 9.76→10.08
```

Segment 1's first word starts at 3.97 (its VAD span start), not at 0 — the `words_onto_segment` reuse working on CoreML with no code of its own.

Both #905 e2e cases (`word timings track real speech and stay inside their segment`, `kesha --json --timestamps carries word timings through the CLI`) now take their **real** branch rather than the absent-capability one when run against this binary — 101 `expect()` calls, no `skipping word-timing e2e` warning.

## Merge order and the pin

The pin bump **supersedes #904's**: `fcdf070` is a child of that PR's `1f4c99b`, so whichever lands first, the other is a fast-forward with no conflict in `rust/Cargo.toml` beyond the one line, and the fork branch is linear. If #904 merges first this PR's `Cargo.toml` line replaces its rev with a descendant; if this merges into #905's branch first, the pin change rides along and #904 rebases onto a rev that already contains its own commit. Neither order loses the ANE-level work.

## Gates

| Gate | Result |
|---|---|
| `just ALL=1 preflight` | exit 0 — TS suite + lint, `cargo fmt` + `clippy --all-targets -D warnings`, **560/560** nextest, CoreML check |
| `just verify-darwin-full` | clean — the only lane that compiles this code |
| `cargo nextest run --features coreml --no-default-features` | **234/234** passed, 4 skipped — where the new backend tests actually execute |
| `bun test tests/integration/e2e-engine.test.ts` (against the built CoreML binary) | 26 pass, 0 fail, 190 expects |
| Fork: `cargo test` | 24 + 4 + 5 pass; model-backed word test 20.37 s pass on this M2 |

`/tmp/fluidaudio-720/` deleted.
