### PR TITLE
fix(cli): embed completions and the man page so the compiled binary can print them

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN bun install --frozen-lockfile --production --ignore-scripts
 
 COPY bin ./bin
 COPY src ./src
+COPY completions ./completions
+COPY man ./man
 COPY tests/fixtures/benchmark ./fixtures/benchmark
 COPY tests/fixtures/benchmark-en ./fixtures/benchmark-en
 COPY BENCHMARK.md LICENSE NOTICES.md README.md SKILL.md ./

--- a/flake.nix
+++ b/flake.nix
@@ -248,6 +248,8 @@
             fileset = lib.fileset.unions [
               ./bin
               ./src
+              ./completions
+              ./man
               ./package.json
               ./tsconfig.json
               ./openclaw.plugin.json
@@ -263,7 +265,7 @@
             runHook preInstall
 
             mkdir -p $out/lib/kesha $out/bin
-            cp -r bin src package.json tsconfig.json \
+            cp -r bin src completions man package.json tsconfig.json \
                   openclaw-plugin.cjs openclaw.plugin.json SKILL.md LICENSE NOTICES.md \
                   $out/lib/kesha/
             ln -s ${keshaNodeModules} $out/lib/kesha/node_modules

--- a/packaging/homebrew/Formula/kesha-voice-kit.rb
+++ b/packaging/homebrew/Formula/kesha-voice-kit.rb
@@ -8,7 +8,7 @@ class KeshaVoiceKit < Formula
   depends_on "oven-sh/bun/bun"
 
   def install
-    libexec.install "bin", "src", "package.json", "bun.lock", "tsconfig.json"
+    libexec.install "bin", "src", "completions", "man", "package.json", "bun.lock", "tsconfig.json"
     libexec.install "openclaw.plugin.json", "openclaw-plugin.cjs"
     libexec.install "LICENSE", "NOTICES.md", "README.md"
 

--- a/packaging/homebrew/Formula/kesha-voice-kit.rb
+++ b/packaging/homebrew/Formula/kesha-voice-kit.rb
@@ -1,8 +1,9 @@
 class KeshaVoiceKit < Formula
   desc "Local speech-to-text, text-to-speech, and language detection toolkit"
   homepage "https://github.com/drakulavich/kesha-voice-kit"
-  url "https://github.com/drakulavich/kesha-voice-kit/archive/refs/tags/v1.18.0.tar.gz"
-  sha256 "4c55e0e813f192970729dddcc11e6e85979fbec7a888bad2695c4aa88524ab14"
+  # Release rewrites this pin, but ci.yml's homebrew-formula lane builds it — it must carry every path install stages.
+  url "https://github.com/drakulavich/kesha-voice-kit/archive/refs/tags/v1.24.7.tar.gz"
+  sha256 "92531aaad3537b8e27322f425d8af9fa3fc8cb9592796893155c6bed0ef90b67"
   license "MIT"
 
   depends_on "oven-sh/bun/bun"
@@ -24,5 +25,8 @@ class KeshaVoiceKit < Formula
 
   test do
     assert_match version.to_s, shell_output("#{bin}/kesha --version")
+    # The commands that read staged assets — a payload missing them still passes --version (#914).
+    assert_match "complete -c kesha", shell_output("#{bin}/kesha completions fish")
+    assert_match ".TH KESHA 1", shell_output("#{bin}/kesha manpage")
   end
 end

--- a/src/asset-modules.d.ts
+++ b/src/asset-modules.d.ts
@@ -1,0 +1,20 @@
+// Bun's `with { type: "text" }` imports; tsc has no loader for these extensions.
+declare module "*.bash" {
+  const content: string;
+  export default content;
+}
+
+declare module "*.zsh" {
+  const content: string;
+  export default content;
+}
+
+declare module "*.fish" {
+  const content: string;
+  export default content;
+}
+
+declare module "*.1" {
+  const content: string;
+  export default content;
+}

--- a/src/cli/completions.ts
+++ b/src/cli/completions.ts
@@ -1,13 +1,17 @@
 import { defineCommand } from "citty";
 import { log } from "../log";
+// Inlined because import.meta.url escapes the embedded filesystem in the compiled .deb/.rpm binary (#914).
+import bashCompletions from "../../completions/kesha.bash" with { type: "text" };
+import zshCompletions from "../../completions/kesha.zsh" with { type: "text" };
+import fishCompletions from "../../completions/kesha.fish" with { type: "text" };
 
-const SHELL_FILES = {
-  bash: "kesha.bash",
-  zsh: "kesha.zsh",
-  fish: "kesha.fish",
+const SHELL_SCRIPTS = {
+  bash: bashCompletions,
+  zsh: zshCompletions,
+  fish: fishCompletions,
 } as const;
 
-type Shell = keyof typeof SHELL_FILES;
+type Shell = keyof typeof SHELL_SCRIPTS;
 
 interface CompletionsCommandArgs {
   shell?: string;
@@ -35,7 +39,6 @@ export const completionsCommand = defineCommand({
       log.error("usage: kesha completions <bash|zsh|fish>");
       process.exit(2);
     }
-    const file = new URL(`../../completions/${SHELL_FILES[shell]}`, import.meta.url);
-    process.stdout.write(await Bun.file(file).text());
+    process.stdout.write(SHELL_SCRIPTS[shell]);
   },
 });

--- a/src/cli/manpage.ts
+++ b/src/cli/manpage.ts
@@ -1,12 +1,13 @@
 import { defineCommand } from "citty";
+// Inlined because import.meta.url escapes the embedded filesystem in the compiled .deb/.rpm binary (#914).
+import manpage from "../../man/kesha.1" with { type: "text" };
 
 export const manpageCommand = defineCommand({
   meta: {
     name: "manpage",
     description: "Print the kesha(1) manpage",
   },
-  async run() {
-    const file = new URL("../../man/kesha.1", import.meta.url);
-    process.stdout.write(await Bun.file(file).text());
+  run() {
+    process.stdout.write(manpage);
   },
 });

--- a/tests/integration/compiled-cli-assets.test.ts
+++ b/tests/integration/compiled-cli-assets.test.ts
@@ -1,0 +1,59 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readRepoFile, repoPath } from "../helpers/repo";
+
+// The .deb/.rpm payload is `bun build --compile`d from bin/kesha.js and packaged as that
+// single file, so any asset resolved at runtime instead of embedded is missing there (#914).
+let workDir: string;
+let compiledBin: string;
+
+async function runCompiled(args: string[]): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const proc = Bun.spawn([compiledBin, ...args], { stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { stdout: stdout.replace(/\r\n/g, "\n"), stderr, exitCode };
+}
+
+beforeAll(async () => {
+  workDir = mkdtempSync(join(tmpdir(), "kesha-compiled-"));
+  compiledBin = join(workDir, process.platform === "win32" ? "kesha.exe" : "kesha");
+  const build = Bun.spawn(
+    ["bun", "build", "--compile", `--outfile=${compiledBin}`, repoPath("bin/kesha.js")],
+    { cwd: repoPath("."), stdout: "pipe", stderr: "pipe" },
+  );
+  const [stderr, exitCode] = await Promise.all([new Response(build.stderr).text(), build.exited]);
+  if (exitCode !== 0) throw new Error(`compiling the CLI failed (${exitCode}):\n${stderr}`);
+}, 120_000);
+
+afterAll(() => {
+  if (workDir) rmSync(workDir, { recursive: true, force: true });
+});
+
+describe("compiled CLI carries its bundled assets", () => {
+  test.each(["bash", "zsh", "fish"])("completions %s prints the packaged script", async (shell) => {
+    const result = await runCompiled(["completions", shell]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe(readRepoFile(`completions/kesha.${shell}`));
+  });
+
+  test("manpage prints the packaged man page", async () => {
+    const result = await runCompiled(["manpage"]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe(readRepoFile("man/kesha.1"));
+  });
+
+  test("an unknown shell is still a usage error, not a crash", async () => {
+    const result = await runCompiled(["completions", "powershell"]);
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain("usage: kesha completions <bash|zsh|fish>");
+    expect(result.stdout).toBe("");
+  });
+});

--- a/tests/unit/distribution-assets.test.ts
+++ b/tests/unit/distribution-assets.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { readRepoFile } from "../helpers/repo";
+
+// `completions` and `man` are imported by src/cli/{completions,manpage}.ts, so a payload that
+// omits them fails at module load, not at file read — every path has to stage them (#914).
+describe("every distribution payload stages the bundled assets", () => {
+  test.each([
+    ["packaging/homebrew/Formula/kesha-voice-kit.rb", "completions"],
+    ["packaging/homebrew/Formula/kesha-voice-kit.rb", '"man"'],
+    ["Dockerfile", "COPY completions ./completions"],
+    ["Dockerfile", "COPY man ./man"],
+    ["flake.nix", "./completions"],
+    ["flake.nix", "./man"],
+    ["flake.nix", "cp -r bin src completions man"],
+  ])("%s stages %s", (path, token) => {
+    expect(readRepoFile(path)).toContain(token);
+  });
+
+  test.each(["completions/", "man/"])("the npm package publishes %s", (entry) => {
+    const pkg = JSON.parse(readRepoFile("package.json")) as { files?: string[] };
+
+    expect(pkg.files ?? []).toContain(entry);
+  });
+});


### PR DESCRIPTION
Closes #914.

## The bug

`kesha completions <shell>` and `kesha manpage` need a file that is not next to the code. They fail on **four of the five distribution paths**, two different ways:

**1. The compiled binary can't reach the file.** Both commands resolved their asset with `new URL("../../…", import.meta.url)`. Inside a `bun build --compile` binary that sits under `/$bunfs/root/`, so `../../` walks out of the embedded filesystem to a host path that does not exist. The `.deb`/`.rpm` payload *is* that binary (`.github/scripts/build-linux-packages.mjs:27-34`, packaged as a single file by `packaging/nfpm.yaml`):

```
ENOENT: no such file or directory, open '/completions/kesha.bash'
    at async run (/$bunfs/root/kesha:7340:53)
```

**2. Three payloads never staged the file at all.** The Homebrew formula, the Dockerfile, and the flake's CLI derivation each staged `bin` and `src` without `completions/` or `man/`. Reproduced by staging exactly `bin src package.json bun.lock tsconfig.json` and running both commands — they fail on `origin/main`'s code too, so this predates the compile problem entirely.

Only the npm CLI package and a repository checkout ever worked.

> The first revision of this PR claimed the other paths were fine. That was wrong — Codex review caught it, and the empirical check above confirmed it. The claim is corrected here and in #913's spec.

## The fix

**Embed the assets** (`src/cli/completions.ts`, `src/cli/manpage.ts`): import with `with { type: "text" }` so the bundler inlines them. `src/asset-modules.d.ts` declares `*.bash`/`*.zsh`/`*.fish`/`*.1` for tsc. `completions/` and `man/` stay in `package.json#files` — source-run paths resolve the import from disk at load time.

**Stage the assets** in the three payloads that omitted them: `packaging/homebrew/Formula/kesha-voice-kit.rb`, `Dockerfile`, `flake.nix` (both the `fileset` and the `cp -r`).

**Repin the formula.** Adding `completions`/`man` to the install block turned the `homebrew-formula` lane red: that lane builds the tarball the formula's `url` pins — `v1.18.0` — and those directories did not exist until v1.18.4 (#388). Repinned to `v1.24.7`, the newest tag that carries them *and* whose `package.json#version` equals its tag name, which the formula's own `--version` assertion requires. sha256 computed the way `update-homebrew-tap.mjs` computes it at release time.

## Tests

**`tests/integration/compiled-cli-assets.test.ts`** — compiles `bin/kesha.js` and drives the binary: each of `bash`/`zsh`/`fish` and `manpage` print byte-for-byte what the packaged file holds; an unknown shell is still the exit-2 usage error with clean stdout. Confirmed red before the fix (4 fail; the usage case passed, as it should).

**`tests/unit/distribution-assets.test.ts`** — pins all four payloads. Confirmed red against `origin/main`'s manifests: 7 of 9 fail, the two npm `files` entries pass because that path was always correct.

**The formula's `test do`** now runs `kesha completions fish` and `kesha manpage`. The `homebrew-formula` lane existed all along and stayed green through this bug because `--version` needs nothing off disk.

Between them, every payload that ships an asset is now exercised by something that would fail if the asset went missing.

## Verification

- `just preflight` → **1321 pass, 6 skip, 0 fail**, `tsc --noEmit` clean
- CI green on `ba33e1c`, including `homebrew-formula` (1m5s), `linux-packages`, `integration-tests`, `ts-coverage`, and unit tests on macOS/Ubuntu/Windows
- Source-run path spot-checked by hand, and a staged payload with the assets present verified to print both

## Not in scope

The audit that found this is #913 (docs-only, spec corpus).
