### PR TITLE
fix(coreml): scoped retry for the #841 first-call CoreML timeout (superseded by #912)

### DIFF
--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -482,7 +482,7 @@ jobs:
           cargo nextest run \
             --no-default-features --features coreml \
             --run-ignored all \
-            -E 'test(transcribe_samples_is_stateless_across_calls) + test(debug_routes_silenced_chatter_to_stderr)'
+            -E 'test(transcribe_samples_is_stateless_across_calls) + test(debug_routes_silenced_chatter_to_stderr) + test(only_the_coreml_async_timeout_reads_as_transient)'
 
       - name: 📤 Upload JUnit
         if: always()

--- a/rust/src/backend/fluidaudio.rs
+++ b/rust/src/backend/fluidaudio.rs
@@ -345,6 +345,29 @@ mod tests {
         assert!(out.iter().all(|&v| v == 0.0));
     }
 
+    /// #841's retry gate: only CoreML's async-task timeout earns a second
+    /// attempt. Every other bridge failure — including the other `E5RT` class
+    /// this codebase already documents — must still fail on the first one.
+    #[test]
+    fn only_the_coreml_async_timeout_reads_as_transient() {
+        assert!(is_transient_e5rt_timeout(
+            r#"Transcribe samples with words error: Error Domain=com.apple.CoreML Code=0 "Unable to compute the asynchronous prediction using ML Program. It can be an invalid input data or broken/unsupported model." UserInfo={NSUnderlyingError=0x600000ee0e70 {Error Domain=com.apple.CoreML Code=0 "E5RT: Submit Async failed for [2:1]: Async task: Encoder_main__Op3_Cast has timed out. @ CancelTimedOutAsyncTask_block_invoke (10)"}}"#
+        ));
+
+        for other in [
+            "",
+            "Swift bridge error: Transcription failed",
+            "E5RT encountered an STL exception. msg = unordered_map::at: key not found.",
+            "Transcribe error: invalidAudioData",
+            r#"Error Domain=com.apple.CoreML Code=0 "Unable to compute the asynchronous prediction using ML Program. It can be an invalid input data or broken/unsupported model.""#,
+        ] {
+            assert!(
+                !is_transient_e5rt_timeout(other),
+                "{other:?} must fail the test outright, not be retried"
+            );
+        }
+    }
+
     // Regression: the VAD/chunked paths call `transcribe_samples` once per
     // segment on a single backend instance. Before fluidaudio-rs carried the
     // upstream TDT stateless-reset fix (FluidInference/fluidaudio-rs#15), the

