### PR TITLE
docs(openspec): link the homebrew-formula drift Open Issue to #924

### DIFF
--- a/openspec/specs/cli-distribution/spec.md
+++ b/openspec/specs/cli-distribution/spec.md
@@ -328,7 +328,8 @@ Whichever path put `kesha` on the machine, the Engine and models SHALL still arr
   and `man` against a pin (`v1.18.0`) predating both directories (added in
   v1.18.4, #388) — and had to repin to `v1.24.7`, the newest tag that carries
   them *and* whose `package.json#version` equals its tag name, which the
-  formula's own `--version` assertion requires.
+  formula's own `--version` assertion requires. The repin fixes that instance
+  and nothing structural; tracked as #924.
 - `homebrew-tap.yml` fires on every published release, including Engine
   releases that publish no CLI version (see CLAUDE.md, "un-drafting an engine
   tag still fires 🍺 Homebrew Tap"). The lane's own skip logic is the only thing


### PR DESCRIPTION
One-line follow-up to #913.

The `cli-distribution` Open Issue describes the `homebrew-formula` lane building the pinned tarball instead of the working tree, but landed before #924 existed, so it left the reader with the finding and no place to follow it.

#915's repin to `v1.24.7` fixed the instance that surfaced it; the structural problem — a formula change reviewed against a released source tree — is unchanged and now tracked.

Refs #924

`bun run check:specs` — 17 passed, 0 failed.