### PR TITLE
test: pact the engine transcribe JSON against the TS parser

### DIFF
--- a/rust/tests/transcribe_schema_pact.rs
+++ b/rust/tests/transcribe_schema_pact.rs
@@ -1,0 +1,92 @@
+//! Extractor side of the transcribe schema pact (#917).
+//!
+//! #905 added `words` to `TranscriptionSegment` and the TS parser kept copying
+//! only `start`/`end`/`text`/`speaker`, so the feature was invisible on every
+//! user path while the engine-direct e2e stayed green; `speaker` needed the same
+//! rescue in #199. Serde is the source of truth for what the engine puts on the
+//! wire, so this serializes a fully-populated output — every `Option` `Some` —
+//! and holds it against a committed recording.
+//!
+//! One extractor, two verifiers: `tests/unit/transcribe-schema-pact.test.ts`
+//! drives the same recording through `parseTranscriptionOutput` and the TOON
+//! encoder, so a field added here without a parser change turns that side red.
+
+use std::path::PathBuf;
+
+use kesha_engine::transcribe::{TranscriptionOutput, TranscriptionSegment, WordTiming};
+
+fn fixture_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("rust/ has a parent")
+        .join("tests/fixtures/transcribe-schema.json")
+}
+
+/// Times are binary fractions so the `f32` → JSON → `f64` trip is exact.
+fn fully_populated() -> TranscriptionOutput {
+    TranscriptionOutput {
+        text: "hello world goodbye now".to_string(),
+        segments: vec![
+            TranscriptionSegment {
+                start: 0.0,
+                end: 1.5,
+                text: "hello world".to_string(),
+                speaker: Some(0),
+                words: Some(vec![
+                    WordTiming {
+                        word: "hello".to_string(),
+                        start: 0.0,
+                        end: 0.75,
+                    },
+                    WordTiming {
+                        word: "world".to_string(),
+                        start: 0.75,
+                        end: 1.5,
+                    },
+                ]),
+            },
+            TranscriptionSegment {
+                start: 1.5,
+                end: 3.0,
+                text: "goodbye now".to_string(),
+                speaker: Some(1),
+                words: Some(vec![
+                    WordTiming {
+                        word: "goodbye".to_string(),
+                        start: 1.5,
+                        end: 2.25,
+                    },
+                    WordTiming {
+                        word: "now".to_string(),
+                        start: 2.25,
+                        end: 3.0,
+                    },
+                ]),
+            },
+        ],
+    }
+}
+
+#[test]
+fn the_serialized_output_matches_the_recorded_schema() {
+    let emitted = serde_json::to_value(fully_populated()).expect("serialise");
+    let path = fixture_path();
+
+    if std::env::var_os("KESHA_UPDATE_TRANSCRIBE_PACT").is_some() {
+        let pretty = serde_json::to_string_pretty(&emitted).expect("render");
+        std::fs::write(&path, format!("{pretty}\n")).expect("write the recording");
+    }
+
+    let raw = std::fs::read_to_string(&path).expect("read the recording");
+    let recorded: serde_json::Value = serde_json::from_str(&raw).expect("parse the recording");
+
+    assert_eq!(
+        emitted,
+        recorded,
+        "the transcribe wire format drifted from {}.\n\
+         Re-record with `KESHA_UPDATE_TRANSCRIBE_PACT=1 cargo test --test transcribe_schema_pact`, \
+         then teach `parseTranscriptionOutput` in src/engine.ts to forward the new field — \
+         or name it in EXCLUDED_FIELDS in tests/unit/transcribe-schema-pact.test.ts with a reason.",
+        path.display()
+    );
+}

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -372,7 +372,7 @@ function parseWordTimings(raw: unknown): WordTiming[] | undefined {
   return words;
 }
 