--- a/rust/src/backend/fluidaudio.rs
+++ b/rust/src/backend/fluidaudio.rs
@@ -108,8 +108,9 @@ mod tests {
 
     /// #841: the warm-cache flake fails ~20 s in with a bare "Transcription
     /// failed" on a cleanly restored bundle, and a same-SHA rerun goes green —
-    /// so the failing run is the only place the evidence will ever exist.
-    /// Renders on panic, silent on a passing run.
+    /// so the failing attempt is the only place the evidence will ever exist.
+    /// Renders on panic; the retry below renders it by hand, so an attempt that
+    /// fails and then recovers still files its dump.
     struct FailureDump {
         first_call: Option<String>,
     }
@@ -166,6 +167,43 @@ mod tests {
         out.push_str(&fingerprint(&loc.dir));
         out.push_str("──── end #841 diagnostics ────");
         out
+    }
+
+    /// Whether a failed `transcribe_samples` earns one more attempt. Matched on
+    /// `E5RT` plus the timeout wording rather than on the op name all five #841
+    /// dumps carry (`Encoder_main__Op3_Cast`): op names are regenerated when the
+    /// model is, while an Espresso async task timing out is the class the
+    /// evidence names, and no other CoreML failure here carries one — the
+    /// diarization teardown print is `E5RT encountered an STL exception`.
+    fn is_transient_e5rt_timeout(bridge_output: &str) -> bool {
+        bridge_output.contains("E5RT") && bridge_output.contains("has timed out")
+    }
+
+    /// The Swift bridge collapses every `transcribeSamples` throw to a bare
+    /// "Transcription failed" and prints CoreML's real error with `print`, so the
+    /// only place a failure names its own cause is the stdout `transcribe_samples`
+    /// silences. Swapping the backend's sink for a temp file is what puts that
+    /// text within reach of the retry gate; it is echoed to stderr either way, so
+    /// the log still gets what `KESHA_DEBUG` used to route there.
+    fn transcribe_capturing_bridge_output(
+        be: &mut FluidAudioBackend,
+        samples: &[f32],
+    ) -> (Result<TranscriptionChunk>, String) {
+        use std::io::{Read as _, Seek as _};
+
+        let mut capture = tempfile::tempfile().expect("capture tempfile");
+        let sink = capture.try_clone().ok().map(OwnedFd::from);
+        let restore = std::mem::replace(&mut be.sink, sink);
+        let result = be.transcribe_samples(samples);
+        be.sink = restore;
+
+        let mut bridge_output = String::new();
+        let _ = capture.rewind();
+        let _ = capture.read_to_string(&mut bridge_output);
+        if !bridge_output.is_empty() {
+            eprint!("{bridge_output}");
+        }
+        (result, bridge_output)
     }
 
     /// Hashing all 446 MB every run is too dear; the manifests, vocab and
@@ -394,10 +432,21 @@ mod tests {
         // Declared first so it drops last — after the backend's CoreML teardown.
         let mut dump = FailureDump { first_call: None };
         let mut be = FluidAudioBackend::new().expect("init FluidAudio CoreML backend");
-        let first = be
-            .transcribe_samples(&samples)
-            .expect("first transcribe_samples")
-            .text;
+
+        // #841: five instrumented dumps, one shape — the *first* call times out
+        // inside CoreML ~20 s in on a virtualized runner with no ANE, and the
+        // same SHA goes green on rerun. Since this job is the #592 pin-bump
+        // guard, every occurrence spent a human on that rerun. One retry, scoped
+        // to that signature: a real regression is deterministic and fails both
+        // attempts, and the diagnostics still print per attempt, so the issue
+        // keeps collecting evidence from a run that no longer goes red.
+        let (mut outcome, bridge_output) = transcribe_capturing_bridge_output(&mut be, &samples);
+        if outcome.is_err() && is_transient_e5rt_timeout(&bridge_output) {
+            eprintln!("{}", render_diagnostics(None));
+            eprintln!("#841: first transcribe_samples hit CoreML's async timeout — retrying once");
+            outcome = transcribe_capturing_bridge_output(&mut be, &samples).0;
+        }
+        let first = outcome.expect("first transcribe_samples").text;
         dump.first_call = Some(first.clone());
         let second = be
             .transcribe_samples(&samples)


### PR DESCRIPTION
> **Superseded by #912 — parked as a draft, do not merge as-is.** I built this from the promotion-to-fix directive on #841 before #912 landed (merged 4h earlier, same day). It is left open because it differs from #912 on one axis the owner may care about, not because it is ready.

## What #912 changed underneath this

`transcribe_samples_is_stateless_across_calls` now returns from `skip_without_ane` before it ever calls `transcribe_samples`, on any host reporting zero ANE device lines. That is exactly the `coreml-regression` runner. So **the retry in this PR can never fire**: the lane that flakes now skips the test, and the flake has never been observed on a real-ANE host. Merging this as-is would add ~60 lines of test harness with no lane able to reach the branch — against CLAUDE.md's rule on speculative code. The branch is also left conflicting with `main` on purpose; resolving it means deciding how the retry sits against #912's gate, which is the owner's call, not mine.

## The one axis where the two differ

#912 says it plainly: *"It trades a flaky guard for an absent one… The #592 pin-bump coverage is not restored by this PR."*

A scoped retry does not make that trade. The decoder-state regression the guard exists for — the shared `TdtDecoderState` leaking the previous utterance's terminal token — reproduces through the BNNS/CPU fallback just as it does on the ANE; nothing about that bug needs the Neural Engine. The hosted runner *could* keep asserting it, if the one environment-specific failure mode were absorbed instead of the whole test being skipped.

So the choice is: **skip and lose #592's coverage until a real-ANE runner exists** (#912, shipped), or **retry the one signature and keep asserting decoder state on the hosted runner** (this PR). They are alternatives, not layers.

## If the coverage is wanted back, this is the work

**The signature is not in the Rust error.** The bridge collapses every `transcribeSamples` throw to a bare string — run 31601378858's failed attempt, in full:

```
first transcribe_samples: FluidAudio sample transcription failed

Caused by:
    Swift bridge error: Transcription failed
```

CoreML's real error reaches the world only through a Swift `print`, onto the stdout `transcribe_samples` deliberately silences. Gating on the Rust error alone would retry *any* first-call bridge failure — the directive's option (b) wearing option (a)'s clothes. So the test swaps the backend's stdout sink for a temp file for the duration of the call and gates on what CoreML actually said, echoing it to stderr either way.

**Discriminator: `E5RT` AND `has timed out`.** Not `Encoder_main__Op3_Cast`, though all five dumps carry it — op names are regenerated with the model, so pinning to one would silently stop matching after a pin bump, and a pin bump is exactly when this guard matters. It is the only CoreML failure in this codebase carrying a timeout: the diarization teardown print is `E5RT encountered an STL exception`, #259's is `invalidAudioData`. Not conditioned on the host, since a real regression would reproduce on a virtualized runner too.

**Signal preserved.** The retry-triggering failure still emits the full #841 diagnostics dump (rendered by hand, as no panic occurs), so the evidence base keeps growing from runs that no longer go red. A second failure fails the test exactly as before.

## Evidence

`is_transient_e5rt_timeout` is pure and unit-tested red-first — commit 1 fails to compile, E0425 on both call sites — against the real strings: the positive is the `NSUnderlyingError` E5RT line from the dumps, the negatives are the bare "Transcription failed", the STL-exception E5RT, `invalidAudioData`, and the outer CoreML wrapper with no timeout in it.

The retry wiring was exercised on a real M2 with the Parakeet bundle installed, by temporarily forcing the first call to fail (throwaway, not in the diff):

| forced first call | retries | outcome |
|---|---|---|
| E5RT timeout, once | 1 | **PASS** — dump printed with `first call : never completed`, then recovered |
| E5RT timeout, always | 1 | **FAIL** (exit 100), 2 dumps — a real regression still reproduces |
| `E5RT encountered an STL exception` | 0 | **FAIL** immediately — non-matching failures untouched |

Gates, all clean before #912 was known: the lane's exact nextest filter against the real bundle (3 passed), `just rust-test` (565/565), `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo check --features coreml --no-default-features --all-targets`, `just verify-darwin-full`, `bun run test` (1307 pass), `bunx tsc --noEmit`.

Refs #841, #912, #592.
