### PR TITLE
docs(openspec): spec the four uncovered capabilities found by a corpus audit

### DIFF
--- a/openspec/specs/GLOSSARY.md
+++ b/openspec/specs/GLOSSARY.md
@@ -17,7 +17,14 @@ verbatim; if you need a new term, add it here first.
 | **Recorded Engine version** | The version written beside the installed Engine binary as `<bin>.version`; what is actually on disk, which a mismatch with the Pinned Engine version causes `kesha install` to replace. |
 | **Capabilities JSON** | The machine-readable self-description printed by `kesha-engine --capabilities-json` (protocol version 3); the CLI validates flags against it instead of blindly forwarding them. |
 | **Error code** | A stable `E_*` identifier (e.g. `E_MODEL_MISSING`) printed by the Engine on stderr as `error [E_CODE]: message`; the full taxonomy comes from `--error-codes-json`. |
-| **Exit code** | Process status: 0 success, 1 runtime failure, 2 invalid arguments; `kesha say` additionally uses 4 (synthesis/internal) and 5 (text too long). |
+| **Exit code** | Process status: 0 success, 1 runtime failure, 2 invalid arguments; `kesha say` additionally uses 4 (synthesis/internal) and 5 (text too long). An interrupted run exits 130 (SIGINT) or 143 (SIGTERM). |
+| **CLI package** | The npm tarball `@drakulavich/kesha-voice-kit`: the `kesha` entry point plus its TypeScript sources, run by Bun with no build step. Every distribution path unwraps this same package. |
+| **Distribution path** | A supported way to get the CLI onto a machine: the npm CLI package, the Homebrew formula, the `.deb`/`.rpm` Linux packages, the GHCR container image, or the Nix flake. None of them installs the Engine. |
+| **MCP registry manifest** | `server.json` — the manifest that advertises the CLI package to MCP clients; its version is held equal to the CLI's by the drift gate. |
+| **OpenClaw plugin** | The plugin shipped inside the CLI package (`openclaw.plugin.json` + `openclaw-plugin.cjs`) that lets an OpenClaw agent transcribe voice messages by running the `kesha` CLI as a subprocess. |
+| **Audio ingest** | Opening an audio file and turning it into what a model consumes: decode (symphonia + rubato, never `ffmpeg`), mix to mono, resample to 16 kHz. |
+| **Process tree** | An Engine subprocess together with any Sidecar it spawned; interruption terminates the tree, not just the direct child. |
+| **Star prompt** | The one-time post-install invitation to star the repository, shown on a first install or a major/minor bump and gated by a marker file beside the Engine binary. |
 | **Transcription** | Speech-to-text of an audio file via the Backend (Parakeet TDT 0.6B v3). The CLI's default command. |
 | **Segment** | A time-bounded slice of a Transcription: `{start, end, text}` seconds, optionally with a Speaker label. |
 | **Diarization** | Assigning Speaker labels (cluster indices) to Segments; requires darwin-arm64 and the Sortformer model installed via `kesha install --diarize`. |

--- a/openspec/specs/README.md
+++ b/openspec/specs/README.md
@@ -45,17 +45,21 @@ Specs reference these named personas instead of a generic "user":
 | Spec | Covers |
 |---|---|
 | [transcription](transcription/spec.md) | Default `kesha <file>` command: batch, output formats, VAD, exit codes |
+| [audio-ingest](audio-ingest/spec.md) | Decode, mono mix, 16 kHz resample, duration probes, input rejection |
 | [speaker-diarization](speaker-diarization/spec.md) | `--speakers` labels on transcription segments |
 | [language-detection](language-detection/spec.md) | Audio and text language identification |
 | [tts-synthesis](tts-synthesis/spec.md) | `kesha say`: voices, engines, formats, SSML, normalization |
 | [installation](installation/spec.md) | `kesha install` / `kesha init`: engine + model downloads, integrity |
 | [release-channels](release-channels/spec.md) | Stable vs alpha: tag grammar, opt-in install, derived versions, shared publish path, 30-day prune |
+| [cli-distribution](cli-distribution/spec.md) | How `kesha` itself is installed: npm, Homebrew, `.deb`/`.rpm`, container, Nix |
 | [audio-recording](audio-recording/spec.md) | `kesha record`: microphone capture to WAV |
 | [diagnostics](diagnostics/spec.md) | `doctor`, `status`, `logs`, `stats`, `support-bundle` |
-| [cli-shell-integration](cli-shell-integration/spec.md) | Global flags, color/quiet rules, completions, manpage |
+| [cli-shell-integration](cli-shell-integration/spec.md) | Global flags, `--version`/`--help`, color/quiet rules, completions, manpage |
+| [process-lifecycle](process-lifecycle/spec.md) | Interruption, Engine process-tree termination, signal exit codes |
 | [mcp-server](mcp-server/spec.md) | `kesha mcp`: MCP tools and audio resources |
 | [programmatic-api](programmatic-api/spec.md) | `@drakulavich/kesha-voice-kit/core` exports |
 | [engine-contract](engine-contract/spec.md) | CLI ↔ `kesha-engine` boundary: capabilities, error codes, env vars |
+| [openclaw-plugin](openclaw-plugin/spec.md) | Bundled OpenClaw plugin: CLI-subprocess transcription for agents |
 | [raycast-extension](raycast-extension/spec.md) | Raycast **Dictate to Clipboard**: recording lifecycle, idle auto-stop, clipboard |
 
 ## Validation

--- a/openspec/specs/audio-ingest/spec.md
+++ b/openspec/specs/audio-ingest/spec.md
@@ -44,9 +44,10 @@ The Engine SHALL decode every supported container in-process and SHALL NOT depen
 
 - GIVEN a file in a container the Engine has no demuxer for
 - WHEN Ira transcribes it
-- THEN the Engine fails with the `E_BAD_AUDIO` Error code and a message naming
-  the file
+- THEN the Engine fails with a message naming the file
 - AND no external process is spawned to try again
+- AND the Error code is `E_INTERNAL`, because that failure carries no explicit
+  code — see Open Issues
 
 > *Technical Note — `rust/src/audio.rs:19-24` registers symphonia's enabled
 > codecs plus `symphonia_adapter_libopus::OpusDecoder`; `open_format`
@@ -105,7 +106,7 @@ Every transcription entry point SHALL validate that the input is a supported con
 
 ### Requirement: A missing input is distinguished from an unreadable one
 
-The Engine SHALL report a path that does not exist with the `E_INPUT_NOT_FOUND` Error code and a path that exists but cannot be opened or decoded with `E_BAD_AUDIO`, so a caller can tell a typo from a corrupt file without parsing prose.
+The Engine SHALL report a path that does not exist with the `E_INPUT_NOT_FOUND` Error code, and a path that exists but cannot be **opened**, or whose packet stream raises a hard **decode** fault, with `E_BAD_AUDIO`, so a caller can tell a typo from an unreadable file without parsing prose. Failures raised anywhere else in ingest carry no explicit code — see Open Issues.
 
 #### Scenario: Ira mistypes a filename in a batch
 
@@ -115,18 +116,30 @@ The Engine SHALL report a path that does not exist with the `E_INPUT_NOT_FOUND` 
 - AND `a.ogg` is still transcribed, per
   [transcription](../transcription/spec.md)
 
-#### Scenario: A file exists but cannot be read
+#### Scenario: A file exists but cannot be opened
 
-- GIVEN a file that exists but is truncated, corrupt, or permission-denied
+- GIVEN a file that exists but is permission-denied or otherwise unopenable
 - WHEN Ira transcribes it
 - THEN the failure carries `E_BAD_AUDIO`
 
+#### Scenario: The container is supported but the codec is not
+
+- GIVEN a container the Engine can demux carrying a codec it has no decoder for
+- WHEN Ira transcribes it
+- THEN the failure carries `E_INTERNAL`, not `E_BAD_AUDIO`, because that branch
+  is uncoded — the taxonomy and the code disagree here
+
 > *Technical Note — `open_format` (`rust/src/audio.rs:51-63`) maps
 > `io::ErrorKind::NotFound` to `ErrorCode::InputNotFound` and every other open
-> failure to `ErrorCode::BadAudio`; decode failures are tagged
-> `ErrorCode::BadAudio` at `rust/src/audio.rs:119` and `:137`. Both codes are in
-> the taxonomy printed by `--error-codes-json` and mirrored TS-side in
-> `src/error-codes.ts`. Their category is `Input`
+> failure to `ErrorCode::BadAudio`; hard decode faults are tagged
+> `ErrorCode::BadAudio` at `rust/src/audio.rs:119` and `:137`. Everything raised
+> with a bare `with_context` — unsupported format (`:78`), no supported audio
+> tracks (`:85`), unknown sample rate (`:101`), unsupported codec (`:108`) —
+> stays uncoded, and `code_of` falls back to `ErrorCode::Internal`
+> (`rust/src/errors.rs:193-197`, asserted by
+> `code_of_falls_back_to_internal_for_uncoded`). The coded pair is in the
+> taxonomy printed by `--error-codes-json` and mirrored TS-side in
+> `src/error-codes.ts`; their category is `Input`
 > (`rust/src/errors.rs:266-267`).*
 
 ### Requirement: Recoverable decode faults are skipped, unrecoverable ones stop the read
@@ -211,9 +224,9 @@ The Engine SHALL answer duration from container metadata without decoding, and S
 > `measure_duration_seconds` (`:294`) streams the file retaining no samples and
 > errors when it counts zero frames.*
 
-### Requirement: Language detection reads a bounded prefix, not the whole file
+### Requirement: Language detection sees a bounded prefix of the audio
 
-Audio Language detection SHALL be answered from a bounded prefix of the decoded audio, so detecting the language of a long recording costs a bounded amount of audio rather than the whole file.
+Audio Language detection SHALL be answered from a bounded leading prefix of the decoded audio, so the amount of audio the detector reads does not grow with the length of the recording. This bounds what the model sees, not what the decoder does — the decode itself is not bounded (see Open Issues).
 
 #### Scenario: Maks detects the language of a long meeting recording
 
@@ -246,11 +259,16 @@ Audio Language detection SHALL be answered from a bounded prefix of the decoded 
   buffer unchanged (`rust/src/audio.rs:159-167`, covered by a unit test that
   asserts it does not panic). That is a defensive path, not a specified
   behaviour — what a zero-channel container *should* produce is undecided.
-- Errors raised through `with_context` — unsupported format, no supported audio
-  tracks, unknown sample rate, unsupported codec — carry no explicit Error code
-  and reach the user through whatever default the error layer applies, unlike
-  the open/decode failures that are explicitly coded. Whether they should all be
-  `E_BAD_AUDIO` is unresolved.
+- **Four of the six ingest failure modes report `E_INTERNAL`.** Unsupported
+  format, no supported audio tracks, unknown sample rate, and unsupported codec
+  are raised with a bare `with_context`, so `code_of` falls back to
+  `ErrorCode::Internal` — a code whose own title is "Unexpected internal error"
+  and whose category is `Internal`, for four failures that are squarely the
+  user's input. `E_BAD_AUDIO` exists and is applied only to open and hard-decode
+  failures. A caller cannot currently distinguish "your file is not audio I can
+  read" from "the Engine has a bug". These almost certainly all want
+  `E_BAD_AUDIO`; changing them is a taxonomy change, not a spec change, so it is
+  recorded here rather than asserted above.
 - The set of supported containers is inherited from symphonia's enabled feature
   set plus the Opus adapter. No test pins that list, so a dependency bump could
   silently add or drop a container.

