### PR TITLE
fix(dx): measure every covering suite, now that the runner ceiling is gone

### DIFF
--- a/scripts/mutants-ts.ts
+++ b/scripts/mutants-ts.ts
@@ -4,16 +4,9 @@ import { dirname, join, relative, resolve } from "path";
 // @ts-expect-error stryker.conf.mjs is untyped JS config; reading it keeps one source of truth.
 import baseConfig from "../stryker.conf.mjs";
 
-// Integration suites spawn the CLI and the engine, and a dry run including one of them times
-// out however few suites there are — measured on src/engine.ts with four. Opt in with
-// --with-integration when the source is only exercised across that boundary.
+// Integration suites spawn the CLI and the engine, which costs minutes rather than seconds.
 const TEST_ROOTS = ["tests/unit"];
 const INTEGRATION_ROOT = "tests/integration";
-// The Bun runner's dry run stops answering on a large set — the limit stryker.conf.mjs
-// documents, met from the other side. It is cost- rather than count-shaped: 12 light suites
-// ran, 15 engine-spawning ones did not, and neither timeoutMS, dryRunTimeoutMinutes nor
-// bun.timeout moves it. Suites are added a hop-tier at a time while the total fits.
-const MAX_SUITES = 12;
 const GENERATED_CONFIG = `stryker.generated.${process.pid}.json`;
 
 const USAGE = [
@@ -97,7 +90,7 @@ export function reachableModules(
 
 /**
  * Covering suites, nearest first: a direct importer ranks above one that only reaches the
- * source through a shim. The order is what makes the cap in `main` defensible.
+ * source through a shim. The order is what the run reports, not what it selects.
  */
 export function rankCoveringTests(
   sources: string[],
@@ -116,23 +109,6 @@ export function rankCoveringTests(
       return hops.length === 0 ? [] : [{ path: test.path, hops: Math.min(...hops) }];
     })
     .sort((a, b) => a.hops - b.hops || a.path.localeCompare(b.path));
-}
-
-/**
- * Whole hop-tiers while they fit: mixing half of a tier in would make the reported score depend
- * on filename order. Always yields the nearest tier, even when that one alone is over budget —
- * measuring the closest suites beats refusing to measure.
- */
-export function takeNearestTiers<T extends { hops: number }>(ranked: T[], max: number): T[] {
-  const kept: T[] = [];
-  for (let i = 0; i < ranked.length; ) {
-    const hops = ranked[i]!.hops;
-    const tier = ranked.slice(i).filter((test) => test.hops === hops);
-    if (kept.length > 0 && kept.length + tier.length > max) break;
-    kept.push(...tier);
-    i += tier.length;
-  }
-  return kept;
 }
 
 export function selectCoveringTests(
@@ -195,17 +171,9 @@ async function main(argv: string[]): Promise<number> {
     return 1;
   }
 
-  const kept = takeNearestTiers(ranked, MAX_SUITES);
-  const testFiles = kept.map((test) => test.path);
+  const testFiles = ranked.map((test) => test.path);
   console.error(`mutating ${sources.join(", ")} against ${testFiles.length} suite(s):`);
-  for (const test of kept) console.error(`  ${test.path}${test.hops > 1 ? ` (${test.hops} hops)` : ""}`);
-  const dropped = ranked.slice(kept.length);
-  if (dropped.length > 0) {
-    console.error(
-      `not measured: ${dropped.length} further suite(s) reach these sources, but the Bun runner's dry run stops answering on a set this size. A survivor below may still be killed by:`,
-    );
-    for (const test of dropped) console.error(`  ${test.path} (${test.hops} hops)`);
-  }
+  for (const test of ranked) console.error(`  ${test.path}${test.hops > 1 ? ` (${test.hops} hops)` : ""}`);
 
   // Written beside stryker.conf.mjs on purpose: `ignorePatterns` resolve against the config's
   // directory, and a config outside the repo root sends the sandbox copy into rust/target.

--- a/tests/unit/mutants-ts-selection.test.ts
+++ b/tests/unit/mutants-ts-selection.test.ts
@@ -4,7 +4,6 @@ import {
   rankCoveringTests,
   reachableModules,
   selectCoveringTests,
-  takeNearestTiers,
   testFileCandidates,
   toPosix,
 } from "../../scripts/mutants-ts";
@@ -120,7 +119,7 @@ describe("which suites are measured against a source", () => {
     ]);
   });
 
