### PR TITLE
ci: turn off Repowise's AI-authored regression gate, keep health scoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ result
 .codegraph/
 .codex/
 skills-lock.json
+# repowise keeps a multi-MB local index here; only the PR-bot config is shared.
+.repowise/*
+!.repowise/bot.yaml
 
 # Mutation testing scratch (stryker sandbox, cargo-mutants output)
 .stryker-tmp/

--- a/.repowise/bot.yaml
+++ b/.repowise/bot.yaml
@@ -1,0 +1,6 @@
+# Every PR here is agent-authored, so the AI share of any regression is the
+# larger one by construction and the finding names nothing to fix. Waived by
+# the owner on #770, #784, #812, #892, #905 before being turned off in #918.
+# The other gate rules, the health delta and the PR comment all stay on.
+health_gate:
+  block_ai_regression: false


### PR DESCRIPTION
Closes #918

## What the gate is

Repowise's PR bot posts a `Repowise / code health` check run whose blocking rules are documented at [docs/hosted/bot § The merge gate](https://www.repowise.dev/docs/hosted/bot). Four rules exist; the one that has been failing us is:

| Rule | Blocks when |
|---|---|
| `repo_drop_block` | repo health score drops by more than N points (default 0.3) |
| `min_new_file_score` | a changed file scores below a floor |
| `block_on_introduced` | the PR introduces any new marker in added lines |
| **`block_ai_regression`** | **AI-authored files account for the larger share of the regression** |

`block_ai_regression` is unsatisfiable here by construction. Every PR in this repo is agent-authored, so there are no human hunks to compare against and the AI share of any regression is always the larger one. The rendered message — "AI-authored files account for the larger share of this PR's regression (−1.5 vs −0.0 human)" — names no file, no marker and no action.

Evidence from the check-run API, all four the same single-bullet failure with a `−0.0 human` denominator:

```
PR #784  failure  (-1.1 vs -0.0 human)
PR #812  failure  (-0.1 vs -0.0 human)
PR #892  failure  (-1.5 vs -0.0 human)
PR #905  failure  (-0.5 vs -0.0 human)
```

## Before / after

Before: no `.repowise/bot.yaml` in the repo, so the gate config came entirely from the hosted dashboard, and `block_ai_regression` blocked any PR with a negative health delta.

After: `health_gate.block_ai_regression: false` is committed. Only that key is set — per the docs, "fields it omits keep the YAML/default value", so `repo_drop_block`, `min_new_file_score`, `block_on_introduced` and `health_gate.mode` keep whatever they have today.

Everything else Repowise does is untouched: the health delta table, change map, hotspot and hidden-coupling sections all still post. That reporting has earned its place — the co-change hint on #876 was real.

## The dashboard caveat

The docs are explicit that **the dashboard overlays the YAML**: "any field set there wins". The gate is `off` by default and this repo had no `bot.yaml` until now, so the current blocking config demonstrably lives in the dashboard. If it sets `block_ai_regression` (or a `health_gate.profile` of `block-on-ai-regression`) explicitly, this file loses and the gate keeps firing.

So this PR is the durable, versioned half. If a post-merge PR still trips the same rule, clear it owner-side at **repowise.dev/dashboard → the kesha-voice-kit repo → Settings → PR Bot → Health gate → `block_ai_regression` off** (and if a profile is selected there, switch off `block-on-ai-regression`). Leave `health_gate.mode` alone — the other rules are worth keeping.

## Also in this diff

`.repowise/` was untracked but not ignored, so the local Repowise index (a 5 MB `duplication_cache.pkl`, `wiki.db`) sat in `git status` waiting for a careless `git add .repowise/`. Now the directory is ignored except `bot.yaml`. Verified both directions: `bot.yaml` stages, dropped-in `wiki.db` / `duplication_cache.pkl` do not appear in `git status --untracked-files=all`.

## Verification

Config-only change, no TS or Rust touched, so the path-filtered test and coverage jobs do not apply. `.repowise/bot.yaml` parses as `{'health_gate': {'block_ai_regression': False}}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBTpJjqyYFW6W8LHJ2nwy