--- a/openspec/specs/audio-ingest/spec.md
+++ b/openspec/specs/audio-ingest/spec.md
@@ -1,0 +1,256 @@
+# Audio Ingest Specification
+
+## Purpose
+
+Audio ingest is the Engine's front door: every audio path a user hands to
+Transcription, Language detection (audio), or Diarization is opened, decoded,
+mixed to mono, and resampled here before any model sees it. It is also where a
+bad file is supposed to be rejected — cheaply, with a coded error, before a
+Backend spends twenty-five seconds cold-loading on input that was never usable.
+
+Ira cares that a corrupt file in a batch fails with a stable Error code instead
+of a cryptic model failure. Maks cares that voice notes from any messenger just
+work without installing anything else.
+
+## Non-Goals
+
+- Transcoding or exporting audio. Kesha reads audio; the only audio it writes is
+  synthesized speech ([tts-synthesis](../tts-synthesis/spec.md)) and microphone
+  captures ([audio-recording](../audio-recording/spec.md)).
+- Requiring, detecting, or shelling out to any external media tool. `ffmpeg` is
+  not a dependency and never becomes one.
+- Splitting audio into utterances. VAD windowing and chunking are
+  [transcription](../transcription/spec.md)'s concern and run on the samples
+  this capability produces.
+- Live microphone capture, which reaches the model through
+  [audio-recording](../audio-recording/spec.md) rather than through a file
+  decode.
+
+## Requirements
+
+### Requirement: Audio decoding needs no external media tool
+
+The Engine SHALL decode every supported container in-process and SHALL NOT depend on `ffmpeg` or any other external media tool being installed. A container it cannot decode is an error, never a fallback to an external process.
+
+#### Scenario: Maks transcribes a Telegram voice note on a clean machine
+
+- GIVEN Maks has installed the CLI and run `kesha install`, and no `ffmpeg` is
+  on the machine
+- WHEN Maks runs `kesha voice.ogg` on an OGG/Opus voice note
+- THEN the file is decoded and transcribed
+- AND nothing reports a missing media tool
+
+#### Scenario: A container the Engine cannot demux
+
+- GIVEN a file in a container the Engine has no demuxer for
+- WHEN Ira transcribes it
+- THEN the Engine fails with the `E_BAD_AUDIO` Error code and a message naming
+  the file
+- AND no external process is spawned to try again
+
+> *Technical Note — `rust/src/audio.rs:19-24` registers symphonia's enabled
+> codecs plus `symphonia_adapter_libopus::OpusDecoder`; `open_format`
+> (`rust/src/audio.rs:50`) probes with symphonia's enabled formats. Supported
+> containers/codecs are whatever those registries carry — MP3, WAV, FLAC, AAC,
+> OGG/Vorbis, Opus, AIFF, and more. CLAUDE.md states the no-`ffmpeg` property
+> as a project invariant.*
+
+### Requirement: A file's extension is a hint, not the decision
+
+The Engine SHALL determine a file's container by probing its contents, using the path extension only as a case-insensitive hint, so that an unusually-cased or misleading extension does not by itself decide whether a file can be read.
+
+#### Scenario: Maks transcribes a file exported with an uppercase extension
+
+- GIVEN a screen recorder wrote `Recording.M4A`
+- WHEN Maks runs `kesha Recording.M4A`
+- THEN it decodes exactly as `recording.m4a` would
+
+#### Scenario: A file with no extension at all
+
+- GIVEN an existing file named `voicenote` with no extension
+- WHEN Maks runs `kesha voicenote`
+- THEN the Engine probes the contents with no hint and decodes it if the
+  container is supported
+
+> *Technical Note — `build_hint` (`rust/src/audio.rs:36`) lowercases the
+> extension before handing it to symphonia and returns an empty `Hint` when the
+> path has no extension or a non-UTF-8 one. Routing a bare extensionless
+> existing file to transcription instead of the unknown-command handler is
+> specified in [cli-shell-integration](../cli-shell-integration/spec.md).*
+
+### Requirement: Unusable input is rejected before a Backend is loaded
+
+Every transcription entry point SHALL validate that the input is a supported container holding at least one audio track before loading a Backend, so an unusable file fails in milliseconds with a message about the file rather than after a model cold-load with a message about the model.
+
+#### Scenario: Ira transcribes a video-only container
+
+- GIVEN a `.webm` carrying only a video track
+- WHEN Ira runs `kesha clip.webm`
+- THEN the Engine fails with an error stating the file has no supported audio
+  tracks
+- AND it fails before any ASR model is loaded
+
+#### Scenario: A readable, supported file
+
+- GIVEN a WAV file with one audio track
+- WHEN Ira transcribes it
+- THEN validation passes without decoding any frames, and transcription proceeds
+
+> *Technical Note — `ensure_audio_track` (`rust/src/audio.rs:321`) calls
+> `open_format` and discards the reader: container headers only, never a frame
+> decode and never an `n_frames` scan, so it stays cheap on the Xing-less CBR
+> MP3 worst case. Its doc comment records the failure it was added for —
+> FluidAudio's "Swift bridge error: Transcription failed" landing ~25 s into
+> the ASR cold-load on a file already known to be unusable.*
+
+### Requirement: A missing input is distinguished from an unreadable one
+
+The Engine SHALL report a path that does not exist with the `E_INPUT_NOT_FOUND` Error code and a path that exists but cannot be opened or decoded with `E_BAD_AUDIO`, so a caller can tell a typo from a corrupt file without parsing prose.
+
+#### Scenario: Ira mistypes a filename in a batch
+
+- GIVEN `a.ogg` exists and `b.ogg` does not
+- WHEN Ira runs `kesha a.ogg b.ogg`
+- THEN the `b.ogg` failure carries `E_INPUT_NOT_FOUND`
+- AND `a.ogg` is still transcribed, per
+  [transcription](../transcription/spec.md)
+
+#### Scenario: A file exists but cannot be read
+
+- GIVEN a file that exists but is truncated, corrupt, or permission-denied
+- WHEN Ira transcribes it
+- THEN the failure carries `E_BAD_AUDIO`
+
+> *Technical Note — `open_format` (`rust/src/audio.rs:51-63`) maps
+> `io::ErrorKind::NotFound` to `ErrorCode::InputNotFound` and every other open
+> failure to `ErrorCode::BadAudio`; decode failures are tagged
+> `ErrorCode::BadAudio` at `rust/src/audio.rs:119` and `:137`. Both codes are in
+> the taxonomy printed by `--error-codes-json` and mirrored TS-side in
+> `src/error-codes.ts`. Their category is `Input`
+> (`rust/src/errors.rs:266-267`).*
+
+### Requirement: Recoverable decode faults are skipped, unrecoverable ones stop the read
+
+The Engine SHALL continue past packet-level decode faults and end the read cleanly when the stream ends or a reset is required, so a locally damaged file still yields the audio around the damage instead of failing outright. A fault that is neither SHALL surface as `E_BAD_AUDIO`.
+
+#### Scenario: Maks transcribes a voice note with a damaged packet
+
+- GIVEN a file with one undecodable packet in the middle
+- WHEN Maks transcribes it
+- THEN the damaged packet is skipped and the rest of the audio is transcribed
+
+#### Scenario: The container declares no sample rate
+
+- GIVEN a track whose codec parameters carry no sample rate
+- WHEN Ira transcribes it
+- THEN the Engine fails with an error naming the file rather than guessing a
+  rate
+
+> *Technical Note — `decode_packets` (`rust/src/audio.rs:96`): `IoError` and
+> `ResetRequired` from `next_packet` break the loop; `IoError` and `DecodeError`
+> from `decoder.decode` `continue`; anything else is returned as
+> `ErrorCode::BadAudio`. A missing `codec_params.sample_rate` errors at
+> `rust/src/audio.rs:99-101`. Packets belonging to other tracks are skipped.*
+
+### Requirement: Models receive mono audio at one fixed sample rate
+
+The Engine SHALL present decoded audio to every model as single-channel samples at 16 kHz, mixing multi-channel input by averaging its channels and resampling through the same filter shape used by live capture, so a stereo 48 kHz recording and a mono 16 kHz one reach the model the same way.
+
+#### Scenario: Maks transcribes a stereo 48 kHz recording
+
+- GIVEN a two-channel 48 kHz WAV
+- WHEN Maks transcribes it
+- THEN the model receives one channel of 16 kHz samples, roughly one sixteen-
+  thousandth of the original duration in samples per second
+- AND the transcript is produced normally
+
+#### Scenario: Input is already mono at the target rate
+
+- GIVEN a mono 16 kHz WAV
+- WHEN Ira transcribes it
+- THEN the samples pass through unchanged, with no resampling applied
+
+> *Technical Note — `TARGET_SAMPLE_RATE` is `16000`
+> (`rust/src/audio.rs:17`). `mix_to_mono` (`:159`) averages interleaved frames
+> and returns mono input untouched; `resample_mono` (`:189`) short-circuits when
+> the rates match and otherwise runs `sinc_resampler` (`:173`) — a 128-tap
+> Blackman-Harris windowed sinc with cubic interpolation, `FixedAsync::Input`,
+> chunk size 1024 — the same construction the live capture path uses.
+> `load_audio` (`:263`) is decode → mix → resample. Unit tests at
+> `rust/src/audio.rs:329-378` cover the mono pass-through, the averaging, and
+> output length within ±16 frames for 8 k/22.05 k/44.1 k/48 kHz.*
+
+### Requirement: Duration is probed cheaply and measured only when required
+
+The Engine SHALL answer duration from container metadata without decoding, and SHALL report the duration as unknown when the container declares no frame count. A full decode pass to count frames SHALL be used only where the duration is required, never for an advisory routing decision.
+
+#### Scenario: Long audio auto-engages VAD
+
+- GIVEN a two-hour MP3 whose container declares its frame count
+- WHEN Ira transcribes it
+- THEN the duration is known without decoding, and VAD engages per
+  [transcription](../transcription/spec.md)
+
+#### Scenario: A streaming OGG that declares no frame count
+
+- GIVEN an OGG/Opus file with no frame count in the container
+- WHEN the Engine probes its duration
+- THEN the duration is reported as unknown rather than triggering a full decode
+  to find out
+
+#### Scenario: A container that decodes to nothing
+
+- GIVEN a truncated or metadata-only container
+- WHEN a caller requires the measured duration
+- THEN the Engine fails with a message saying no audio frames were decoded and
+  suggesting a re-export or transcribing without timestamps
+
+> *Technical Note — `probe_duration_seconds` (`rust/src/audio.rs:280`) divides
+> `codec_params.n_frames` by the sample rate and returns `Ok(None)` when either
+> is absent; its doc comment forbids falling back to a decode-and-measure.
+> `measure_duration_seconds` (`:294`) streams the file retaining no samples and
+> errors when it counts zero frames.*
+
+### Requirement: Language detection reads a bounded prefix, not the whole file
+
+Audio Language detection SHALL be answered from a bounded prefix of the decoded audio, so detecting the language of a long recording costs a bounded amount of audio rather than the whole file.
+
+#### Scenario: Maks detects the language of a long meeting recording
+
+- GIVEN a 90-minute recording
+- WHEN language detection runs on it
+- THEN only the leading seconds are used, per
+  [language-detection](../language-detection/spec.md)
+
+#### Scenario: The file is shorter than the bound
+
+- GIVEN a 4-second voice note
+- WHEN language detection runs on it
+- THEN all of the available audio is used and detection still returns a code and
+  confidence
+
+> *Technical Note — `load_audio_truncated` (`rust/src/audio.rs:269`) decodes via
+> `load_audio` and keeps the first `max_seconds * TARGET_SAMPLE_RATE` samples.
+> The window used for detection (first 10 s, ECAPA-TDNN VoxLingua107) is
+> specified in [language-detection](../language-detection/spec.md).*
+
+## Open Issues
+
+- `load_audio_truncated` decodes the entire file and then discards the tail, so
+  the bounded-prefix guarantee is about what the model sees, not about decode
+  cost. On a 90-minute file, language detection still pays a full decode.
+- `load_audio` materialises every decoded sample in memory before mixing and
+  resampling, so peak memory scales with duration. Nothing caps it, and no
+  requirement above states a supported maximum input length.
+- `mix_to_mono` treats a zero-channel track as mono and returns the interleaved
+  buffer unchanged (`rust/src/audio.rs:159-167`, covered by a unit test that
+  asserts it does not panic). That is a defensive path, not a specified
+  behaviour — what a zero-channel container *should* produce is undecided.
+- Errors raised through `with_context` — unsupported format, no supported audio
+  tracks, unknown sample rate, unsupported codec — carry no explicit Error code
+  and reach the user through whatever default the error layer applies, unlike
+  the open/decode failures that are explicitly coded. Whether they should all be
+  `E_BAD_AUDIO` is unresolved.
+- The set of supported containers is inherited from symphonia's enabled feature
+  set plus the Opus adapter. No test pins that list, so a dependency bump could
+  silently add or drop a container.