-  // Integration suites spawn the CLI, and one of them in the set times out the dry run.
+  // Integration suites spawn the CLI and the engine, so they cost minutes rather than seconds.
   test("the repository's unit suites are discovered, and integration only on request", () => {
     const found = testFileCandidates();
 
@@ -130,29 +129,5 @@ describe("which suites are measured against a source", () => {
     expect(testFileCandidates(["tests/integration"])).toContain(
       "tests/integration/cli-contracts.test.ts",
     );
-  });
-});
-
-describe("how many suites the runner is given", () => {
-  const tier = (hops: number, count: number) =>
-    Array.from({ length: count }, (_, i) => ({ path: `t${hops}-${i}.test.ts`, hops }));
-
-  test("a whole tier is taken or none of it, so the score cannot depend on filename order", () => {
-    const ranked = [...tier(1, 3), ...tier(2, 20)];
-
-    expect(takeNearestTiers(ranked, 12)).toEqual(tier(1, 3));
-  });
-
-  test("further tiers are added while they fit", () => {
-    const ranked = [...tier(1, 3), ...tier(2, 4), ...tier(3, 30)];
-
-    expect(takeNearestTiers(ranked, 12)).toEqual([...tier(1, 3), ...tier(2, 4)]);
-  });
-
-  // Measuring the closest suites beats refusing to measure, even when that tier alone is over.
-  test("the nearest tier is kept even when it alone exceeds the budget", () => {
-    const ranked = tier(1, 40);
-
-    expect(takeNearestTiers(ranked, 12)).toEqual(tier(1, 40));
   });
 });


### PR DESCRIPTION
## The cap was load-bearing on a false premise

`scripts/mutants-ts.ts` capped selection at `MAX_SUITES = 12`, justified as:

> It is cost- rather than count-shaped: 12 light suites ran, 15 engine-spawning ones did not, and neither `timeoutMS`, `dryRunTimeoutMinutes` nor `bun.timeout` moves it.

Cost-shaped is right. The rest is not. With the child ceiling raised in #903, 70 suites — every unit suite plus `tests/integration/e2e-engine.test.ts`, which spawns the real engine — dry-run in 64 s and return the same 97.73% / 1 survivor the hand-paired run does.

## What the cap cost

`src/engine.ts` has 32 covering suites. The tool measured **4**, then printed:

```
not measured: 28 further suite(s) reach these sources, but the Bun runner's
dry run stops answering on a set this size.
```

Every mutant those 28 suites would have killed was reported as a survivor or as uncovered.

## The number

`bun scripts/mutants-ts.ts src/engine.ts`, all 29 unit suites:

| | #794 (3 suites) | this branch (29 suites) |
|---|---:|---:|
| mutation score | 49.6% | **62.41%** |
| killed | — | 253 |
| survived | 104 | 88 |
| no coverage | 77 | 65 |
| timeout | — | 1 |

8.94 tests per mutant, 20 m 17 s. `engine.ts` did not change; the measurement did. #897 predicted this shape — "pessimistic, not wrong" — and it is 12.8 points of pessimism.

The single timeout is now meaningful rather than an artefact: at `bun.timeout` 180 s it is not the ceiling firing, and per `totalDetected = timeout + killed` it still scores as caught.

## Deletions

`takeNearestTiers` and its three tests go with the cap — whole-tier ordering only ever mattered as a rule for deciding what to drop. `main()` now hands stryker exactly what `selectCoveringTests` returns, and that function's own tests already cover it, so nothing new is asserted here.

The two comments stating the disproven cause are replaced with the real one: integration suites are opt-in because they cost minutes, not because they break the runner.

## Verification

`just preflight` — 1245 pass / 6 skip / 0 fail, `tsc --noEmit` clean, selection suite 10 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZwnEPwLkVUyfMLNfX9JcW