-function parseTranscriptionOutput(stdout: string): TranscriptionOutput {
+export function parseTranscriptionOutput(stdout: string): TranscriptionOutput {
   const parsed = JSON.parse(stdout);
   if (typeof parsed?.text !== "string" || !Array.isArray(parsed?.segments)) {
     throw new Error("Invalid transcription JSON returned by kesha-engine");

--- a/tests/fixtures/transcribe-schema.json
+++ b/tests/fixtures/transcribe-schema.json
@@ -1,0 +1,41 @@
+{
+  "segments": [
+    {
+      "end": 1.5,
+      "speaker": 0,
+      "start": 0.0,
+      "text": "hello world",
+      "words": [
+        {
+          "end": 0.75,
+          "start": 0.0,
+          "word": "hello"
+        },
+        {
+          "end": 1.5,
+          "start": 0.75,
+          "word": "world"
+        }
+      ]
+    },
+    {
+      "end": 3.0,
+      "speaker": 1,
+      "start": 1.5,
+      "text": "goodbye now",
+      "words": [
+        {
+          "end": 2.25,
+          "start": 1.5,
+          "word": "goodbye"
+        },
+        {
+          "end": 3.0,
+          "start": 2.25,
+          "word": "now"
+        }
+      ]
+    }
+  ],
+  "text": "hello world goodbye now"
+}

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -403,32 +403,6 @@ describe("TOON output (#138)", () => {
     expect(decoded).toEqual(input);
   });
 
-  /** #720: `words` is the first doubly-nested array in the payload — segments inside
-   * a result, words inside a segment. TOON's tabular encoding treats that shape
-   * differently from the flat rows every other test here covers. */
-  test("round-trips segments carrying word timings", () => {
-    const input = [
-      {
-        file: "a.ogg",
-        text: "Hello world",
-        lang: "en",
-        segments: [
-          {
-            start: 0,
-            end: 1.25,
-            text: "Hello world",
-            words: [
-              { word: "Hello", start: 0, end: 0.4 },
-              { word: "world", start: 0.4, end: 1.2 },
-            ],
-          },
-        ],
-      },
-    ];
-    expect(decodeToon(formatToonOutput(input))).toEqual(input);
-    expect(JSON.parse(formatJsonOutput(input))).toEqual(input);
-  });
-
   test("ends with a trailing newline so it composes in pipelines", () => {
     const output = formatToonOutput([{ file: "a.ogg", text: "Hi", lang: "en" }]);
     expect(output.endsWith("\n")).toBe(true);

--- a/tests/unit/transcribe-schema-pact.test.ts
+++ b/tests/unit/transcribe-schema-pact.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Consumer side of the transcribe schema pact (#917).
+ *
+ * `rust/tests/transcribe_schema_pact.rs` records everything the engine's
+ * transcribe JSON can carry into `tests/fixtures/transcribe-schema.json`; this
+ * drives that recording through the seams every consumer reads it by — the
+ * parser behind `transcribeWithSegments`, the CLI's `--json`, and `--toon`.
+ * A field the Rust side gains and the TS side drops is red here, which is what
+ * `words` (#905) and `speaker` (#199) each needed and neither had.
+ */
+import { decode as decodeToon } from "@toon-format/toon";
+import { describe, expect, it } from "bun:test";
+import { formatJsonOutput, formatToonOutput } from "../../src/cli";
+import { parseTranscriptionOutput } from "../../src/engine";
+import { readRepoFile } from "../helpers/repo";
+
+const FIXTURE = "tests/fixtures/transcribe-schema.json";
+
+/**
+ * Paths the parser drops on purpose, in `fieldPaths` notation
+ * (`segments[].speaker`), each with its reason. Empty means the seam forwards
+ * everything the engine emits; an entry here is the reviewed alternative to a
+ * field silently going missing, so it must say why the user does not need it.
+ */
+const EXCLUDED_FIELDS: Record<string, string> = {};
+
+/** Every field path in `value`, with array indices collapsed to `[]`. */
+function fieldPaths(value: unknown, prefix = ""): string[] {
+  if (Array.isArray(value)) return value.flatMap((item) => fieldPaths(item, `${prefix}[]`));
+  if (value === null || typeof value !== "object") return [];
+  return Object.entries(value).flatMap(([key, child]) => {
+    const path = prefix ? `${prefix}.${key}` : key;
+    return [path, ...fieldPaths(child, path)];
+  });
+}
+
+function withoutExcluded(value: unknown, prefix = ""): unknown {
+  if (Array.isArray(value)) return value.map((item) => withoutExcluded(item, `${prefix}[]`));
+  if (value === null || typeof value !== "object") return value;
+  const kept: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(value)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (path in EXCLUDED_FIELDS) continue;
+    kept[key] = withoutExcluded(child, path);
+  }
+  return kept;
+}
+
+const raw = readRepoFile(FIXTURE);
+const recorded = JSON.parse(raw);
+const parsed = parseTranscriptionOutput(raw);
+const recordedPaths = new Set(fieldPaths(recorded));
+
+describe("transcribe schema pact — the parser", () => {
+  it("forwards every field the engine records", () => {
+    const parsedPaths = new Set(fieldPaths(parsed));
+    const dropped = [...recordedPaths].filter(
+      (path) => !parsedPaths.has(path) && !(path in EXCLUDED_FIELDS),
+    );
+    expect(
+      dropped,
+      `parseTranscriptionOutput drops ${dropped.join(", ")} — forward it, or name it in EXCLUDED_FIELDS with a reason`,
+    ).toEqual([]);
+  });
+
+  it("copies the recorded values, not just the keys", () => {
+    expect(parsed).toEqual(withoutExcluded(recorded) as typeof parsed);
+  });
+
+  it("excludes only fields the recording still carries", () => {
+    // A stale exclusion is a hole: the path it names could come back forwarding nothing.
+    expect(Object.keys(EXCLUDED_FIELDS).filter((path) => !recordedPaths.has(path))).toEqual([]);
+  });
+});
+
+describe("transcribe schema pact — the output encoders", () => {
+  const results = [{ file: "a.ogg", lang: "en", text: parsed.text, segments: parsed.segments }];
+
+  it("round-trips the parsed output through --toon", () => {
+    expect(decodeToon(formatToonOutput(results)) as unknown).toEqual(results);
+  });
+
+  it("round-trips the parsed output through --json", () => {
+    expect(JSON.parse(formatJsonOutput(results))).toEqual(results);
+  });
+});


### PR DESCRIPTION
Closes #917

## The gap

PR #905 added `words` to `TranscriptionSegment` on the Rust side. `parseTranscriptionOutput` in `src/engine.ts` kept copying only `start`/`end`/`text`/`speaker`, so per-word timings never reached the CLI's `--json`/`--toon`, the programmatic API, or MCP — while the engine-direct e2e stayed green, because it reads the engine's stdout rather than the parsed result. `speaker` needed exactly the same rescue in #199. Nothing structural stood between us and a third.

## The pact

One extractor, two verifiers, following the #798 capabilities pact.

**Extractor — `rust/tests/transcribe_schema_pact.rs`.** Serializes a fully-populated `TranscriptionOutput` (every `Option` `Some`: `speaker`, `words`, word-level `word`/`start`/`end`) and holds it against `tests/fixtures/transcribe-schema.json`. Serde is the source of truth for the wire format, so no `schemars` dependency is needed and nothing new lands in `Cargo.toml`. The comparison is between parsed `serde_json::Value`s, so key order and whitespace are free — only the field set and the values are the contract. `KESHA_UPDATE_TRANSCRIBE_PACT=1` re-records.

**TS verifier — `tests/unit/transcribe-schema-pact.test.ts`.** Drives the same recording through `parseTranscriptionOutput` and asserts (a) every recorded field path reaches the parsed result or is named in `EXCLUDED_FIELDS` with a reason, (b) the values are copied, not just the keys, and (c) no `EXCLUDED_FIELDS` entry names a path the recording no longer carries — a stale exclusion is a hole. `EXCLUDED_FIELDS` is empty today: the parser forwards everything the engine emits.

Traversal goes all the way to word level, with array indices collapsed to `[]` (`segments[].words[].start`), because that is the depth at which the parser copies — `parseWordTimings` validates each of `word`/`start`/`end` individually, so a fourth key added there would be dropped just as `words` was.

**TOON verifier.** The parsed output goes through `formatToonOutput` + `decode` and `formatJsonOutput` + `JSON.parse`. #905 had to hand-write a word-timing TOON case in `cli.test.ts` (`words` is the first doubly-nested array in the payload and TOON's tabular encoding treats that shape differently); the fixture-driven version covers it and grows on its own, so the hand-built one is deleted rather than duplicated.

`parseTranscriptionOutput` gains an `export`. The alternative was driving a fake-engine subprocess, which adds nothing for a field-forwarding question and would cost Windows coverage — the fake-engine tests are `test.skip` on win32.

## Fixture location

`tests/fixtures/transcribe-schema.json`, the name #917 proposed. `tests/fixtures/capabilities/` is a directory because it holds one recording per published target; this pact has a single recording, since the wire format is shared across every build (the capabilities pact already asserts one `protocolVersion` across all targets). Both Rust and TS reach it by repo root — the Rust side via `CARGO_MANIFEST_DIR/..`, the same way `rust/tests/mini_model_pact.rs` reaches `tests/fixtures/mini-models/`.

## Proof that the guard fires

Scratch run on top of this commit: `pub confidence: f32` added to `TranscriptionSegment` (a plausible next field), construction sites fixed, fixture untouched.

**Arm 1 — Rust struct changed, recording not updated:**

```
running 1 test
test the_serialized_output_matches_the_recorded_schema ... FAILED

thread 'the_serialized_output_matches_the_recorded_schema' panicked at tests/transcribe_schema_pact.rs:85:5:
assertion `left == right` failed: the transcribe wire format drifted from
/Users/.../tests/fixtures/transcribe-schema.json.
Re-record with `KESHA_UPDATE_TRANSCRIBE_PACT=1 cargo test --test transcribe_schema_pact`, then teach
`parseTranscriptionOutput` in src/engine.ts to forward the new field — or name it in EXCLUDED_FIELDS in
tests/unit/transcribe-schema-pact.test.ts with a reason.
  left: Object {"segments": Array [Object {"confidence": Number(0.5), "end": Number(1.5), ...
 right: Object {"segments": Array [Object {"end": Number(1.5), ...

test result: FAILED. 0 passed; 1 failed
```

**Arm 2 — developer follows the message, re-records, and stops there:**

```
$ KESHA_UPDATE_TRANSCRIBE_PACT=1 cargo test --test transcribe_schema_pact
test result: ok. 1 passed; 0 failed

$ bun test tests/unit/transcribe-schema-pact.test.ts
error: parseTranscriptionOutput drops segments[].confidence — forward it, or name it in EXCLUDED_FIELDS with a reason
- []
+ [
+   "segments[].confidence",
+ ]
(fail) transcribe schema pact — the parser > forwards every field the engine records

error: expect(received).toEqual(expected)
@@ -3,3 +3,3 @@
      {
-       "confidence": 0.5,
        "end": 1.5,
(fail) transcribe schema pact — the parser > copies the recorded values, not just the keys

 3 pass
 2 fail
```

That is the #905 failure mode, caught on the PR that introduces it. The scratch changes were reverted; both sides are green at HEAD.

## Gates

| gate | result |
| --- | --- |
| `just preflight` (TS + Rust) | pass — 1311 pass / 6 skip / 0 fail TS, `tsc --noEmit` clean, 566 Rust tests pass |
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --all-targets --features tts -- -D warnings` | clean |
| `cargo check --features coreml --no-default-features --all-targets` | clean |

`preflight` skipped its own CoreML step (no `rust/src/backend/` changes); it was run explicitly anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
