### PR TITLE
chore(rust): move the warnings gate into Cargo.toml [lints]

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -114,6 +114,17 @@ cpal = "0.15"
 [dev-dependencies]
 tempfile = "3"
 
+# Levels here also reach `cargo build`/`cargo test`/rust-analyzer; ci.yml's `-- -D warnings` only covers what CI runs.
+[lints.rust]
+# Edition-2024 default adopted early: no unsafe op outside an explicit block.
+unsafe_op_in_unsafe_fn = "deny"
+
+[lints.clippy]
+# Makes the existing SAFETY-comment discipline a build gate, not a review habit.
+undocumented_unsafe_blocks = "deny"
+# One op per block, so a SAFETY comment cannot silently start covering a second call.
+multiple_unsafe_ops_per_block = "deny"
+
 [profile.release]
 lto = true
 strip = true

--- a/rust/src/fluid_stdout.rs
+++ b/rust/src/fluid_stdout.rs
@@ -18,13 +18,27 @@
 use std::io::Write;
 use std::os::fd::OwnedFd;
 
+/// `dup` a descriptor into an owned handle, or `None` when the call failed.
+/// Every caller here treats failure as best-effort: run unguarded rather than
+/// point fd 1 somewhere it cannot be recovered from.
+fn dup_owned(fd: std::os::fd::RawFd) -> Option<OwnedFd> {
+    use std::os::fd::FromRawFd;
+    // SAFETY: dup either returns a fresh descriptor this process owns, or -1.
+    let raw = unsafe { libc::dup(fd) };
+    if raw < 0 {
+        return None;
+    }
+    // SAFETY: raw came from the dup above, so OwnedFd is its sole owner and closes it on drop.
+    Some(unsafe { OwnedFd::from_raw_fd(raw) })
+}
+
 /// Run `f` with the process's stdout temporarily redirected to `devnull`.
 /// Restoring stdout in a `Drop` impl keeps the redirect short-lived even if `f`
 /// panics. `devnull` is a caller-owned fd (the ASR hot path caches one on the
 /// backend); passing `None` runs `f` with stdout untouched (best-effort fallback
 /// when opening /dev/null failed).
 pub(crate) fn with_silenced_stdout<R>(devnull: Option<&OwnedFd>, f: impl FnOnce() -> R) -> R {
-    use std::os::fd::{AsRawFd, FromRawFd};
+    use std::os::fd::AsRawFd;
 
     struct StdoutGuard {
         saved: Option<OwnedFd>,
@@ -75,18 +89,8 @@ pub(crate) fn with_silenced_stdout<R>(devnull: Option<&OwnedFd>, f: impl FnOnce(
         }
     }
 
-    // SAFETY: dup(STDOUT) returns a fresh fd we own; OwnedFd takes
-    // responsibility for closing it on drop. dup failure is best-effort —
-    // we just run f without a guard, never worse than the pre-#259
-    // behaviour.
-    let saved: Option<OwnedFd> = unsafe {
-        let raw = libc::dup(libc::STDOUT_FILENO);
-        if raw < 0 {
-            None
-        } else {
-            Some(OwnedFd::from_raw_fd(raw))
-        }
-    };
+    // A failed dup is best-effort: run f unguarded, never worse than pre-#259 behaviour.
+    let saved = dup_owned(libc::STDOUT_FILENO);
     let have_save = saved.is_some();
     let _guard = StdoutGuard { saved };
 
@@ -143,13 +147,9 @@ pub(crate) fn with_silenced_stdout<R>(devnull: Option<&OwnedFd>, f: impl FnOnce(
     feature = "system_diarize"
 ))]
 pub(crate) fn oneshot_sink() -> Option<OwnedFd> {
-    use std::os::fd::FromRawFd;
-
     if crate::debug::enabled() {
-        // SAFETY: dup(STDERR) hands back a fresh fd that OwnedFd will close.
-        let raw = unsafe { libc::dup(libc::STDERR_FILENO) };
-        if raw >= 0 {
-            return Some(unsafe { OwnedFd::from_raw_fd(raw) });
+        if let Some(stderr) = dup_owned(libc::STDERR_FILENO) {
+            return Some(stderr);
         }
     }
     std::fs::OpenOptions::new()
@@ -206,19 +206,11 @@ pub(crate) struct StdoutShield {
 ))]
 impl StdoutShield {
     pub(crate) fn new() -> Self {
-        use std::os::fd::{AsRawFd, FromRawFd};
+        use std::os::fd::AsRawFd;
 
-        // SAFETY: dup(STDOUT) returns a fresh fd we own; File takes ownership and
-        // closes it on drop. The original stdout (the pipe the parent reads) stays
-        // referenced by this dup.
-        let real_stdout: Option<std::fs::File> = unsafe {
-            let raw = libc::dup(libc::STDOUT_FILENO);
-            if raw < 0 {
-                None
-            } else {
-                Some(std::fs::File::from_raw_fd(raw))
-            }
-        };
+        // The original stdout — the pipe the parent reads — stays referenced by this dup.
+        let real_stdout: Option<std::fs::File> =
+            dup_owned(libc::STDOUT_FILENO).map(std::fs::File::from);
 
         // Only redirect fd 1 if we actually saved the real stdout — otherwise we'd
         // point fd 1 at /dev/null with no way to emit the payload.
@@ -275,11 +267,33 @@ mod tests {
     impl Drop for RestoreFd {
         fn drop(&mut self) {
             // SAFETY: self.saved is the dup of the original fd we own.
-            unsafe {
-                libc::dup2(self.saved, self.target);
-                libc::close(self.saved);
-            }
+            unsafe { libc::dup2(self.saved, self.target) };
+            // SAFETY: dup2 kept its own reference on the target, so this drops only our copy.
+            unsafe { libc::close(self.saved) };
         }
+    }
+
+    /// Point `target` at `capture`, handing back the guard that puts it back.
+    fn redirect(target: std::os::fd::RawFd, capture: &std::fs::File) -> RestoreFd {
+        let saved = dup_owned(target).expect("dup the fd under test");
+        // SAFETY: dup2 atomically replaces target with a duplicate of the capture file.
+        assert!(unsafe { libc::dup2(capture.as_raw_fd(), target) } >= 0);
+        RestoreFd {
+            saved: std::os::fd::IntoRawFd::into_raw_fd(saved),
+            target,
+        }
+    }
+
+    /// Write through C stdio, the way the FluidAudio bridge and the Espresso
+    /// runtime do — buffered, so the guard's flush ordering is what is on test.
+    fn c_print(msg: &core::ffi::CStr) {
+        // SAFETY: msg is a NUL-terminated C string and the format string takes no arguments.
+        unsafe { libc::printf(msg.as_ptr()) };
+    }
+
+    fn c_flush() {
+        // SAFETY: fflush(NULL) flushes every open C output stream and borrows nothing.
+        unsafe { libc::fflush(std::ptr::null_mut()) };
     }
 
     /// #841: the bridge collapses every transcribe throw to "Transcription
@@ -295,20 +309,12 @@ mod tests {
     fn debug_routes_silenced_chatter_to_stderr() {
         std::env::set_var("KESHA_DEBUG", "1");
         let mut capture = tempfile::tempfile().expect("capture tempfile");
-        let saved_real = unsafe { libc::dup(libc::STDERR_FILENO) };
-        assert!(saved_real >= 0, "dup stderr failed");
-        let _restore = RestoreFd {
-            saved: saved_real,
-            target: libc::STDERR_FILENO,
-        };
-        assert!(unsafe { libc::dup2(capture.as_raw_fd(), libc::STDERR_FILENO) } >= 0);
+        let _restore = redirect(libc::STDERR_FILENO, &capture);
 
         // Taken after the redirect: the sink dups whatever fd 2 points at now.
         let sink = oneshot_sink();
         with_silenced_stdout(sink.as_ref(), || {
-            // SAFETY: NUL-terminated literal; printf buffers via C stdio,
-            // exactly like the Swift bridge's print.
-            unsafe { libc::printf(c"Transcribe samples error: simulated\n".as_ptr()) };
+            c_print(c"Transcribe samples error: simulated\n");
         });
         drop(_restore);
 
@@ -329,13 +335,7 @@ mod tests {
     #[test]
     fn silenced_scope_discards_buffered_c_stdio_before_restore() {
         let mut capture = tempfile::tempfile().expect("capture tempfile");
-        let saved_real = unsafe { libc::dup(libc::STDOUT_FILENO) };
-        assert!(saved_real >= 0, "dup stdout failed");
-        let _restore = RestoreFd {
-            saved: saved_real,
-            target: libc::STDOUT_FILENO,
-        };
-        assert!(unsafe { libc::dup2(capture.as_raw_fd(), libc::STDOUT_FILENO) } >= 0);
+        let _restore = redirect(libc::STDOUT_FILENO, &capture);
 
         let devnull = std::fs::OpenOptions::new()
             .write(true)
@@ -343,15 +343,10 @@ mod tests {
             .ok()
             .map(OwnedFd::from);
         with_silenced_stdout(devnull.as_ref(), || {
-            // SAFETY: NUL-terminated literal; printf buffers via C stdio,
-            // exactly like the Swift bridge's print.
-            unsafe { libc::printf(c"leaky diagnostics\n".as_ptr()) };
+            c_print(c"leaky diagnostics\n");
         });
-        // SAFETY: same as above; the post-guard write must reach real stdout.
-        unsafe {
-            libc::printf(c"after guard\n".as_ptr());
-            libc::fflush(std::ptr::null_mut());
-        }
+        c_print(c"after guard\n");
+        c_flush();
         drop(_restore);
 
         let mut contents = String::new();
@@ -378,33 +373,19 @@ mod tests {
     #[test]
     fn shield_holds_fd1_through_drop() {
         let mut capture = tempfile::tempfile().expect("capture tempfile");
-        let saved_real = unsafe { libc::dup(libc::STDOUT_FILENO) };
-        assert!(saved_real >= 0, "dup stdout failed");
-        let _restore = RestoreFd {
-            saved: saved_real,
-            target: libc::STDOUT_FILENO,
-        };
-        assert!(unsafe { libc::dup2(capture.as_raw_fd(), libc::STDOUT_FILENO) } >= 0);
+        let _restore = redirect(libc::STDOUT_FILENO, &capture);
 
         {
             let shield = StdoutShield::new();
-            // SAFETY: NUL-terminated literals; printf goes through C stdio, like
-            // the Espresso runtime's own prints.
-            unsafe {
-                libc::printf(c"E5RT between calls\n".as_ptr());
-                libc::fflush(std::ptr::null_mut());
-            }
+            c_print(c"E5RT between calls\n");
+            c_flush();
             shield.write_stdout(b"transcript\n").expect("write payload");
-            unsafe {
-                libc::printf(c"E5RT at teardown\n".as_ptr());
-                libc::fflush(std::ptr::null_mut());
-            }
+            c_print(c"E5RT at teardown\n");
+            c_flush();
         }
-        // SAFETY: as above; fires after the shield dropped, as a teardown print can.
-        unsafe {
-            libc::printf(c"E5RT after drop\n".as_ptr());
-            libc::fflush(std::ptr::null_mut());
-        }
+        // Fires after the shield dropped, as a CoreML teardown print can.
+        c_print(c"E5RT after drop\n");
+        c_flush();
         drop(_restore);
 
         let mut contents = String::new();

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -4768,6 +4768,7 @@ mod retry_tests {
             truncated_response(&body, cut),
             partial_response(&body, cut),
         ]);
+        let _lock = crate::util::test_env::lock();
         let _guard = crate::util::test_env::EnvGuard::set("KESHA_MODEL_MIRROR", &base);
         let cache = TempCache::new("mirror-resume");
         let file = model_file(

--- a/rust/src/transcribe/diarize.rs
+++ b/rust/src/transcribe/diarize.rs
@@ -1130,9 +1130,7 @@ mod tests {
     fn compute_units_default_to_all_and_reject_junk() {
         let _guard = crate::util::test_env::lock();
 
-        unsafe {
-            std::env::remove_var(COMPUTE_UNITS_ENV);
-        }
+        let _unset = crate::util::test_env::EnvGuard::unset(COMPUTE_UNITS_ENV);
         assert_eq!(compute_units_from_env().unwrap(), DiarizeComputeUnits::All);
 
         let _env = crate::util::test_env::EnvGuard::set(COMPUTE_UNITS_ENV, "CPU-Only");
@@ -1151,9 +1149,7 @@ mod tests {
     fn total_timeout_is_opt_in() {
         let _guard = crate::util::test_env::lock();
 
-        unsafe {
-            std::env::remove_var(TOTAL_TIMEOUT_ENV);
-        }
+        let _unset = crate::util::test_env::EnvGuard::unset(TOTAL_TIMEOUT_ENV);
         assert_eq!(total_timeout_from_env().unwrap(), None);
 
         let _env = crate::util::test_env::EnvGuard::set(TOTAL_TIMEOUT_ENV, "3600");
@@ -1189,9 +1185,7 @@ mod tests {
     fn load_budget_is_overridable_but_never_zero() {
         let _guard = crate::util::test_env::lock();
 
-        unsafe {
-            std::env::remove_var(LOAD_TIMEOUT_ENV);
-        }
+        let _unset = crate::util::test_env::EnvGuard::unset(LOAD_TIMEOUT_ENV);
         assert_eq!(
             load_budget_from_env().unwrap(),
             Duration::from_secs(MODEL_LOAD_BUDGET_SECS)

--- a/rust/src/tts/encode.rs
+++ b/rust/src/tts/encode.rs
@@ -259,8 +259,10 @@ impl Drop for OpusEncoder {
 /// Resolve a libopus error code to its static message string.
 #[cfg(feature = "tts")]
 fn opus_err_str(code: core::ffi::c_int) -> String {
-    // SAFETY: opus_strerror returns a non-null static NUL-terminated C string for any code.
-    unsafe { core::ffi::CStr::from_ptr(opusic_sys::opus_strerror(code)) }
+    // SAFETY: opus_strerror accepts any c_int, returning a message for unknown codes.
+    let msg = unsafe { opusic_sys::opus_strerror(code) };
+    // SAFETY: that pointer is non-null and points at a static NUL-terminated C string.
+    unsafe { core::ffi::CStr::from_ptr(msg) }
         .to_string_lossy()
         .into_owned()
 }

--- a/rust/src/util.rs
+++ b/rust/src/util.rs
@@ -48,12 +48,14 @@ pub mod test_env {
     impl EnvGuard {
         pub fn set(key: &'static str, val: &str) -> Self {
             let original = std::env::var(key).ok();
+            // SAFETY: the caller holds [`lock`], so no other test thread touches the environment.
             unsafe { std::env::set_var(key, val) };
             Self { key, original }
         }
 
         pub fn unset(key: &'static str) -> Self {
             let original = std::env::var(key).ok();
+            // SAFETY: the caller holds [`lock`], so no other test thread touches the environment.
             unsafe { std::env::remove_var(key) };
             Self { key, original }
         }
@@ -61,8 +63,11 @@ pub mod test_env {
 
     impl Drop for EnvGuard {
         fn drop(&mut self) {
+            // Locals drop in reverse order, so a test that took [`lock`] first still holds it here.
             match &self.original {
+                // SAFETY: restoration is serialized by that still-held lock, like the set was.
                 Some(v) => unsafe { std::env::set_var(self.key, v) },
+                // SAFETY: restoration is serialized by that still-held lock, like the unset was.
                 None => unsafe { std::env::remove_var(self.key) },
             }
         }

--- a/rust/src/util.rs
+++ b/rust/src/util.rs
@@ -48,14 +48,16 @@ pub mod test_env {
     impl EnvGuard {
         pub fn set(key: &'static str, val: &str) -> Self {
             let original = std::env::var(key).ok();
-            // SAFETY: the caller holds [`lock`], so no other test thread touches the environment.
+            // SAFETY: callers must hold [`lock`], which serializes every env-mutating
+            // test in the crate. #954 tracks making that a type-level requirement.
             unsafe { std::env::set_var(key, val) };
             Self { key, original }
         }
 
         pub fn unset(key: &'static str) -> Self {
             let original = std::env::var(key).ok();
-            // SAFETY: the caller holds [`lock`], so no other test thread touches the environment.
+            // SAFETY: callers must hold [`lock`], which serializes every env-mutating
+            // test in the crate. #954 tracks making that a type-level requirement.
             unsafe { std::env::remove_var(key) };
             Self { key, original }
         }
@@ -65,9 +67,9 @@ pub mod test_env {
         fn drop(&mut self) {
             // Locals drop in reverse order, so a test that took [`lock`] first still holds it here.
             match &self.original {
-                // SAFETY: restoration is serialized by that still-held lock, like the set was.
+                // SAFETY: restoration runs under that still-held lock, like the set did.
                 Some(v) => unsafe { std::env::set_var(self.key, v) },
-                // SAFETY: restoration is serialized by that still-held lock, like the unset was.
+                // SAFETY: restoration runs under that still-held lock, like the unset did.
                 None => unsafe { std::env::remove_var(self.key) },
             }
         }


### PR DESCRIPTION
## Why

`-D warnings` lives only in `ci.yml`'s clippy invocation. `cargo build`, `cargo test` and rust-analyzer never see it, so a violation surfaces on a pull request instead of in the editor that produced it. Moving the levels into `rust/Cargo.toml` makes the gate travel with the crate.

Three lints, picked because the crate already satisfies them by hand — this locks in existing discipline rather than imposing a new one:

| Lint | Why this crate |
|---|---|
| `unsafe_op_in_unsafe_fn` | The edition-2024 default, adopted early. Already satisfied everywhere. |
| `clippy::undocumented_unsafe_blocks` | Every `unsafe` block here already carries a SAFETY comment. Makes it a build gate, not a review habit. |
| `clippy::multiple_unsafe_ops_per_block` | One op per block, so a SAFETY comment cannot silently start covering a second call added later. |

The crate juggles process file descriptors (`fluid_stdout.rs`), a raw libopus pointer (`tts/encode.rs`) and raw-fd adoption (`debug.rs`). That is the code where "someone will notice in review" is the weakest guarantee available.

## What enabling them found

23 sites. **5** under default features. **18** more under the darwin release feature set — which plain `cargo clippy` never compiles, so they were invisible to the default gate. That gap is itself part of the argument for this change.

The fixes are not all comments:

- **`fluid_stdout.rs`** grows `dup_owned`, collapsing three hand-rolled `dup` + `from_raw_fd` blocks into one place that explains the ownership transfer once. Its tests grow `redirect` / `c_print` / `c_flush`, replacing six copies of the same fd-juggling preamble. Net −7 lines across the file.
- **`diarize.rs`** had three raw `std::env::remove_var` calls that bypassed `EnvGuard` and therefore never restored the variable. They now go through `EnvGuard::unset`. A developer whose shell exports `KESHA_DIARIZE_COMPUTE_UNITS` no longer has it wiped for the rest of the process — a real behaviour fix that the lint surfaced.
- **`util.rs`**'s new SAFETY comments state the invariant the module previously documented only in prose: env mutation is serialized by `test_env::lock`, and `Drop` is covered because locals drop in reverse declaration order.

## Verification

- `just preflight` — green (1325 TS pass, 566 Rust pass).
- `just verify-darwin-full` — green. Required here: the diff touches `rust/src/tts/**` and the fluidaudio-adjacent modules, and it is the only gate that compiles them.
- `cargo nextest run --features coreml,tts,system_tts,system_kokoro,system_diarize,system_text_lang --no-default-features -E 'test(fluid_stdout)'` — 3/3 pass, so the fd-guard refactor is exercised, not just compiled.
- `cargo fmt --check` clean.

The one `LEAK` marker in the nextest summary is `audio::tests::resample_mono_same_rate_is_identity`, which this diff does not touch.

## Follow-ups

This came out of a Rust audit; the remaining findings are filed separately rather than piled in here:
#949 (`ErrorCode::ALL` drift, P1) · #950 (split `models.rs`) · #951 (fd-1 threading invariant) · #952 (`record.rs` backpressure) · #953 (`home_dir().expect()` vs the error-code contract) · #954 (`EnvGuard` typestate) · #955 (toolchain pin + edition 2024) · #956 (unreachable panics) · #957 (`set_ctl(&self)`) · #958 (`&str` vs `&Path`)

#954 and #955 are the direct descendants of this PR: the SAFETY comments added to `util.rs` here spell out the lock invariant that #954 proposes to enforce in the type, and #955 pins the compiler whose lint behaviour this gate now depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZwnEPwLkVUyfMLNfX9JcW
