### PR TITLE
fix(ci): let the CoreML guard skip a host with no Neural Engine

### DIFF
--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -479,9 +479,12 @@ jobs:
       - name: 🧪 CoreML decoder-state regression
         run: |
           cd rust
+          # Without this nextest swallows a passing test's output, and the ANE gate's
+          # "this guard did not run" line is exactly that (#841).
           cargo nextest run \
             --no-default-features --features coreml \
             --run-ignored all \
+            --success-output immediate \
             -E 'test(transcribe_samples_is_stateless_across_calls) + test(debug_routes_silenced_chatter_to_stderr)'
 
       - name: 📤 Upload JUnit

--- a/rust/src/backend/fluidaudio.rs
+++ b/rust/src/backend/fluidaudio.rs
@@ -243,6 +243,68 @@ mod tests {
         }
     }
 
+    #[derive(Debug, PartialEq, Eq)]
+    enum AneGate {
+        Run,
+        Skip,
+        Absent,
+    }
+
+    /// `KESHA_REQUIRE_ANE_TESTS` names what the lane promised, the way
+    /// `KESHA_REQUIRE_MODEL_TESTS` does for weights: unset/empty/`0` lets an
+    /// ANE-less host skip, anything else turns that absence into a failure.
+    fn ane_gate(ane_lines: usize, required: Option<&str>) -> AneGate {
+        match (ane_lines, required) {
+            (0, None | Some("") | Some("0")) => AneGate::Skip,
+            (0, Some(_)) => AneGate::Absent,
+            _ => AneGate::Run,
+        }
+    }
+
+    /// #841: CoreML falls back off the ANE on a virtualized runner and the encoder's first
+    /// call times out at random, so this guard went red on PRs that could not have broken it.
+    fn skip_without_ane(test: &str) -> bool {
+        match ane_gate(
+            ane_lines(),
+            std::env::var("KESHA_REQUIRE_ANE_TESTS").ok().as_deref(),
+        ) {
+            AneGate::Run => false,
+            AneGate::Skip => {
+                eprintln!(
+                    "SKIP {test}: no Apple Neural Engine on this host ({}), so this guard did \
+                     not run — set KESHA_REQUIRE_ANE_TESTS=1 on a lane that promises one (#841)",
+                    probe("sysctl", &["-n", "hw.model"]).trim()
+                );
+                true
+            }
+            AneGate::Absent => panic!(
+                "KESHA_REQUIRE_ANE_TESTS is set but this host reports no Apple Neural Engine \
+                 ({}) — the lane promised hardware it does not have (#841)",
+                probe("sysctl", &["-n", "hw.model"]).trim()
+            ),
+        }
+    }
+
+    #[test]
+    fn a_host_with_a_neural_engine_runs_whatever_the_lane_asked_for() {
+        assert_eq!(ane_gate(32, None), AneGate::Run);
+        assert_eq!(ane_gate(32, Some("1")), AneGate::Run);
+    }
+
+    #[test]
+    fn a_host_without_one_skips_unless_the_lane_promised_it() {
+        assert_eq!(ane_gate(0, None), AneGate::Skip);
+        assert_eq!(ane_gate(0, Some("")), AneGate::Skip);
+        assert_eq!(ane_gate(0, Some("0")), AneGate::Skip);
+    }
+
+    /// Skipping is right for a runner that never had one; it would be a lie for a lane that
+    /// promised one, which is the only way this guard reports coverage it never had.
+    #[test]
+    fn a_lane_that_promised_one_fails_rather_than_passing_vacuously() {
+        assert_eq!(ane_gate(0, Some("1")), AneGate::Absent);
+    }
+
     /// Mirrors #742's `ioreg -c AppleARMIODevice | grep -ci ane` so the numbers
     /// in that thread and this dump are comparable.
     fn ane_lines() -> usize {
@@ -354,6 +416,9 @@ mod tests {
     #[test]
     #[ignore = "needs cached CoreML Parakeet models + Apple Neural Engine; run with --run-ignored on macOS arm64"]
     fn transcribe_samples_is_stateless_across_calls() {
+        if skip_without_ane("transcribe_samples_is_stateless_across_calls") {
+            return;
+        }
         let wav = concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/../tests/fixtures/benchmark-en/03-review-pull-request.ogg"
@@ -406,6 +471,9 @@ mod tests {
     #[test]
     #[ignore = "needs cached CoreML Parakeet models + Apple Neural Engine; run with --run-ignored on macOS arm64"]
     fn real_speech_yields_words_the_segmenting_paths_will_accept() {
+        if skip_without_ane("real_speech_yields_words_the_segmenting_paths_will_accept") {
+            return;
+        }
         let wav = concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/../tests/fixtures/benchmark-en/01-check-email.ogg"


### PR DESCRIPTION
## The guard was running outside its own precondition

`transcribe_samples_is_stateless_across_calls` declares what it needs:

```rust
#[ignore = "needs cached CoreML Parakeet models + Apple Neural Engine; run with --run-ignored on macOS arm64"]
```

`coreml-regression` runs it on `macos-14`, where `ioreg -c AppleARMIODevice | grep -ci ane` is **0**. The repo already recorded this — the comment on the neighbouring words test reads:

> Deliberately outside `coreml-regression`'s two-test allowlist in `rust-test.yml`: that job runs on a virtualized runner with no Neural Engine, and this needs a real one.

One ANE-dependent test was kept out of the job for exactly the reason the other one was left in.

## Which is why #841 looks like a flake and is not one

Five instances in two days, all the same shape: `VirtualMac2,1`, `kern.hv_vmm_present=1`, ANE device lines `0`, first call never completing, E5RT `Encoder_main__Op3_Cast has timed out`. Seen on a cold-downloaded bundle *and* on a clean v2 cache hit, so the cache is excluded from both sides; every occurrence went green on a same-SHA rerun, on PRs that could not have touched the backend (a docs/justfile delta, a words-path addition that never executed).

CoreML falls back off the ANE on that host and the encoder stalls. That is a precondition violation, not decoder-state corruption — and a guard that fails at random is one people learn to re-run, which un-builds the #592 pin-bump gate this job exists to be.

## The gate

`KESHA_REQUIRE_ANE_TESTS`, mirroring `KESHA_REQUIRE_MODEL_TESTS` for weights (`rust/tests/common/mod.rs`) — the pattern CLAUDE.md already calls the enforced one:

| host | lane promised an ANE | outcome |
|---|---|---|
| ANE present | either | runs |
| no ANE | no | **skips**, printing the host and why |
| no ANE | `KESHA_REQUIRE_ANE_TESTS=1` | **fails**, naming the promise it cannot keep |

Three unit tests cover the decision table; the probe itself is the `ane_lines()` already used by the #841 diagnostics, so the numbers stay comparable with #742's thread. Both ANE-dependent tests take the gate, not only the one CI runs today — otherwise adding the words test to the allowlist later brings the same failure back.

## What this costs

It trades a flaky guard for an absent one, and makes the run say which it is. The #592 pin-bump coverage is not restored by this PR — restoring it needs a real-ANE runner, or compute units pinned off the ANE inside `fluidaudio-rs` (a fork change and a pin bump, guarded by this very job). Both are out of reach from here; this stops the false signal in the meantime.

No workflow change: `coreml-regression` does not promise an ANE, so it skips and reports it.

## Verification

`just preflight` — 565/565 nextest, `tsc --noEmit` clean, CoreML build check passes. The three new decision-table tests run on any host.

Refs #841, #592.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZwnEPwLkVUyfMLNfX9JcW