--- a/openspec/specs/cli-distribution/spec.md
+++ b/openspec/specs/cli-distribution/spec.md
@@ -320,9 +320,16 @@ Whichever path put `kesha` on the machine, the Engine and models SHALL still arr
 - The Homebrew formula in `packaging/homebrew/Formula/kesha-voice-kit.rb` is a
   template kept in this repository; the tap that users install from is
   `drakulavich/homebrew-tap`, updated by `.github/workflows/homebrew-tap.yml`
-  on `release: published`. The in-repo copy pins an older version
-  (`v1.18.0`) than the current CLI, and nothing fails when it goes stale —
-  there is no check that the in-repo template and the published tap agree.
+  on `release: published`. The in-repo copy pins an older version than the
+  current CLI, and nothing fails when it goes stale — there is no check that the
+  in-repo template and the published tap agree. This is not cosmetic: the
+  `homebrew-formula` CI lane builds **the pinned tarball**, not the working
+  tree, so it reviews a released tree while the formula around it is the
+  proposed one. #915 hit exactly that — an install block staging `completions`
+  and `man` against a pin (`v1.18.0`) predating both directories (added in
+  v1.18.4, #388) — and had to repin to `v1.24.7`, the newest tag that carries
+  them *and* whose `package.json#version` equals its tag name, which the
+  formula's own `--version` assertion requires.
 - `homebrew-tap.yml` fires on every published release, including Engine
   releases that publish no CLI version (see CLAUDE.md, "un-drafting an engine
   tag still fires 🍺 Homebrew Tap"). The lane's own skip logic is the only thing

--- a/openspec/specs/cli-distribution/spec.md
+++ b/openspec/specs/cli-distribution/spec.md
@@ -19,9 +19,8 @@ job, and no distribution path changes that.
   Never-auto-download rule holds across all of them.
 - Choosing which Engine release a CLI resolves — that is the Pinned Engine
   version, specified in [installation](../installation/spec.md).
-- Which version reaches which Channel, and when. Release-lane mechanics are
-  proposed by the in-flight `alpha-release-channel` change and have no baseline
-  capability yet — see Open Issues.
+- Which version reaches which Channel, and when — see
+  [release-channels](../release-channels/spec.md).
 - The shape of the `./core` exports map — see
   [programmatic-api](../programmatic-api/spec.md).
 - Publishing the OpenClaw plugin to ClawHub — see
@@ -343,12 +342,12 @@ Whichever path put `kesha` on the machine, the Engine and models SHALL still arr
 - No test asserts that the Homebrew, Linux-package, container, and Nix paths
   produce the same CLI version — the "same contents everywhere" requirement is
   held by construction, not by a gate.
-- **There is no baseline capability for release channels**, yet this spec's
-  Non-Goals and the Glossary's Channel / Alpha / Prerelease entries both lean on
-  one. The in-flight `alpha-release-channel` change proposes a `release-channels`
-  capability; until it is archived into `openspec/specs/`, tag grammar, dist-tag
-  handling, provenance, and the independent CLI/Engine versioning scheme have no
-  baseline home. This is a corpus gap, not a reading-order preference.
+- The independent CLI/Engine versioning scheme — why `package.json#version` may
+  lead `keshaEngine.version`, and the `check:versions` rules that hold them
+  together — has no baseline home. [release-channels](../release-channels/spec.md)
+  covers tag grammar and channels; [installation](../installation/spec.md)
+  covers what an install resolves; neither states the versioning contract
+  itself, which is only in CLAUDE.md and the gate script.
 - `nix build .#kesha` cannot succeed as committed (`lib.fakeHash`), so the CLI
   half of the flake is documented-but-unbuildable. `docs/nix-install.md` and the
   README both present `nix run` as a working install path.

--- a/openspec/specs/cli-distribution/spec.md
+++ b/openspec/specs/cli-distribution/spec.md
@@ -19,8 +19,9 @@ job, and no distribution path changes that.
   Never-auto-download rule holds across all of them.
 - Choosing which Engine release a CLI resolves — that is the Pinned Engine
   version, specified in [installation](../installation/spec.md).
-- Which version reaches which Channel, and when. Release-lane mechanics live in
-  the release-channels capability.
+- Which version reaches which Channel, and when. Release-lane mechanics are
+  proposed by the in-flight `alpha-release-channel` change and have no baseline
+  capability yet — see Open Issues.
 - The shape of the `./core` exports map — see
   [programmatic-api](../programmatic-api/spec.md).
 - Publishing the OpenClaw plugin to ClawHub — see
@@ -122,9 +123,9 @@ The CLI package SHALL declare no `postinstall` or equivalent lifecycle script, s
 > in `package.json#files` so `kesha install --plan` can size the download
 > without the Engine present.*
 
-### Requirement: The published file list carries runtime assets and excludes test sources
+### Requirement: Every payload carries the assets the CLI loads, and no test sources
 
-The CLI package SHALL publish everything the CLI reads at runtime — the entry point, sources, shell completion scripts, the man page, the install plan metadata, and the OpenClaw plugin files — and SHALL exclude test sources.
+Each distribution path SHALL stage every asset the CLI loads at startup — the entry point, sources, shell completion scripts, the man page, the install plan metadata, and the OpenClaw plugin files — and SHALL exclude test sources. A payload that stages the sources without the assets beside them is incomplete, not merely reduced: the commands that need them fail.
 
 #### Scenario: Maks prints completions from a global install
 
@@ -132,6 +133,14 @@ The CLI package SHALL publish everything the CLI reads at runtime — the entry 
 - WHEN Maks runs `kesha completions zsh` and `kesha manpage`
 - THEN both print their bundled files, because `completions/` and `man/` ship
   in the package and are resolved relative to the installed sources
+
+#### Scenario: A payload stages the sources but not the assets
+
+- GIVEN a payload that stages `bin/` and `src/` without `completions/` and
+  `man/`
+- WHEN a user runs `kesha completions bash` or `kesha manpage` from it
+- THEN the command fails rather than printing, because the asset is not on disk
+  where the source expects it
 
 #### Scenario: A script names a repository path that is not published
 
@@ -144,7 +153,9 @@ The CLI package SHALL publish everything the CLI reads at runtime — the entry 
 > `tsconfig.json`, `openclaw.plugin.json`, `openclaw-plugin.cjs`, two docs
 > pages, `SKILL.md`, `LICENSE`, `NOTICES.md`, `README.md`, and the
 > `!src/__tests__` exclusion. `tests/unit/package-metadata.test.ts` covers the
-> `model-plan.json` entry and the script-path existence check.*
+> `model-plan.json` entry and the script-path existence check. Until #915 the
+> npm package was the **only** payload that satisfied this requirement — see
+> Open Issues.*
 
 ### Requirement: Linux packages install one command and its documentation
 
@@ -203,29 +214,35 @@ The published container image SHALL run the CLI as a non-root user, resolve the 
 > and on `v*` tags excluding `v*-alpha*`. `compose.yml` mirrors the same mount
 > layout; usage is documented in `docs/docker.md`.*
 
-### Requirement: The Nix flake builds the CLI and the Engine from source
+### Requirement: The Nix flake is an alternate build path, and never a release gate
 
-The Nix flake SHALL expose the CLI and a from-source Engine build for `aarch64-darwin` and `x86_64-linux`, with the CLI pointed at the Engine the same flake built. It is an alternate reproducible path, not a release gate — no published artifact depends on it.
+The Nix flake SHALL define the CLI and a from-source Engine build for `aarch64-darwin` and `x86_64-linux`, with the CLI pointed at the Engine the same flake built. No published artifact SHALL depend on it, so a flake that does not build blocks nothing.
 
-#### Scenario: Maks runs Kesha through Nix without an npm install
+#### Scenario: Maks builds the Engine through Nix
 
 - GIVEN Maks has Nix with flakes enabled on Apple Silicon
-- WHEN Maks runs `nix run github:drakulavich/kesha-voice-kit -- install`
-- THEN the CLI runs against the Engine built by the flake rather than a
-  downloaded release binary
+- WHEN Maks runs `nix build .#kesha-engine`
+- THEN the Engine is built from source, carrying the Pinned Engine version in
+  a file beside the binary
 
-#### Scenario: The flake fails to evaluate
+#### Scenario: The CLI derivation cannot build
 
-- WHEN the flake breaks on a supported system
-- THEN no release lane fails as a result, because no published artifact is built
-  through it
+- GIVEN the CLI's dependency derivation carries a placeholder output hash that
+  no one has populated
+- WHEN a user runs `nix run` or `nix build .#kesha`
+- THEN it fails with a hash mismatch, and the documented recovery is to read the
+  real hash out of that error and paste it in
+- AND no release lane fails as a result
 
 > *Technical Note — `flake.nix` exposes `packages.kesha` and
 > `packages.kesha-engine`; `kesha-engine` is built with naersk and records
 > `package.json#keshaEngine.version` into `bin/kesha-engine.version`
 > (`flake.nix:144-167`), and the `kesha` wrapper sets `KESHA_ENGINE_BIN` to it
-> (`flake.nix:280`). Usage: `docs/nix-install.md`. CLAUDE.md states explicitly
-> that the flake is not a CI gate.*
+> (`flake.nix:280`). `keshaNodeModules.outputHash` is `lib.fakeHash`
+> (`flake.nix:230`), and the comment above it (`flake.nix:188-205`) states
+> plainly that `packages.default`, `apps.default`, and the README's `nix run` /
+> `nix profile install` snippets all fail until it is populated. Usage:
+> `docs/nix-install.md`. CLAUDE.md states the flake is not a CI gate.*
 
 ### Requirement: The MCP registry manifest names a published CLI version
 
@@ -279,20 +296,27 @@ Whichever path put `kesha` on the machine, the Engine and models SHALL still arr
 
 ## Open Issues
 
-- **`kesha completions` and `kesha manpage` are broken on the Linux-package
-  path.** Both read their file relative to `import.meta.url`
-  (`src/cli/completions.ts:38`, `src/cli/manpage.ts:9`), which in a
-  `bun build --compile` binary resolves outside the embedded filesystem. Every
-  other path ships the sources, so only the `.deb`/`.rpm` is affected.
-  Reproduced against this commit by compiling `./bin/kesha.js` for the host and
-  running both commands: each dies with an unhandled `ENOENT` for
-  `/completions/kesha.bash` and `/man/kesha.1` respectively, printing a stack
-  trace and exiting 1 — not the exit-2 usage error
-  [cli-shell-integration](../cli-shell-integration/spec.md) specifies for bad
-  input, and not a message a user can act on. `model-plan.json` is unaffected
-  because it is a static import, and `kesha install --plan` was verified working
-  in the same binary. Needs a GitHub issue; the fix is to embed both assets
-  rather than resolve them at runtime.
+- **`kesha completions` and `kesha manpage` are broken on four of the five
+  paths** (#914, fixed by #915). Both read their file relative to
+  `import.meta.url` (`src/cli/completions.ts:38`, `src/cli/manpage.ts:9`), which
+  fails two different ways:
+  - In the `.deb`/`.rpm`'s `bun build --compile` binary the path resolves
+    outside the embedded filesystem. Reproduced by compiling `./bin/kesha.js`
+    for the host: an unhandled `ENOENT` for `/completions/kesha.bash` and
+    `/man/kesha.1`, stack trace, exit 1 — not the exit-2 usage error
+    [cli-shell-integration](../cli-shell-integration/spec.md) specifies, and not
+    a message a user can act on.
+  - Homebrew, the container image, and Nix stage `bin` and `src` **without**
+    `completions/` or `man/` (`packaging/homebrew/Formula/kesha-voice-kit.rb:11`,
+    `Dockerfile:11`, `flake.nix:248` and `:266`), so the file the source looks
+    for is simply absent. Reproduced by staging exactly `bin src package.json
+    bun.lock tsconfig.json` and running both commands.
+
+  Only the npm CLI package and a repository checkout ever worked.
+  `model-plan.json` is unaffected because it is a static import, and
+  `kesha install --plan` was verified working in the compiled binary. An earlier
+  revision of this spec claimed only the Linux packages were affected; that was
+  wrong, and Codex review caught it.
 - The Homebrew formula in `packaging/homebrew/Formula/kesha-voice-kit.rb` is a
   template kept in this repository; the tap that users install from is
   `drakulavich/homebrew-tap`, updated by `.github/workflows/homebrew-tap.yml`
@@ -312,3 +336,12 @@ Whichever path put `kesha` on the machine, the Engine and models SHALL still arr
 - No test asserts that the Homebrew, Linux-package, container, and Nix paths
   produce the same CLI version — the "same contents everywhere" requirement is
   held by construction, not by a gate.
+- **There is no baseline capability for release channels**, yet this spec's
+  Non-Goals and the Glossary's Channel / Alpha / Prerelease entries both lean on
+  one. The in-flight `alpha-release-channel` change proposes a `release-channels`
+  capability; until it is archived into `openspec/specs/`, tag grammar, dist-tag
+  handling, provenance, and the independent CLI/Engine versioning scheme have no
+  baseline home. This is a corpus gap, not a reading-order preference.
+- `nix build .#kesha` cannot succeed as committed (`lib.fakeHash`), so the CLI
+  half of the flake is documented-but-unbuildable. `docs/nix-install.md` and the
+  README both present `nix run` as a working install path.

--- a/openspec/specs/cli-distribution/spec.md
+++ b/openspec/specs/cli-distribution/spec.md
@@ -1,0 +1,314 @@
+# CLI Distribution Specification
+
+## Purpose
+
+This spec covers how the `kesha` CLI itself reaches a machine — the npm CLI
+package and every wrapper built on top of it: Homebrew, `.deb`/`.rpm`, the GHCR
+container image, and the Nix flake. It also covers the MCP registry manifest,
+which advertises the same npm package to MCP clients. Ira picks a distribution
+path that fits a CI image; Maks installs from Homebrew on his Mac; Sona points
+an MCP client at the published registry entry.
+
+The [installation](../installation/spec.md) spec starts where this one stops:
+once `kesha` is on PATH, acquiring the Engine and models is `kesha install`'s
+job, and no distribution path changes that.
+
+## Non-Goals
+
+- Downloading the Engine or models. Every path below ships the CLI only; the
+  Never-auto-download rule holds across all of them.
+- Choosing which Engine release a CLI resolves — that is the Pinned Engine
+  version, specified in [installation](../installation/spec.md).
+- Which version reaches which Channel, and when. Release-lane mechanics live in
+  the release-channels capability.
+- The shape of the `./core` exports map — see
+  [programmatic-api](../programmatic-api/spec.md).
+- Publishing the OpenClaw plugin to ClawHub — see
+  [openclaw-plugin](../openclaw-plugin/spec.md).
+
+## Requirements
+
+### Requirement: Every distribution path delivers the same CLI, built from the CLI package
+
+Each supported distribution path SHALL deliver the CLI package's `bin/kesha.js` entry point and its sources, and SHALL report the same version the CLI package carries. A path MAY compile that entry point into a standalone binary instead of shipping the sources, but no path may deliver a CLI built from anything else.
+
+#### Scenario: Maks installs from Homebrew instead of npm
+
+- GIVEN Maks has never installed Kesha
+- WHEN Maks runs `brew install drakulavich/tap/kesha-voice-kit`
+- THEN `kesha --version` prints the same version the npm CLI package carries
+- AND the installed command runs the same `bin/kesha.js` entry point that
+  `bun add -g @drakulavich/kesha-voice-kit` would install
+
+#### Scenario: Ira installs the .deb, which carries no sources
+
+- GIVEN the Linux package installs a standalone binary rather than the sources
+- WHEN Ira runs `kesha --help`
+- THEN it prints the same command list as a global install of the same version,
+  because the binary was compiled from that version's entry point
+
+#### Scenario: A path builds the CLI from something other than the package
+
+- WHEN a distribution path would ship a CLI not derived from the CLI package at
+  that version
+- THEN it is not a supported path
+
+> *Technical Note — `bin/kesha.js:1-4` is a four-line `#!/usr/bin/env bun`
+> shim over `runCli` from `src/cli/dispatch.ts`. `package.json#bin` maps
+> `kesha → bin/kesha.js`; `package.json#files` publishes `bin/` and `src/`
+> as-is. Homebrew installs `bin`, `src`, `package.json`, `bun.lock`,
+> `tsconfig.json` into `libexec` and writes a shell wrapper that execs Bun
+> against `libexec/bin/kesha.js`
+> (`packaging/homebrew/Formula/kesha-voice-kit.rb:11-24`). `Dockerfile:10-19`
+> copies `bin` and `src` and symlinks `/usr/local/bin/kesha`. The Linux packages
+> are the compiled case: `.github/scripts/build-linux-packages.mjs:27-34` runs
+> `bun build --compile --target=bun-linux-x64 ./bin/kesha.js` and nfpm packages
+> the single resulting file.*
+
+### Requirement: Bun is present on every distribution path, as a dependency or compiled in
+
+The CLI package SHALL declare Bun >= 1.3.0 as its required runtime, and every wrapper path SHALL either depend on Bun, bundle it, or embed it in a compiled binary, so that a successful install never produces a `kesha` that cannot start.
+
+#### Scenario: Maks installs the Homebrew formula on a Mac without Bun
+
+- GIVEN Bun is not installed
+- WHEN Maks runs `brew install drakulavich/tap/kesha-voice-kit`
+- THEN Homebrew installs Bun as a dependency first
+- AND `kesha --version` succeeds afterwards
+
+#### Scenario: Ira installs the .deb on a host with no Bun
+
+- GIVEN no Bun is installed on a glibc-based `amd64` host
+- WHEN Ira installs the `.deb` and runs `kesha --version`
+- THEN it succeeds, because the runtime is embedded in the compiled binary
+
+#### Scenario: The compiled binary meets a C library it was not built for
+
+- GIVEN a musl-based distribution such as Alpine
+- WHEN the Linux package's binary is run there
+- THEN it does not run, and the documented alternative is the container image
+
+#### Scenario: A user runs the entry point under a runtime that is not Bun
+
+- GIVEN a user invokes `bin/kesha.js` with a runtime other than Bun
+- THEN startup fails, because the CLI uses Bun-native APIs and ships no
+  compatibility layer
+
+> *Technical Note — `package.json#engines.bun` is `>=1.3.0`
+> (`package.json:88-90`). `packaging/homebrew/Formula/kesha-voice-kit.rb:8`
+> declares `depends_on "oven-sh/bun/bun"`. `Dockerfile:1` pins
+> `oven/bun:1.3.14-slim`. The Linux binary is compiled for `bun-linux-x64`
+> (glibc); `docs/linux-packages.md` states the musl limitation and points at the
+> container image.*
+
+### Requirement: The published package runs no install-time lifecycle script
+
+The CLI package SHALL declare no `postinstall` or equivalent lifecycle script, so that installing it downloads nothing beyond the package itself.
+
+#### Scenario: Ira installs the CLI inside a CI image build
+
+- WHEN Ira runs `bun add -g @drakulavich/kesha-voice-kit` in a Dockerfile layer
+- THEN the install completes without contacting GitHub Releases or HuggingFace
+- AND the layer grows by the package size only, not by gigabytes of models
+
+#### Scenario: A lifecycle script is added
+
+- WHEN a `postinstall` script is added to the CLI package
+- THEN the package-metadata check fails, because the Never-auto-download rule
+  must hold at the package-manager level too
+
+> *Technical Note — asserted by `tests/unit/package-metadata.test.ts` ("does
+> not publish lifecycle scripts"), which also asserts `model-plan.json` stays
+> in `package.json#files` so `kesha install --plan` can size the download
+> without the Engine present.*
+
+### Requirement: The published file list carries runtime assets and excludes test sources
+
+The CLI package SHALL publish everything the CLI reads at runtime — the entry point, sources, shell completion scripts, the man page, the install plan metadata, and the OpenClaw plugin files — and SHALL exclude test sources.
+
+#### Scenario: Maks prints completions from a global install
+
+- GIVEN Maks installed the CLI from npm and never cloned the repository
+- WHEN Maks runs `kesha completions zsh` and `kesha manpage`
+- THEN both print their bundled files, because `completions/` and `man/` ship
+  in the package and are resolved relative to the installed sources
+
+#### Scenario: A script names a repository path that is not published
+
+- WHEN a `package.json` script references a path under `tests/`, `src/`,
+  `scripts/`, or `.github/` that does not exist
+- THEN the package-metadata check fails, naming the script and the path
+
+> *Technical Note — `package.json#files` (`package.json:13-30`) lists `bin/`,
+> `completions/`, `man/`, `src/`, `model-plan.json`, `package.json`,
+> `tsconfig.json`, `openclaw.plugin.json`, `openclaw-plugin.cjs`, two docs
+> pages, `SKILL.md`, `LICENSE`, `NOTICES.md`, `README.md`, and the
+> `!src/__tests__` exclusion. `tests/unit/package-metadata.test.ts` covers the
+> `model-plan.json` entry and the script-path existence check.*
+
+### Requirement: Linux packages install one command and its documentation
+
+A `.deb` or `.rpm` SHALL install the `kesha` command to a directory already on the default PATH, install the licence and notices alongside it, and declare the certificate bundle it needs to reach GitHub Releases during a later `kesha install`.
+
+#### Scenario: Ira installs the .deb on a minimal image
+
+- GIVEN a minimal `amd64` Debian image
+- WHEN Ira installs the published `.deb`
+- THEN `kesha` resolves on PATH without further configuration
+- AND `kesha install` can reach GitHub Releases, because `ca-certificates` came
+  in as a dependency
+
+#### Scenario: A non-amd64 Linux host
+
+- GIVEN an `arm64` Linux host
+- WHEN the user looks for a Linux package
+- THEN none is published for that architecture, and the documented path is the
+  npm CLI package
+
+> *Technical Note — `packaging/nfpm.yaml`: `arch: amd64`, `kesha → /usr/bin`
+> mode 0755, `LICENSE` / `NOTICES.md` / `README.md` under
+> `/usr/share/doc/kesha-voice-kit/`, and a `ca-certificates` dependency in both
+> the `deb` and `rpm` overrides. Which release may attach them is specified in
+> [installation](../installation/spec.md) ("Linux packages ship only from a
+> release that publishes the same CLI version"); build-side coverage lives in
+> `tests/unit/linux-packaging.test.ts`.*
+
+### Requirement: The container image is file-in, file-out and keeps the Model cache on a mount point
+
+The published container image SHALL run the CLI as a non-root user, resolve the Model cache to a fixed path a volume can be mounted at, and default its working directory to a mount point for the user's audio. Microphone capture is not available inside the image.
+
+#### Scenario: Ira transcribes a file with the container image
+
+- GIVEN Ira mounts a named volume at the cache path and the working directory at
+  the work path
+- WHEN Ira runs the image with `install` and then with `audio.ogg`
+- THEN the models land in the mounted volume and are reused by the second run
+- AND the transcript is written to stdout
+
+#### Scenario: Ira tries to record inside the container
+
+- WHEN Ira runs `record --out out.wav` in the container
+- THEN recording fails, because the container has no microphone access
+
+#### Scenario: The cache path is not mounted
+
+- WHEN Ira runs the image twice without mounting the cache path
+- THEN the second run finds no Engine and asks for `kesha install`, because the
+  first run's download died with its container
+
+> *Technical Note — `Dockerfile`: `KESHA_CACHE_DIR=/cache/kesha`,
+> `USER bun`, `WORKDIR /work`, `ENTRYPOINT ["kesha"]`, `CMD ["--help"]`, plus a
+> legacy `/usr/local/bin/parakeet` symlink beside `kesha`. Published to GHCR by
+> `.github/workflows/docker.yml` for `linux/amd64` only, on pushes to `main`
+> and on `v*` tags excluding `v*-alpha*`. `compose.yml` mirrors the same mount
+> layout; usage is documented in `docs/docker.md`.*
+
+### Requirement: The Nix flake builds the CLI and the Engine from source
+
+The Nix flake SHALL expose the CLI and a from-source Engine build for `aarch64-darwin` and `x86_64-linux`, with the CLI pointed at the Engine the same flake built. It is an alternate reproducible path, not a release gate — no published artifact depends on it.
+
+#### Scenario: Maks runs Kesha through Nix without an npm install
+
+- GIVEN Maks has Nix with flakes enabled on Apple Silicon
+- WHEN Maks runs `nix run github:drakulavich/kesha-voice-kit -- install`
+- THEN the CLI runs against the Engine built by the flake rather than a
+  downloaded release binary
+
+#### Scenario: The flake fails to evaluate
+
+- WHEN the flake breaks on a supported system
+- THEN no release lane fails as a result, because no published artifact is built
+  through it
+
+> *Technical Note — `flake.nix` exposes `packages.kesha` and
+> `packages.kesha-engine`; `kesha-engine` is built with naersk and records
+> `package.json#keshaEngine.version` into `bin/kesha-engine.version`
+> (`flake.nix:144-167`), and the `kesha` wrapper sets `KESHA_ENGINE_BIN` to it
+> (`flake.nix:280`). Usage: `docs/nix-install.md`. CLAUDE.md states explicitly
+> that the flake is not a CI gate.*
+
+### Requirement: The MCP registry manifest names a published CLI version
+
+The MCP registry manifest SHALL name the npm CLI package and a version equal to the CLI version in the repository, and the drift gate SHALL fail when they disagree, so a client resolving the registry entry never asks npm for a version that was never published.
+
+#### Scenario: Sona adds Kesha from the MCP registry
+
+- GIVEN Sona's MCP client resolves the registry entry
+- WHEN the client launches the server
+- THEN it runs the published npm CLI package with the `mcp` argument over stdio,
+  which is the invocation [mcp-server](../mcp-server/spec.md) specifies
+
+#### Scenario: A version bump misses the manifest
+
+- GIVEN the CLI version is bumped in `package.json` only
+- WHEN the version drift gate runs
+- THEN it fails, naming both versions
+
+#### Scenario: The manifest is missing or unreadable
+
+- WHEN the manifest cannot be read from the repository root
+- THEN the drift gate fails with a message saying the manifest must stay there
+
+> *Technical Note — `server.json` carries `version` and
+> `packages[0].version`, `registryType: npm`, `transport: stdio`, and the
+> positional `mcp` argument. `.github/scripts/check-versions.ts` reads it and
+> exits non-zero on drift or on an unreadable file; run as
+> `bun run check:versions`, part of `bun run check`.*
+
+### Requirement: No distribution path downloads the Engine or models
+
+Whichever path put `kesha` on the machine, the Engine and models SHALL still arrive only through an explicit `kesha install` (or `kesha init`).
+
+#### Scenario: Maks transcribes immediately after `brew install`
+
+- GIVEN Maks has just installed the Homebrew formula
+- WHEN Maks runs `kesha meeting.ogg`
+- THEN the CLI fails with an error naming the missing component and a
+  `kesha install` hint
+- AND nothing is downloaded
+
+#### Scenario: Ira builds a CI image and expects models baked in
+
+- WHEN Ira installs the `.deb` in an image build and runs no `kesha install`
+- THEN the image contains the CLI only, and the first transcription in that
+  image fails with the same install hint
+
+> *Technical Note — the rule and its enforcement points are specified in
+> [installation](../installation/spec.md); this requirement exists so no
+> distribution path is read as an exception to it.*
+
+## Open Issues
+
+- **`kesha completions` and `kesha manpage` are broken on the Linux-package
+  path.** Both read their file relative to `import.meta.url`
+  (`src/cli/completions.ts:38`, `src/cli/manpage.ts:9`), which in a
+  `bun build --compile` binary resolves outside the embedded filesystem. Every
+  other path ships the sources, so only the `.deb`/`.rpm` is affected.
+  Reproduced against this commit by compiling `./bin/kesha.js` for the host and
+  running both commands: each dies with an unhandled `ENOENT` for
+  `/completions/kesha.bash` and `/man/kesha.1` respectively, printing a stack
+  trace and exiting 1 — not the exit-2 usage error
+  [cli-shell-integration](../cli-shell-integration/spec.md) specifies for bad
+  input, and not a message a user can act on. `model-plan.json` is unaffected
+  because it is a static import, and `kesha install --plan` was verified working
+  in the same binary. Needs a GitHub issue; the fix is to embed both assets
+  rather than resolve them at runtime.
+- The Homebrew formula in `packaging/homebrew/Formula/kesha-voice-kit.rb` is a
+  template kept in this repository; the tap that users install from is
+  `drakulavich/homebrew-tap`, updated by `.github/workflows/homebrew-tap.yml`
+  on `release: published`. The in-repo copy pins an older version
+  (`v1.18.0`) than the current CLI, and nothing fails when it goes stale —
+  there is no check that the in-repo template and the published tap agree.
+- `homebrew-tap.yml` fires on every published release, including Engine
+  releases that publish no CLI version (see CLAUDE.md, "un-drafting an engine
+  tag still fires 🍺 Homebrew Tap"). The lane's own skip logic is the only thing
+  keeping an Engine tag out of the tap; that skip is not specified here.
+- The container image publishes on every push to `main`, so the `main`-tagged
+  image can be ahead of any released CLI version. Only tag-triggered images
+  correspond to a release.
+- `Dockerfile` still installs a `/usr/local/bin/parakeet` symlink. No spec, doc,
+  or test references that name; it appears to be a legacy alias with no stated
+  deprecation.
+- No test asserts that the Homebrew, Linux-package, container, and Nix paths
+  produce the same CLI version — the "same contents everywhere" requirement is
+  held by construction, not by a gate.

--- a/openspec/specs/cli-shell-integration/spec.md
+++ b/openspec/specs/cli-shell-integration/spec.md
@@ -229,32 +229,40 @@ The CLI SHALL print its own version — the version of the installed CLI package
 > version, and empty invocation keep stable stream contracts" test in
 > `tests/integration/cli-contracts.test.ts`.*
 
-### Requirement: `--help` and a bare invocation both print usage, and differ only in Exit code
+### Requirement: `--help` and a bare invocation both print usage to stdout, and differ in Exit code
 
-The CLI SHALL print usage listing the transcription form and every subcommand to stdout with an empty stderr, exiting 0 when help was asked for and 1 when the CLI was invoked with no arguments at all.
+The CLI SHALL print usage to stdout with an empty stderr in both cases, exiting 0 when help was asked for and 1 when the CLI was invoked with no arguments at all, so a script that lost its argument fails rather than silently succeeding.
 
 #### Scenario: Maks asks what the CLI can do
 
 - WHEN Maks runs `kesha --help`
-- THEN stdout names the product, the transcription form, and the subcommands
-  with their flags
+- THEN stdout names the product, the transcription form, and the flags of the
+  top-level transcription command
 - AND stderr is empty
 - AND the process exits 0
 
 #### Scenario: Ira invokes the CLI with no arguments in a script
 
 - WHEN `kesha` runs with no arguments
-- THEN stdout carries the usage block, starting with the
-  `kesha <audio_file> [audio_file ...]` form and listing every subcommand
+- THEN stdout carries a usage block starting with the
+  `kesha <audio_file> [audio_file ...]` form
 - AND stderr is empty
-- AND the process exits 1, so a script that lost its argument fails rather than
-  silently succeeding
+- AND the process exits 1
 
-> *Technical Note — the no-argument usage block is
+#### Scenario: A subcommand exists but the usage block does not name it
+
+- GIVEN a subcommand the hard-coded usage block omits
+- WHEN Ira reads that block to discover the command set
+- THEN the subcommand is still dispatchable, and still absent from the listing
+  — the block is maintained by hand and drifts (see Open Issues)
+
+> *Technical Note — the no-argument usage block is a hand-maintained string at
 > `src/cli/main.ts:533-547`, printed with `log.info` (stdout) followed by
-> `process.exit(1)`. `--help` is citty's own renderer over the command's `meta`
-> and `args`. Both stream contracts are asserted in
-> `tests/integration/cli-contracts.test.ts`.*
+> `process.exit(1)`; it lists ten subcommands and omits `init` and `mcp`, both
+> of which `SUBCOMMANDS` in `src/cli/dispatch.ts:10-23` dispatches. `--help` is
+> citty's own renderer over the main command's `meta` and `args`, so it shows
+> the transcription flags, not each subcommand's. Both stream contracts are
+> asserted in `tests/integration/cli-contracts.test.ts`.*
 
 ### Requirement: Result-producing commands follow the stdout-purity principle
 
@@ -307,6 +315,11 @@ When the first positional token is not a file and not a known subcommand, the CL
 - There is no `--color` flag to force color on when stdout is not a TTY (e.g.
   inside tmux with `TERM=dumb`); `FORCE_COLOR` from picocolors is the current
   workaround.
+- The bare-invocation usage block omits `init` and `mcp` — two dispatchable
+  subcommands, one of them the command interactive missing-model errors
+  recommend ([installation](../installation/spec.md), "Documented install entry
+  points match interactive hints"). Nothing keeps the hand-written list and
+  `SUBCOMMANDS` in sync, so it will drift again.
 - `kesha completions` and `kesha manpage` both resolve their file relative to
   `import.meta.url`, which does not survive the `bun build --compile` step the
   `.deb`/`.rpm` are built with, so on that install path both crash with an

--- a/openspec/specs/cli-shell-integration/spec.md
+++ b/openspec/specs/cli-shell-integration/spec.md
@@ -203,6 +203,59 @@ and exit 0. No arguments are accepted.
 > via `new URL("../../man/kesha.1", import.meta.url)`. Written directly to
 > `process.stdout` — no colorization.*
 
+### Requirement: `--version` prints the CLI version and nothing else
+
+The CLI SHALL print its own version — the version of the installed CLI package, not the Engine's — to stdout as a bare SemVer string, write nothing to stderr, and exit 0.
+
+#### Scenario: Ira pins a version in a CI script
+
+- WHEN Ira runs `kesha --version`
+- THEN stdout is a bare SemVer string such as `1.28.0`, optionally with a
+  prerelease suffix
+- AND stderr is empty
+- AND the process exits 0
+
+#### Scenario: The Engine is not installed
+
+- GIVEN no Engine binary is present
+- WHEN Ira runs `kesha --version`
+- THEN it still prints the CLI version and exits 0, because the CLI version does
+  not depend on the Engine
+
+> *Technical Note — citty renders `meta.version`, set from `packageVersion`
+> (`src/cli/main.ts:412-416`), which reads `package.json#version` via
+> `src/package-info.ts`. The Pinned Engine version is a separate field and is
+> surfaced by `kesha status`, not here. Asserted by the "entrypoint help,
+> version, and empty invocation keep stable stream contracts" test in
+> `tests/integration/cli-contracts.test.ts`.*
+
+### Requirement: `--help` and a bare invocation both print usage, and differ only in Exit code
+
+The CLI SHALL print usage listing the transcription form and every subcommand to stdout with an empty stderr, exiting 0 when help was asked for and 1 when the CLI was invoked with no arguments at all.
+
+#### Scenario: Maks asks what the CLI can do
+
+- WHEN Maks runs `kesha --help`
+- THEN stdout names the product, the transcription form, and the subcommands
+  with their flags
+- AND stderr is empty
+- AND the process exits 0
+
+#### Scenario: Ira invokes the CLI with no arguments in a script
+
+- WHEN `kesha` runs with no arguments
+- THEN stdout carries the usage block, starting with the
+  `kesha <audio_file> [audio_file ...]` form and listing every subcommand
+- AND stderr is empty
+- AND the process exits 1, so a script that lost its argument fails rather than
+  silently succeeding
+
+> *Technical Note — the no-argument usage block is
+> `src/cli/main.ts:533-547`, printed with `log.info` (stdout) followed by
+> `process.exit(1)`. `--help` is citty's own renderer over the command's `meta`
+> and `args`. Both stream contracts are asserted in
+> `tests/integration/cli-contracts.test.ts`.*
+
 ### Requirement: Result-producing commands follow the stdout-purity principle
 
 The CLI SHALL write only the primary result to stdout for commands whose
@@ -254,3 +307,8 @@ When the first positional token is not a file and not a known subcommand, the CL
 - There is no `--color` flag to force color on when stdout is not a TTY (e.g.
   inside tmux with `TERM=dumb`); `FORCE_COLOR` from picocolors is the current
   workaround.
+- `kesha completions` and `kesha manpage` both resolve their file relative to
+  `import.meta.url`, which does not survive the `bun build --compile` step the
+  `.deb`/`.rpm` are built with, so on that install path both crash with an
+  unhandled `ENOENT` instead of printing or failing cleanly. Reproduction and
+  scope: [cli-distribution](../cli-distribution/spec.md), Open Issues.

--- a/openspec/specs/installation/spec.md
+++ b/openspec/specs/installation/spec.md
@@ -666,9 +666,9 @@ install proceeds without it.
 > `@clack/prompts::multiselect` with `required: false` (no-selection = skip TTS).
 > TTY check: `process.stdin.isTTY === true && process.stdout.isTTY === true`.*
 
-### Requirement: The star prompt appears at most once per meaningful version, and never blocks
+### Requirement: The star prompt is gated to meaningful version bumps and bounded in time
 
-After a successful install the CLI MAY print a one-time invitation to star the repository, and SHALL show it at most once for a given CLI version, only on a first install or a major/minor bump, never on a patch-only bump, and never in a way that blocks or fails the install.
+After a successful install the CLI MAY print an invitation to star the repository, and SHALL show it only on a first install or a major/minor bump — never on a patch-only bump — and SHALL bound how long it waits on any external probe before printing.
 
 #### Scenario: Maks installs for the first time
 
@@ -691,6 +691,13 @@ After a successful install the CLI MAY print a one-time invitation to star the r
   the probe
 - AND the install still exits 0
 
+#### Scenario: The marker cannot be written
+
+- GIVEN the engine directory is read-only, so the marker write fails
+- WHEN the invitation is shown
+- THEN the install still succeeds, and the next install for the same version
+  prompts again, because nothing recorded that it already asked
+
 #### Scenario: The repository is already starred
 
 - GIVEN an authenticated `gh` reports the repository is already starred
@@ -705,7 +712,10 @@ After a successful install the CLI MAY print a one-time invitation to star the r
 > (`src/star.ts:16`) and is written *before* printing, so one run never prompts
 > twice and a write failure is non-fatal. `GH_PROBE_TIMEOUT_MS` is 2 000 ms
 > (`src/star.ts:6`), sized to clear a healthy `gh auth status` (0.77–1.21 s
-> measured) but not a wedged one that blocked install 11–25 s (#810). Covered by
+> measured) but not a wedged one that blocked install 11–25 s (#810). Only the
+> marker write is guarded (`src/star.ts:85`); the call sits inside
+> `performInstall`'s `try` (`src/cli/install.ts:239`), so anything else it
+> throws lands in the catch that exits 1 — see Open Issues. Covered by
 > `tests/unit/star.test.ts`.*
 
 ### Requirement: Install cost is stated before download
@@ -726,3 +736,9 @@ Interactive missing-model errors recommend `kesha init`; the Quick Start SHALL m
 
 - `kesha record` has no Windows or Linux microphone capture; `record.rs` gates capture on
   macOS and the README directs other platforms to pass an existing audio file.
+- **A star prompt failure can fail an install that already succeeded.**
+  `maybeAskForStar` runs inside `performInstall`'s `try` after the engine is on
+  disk, and only its marker write is guarded. A throw from `Bun.which`, either
+  `gh` spawn, or the logger reaches the catch, which reports the install as
+  `failed` and exits 1 — after every byte was downloaded and verified. The
+  prompt is cosmetic and should not be able to do that.

--- a/openspec/specs/installation/spec.md
+++ b/openspec/specs/installation/spec.md
@@ -666,6 +666,48 @@ install proceeds without it.
 > `@clack/prompts::multiselect` with `required: false` (no-selection = skip TTS).
 > TTY check: `process.stdin.isTTY === true && process.stdout.isTTY === true`.*
 
+### Requirement: The star prompt appears at most once per meaningful version, and never blocks
+
+After a successful install the CLI MAY print a one-time invitation to star the repository, and SHALL show it at most once for a given CLI version, only on a first install or a major/minor bump, never on a patch-only bump, and never in a way that blocks or fails the install.
+
+#### Scenario: Maks installs for the first time
+
+- GIVEN Maks has never installed Kesha
+- WHEN `kesha install` finishes successfully
+- THEN the invitation is printed once
+- AND running `kesha install` again for the same version prints nothing
+
+#### Scenario: Ira upgrades by a patch version in CI
+
+- GIVEN a previous install recorded version `1.28.0`
+- WHEN Ira installs `1.28.1`
+- THEN no invitation is printed, because a patch bump is not a meaningful bump
+
+#### Scenario: The environment cannot be probed
+
+- GIVEN `gh` is absent, unauthenticated, or wedged
+- WHEN the invitation would be shown
+- THEN the plain invitation is printed anyway, without waiting indefinitely on
+  the probe
+- AND the install still exits 0
+
+#### Scenario: The repository is already starred
+
+- GIVEN an authenticated `gh` reports the repository is already starred
+- WHEN the invitation would be shown
+- THEN nothing is printed, and the slot is still consumed so the same version
+  never asks again
+
+> *Technical Note — `maybeAskForStar` (`src/star.ts:62`) is called after
+> `installEngine` succeeds (`src/cli/install.ts:239`).
+> `shouldShowStarPrompt` (`src/star.ts:42`) returns true for an absent marker
+> and for a major-or-minor increase only. The marker is `<engine-bin>.star-seen`
+> (`src/star.ts:16`) and is written *before* printing, so one run never prompts
+> twice and a write failure is non-fatal. `GH_PROBE_TIMEOUT_MS` is 2 000 ms
+> (`src/star.ts:6`), sized to clear a healthy `gh auth status` (0.77–1.21 s
+> measured) but not a wedged one that blocked install 11–25 s (#810). Covered by
+> `tests/unit/star.test.ts`.*
+
 ### Requirement: Install cost is stated before download
 User-facing install documentation SHALL state the approximate download/disk cost of `kesha install` (~2.7 GB) and the quiet-progress behavior of the model step next to the command itself, and SHALL present `kesha install --plan` (exact sizes, downloads nothing) and `kesha status --disk` as the user-facing cost-inspection commands.
 

--- a/openspec/specs/openclaw-plugin/spec.md
+++ b/openspec/specs/openclaw-plugin/spec.md
@@ -96,7 +96,7 @@ The plugin SHALL require that the CLI, Engine, and models are already installed,
 
 ### Requirement: A failed transcription yields an empty transcript rather than a raised error
 
-The plugin SHALL absorb every failure — spawn failure, non-zero exit, timeout, unparseable output — and return an empty transcript, so a bad audio message cannot crash the agent's message handling.
+The plugin SHALL absorb every failure that occurs once transcription has started — spawn failure, non-zero exit, timeout, unparseable output — and return an empty transcript, so a bad audio message cannot crash the agent's message handling. Failures before that point are not absorbed (see Open Issues).
 
 #### Scenario: The CLI exits non-zero on a corrupt attachment
 
@@ -112,11 +112,13 @@ The plugin SHALL absorb every failure — spawn failure, non-zero exit, timeout,
 - THEN the subprocess is stopped and the plugin returns an empty transcript
 - AND a caller-supplied timeout is honoured in place of the default
 
-> *Technical Note — every failure branch in `openclaw-plugin.cjs:50-70` returns
-> `{ text: "" }`; the `finally` block unlinks the temporary file best-effort.
-> `DEFAULT_TIMEOUT_MS` is 60 000 and is overridden by `req.timeoutMs`
-> (`:30`, `:50`). This deliberately trades the corpus-wide "never swallow
-> errors" rule for host stability — see Open Issues.*
+> *Technical Note — every failure branch inside the `try` at
+> `openclaw-plugin.cjs:45-70` returns `{ text: "" }`; the `finally` block
+> unlinks the temporary file best-effort. `DEFAULT_TIMEOUT_MS` is 60 000
+> (`:29`) and is overridden by `req.timeoutMs` (`:48`). The `try` opens at `:45`
+> — after the write at `:43` — so the write is outside it. This deliberately
+> trades the corpus-wide "never swallow errors" rule for host stability — see
+> Open Issues.*
 
 ### Requirement: Temporary audio never outlives the request
 
@@ -127,14 +129,17 @@ The plugin SHALL write the audio it was handed to a per-request temporary file u
 - WHEN the plugin finishes a successful transcription
 - THEN the temporary audio file no longer exists
 
-#### Scenario: Two messages are transcribed concurrently
+#### Scenario: Two messages arrive in the same millisecond
 
-- GIVEN two requests are in flight in the same host process
-- WHEN both write temporary files
-- THEN their paths differ, so neither overwrites or deletes the other's audio
+- GIVEN two requests with the same file extension start within one millisecond
+  in the same host process
+- WHEN both compose their temporary path
+- THEN the paths collide, and one request overwrites the other's audio and
+  deletes the file the other is still using — the name carries no per-request
+  uniqueness beyond the clock (see Open Issues)
 
-> *Technical Note — `tempAudioPath` (`openclaw-plugin.cjs:33`) composes
-> `kesha-<pid>-<timestamp><ext>` under `os.tmpdir()`. Deletion happens in the
+> *Technical Note — `tempAudioPath` (`openclaw-plugin.cjs:32`) composes
+> `kesha-<pid>-<Date.now()><ext>` under `os.tmpdir()`. Deletion happens in the
 > `finally` of `transcribeAudio` and swallows its own error.*
 
 ### Requirement: The plugin source carries no token that trips the host's scanner
@@ -199,6 +204,16 @@ Publishing the plugin to the OpenClaw registry SHALL be its own deliberate step,
   swallow errors; never return success on failure" rule. An empty transcript is
   indistinguishable from silence that genuinely transcribed to nothing, so a
   misconfigured install looks like a quiet user.
+- **The temporary write is outside the `try`.** `fs.writeFileSync` runs at
+  `openclaw-plugin.cjs:43` and the `try` opens at `:45`, so a full disk, a
+  read-only or missing `os.tmpdir()`, or a permission error throws straight into
+  the host — the one failure the absorb-everything contract does not cover, and
+  the one most likely to hit every request rather than one.
+- **Temporary paths are not collision-safe.** `kesha-<pid>-<Date.now()><ext>`
+  repeats for two same-extension requests in the same millisecond in one
+  process. `Date.now()` has millisecond resolution and OpenClaw can hand the
+  provider concurrent messages; the `finally` then deletes a file the other
+  request may still be reading. A counter or `randomUUID()` would close it.
 - `openclaw.plugin.json` advertises "25 languages" and "~19x faster than
   Whisper" independently of the README and `server.json`. Nothing keeps those
   claims in sync when the supported-language set changes.

--- a/openspec/specs/openclaw-plugin/spec.md
+++ b/openspec/specs/openclaw-plugin/spec.md
@@ -1,0 +1,207 @@
+# OpenClaw Plugin Specification
+
+## Purpose
+
+The OpenClaw plugin gives an LLM agent ears: a voice message arriving in any
+channel OpenClaw is connected to gets transcribed locally by Kesha before the
+agent reads it. The plugin ships inside the CLI package and drives the `kesha`
+command as a subprocess — it is a thin adapter, not a second implementation of
+Transcription.
+
+This is Maks's main workflow: voice notes in Telegram, transcribed on his own
+laptop, no API key anywhere.
+
+## Non-Goals
+
+- Transcription itself. The plugin shells out to the CLI and specifies nothing
+  about how audio becomes text — see [transcription](../transcription/spec.md).
+- Speaking. `kesha say` produces messenger-ready OGG/Opus, but the plugin does
+  not register a synthesis capability; invoking it is left to a host hook or
+  agent tool.
+- Installing or updating OpenClaw itself, and the shape of OpenClaw's own
+  configuration file beyond the keys this integration is documented against.
+- The MCP server, which is a different integration for a different protocol —
+  see [mcp-server](../mcp-server/spec.md).
+
+## Requirements
+
+### Requirement: The plugin ships inside the CLI package
+
+The plugin manifest and its entry module SHALL be published as part of the CLI package and declared as an OpenClaw extension there, so installing the plugin needs no artifact the CLI install did not already deliver.
+
+#### Scenario: Maks installs the plugin after installing the CLI
+
+- GIVEN Maks has run `bun add -g @drakulavich/kesha-voice-kit`
+- WHEN Maks runs `openclaw plugins install @drakulavich/kesha-voice-kit`
+- THEN OpenClaw finds the manifest and entry module inside the package and
+  registers the plugin
+
+#### Scenario: The plugin files are dropped from the published package
+
+- WHEN either plugin file stops being published
+- THEN the plugin cannot be installed from npm at all, because no other artifact
+  carries it
+
+> *Technical Note — `openclaw.plugin.json` and `openclaw-plugin.cjs` are listed
+> in `package.json#files`, and `package.json#openclaw.extensions` points at the
+> `.cjs`. `package.json#openclaw.compat.pluginApi` and
+> `#openclaw.build.openclawVersion` are required by ClawHub's publisher — see
+> `docs/runbooks/openclaw-plugin.md`. The manifest's required fields are `id`
+> and a JSON-Schema-shaped `configSchema`; `configPatch` is not a valid field
+> and is silently discarded by the loader.*
+
+### Requirement: Transcription runs through the installed CLI as a subprocess
+
+The plugin SHALL obtain transcripts by invoking the installed `kesha` command as a subprocess and reading its machine-readable output. It SHALL NOT link the Engine, embed a model, or reimplement any part of Transcription.
+
+#### Scenario: Maks's agent receives a voice message
+
+- GIVEN `kesha` is on PATH with the Engine and models installed
+- WHEN a voice message reaches OpenClaw and audio understanding is enabled
+- THEN the audio is written to a temporary file, `kesha` transcribes it, and the
+  agent sees the transcript text
+
+#### Scenario: A request arrives with no audio
+
+- WHEN the plugin is handed a request carrying no audio buffer
+- THEN it returns an empty transcript without spawning anything
+
+> *Technical Note — `transcribeAudio` in `openclaw-plugin.cjs:39-72` writes the
+> buffer to `os.tmpdir()` keeping the original extension (defaulting to `.ogg`),
+> runs `spawnSync("kesha", ["--json", tmp])`, and reads `parsed[0].text` from
+> the result array. It reports the model id `parakeet-tdt-0.6b-v3` on success.
+> The registered provider declares `capabilities: ["audio"]` and
+> `autoPriority: { audio: 50 }` (`:75-84`).*
+
+### Requirement: The plugin never triggers a download
+
+The plugin SHALL require that the CLI, Engine, and models are already installed, and SHALL NOT download or install anything itself. The Never-auto-download rule applies to it exactly as it applies to the CLI.
+
+#### Scenario: A voice message arrives before `kesha install` was run
+
+- GIVEN `kesha` is on PATH but no Engine is installed
+- WHEN a voice message reaches the plugin
+- THEN nothing is downloaded, and the agent receives no transcript
+
+#### Scenario: The CLI is not installed at all
+
+- GIVEN `kesha` does not resolve on PATH
+- WHEN a voice message reaches the plugin
+- THEN the spawn fails and the plugin returns an empty transcript
+
+> *Technical Note — the prerequisites (`bun add -g`, then `kesha install`, plus
+> `kesha install --tts` only if `kesha say` is used) are stated in the header
+> comment of `openclaw-plugin.cjs:14-18` and in `docs/openclaw.md`. The plugin
+> holds no install code path.*
+
+### Requirement: A failed transcription yields an empty transcript rather than a raised error
+
+The plugin SHALL absorb every failure — spawn failure, non-zero exit, timeout, unparseable output — and return an empty transcript, so a bad audio message cannot crash the agent's message handling.
+
+#### Scenario: The CLI exits non-zero on a corrupt attachment
+
+- GIVEN a corrupt audio attachment
+- WHEN the plugin transcribes it
+- THEN `kesha` exits non-zero and the plugin returns an empty transcript
+- AND the temporary file is deleted regardless
+
+#### Scenario: Transcription outruns the timeout
+
+- GIVEN a long recording and the default timeout
+- WHEN transcription has not finished in time
+- THEN the subprocess is stopped and the plugin returns an empty transcript
+- AND a caller-supplied timeout is honoured in place of the default
+
+> *Technical Note — every failure branch in `openclaw-plugin.cjs:50-70` returns
+> `{ text: "" }`; the `finally` block unlinks the temporary file best-effort.
+> `DEFAULT_TIMEOUT_MS` is 60 000 and is overridden by `req.timeoutMs`
+> (`:30`, `:50`). This deliberately trades the corpus-wide "never swallow
+> errors" rule for host stability — see Open Issues.*
+
+### Requirement: Temporary audio never outlives the request
+
+The plugin SHALL write the audio it was handed to a per-request temporary file under the system temporary directory and SHALL delete it once the request finishes, whether it succeeded or failed.
+
+#### Scenario: A voice message is transcribed successfully
+
+- WHEN the plugin finishes a successful transcription
+- THEN the temporary audio file no longer exists
+
+#### Scenario: Two messages are transcribed concurrently
+
+- GIVEN two requests are in flight in the same host process
+- WHEN both write temporary files
+- THEN their paths differ, so neither overwrites or deletes the other's audio
+
+> *Technical Note — `tempAudioPath` (`openclaw-plugin.cjs:33`) composes
+> `kesha-<pid>-<timestamp><ext>` under `os.tmpdir()`. Deletion happens in the
+> `finally` of `transcribeAudio` and swallows its own error.*
+
+### Requirement: The plugin source carries no token that trips the host's scanner
+
+The plugin entry module SHALL NOT contain the substrings OpenClaw's `dangerous-exec` scanner treats as forbidden, anywhere in the file — comments included — because the scanner matches raw text rather than parsed code, and a match blocks installation of an otherwise legitimate local-CLI wrapper.
+
+#### Scenario: Maks installs the published plugin
+
+- WHEN OpenClaw scans the entry module during installation
+- THEN no rule fires and the plugin installs
+
+#### Scenario: An edit names the forbidden module in a comment
+
+- WHEN a comment in the entry module spells the forbidden module name
+- THEN the scanner fires even though the code is unchanged, and the plugin is
+  blocked
+
+> *Technical Note — the module specifier is split across a `+` at
+> `openclaw-plugin.cjs:25` precisely so the substring is absent from the source;
+> the reason is recorded in the comment above it and in
+> `docs/runbooks/openclaw-plugin.md` ("Comments count — it's a naive regex, not
+> AST-aware"). CLAUDE.md repeats the prohibition. This is also why the entry
+> module is CommonJS requiring Node built-ins rather than Bun-native APIs: it
+> runs inside OpenClaw's runtime, not Kesha's.*
+
+### Requirement: Plugin distribution is independent of the CLI and Engine releases
+
+Publishing the plugin to the OpenClaw registry SHALL be its own deliberate step, not a side effect of publishing the CLI to npm or cutting an Engine release.
+
+#### Scenario: A CLI release is published
+
+- WHEN a CLI version is published to npm
+- THEN nothing is published to the OpenClaw registry as a result
+
+#### Scenario: The registry listing goes stale
+
+- GIVEN several CLI releases have shipped with no registry publish
+- THEN the registry listing stays on its last published version, and nothing
+  fails to report the drift
+
+> *Technical Note — `docs/runbooks/openclaw-plugin.md` states the ClawHub
+> publish is independent of npm publish, GitHub releases, and
+> `build-engine.yml`, and that no CI lane performs it. `--force` overwrites an
+> existing install; `openclaw plugins uninstall` is interactive with no
+> non-interactive flag.*
+
+## Open Issues
+
+- **The registered provider is not the path that transcribes.** Per
+  `docs/runbooks/openclaw-plugin.md`, OpenClaw routes audio through the
+  `type: "cli"` entry in `tools.media.audio.models`, which spawns `kesha`
+  directly; `registerMediaUnderstandingProvider` requires an API key via
+  `requireApiKey()` and silently fails for local CLI tools, so the registration
+  exists for discoverability only. On the documented default configuration
+  `transcribeAudio` never runs — meaning most of the requirements above describe
+  a code path users do not exercise. Worth an issue to either wire it up or
+  retire it.
+- **Nothing tests the plugin.** No unit or integration test loads
+  `openclaw-plugin.cjs`, asserts its provider registration, or checks the
+  scanner constraint. All of it is held by review and by the runbook.
+- The swallow-everything error contract conflicts with the repository's "never
+  swallow errors; never return success on failure" rule. An empty transcript is
+  indistinguishable from silence that genuinely transcribed to nothing, so a
+  misconfigured install looks like a quiet user.
+- `openclaw.plugin.json` advertises "25 languages" and "~19x faster than
+  Whisper" independently of the README and `server.json`. Nothing keeps those
+  claims in sync when the supported-language set changes.
+- The plugin passes `--json` without `--timestamps`; the timestamped variant
+  documented in `docs/openclaw.md` is a user-side configuration of the
+  `type: "cli"` path, not something the plugin can select.

--- a/openspec/specs/process-lifecycle/spec.md
+++ b/openspec/specs/process-lifecycle/spec.md
@@ -1,0 +1,175 @@
+# Process Lifecycle Specification
+
+## Purpose
+
+Every command that does real work spawns the Engine as a subprocess, and some of
+those runs take minutes. This spec covers what happens when such a run is
+interrupted: which processes are terminated, how long they are given, what exit
+code the CLI reports, and what a caller who cancels programmatically observes.
+
+Ira runs batches in CI where a job cancellation must not leave a model-loading
+Engine holding a runner's CPU. Maks presses Ctrl-C on a long meeting
+transcription and expects his terminal back. Sona cancels an in-flight call from
+her agent and needs a distinguishable outcome rather than an empty transcript.
+
+## Non-Goals
+
+- The Raycast extension's own termination ladder, which manages processes it
+  spawned itself — see [raycast-extension](../raycast-extension/spec.md).
+- Partial-download cleanup when an install is interrupted — see
+  [installation](../installation/spec.md).
+- Cooperative stop conditions that are not interruptions: `kesha record` ending
+  on stdin EOF or `--max-seconds`
+  ([audio-recording](../audio-recording/spec.md)), and Diarization's adaptive
+  timeout ([speaker-diarization](../speaker-diarization/spec.md)).
+- Signal handling inside the Engine itself; this spec covers what the CLI does
+  to the Engine.
+
+## Requirements
+
+### Requirement: An interrupted command terminates the Engine and reports the signal in its Exit code
+
+When the CLI receives an interrupt or termination signal while an Engine subprocess is running, it SHALL terminate that subprocess and SHALL exit with the code conventionally derived from the signal — 130 for interrupt, 143 for termination — rather than with the command's own success or failure code.
+
+#### Scenario: Maks interrupts a long transcription
+
+- GIVEN Maks is transcribing a two-hour recording
+- WHEN Maks presses Ctrl-C
+- THEN the Engine subprocess is terminated
+- AND the CLI exits 130
+- AND no Engine process is left running
+
+#### Scenario: Ira's CI job is cancelled
+
+- GIVEN Ira's pipeline sends a termination signal to `kesha` mid-batch
+- WHEN the signal arrives
+- THEN the Engine subprocess is terminated and the CLI exits 143
+
+#### Scenario: A signal arrives when nothing is running
+
+- GIVEN no Engine subprocess is active
+- WHEN the CLI receives an interrupt
+- THEN it still exits with the signal's code without waiting on a cleanup that
+  has nothing to clean
+
+> *Technical Note — `ensureSignalHandlers` (`src/process-tree.ts:101-107`)
+> installs one `SIGINT` handler (exit code 130) and one `SIGTERM` handler (exit
+> code 143) the first time any Engine process is registered.
+> `terminateActiveProcessTrees` (`:109`) sets `process.exitCode`, signals every
+> registered process, then schedules the actual `process.exit`. With no active
+> processes the delay is `SIGNAL_EXIT_BUFFER_MS` (50 ms) instead of the full
+> grace window. These codes extend the Exit code taxonomy in the Glossary.*
+
+### Requirement: Termination targets the whole process tree, not just the direct child
+
+The CLI SHALL terminate the Engine's whole process tree, so that helpers the Engine spawned — the AVSpeech and text-language Sidecars among them — do not survive the run that started them.
+
+#### Scenario: Maks interrupts a synthesis that is driving a Sidecar
+
+- GIVEN `kesha say` is running with a `macos-*` Voice id, so the AVSpeech
+  Sidecar is running under the Engine
+- WHEN Maks presses Ctrl-C
+- THEN both the Engine and the Sidecar are terminated
+
+#### Scenario: The process tree cannot be addressed
+
+- GIVEN the subprocess has no usable process id, or the platform call to signal
+  the group fails
+- WHEN termination runs
+- THEN the CLI falls back to signalling the direct child, and a child that has
+  already exited is not treated as an error
+
+> *Technical Note — `terminateProcessTree` (`src/process-tree.ts:60`) signals
+> the negated pid (the process group) on POSIX and shells out to `taskkill /PID
+> <pid> /T` (adding `/F` for a force kill) on Windows; both fall back to
+> `safeKillDirect` (`:88`), which swallows the error from a process that exited
+> between the decision and the signal. Registration happens in `src/engine.ts`
+> (`:152`, `:454`) and `src/synth.ts:177`.*
+
+### Requirement: A subprocess that ignores the first signal is force-killed
+
+The CLI SHALL escalate to an unignorable kill after a bounded grace period, so a subprocess wedged inside a native call cannot hold the terminal open indefinitely.
+
+#### Scenario: The Engine is wedged in a native call
+
+- GIVEN the Engine is inside a CoreML call that does not observe the first
+  signal
+- WHEN Maks presses Ctrl-C
+- THEN the Engine is force-killed shortly afterwards and the CLI exits 130
+
+#### Scenario: The Engine exits cooperatively
+
+- GIVEN the Engine handles the first signal and exits promptly
+- WHEN it exits before the grace period elapses
+- THEN no force kill is needed, and the CLI still exits with the signal's code
+
+> *Technical Note — `FORCE_KILL_GRACE_MS` is 1 000 ms
+> (`src/process-tree.ts:13`); `scheduleForceKill` (`:96`) arms the escalation.
+> During signal cleanup the timer is deliberately `ref`'d so the escalation
+> survives an otherwise-idle event loop, whereas the timer armed for a
+> programmatic abort is `unref`'d.*
+
+### Requirement: The CLI does not exit before cleanup has had its window
+
+The CLI SHALL let signal cleanup complete before exiting, so an interrupted command reports the signal's Exit code rather than racing its own failure path, and no subprocess outlives the CLI.
+
+#### Scenario: A batch fails because its files were interrupted
+
+- GIVEN Ira interrupts `kesha a.ogg b.ogg c.ogg` partway through
+- WHEN the interrupted files are recorded as failures
+- THEN the CLI waits for the pending cleanup and exits 130, not 1
+
+#### Scenario: A batch fails for reasons unrelated to any signal
+
+- GIVEN no signal was received and every file failed
+- WHEN the batch finishes
+- THEN the CLI exits 1 as [transcription](../transcription/spec.md) specifies
+
+> *Technical Note — `src/cli/main.ts:612-619` checks
+> `getPendingSignalExitCode()` before the generic `process.exit(1)` and awaits
+> `waitForPendingSignalCleanup()` when one is pending. The cleanup promise
+> resolves after `FORCE_KILL_GRACE_MS + SIGNAL_EXIT_BUFFER_MS` when processes
+> were signalled (`src/process-tree.ts:122-132`).*
+
+### Requirement: A programmatic abort is a distinguishable outcome, not an empty result
+
+When a caller of the Core API cancels an in-flight call, the call SHALL fail with an abort error rather than returning a partial or empty result, and the Engine subprocess it started SHALL be terminated.
+
+#### Scenario: Sona cancels a transcription from her agent
+
+- GIVEN Sona passed an abort signal into a Core API call and the Engine is
+  running
+- WHEN she aborts it
+- THEN the call rejects with an error named `AbortError`
+- AND the Engine subprocess is terminated, escalating to a force kill if needed
+
+#### Scenario: The signal is already aborted before the call starts
+
+- GIVEN Sona passes an already-aborted signal
+- WHEN she makes the call
+- THEN it rejects with the same abort error without spawning an Engine at all
+
+> *Technical Note — `engineAbortError` (`src/process-tree.ts:24`) returns an
+> `Error` with `name = "AbortError"` and the message `kesha-engine process
+> aborted`. `src/engine.ts:147` rejects on an already-aborted signal before
+> spawning; the abort listener at `:155-160` terminates the tree and arms the
+> force kill, and `:185` converts the completed run into the abort error. The
+> abort path is not reachable from the CLI — see Open Issues.*
+
+## Open Issues
+
+- Exit codes 130 and 143 are not documented in `docs/errors.md` alongside 0/1/2
+  (and `say`'s 4/5), and the Glossary's Exit code entry did not list them before
+  this spec. Nothing tests them end to end.
+- The abort path (`opts.signal`) is reachable only from the Core API; no CLI
+  flag or timeout wires an `AbortSignal` into a run. The Raycast extension gets
+  its cancellation by killing the CLI process instead, which lands on the signal
+  path above rather than this one.
+- `waitForPendingSignalCleanup` is consulted only in the main transcription
+  command (`src/cli/main.ts`). `kesha say`, `kesha record`, and `kesha install`
+  rely on the handler's own `process.exit`, so their interrupted exit code is
+  set by the same handler but never awaited by the command — whether that can
+  race a command-owned `process.exit` is untested.
+- The Windows path spawns `taskkill` and does not wait for it, so on Windows the
+  tree kill is fire-and-forget; nothing verifies it completed before the CLI
+  exits.

--- a/openspec/specs/process-lifecycle/spec.md
+++ b/openspec/specs/process-lifecycle/spec.md
@@ -7,6 +7,9 @@ those runs take minutes. This spec covers what happens when such a run is
 interrupted: which processes are terminated, how long they are given, what exit
 code the CLI reports, and what a caller who cancels programmatically observes.
 
+It covers the spawns that opt in by registering themselves. Two short-lived
+spawns do not, and are listed under Open Issues rather than quietly implied.
+
 Ira runs batches in CI where a job cancellation must not leave a model-loading
 Engine holding a runner's CPU. Maks presses Ctrl-C on a long meeting
 transcription and expects his terminal back. Sona cancels an in-flight call from
@@ -27,9 +30,9 @@ her agent and needs a distinguishable outcome rather than an empty transcript.
 
 ## Requirements
 
-### Requirement: An interrupted command terminates the Engine and reports the signal in its Exit code
+### Requirement: An interrupted command terminates the registered Engine subprocess and reports the signal in its Exit code
 
-When the CLI receives an interrupt or termination signal while an Engine subprocess is running, it SHALL terminate that subprocess and SHALL exit with the code conventionally derived from the signal — 130 for interrupt, 143 for termination — rather than with the command's own success or failure code.
+When the CLI receives an interrupt or termination signal while a registered Engine subprocess is running, it SHALL terminate that subprocess and SHALL exit with the code conventionally derived from the signal — 130 for interrupt, 143 for termination — rather than with the command's own success or failure code. Transcription, Language detection, synthesis, and recording register; the two `--list-voices` spawns do not (see Open Issues).
 
 #### Scenario: Maks interrupts a long transcription
 
@@ -173,3 +176,11 @@ When a caller of the Core API cancels an in-flight call, the call SHALL fail wit
 - The Windows path spawns `taskkill` and does not wait for it, so on Windows the
   tree kill is fire-and-forget; nothing verifies it completed before the CLI
   exits.
+- **Two Engine spawns never register.** `kesha say --list-voices`
+  (`src/cli/say.ts:315`) and the MCP `listVoices` (`src/mcp/voices.ts:115`) both
+  call `spawnEngineProcess` directly and await it without
+  `registerProcessTree`, so they join no process tree and install no signal
+  handler of their own. Interrupting either leaves the Engine to be reaped by
+  the shell rather than terminated by the CLI. Both are short-lived, which is
+  presumably why it never surfaced — but "short-lived" is not the contract this
+  spec states, and an Engine cold-load can take seconds.


### PR DESCRIPTION
## What

A full audit of every user-facing surface against the baseline spec corpus, and specs for everything it found uncovered. Rebased onto `main` after #911 archived `release-channels`.

**Covered before this PR:** 13 capabilities. **Uncovered:** 4 capabilities + 2 behaviours inside specs that otherwise exist.

### New baseline specs

| Spec | Why it was missing |
|---|---|
| `cli-distribution` | `installation` covers acquiring the *Engine*; its Non-Goals explicitly exclude the CLI package itself. Nothing described npm, Homebrew, `.deb`/`.rpm`, the GHCR image, the Nix flake, or `server.json`. |
| `audio-ingest` | `engine-contract` Non-Goals say "the Engine's audio decode pipeline (symphonia + rubato) is not specified here" — and no spec picked it up. |
| `process-lifecycle` | Interruption was specced only for installs (Ctrl-C during a download) and for Raycast's own process ladder. The CLI's own `SIGINT`/`SIGTERM` → process-tree kill → exit 130/143 path had nothing. |
| `openclaw-plugin` | A shipped, documented, README-advertised integration with zero spec coverage and zero tests. |

### Added to existing specs

- **`cli-shell-integration`** — `--version`, `--help`, and the bare-invocation usage block. All three have stream contracts asserted in `cli-contracts.test.ts` with no requirement behind them.
- **`installation`** — the post-install star prompt.

## Bug found while writing the specs

`kesha completions` and `kesha manpage` are broken on four of the five distribution paths — the compiled `.deb`/`.rpm` binary can't reach its assets, and Homebrew/Docker/Nix never staged them. Filed as #914, fixed in **#915**. Only npm and a repo checkout ever worked.

## Corrections after adversarial review

Codex reviewed the first revision and found **nine factual defects** — requirements asserting behaviour the code does not have. `openspec validate --specs --strict` passed on all of them, which is the point: it is a structural gate and knows nothing about whether a spec matches the code. Each was verified against the source before being accepted:

1. **Asset scope was wrong** — I claimed only the Linux packages were affected. Homebrew, the container image and Nix stage `bin`/`src` without the assets either.
2. **The Nix requirement was aspirational** — `keshaNodeModules.outputHash` is `lib.fakeHash`, and the comment above it says every CLI build fails until someone populates it. `nix run` is not a working path.
3. **`E_BAD_AUDIO` was over-promised** — `code_of` falls back to `ErrorCode::Internal` for anything uncoded, and four of the six ingest failures are uncoded. They report `E_INTERNAL`.
4. **"Bounded decode cost" was false** — `load_audio_truncated` decodes the whole file, then truncates. The bound is on what the model sees, nothing else.
5. **`--help` was overstated** — it shows top-level transcription flags, not each subcommand's, and the hand-written usage block omits `init` and `mcp`. Both are dispatchable, and `init` is what missing-model errors recommend.
6. **Star prompt guarantees were too strong** — a failed marker write falls through and prompts again next run, and `maybeAskForStar` sits inside `performInstall`'s `try`, so a throw from `Bun.which`, a `gh` spawn or the logger turns a completed install into exit 1.
7. **OpenClaw doesn't absorb everything** — the temp write at `:43` is outside the `try` at `:45`, and `kesha-<pid>-<Date.now()>` collides for two same-extension requests in the same millisecond.
8. **Process lifecycle didn't cover every spawn** — `say --list-voices` and MCP `listVoices` spawn the Engine without registering it.
9. **A dangling capability reference** — since fixed for real by #911 landing `release-channels`.

Everything that turned out to be true-but-unwanted moved to Open Issues rather than being quietly dropped, per the corpus rule "never invent a resolution".

## Also recorded, not resolved

- **The OpenClaw provider path is dead on the documented config.** Per `docs/runbooks/openclaw-plugin.md`, real transcription routes through `tools.media.audio.models` `type: "cli"`; `registerMediaUnderstandingProvider` needs `requireApiKey()` and silently fails for local CLI tools. `transcribeAudio` never runs for users on the documented setup — wire it up or retire it.
- **Nothing tests `openclaw-plugin.cjs`**, including the `dangerous-exec` scanner constraint CLAUDE.md calls out.
- **`homebrew-formula` CI builds the pinned tarball, not the working tree** — so a formula change is reviewed against a released tree. #915 hit exactly that.
- `nix build .#kesha` cannot succeed as committed, while the README presents `nix run` as an install path.
- Exit codes 130/143 are undocumented in `docs/errors.md` and untested.
- `load_audio` materialises the whole file in memory; no requirement states a supported maximum input length.
- Four ingest failures report `E_INTERNAL` for what is squarely bad user input.

## Scope

Docs-only — `openspec/specs/**`. No source, test, or workflow changes.

## Verification

- `bun run check:specs` → **17 passed, 0 failed**
- CI green on `232c9f2`, `openspec-validate` included
