### PR TITLE
ci: weekly canary holding model-plan.json sizes to the bytes upstream serves

### DIFF
--- a/.github/scripts/check-model-plan-sizes.ts
+++ b/.github/scripts/check-model-plan-sizes.ts
@@ -194,7 +194,9 @@ export async function liveSize(
         headers: { "accept-encoding": "identity" },
         signal: AbortSignal.timeout(30_000),
       });
-      if (res.ok) return contentLength(res.headers);
+      // Retried like a dropped connection: a CDN omitting Content-Length intermittently would otherwise spend its one attempt and file the drift issue.
+      const bytes = res.ok ? contentLength(res.headers) : null;
+      if (bytes !== null) return bytes;
     } catch {
       // Swallowed so the loop can retry; a transient blip must never read as a wrong size.
     }

--- a/.github/scripts/check-model-plan-sizes.ts
+++ b/.github/scripts/check-model-plan-sizes.ts
@@ -1,0 +1,269 @@
+#!/usr/bin/env bun
+/**
+ * Holds every `model-plan.json` size against the bytes its pinned URL actually serves.
+ *
+ * #887/#896 found `kesha install --plan` under-reporting CharsiuG2P by 72.9 MB, hand-written
+ * in #509 and undetected for two months: `assert_plan_paths` compares `relPath` only, and no
+ * offline test can falsify a size. The honest invariant needs the network, which is why this
+ * runs weekly rather than per PR (#920).
+ *
+ * `relPath` is the join key. `model-plan.json` records the sizes, `rust/src/models.rs` records
+ * the URLs, and the rust manifest test already holds those two path lists identical. The URLs
+ * are read out of models.rs instead of copied here, so this file cannot drift from the pins —
+ * and a plan entry whose `relPath` resolves to no URL fails the run rather than being skipped,
+ * which is what stops a parser regression from going quietly green.
+ *
+ * HEAD only: no downloads, no cache impact. `KESHA_MODEL_MIRROR` is deliberately not honoured —
+ * the subject here is upstream truth.
+ */
+import { readFileSync } from "node:fs";
+import { humanBytes } from "../../src/format";
+
+export interface PlanEntry {
+  group: string;
+  relPath: string;
+  sizeBytes: number;
+}
+
+export interface Verdict {
+  entry: PlanEntry;
+  status: "ok" | "drift" | "unchecked";
+  message: string;
+}
+
+function planFile(group: string, value: unknown): PlanEntry {
+  const { relPath, sizeBytes } = (value ?? {}) as { relPath?: unknown; sizeBytes?: unknown };
+  if (typeof relPath !== "string" || typeof sizeBytes !== "number") {
+    throw new Error(`install plan ${group} needs relPath and sizeBytes, got ${JSON.stringify(value)}`);
+  }
+  return { group, relPath, sizeBytes };
+}
+
+/** Every recorded file in the plan, whatever shape its group takes. */
+export function flattenPlan(plan: unknown): PlanEntry[] {
+  const entries: PlanEntry[] = [];
+  for (const [group, value] of Object.entries(plan as Record<string, unknown>)) {
+    if (Array.isArray(value)) entries.push(...value.map((file) => planFile(group, file)));
+    else if (value && typeof value === "object" && "relPath" in value) entries.push(planFile(group, value));
+    else
+      for (const [lang, file] of Object.entries(value as Record<string, unknown>))
+        entries.push(planFile(`${group}.${lang}`, file));
+  }
+  return entries;
+}
+
+function balanced(source: string, from: number, open: string, close: string) {
+  const start = source.indexOf(open, from);
+  if (start === -1) return null;
+  let depth = 0;
+  for (let i = start; i < source.length; i++) {
+    if (source[i] === open) depth++;
+    else if (source[i] === close && --depth === 0) return { inner: source.slice(start + 1, i), end: i + 1 };
+  }
+  return null;
+}
+
+/** Joins the string literals of a `concat!(…)` or yields the single literal. */
+function literalValue(text: string): string | null {
+  const parts = [...text.matchAll(/"((?:[^"\\]|\\.)*)"/g)].map((m) => m[1]);
+  return parts.length > 0 ? parts.join("") : null;
+}
+
+function topLevelArgs(text: string): string[] {
+  const args: string[] = [];
+  let depth = 0;
+  let inString = false;
+  let current = "";
+  for (const ch of text) {
+    if (ch === '"') inString = !inString;
+    if (!inString && ch === "(") depth++;
+    if (!inString && ch === ")") depth--;
+    if (!inString && ch === "," && depth === 0) {
+      args.push(current);
+      current = "";
+      continue;
+    }
+    current += ch;
+  }
+  args.push(current);
+  return args.map((a) => a.trim()).filter(Boolean);
+}
+
+interface MacroArm {
+  params: string[];
+  template: string;
+}
+
+/**
+ * Expands the `ModelFile`-building macros in place, so their entries are read from the same
+ * url template the compiler uses. Kokoro's voice packs exist only in that form.
+ */
+function expandModelFileMacros(source: string): string {
+  const macros = new Map<string, MacroArm>();
+  let stripped = "";
+  let at = 0;
+  for (const decl of source.matchAll(/macro_rules!\s+(\w+)\s*\{/g)) {
+    const body = balanced(source, decl.index + decl[0].length - 1, "{", "}");
+    if (!body) continue;
+    const arm = /\(([^)]*)\)\s*=>\s*\{/.exec(body.inner);
+    const template = arm && balanced(body.inner, arm.index + arm[0].length - 1, "{", "}");
+    if (arm && template && template.inner.includes("ModelFile")) {
+      macros.set(decl[1], {
+        params: [...arm[1].matchAll(/(\$\w+):/g)].map((p) => p[1]),
+        template: template.inner,
+      });
+    }
+    // The definition itself must not reach the ModelFile scan: its `$name` placeholders
+    // would register as a rel_path nothing resolves.
+    stripped += source.slice(at, decl.index);
+    at = body.end;
+  }
+  stripped += source.slice(at);
+
+  for (const [name, arm] of macros) {
+    // A self-referential template would never stop expanding; models.rs has none today.
+    if (arm.template.includes(`${name}!`)) continue;
+    const call = new RegExp(`\\b${name}!\\s*\\(`);
+    for (let match = call.exec(stripped); match; match = call.exec(stripped)) {
+      const args = balanced(stripped, match.index + match[0].length - 1, "(", ")");
+      if (!args) break;
+      const values = topLevelArgs(args.inner);
+      const expanded = arm.params.reduce(
+        (text, param, i) => text.split(param).join(values[i] ?? '""'),
+        arm.template,
+      );
+      stripped = stripped.slice(0, match.index) + expanded + stripped.slice(args.end);
+    }
+  }
+  return stripped;
+}
+
+/** `rel_path` → `url` for every `ModelFile` pinned in models.rs, `cfg` gating included. */
+export function parseManifestUrls(source: string): Map<string, string> {
+  const urls = new Map<string, string>();
+  const modelFile = /ModelFile\s*\{\s*rel_path:\s*([\s\S]*?),\s*url:\s*([\s\S]*?),\s*sha256:/g;
+  for (const match of expandModelFileMacros(source).matchAll(modelFile)) {
+    const relPath = literalValue(match[1]);
+    const url = literalValue(match[2]);
+    if (relPath && url) urls.set(relPath, url);
+  }
+  return urls;
+}
+
+/**
+ * The transfer length is not the file length: HuggingFace gzips small text files, and the
+ * compressed count would read as drift for every one of them.
+ */
+export function contentLength(headers: Headers): number | null {
+  const encoding = headers.get("content-encoding");
+  if (encoding && encoding !== "identity") return null;
+  const raw = headers.get("content-length");
+  const bytes = raw === null ? Number.NaN : Number(raw);
+  return Number.isInteger(bytes) ? bytes : null;
+}
+
+/** Just enough of `fetch` to be substitutable in a test. */
+export type FetchLike = (url: string, init: RequestInit) => Promise<Response>;
+
+export interface LiveSizeOptions {
+  fetchImpl?: FetchLike;
+  attempts?: number;
+  backoffMs?: number;
+}
+
+/**
+ * Bytes the URL serves, or null if the run could not find out.
+ *
+ * Backed off in seconds, not milliseconds: bun's fetch drops connections to github.com
+ * ("socket connection was closed unexpectedly") in bursts lasting tens of seconds, so a
+ * fast retry just lands in the same burst. Measured at 4/6 from cold processes while a
+ * 250 ms/500 ms retry failed every time. A weekly job that files an issue over that would
+ * train everyone to ignore it.
+ */
+export async function liveSize(
+  url: string,
+  { fetchImpl = fetch, attempts = 4, backoffMs = 1000 }: LiveSizeOptions = {},
+): Promise<number | null> {
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    if (attempt > 1) await Bun.sleep(backoffMs * 2 ** (attempt - 2));
+    try {
+      // The size lives on the far side of HuggingFace's 302, and only in an identity encoding.
+      const res = await fetchImpl(url, {
+        method: "HEAD",
+        redirect: "follow",
+        headers: { "accept-encoding": "identity" },
+        signal: AbortSignal.timeout(30_000),
+      });
+      if (res.ok) return contentLength(res.headers);
+    } catch {
+      // Swallowed so the loop can retry; a transient blip must never read as a wrong size.
+    }
+  }
+  return null;
+}
+
+export function compareEntry(entry: PlanEntry, live: number | null): Verdict {
+  const where = `${entry.relPath} (${entry.group})`;
+  if (live === null) {
+    return { entry, status: "unchecked", message: `${where}: no Content-Length could be read` };
+  }
+  if (live === entry.sizeBytes) {
+    return { entry, status: "ok", message: `${where}: ${live} bytes` };
+  }
+  const delta = live - entry.sizeBytes;
+  const sign = delta > 0 ? "+" : "-";
+  return {
+    entry,
+    status: "drift",
+    message:
+      `${where}: recorded ${entry.sizeBytes} bytes (${humanBytes(entry.sizeBytes)}), ` +
+      `live ${live} bytes (${humanBytes(live)}), ` +
+      `delta ${sign}${Math.abs(delta)} bytes (${sign}${humanBytes(Math.abs(delta))})`,
+  };
+}
+
+function argValue(flag: string, fallback: string): string {
+  const at = process.argv.indexOf(flag);
+  return at === -1 ? fallback : (process.argv[at + 1] ?? fallback);
+}
+
+if (import.meta.main) {
+  const planPath = argValue("--plan", "model-plan.json");
+  const manifestPath = argValue("--manifest", "rust/src/models.rs");
+
+  const entries = flattenPlan(JSON.parse(readFileSync(planPath, "utf8")));
+  const urls = parseManifestUrls(readFileSync(manifestPath, "utf8"));
+
+  const unresolved = entries.filter((entry) => !urls.has(entry.relPath));
+  if (unresolved.length > 0) {
+    console.error(
+      `FAIL: ${unresolved.length} plan entr${unresolved.length === 1 ? "y has" : "ies have"} no URL in ${manifestPath}:`,
+    );
+    for (const entry of unresolved) console.error(`  - ${entry.relPath} (${entry.group})`);
+    console.error(`\n  Either the manifest dropped the file, or this script stopped reading it.`);
+    process.exit(1);
+  }
+
+  const verdicts: Verdict[] = [];
+  for (const entry of entries) {
+    const verdict = compareEntry(entry, await liveSize(urls.get(entry.relPath)!));
+    console.log(`${verdict.status === "ok" ? "ok" : verdict.status.toUpperCase()}: ${verdict.message}`);
+    verdicts.push(verdict);
+  }
+
+  const drift = verdicts.filter((v) => v.status === "drift");
+  const unchecked = verdicts.filter((v) => v.status === "unchecked");
+  if (drift.length > 0) {
+    console.error(`\n${drift.length} of ${entries.length} recorded sizes no longer match upstream:`);
+    for (const v of drift) console.error(`  - ${v.message}`);
+    console.error(`\n  Fix: correct sizeBytes in ${planPath} — the live length is the truth.`);
+  }
+  if (unchecked.length > 0) {
+    console.error(`\n${unchecked.length} of ${entries.length} could not be checked at all:`);
+    for (const v of unchecked) console.error(`  - ${v.message}`);
+    console.error(`\n  The sizes are not implicated; this run proved nothing about them.`);
+  }
+  if (drift.length > 0 || unchecked.length > 0) process.exit(1);
+
+  console.log(`\nAll ${entries.length} recorded sizes match the bytes their pinned URLs serve.`);
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,11 @@ jobs:
               - '.github/actions/**'
               # 16 of these scripts have unit tests; without this a script-only edit skips the tests that cover it (check-workflows.ts enforces it).
               - '.github/scripts/**'
+              # The two halves of the install-plan join (#920): the size canary's unit test
+              # asserts every plan entry still resolves to a URL in the manifest, and a change
+              # to either file alone would otherwise never run it.
+              - 'model-plan.json'
+              - 'rust/src/models.rs'
             integration:
               - 'src/**'
               - 'tests/integration/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
               - 'server.json'
               - '.github/workflows/ci.yml'
               - '.github/actions/**'
-              # 16 of these scripts have unit tests; without this a script-only edit skips the tests that cover it (check-workflows.ts enforces it).
+              # Most of these scripts have unit tests; without this a script-only edit skips the tests that cover it (check-workflows.ts enforces it). Deliberately no count — the one that lived here read 16 against an actual 25.
               - '.github/scripts/**'
               # The two halves of the install-plan join (#920): the size canary's unit test
               # asserts every plan entry still resolves to a URL in the manifest, and a change

--- a/.github/workflows/model-plan-size-canary.yml
+++ b/.github/workflows/model-plan-size-canary.yml
@@ -1,0 +1,97 @@
+name: "📏 Model-Plan Size Canary"
+
+# Provider verification for the sizes `kesha install --plan` quotes (#920).
+#
+# The plan's `sizeBytes` are hand-written, and until now nothing could falsify one:
+# `models::manifest_tests::install_plan_model_paths_match_runtime_manifests` compares
+# `relPath` and stops there, because an offline test cannot know what a URL serves.
+# That is how #509 shipped CharsiuG2P as "28.5 MB" against a 101 MB download and how
+# it survived two months until a human noticed (#887, #896).
+#
+# So this job asks the only question that settles it: for every entry in
+# model-plan.json, does the pinned URL serve exactly the recorded number of bytes?
+# HEAD requests only — no downloads, no cache writes, seconds of runtime.
+#
+# Exact match is the bar. Sizes are pinned like the SHA-256s beside them, and a
+# "close enough" tolerance would have passed the 72.9 MB under-report that started
+# this. `KESHA_MODEL_MIRROR` is not honoured: the subject is upstream truth.
+#
+# FIXING A FAILURE. Drift means the recorded number is wrong, not the file — the URLs
+# carry pinned hashes, so weights that actually changed fail `download_verified` long
+# before they reach a user. Correct `sizeBytes` in model-plan.json from the live figure
+# the log prints. If the hash moved too, that is a model bump: use the verify-pin-bump
+# skill instead, and update both.
+
+on:
+  schedule:
+    # Weekly, clear of the capability pact (05:00), the mini-model pact (08:00) and the
+    # real-model canary (11:00) — though this one downloads nothing and contends with none.
+    - cron: "0 14 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  sizes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: 🍞 Setup Bun workspace
+        uses: ./.github/actions/setup-bun
+
+      # Tee'd because the issue body quotes the per-file figures; pipefail keeps the
+      # step's own outcome, which the report and fail steps below both read.
+      - name: 📏 Compare every recorded size against its pinned URL
+        id: check
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -o pipefail
+          bun .github/scripts/check-model-plan-sizes.ts 2>&1 | tee /tmp/model-plan-sizes.log
+
+      - name: 📣 Report a mis-sized plan (scheduled only)
+        if: github.event_name == 'schedule' && steps.check.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        shell: bash
+        run: |
+          {
+            echo "## model-plan.json no longer matches the bytes upstream serves"
+            echo
+            echo "Read the log below before acting — the step fails for three different reasons:"
+            echo
+            echo "- **A recorded size is wrong.** Lines beginning \`DRIFT\` name the file, the"
+            echo "  recorded and live byte counts, and the delta. \`kesha install --plan\` is"
+            echo "  quoting that number to users. Correct \`sizeBytes\` in model-plan.json from"
+            echo "  the live figure; it is the truth by construction."
+            echo "- **A plan entry has no URL.** The run stopped before any request, naming the"
+            echo "  entries it could not resolve. Either rust/src/models.rs dropped the file, or"
+            echo "  \`.github/scripts/check-model-plan-sizes.ts\` stopped being able to read it."
+            echo "- **The sizes could not be checked.** Lines beginning \`UNCHECKED\` mean no"
+            echo "  Content-Length came back. The plan is not implicated; the run proved nothing"
+            echo "  about those entries either way."
+            echo
+            echo '```'
+            cat /tmp/model-plan-sizes.log
+            echo '```'
+            echo
+            echo "Workflow run: $RUN_URL"
+          } > /tmp/model-plan-body.md
+          bash .github/scripts/upsert-audit-issue.sh /tmp/model-plan-body.md "Install plan sizes drifted from upstream" pact-drift
+
+      - name: ❌ Fail a mis-sized plan
+        if: steps.check.outcome == 'failure'
+        shell: bash
+        run: exit 1

--- a/model-plan.json
+++ b/model-plan.json
@@ -36,8 +36,8 @@
   ],
   "diarize": [
     { "relPath": "models/diarize/SortformerNvidiaLow_v2.mlpackage/Manifest.json", "sizeBytes": 617 },
-    { "relPath": "models/diarize/SortformerNvidiaLow_v2.mlpackage/Data/com.apple.CoreML/model.mlmodel", "sizeBytes": 7080357 },
-    { "relPath": "models/diarize/SortformerNvidiaLow_v2.mlpackage/Data/com.apple.CoreML/weights/0-weight.bin", "sizeBytes": 5930400 },
-    { "relPath": "models/diarize/SortformerNvidiaLow_v2.mlpackage/Data/com.apple.CoreML/weights/1-weight.bin", "sizeBytes": 232161600 }
+    { "relPath": "models/diarize/SortformerNvidiaLow_v2.mlpackage/Data/com.apple.CoreML/model.mlmodel", "sizeBytes": 856521 },
+    { "relPath": "models/diarize/SortformerNvidiaLow_v2.mlpackage/Data/com.apple.CoreML/weights/0-weight.bin", "sizeBytes": 8948544 },
+    { "relPath": "models/diarize/SortformerNvidiaLow_v2.mlpackage/Data/com.apple.CoreML/weights/1-weight.bin", "sizeBytes": 235580992 }
   ]
 }

--- a/tests/unit/check-model-plan-sizes.test.ts
+++ b/tests/unit/check-model-plan-sizes.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  compareEntry,
+  contentLength,
+  flattenPlan,
+  liveSize,
+  parseManifestUrls,
+  type FetchLike,
+} from "../../.github/scripts/check-model-plan-sizes";
+import modelPlan from "../../model-plan.json" with { type: "json" };
+
+const repoRoot = join(import.meta.dir, "..", "..");
+
+describe("flattenPlan", () => {
+  test("reads arrays, single files and per-language maps alike", () => {
+    const entries = flattenPlan({
+      vad: [{ relPath: "models/silero-vad/silero_vad.onnx", sizeBytes: 2327524 }],
+      kokoroGraph: { relPath: "models/kokoro-82m/model.onnx", sizeBytes: 325532387 },
+      kokoroVoices: {
+        en: { relPath: "models/kokoro-82m/voices/am_michael.bin", sizeBytes: 522240 },
+      },
+    });
+
+    expect(entries).toEqual([
+      { group: "vad", relPath: "models/silero-vad/silero_vad.onnx", sizeBytes: 2327524 },
+      { group: "kokoroGraph", relPath: "models/kokoro-82m/model.onnx", sizeBytes: 325532387 },
+      {
+        group: "kokoroVoices.en",
+        relPath: "models/kokoro-82m/voices/am_michael.bin",
+        sizeBytes: 522240,
+      },
+    ]);
+  });
+
+  test("refuses an entry with no recorded size rather than skipping it", () => {
+    expect(() => flattenPlan({ vad: [{ relPath: "models/silero-vad/silero_vad.onnx" }] })).toThrow(
+      /sizeBytes/,
+    );
+  });
+});
+
+describe("parseManifestUrls", () => {
+  test("reads a plain ModelFile, including a url wrapped onto its own line", () => {
+    const urls = parseManifestUrls(`
+      const VOSK_RU_FILES: &[ModelFile] = &[
+          ModelFile {
+              rel_path: "models/vosk-ru/model.onnx",
+              url: "https://example.test/model.onnx",
+              sha256: "aa",
+          },
+          ModelFile {
+              rel_path: "models/vosk-ru/bert/vocab.txt",
+              url:
+                  "https://example.test/bert/vocab.txt",
+              sha256: "bb",
+          },
+      ];
+    `);
+
+    expect(urls.get("models/vosk-ru/model.onnx")).toBe("https://example.test/model.onnx");
+    expect(urls.get("models/vosk-ru/bert/vocab.txt")).toBe("https://example.test/bert/vocab.txt");
+  });
+
+  test("expands a macro-built entry through the macro's own url template", () => {
+    const urls = parseManifestUrls(`
+      macro_rules! kokoro_voice {
+          ($name:literal, $sha:literal) => {
+              ModelFile {
+                  rel_path: concat!("models/kokoro-82m/voices/", $name, ".bin"),
+                  url: concat!(
+                      "https://example.test/voices/",
+                      $name,
+                      ".bin"
+                  ),
+                  sha256: $sha,
+              }
+          };
+      }
+
+      const KOKORO_EN_VOICE: ModelFile = kokoro_voice!("am_michael", "cc");
+    `);
+
+    expect(urls.get("models/kokoro-82m/voices/am_michael.bin")).toBe(
+      "https://example.test/voices/am_michael.bin",
+    );
+  });
+
+  test("resolves a url for every model-plan.json entry against the real manifest", () => {
+    const urls = parseManifestUrls(readFileSync(join(repoRoot, "rust", "src", "models.rs"), "utf8"));
+
+    const unresolved = flattenPlan(modelPlan).filter((entry) => !urls.has(entry.relPath));
+    expect(unresolved.map((entry) => entry.relPath)).toEqual([]);
+  });
+});
+
+describe("compareEntry", () => {
+  const entry = {
+    group: "g2pCharsiu",
+    relPath: "models/g2p/byt5-tiny/encoder_model.onnx",
+    sizeBytes: 57234020,
+  };
+
+  test("passes when the live length equals the recorded size", () => {
+    expect(compareEntry(entry, 57234020).status).toBe("ok");
+  });
+
+  // The #896 drift: the plan recorded 12478704 for a file upstream serves as 57234020.
+  test("names the recorded size, the live size and the delta on drift", () => {
+    const verdict = compareEntry({ ...entry, sizeBytes: 12478704 }, 57234020);
+
+    expect(verdict.status).toBe("drift");
+    expect(verdict.message).toContain("models/g2p/byt5-tiny/encoder_model.onnx");
+    expect(verdict.message).toContain("12478704");
+    expect(verdict.message).toContain("11.9 MB");
+    expect(verdict.message).toContain("57234020");
+    expect(verdict.message).toContain("54.6 MB");
+    expect(verdict.message).toContain("+44755316");
+    expect(verdict.message).toContain("+42.7 MB");
+  });
+
+  test("reports a shrunk file with a negative delta", () => {
+    const verdict = compareEntry(entry, 57234000);
+
+    expect(verdict.status).toBe("drift");
+    expect(verdict.message).toContain("-20 bytes");
+  });
+
+  test("separates an unreadable length from drift", () => {
+    const verdict = compareEntry(entry, null);
+
+    expect(verdict.status).toBe("unchecked");
+    expect(verdict.message).toContain("models/g2p/byt5-tiny/encoder_model.onnx");
+  });
+});
+
+describe("contentLength", () => {
+  test("reads a plain byte count", () => {
+    expect(contentLength(new Headers({ "content-length": "93939" }))).toBe(93939);
+  });
+
+  test("refuses a compressed length, which measures the transfer and not the file", () => {
+    expect(
+      contentLength(new Headers({ "content-length": "31000", "content-encoding": "gzip" })),
+    ).toBeNull();
+  });
+
+  test("accepts an explicit identity encoding", () => {
+    expect(
+      contentLength(new Headers({ "content-length": "646", "content-encoding": "identity" })),
+    ).toBe(646);
+  });
+
+  test("yields nothing when the header is absent or unparseable", () => {
+    expect(contentLength(new Headers())).toBeNull();
+    expect(contentLength(new Headers({ "content-length": "many" }))).toBeNull();
+  });
+});
+
+describe("liveSize", () => {
+  const url = "https://example.test/vocab.txt";
+
+  test("asks for an uncompressed body, so the length is the file and not the transfer", async () => {
+    // HuggingFace gzips small text files unless identity is requested: `vocab.txt`
+    // answers 93939 with identity and no Content-Length at all without it.
+    const gzipUnlessIdentity: FetchLike = async (_input, init) =>
+      new Response(null, {
+        headers:
+          new Headers(init?.headers).get("accept-encoding") === "identity"
+            ? { "content-length": "93939" }
+            : { "content-encoding": "gzip" },
+      });
+
+    expect(await liveSize(url, { fetchImpl: gzipUnlessIdentity, backoffMs: 0 })).toBe(93939);
+  });
+
+  test("follows the redirect that carries the real length", async () => {
+    // HF `resolve/` URLs 302 to a CDN; only the final response knows the size.
+    const redirecting: FetchLike = async (_input, init) =>
+      init?.redirect === "follow"
+        ? new Response(null, { headers: { "content-length": "2435420160" } })
+        : new Response(null, { status: 302, headers: { location: "https://cdn.example.test/x" } });
+
+    expect(await liveSize(url, { fetchImpl: redirecting, backoffMs: 0 })).toBe(2435420160);
+  });
+
+  test("retries, so a single blip does not read as drift", async () => {
+    let calls = 0;
+    const flaky: FetchLike = async () => {
+      calls += 1;
+      if (calls === 1) throw new Error("connection reset");
+      return new Response(null, { headers: { "content-length": "646" } });
+    };
+
+    expect(await liveSize(url, { fetchImpl: flaky, backoffMs: 0 })).toBe(646);
+  });
+
+  test("gives up rather than guessing when the host keeps failing", async () => {
+    const dead: FetchLike = async () => new Response(null, { status: 404 });
+
+    expect(await liveSize(url, { fetchImpl: dead, backoffMs: 0 })).toBeNull();
+  });
+});

--- a/tests/unit/check-model-plan-sizes.test.ts
+++ b/tests/unit/check-model-plan-sizes.test.ts
@@ -13,6 +13,9 @@ import modelPlan from "../../model-plan.json" with { type: "json" };
 
 const repoRoot = join(import.meta.dir, "..", "..");
 
+const realManifestUrls = () =>
+  parseManifestUrls(readFileSync(join(repoRoot, "rust", "src", "models.rs"), "utf8"));
+
 describe("flattenPlan", () => {
   test("reads arrays, single files and per-language maps alike", () => {
     const entries = flattenPlan({
@@ -88,10 +91,25 @@ describe("parseManifestUrls", () => {
   });
 
   test("resolves a url for every model-plan.json entry against the real manifest", () => {
-    const urls = parseManifestUrls(readFileSync(join(repoRoot, "rust", "src", "models.rs"), "utf8"));
-
-    const unresolved = flattenPlan(modelPlan).filter((entry) => !urls.has(entry.relPath));
+    const unresolved = flattenPlan(modelPlan).filter((entry) => !realManifestUrls().has(entry.relPath));
     expect(unresolved.map((entry) => entry.relPath)).toEqual([]);
+  });
+
+  // Presence alone passes on a parser emitting a truncated or wrong-host URL; the weekly HEAD would then read that as a size mismatch, not a parse bug.
+  test("reads the real manifest's urls byte-exact, not merely non-empty", () => {
+    const urls = realManifestUrls();
+
+    expect(urls.get("models/parakeet-tdt-v3/vocab.txt")).toBe(
+      "https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx/resolve/main/vocab.txt",
+    );
+    expect(urls.get("models/kokoro-82m/voices/am_michael.bin")).toBe(
+      "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices/am_michael.bin",
+    );
+    expect(
+      urls.get("models/diarize/SortformerNvidiaLow_v2.mlpackage/Data/com.apple.CoreML/weights/0-weight.bin"),
+    ).toBe(
+      "https://huggingface.co/FluidInference/diar-streaming-sortformer-coreml/resolve/main/SortformerNvidiaLow_v2.mlpackage/Data/com.apple.CoreML/weights/0-weight.bin",
+    );
   });
 });
 
@@ -194,6 +212,16 @@ describe("liveSize", () => {
     };
 
     expect(await liveSize(url, { fetchImpl: flaky, backoffMs: 0 })).toBe(646);
+  });
+
+  test("retries a 200 that carries no usable length, not just a dropped connection", async () => {
+    let calls = 0;
+    const omitsLengthOnce: FetchLike = async () => {
+      calls += 1;
+      return new Response(null, { headers: calls === 1 ? {} : { "content-length": "2327524" } });
+    };
+
+    expect(await liveSize(url, { fetchImpl: omitsLengthOnce, backoffMs: 0 })).toBe(2327524);
   });
 
   test("gives up rather than guessing when the host keeps failing", async () => {


### PR DESCRIPTION
A weekly canary that HEADs every `model-plan.json` entry's pinned URL and compares the live `Content-Length` to the recorded `sizeBytes`. Exact match, no downloads, ~10 s.

It found real drift on its first run, so this PR carries the fix too.

Closes #920

## Why this is the only honest check

`kesha install --plan` quotes hand-written sizes. `models::manifest_tests::install_plan_model_paths_match_runtime_manifests` compares `relPath` and stops there, because an offline test cannot know what a URL serves — which is how #509 shipped CharsiuG2P as "28.5 MB" against a 101 MB download and how it survived two months until a human noticed (#887, #896).

`relPath` is the join key. The plan holds the sizes, `rust/src/models.rs` holds the URLs, and the rust manifest test already holds those two path lists identical. The script reads the URLs out of `models.rs` — including the ones only `kokoro_voice!` builds, by expanding the macro's own `concat!` template — so it cannot drift from the pins the way a copied table would. A plan entry that resolves to no URL **fails the run** rather than being skipped; that is what stops a parser regression from going quietly green.

## What it caught

Three diarize entries, wrong since they were written:

| file | recorded | live | delta |
|---|---|---|---|
| `…/model.mlmodel` | 7080357 | 856521 | −5.9 MB |
| `…/weights/0-weight.bin` | 5930400 | 8948544 | +2.9 MB |
| `…/weights/1-weight.bin` | 232161600 | 235580992 | +3.3 MB |

All four Sortformer files hash **exactly** as pinned in `models.rs` (`model.mlmodel` → `478267113144…`, `0-weight` → `ad40d62ccd7a…`, `1-weight` → `e8ebd6767429…`, verified by downloading and hashing each), so upstream has not moved and `kesha install --diarize` works. The numbers were simply wrong. The aggregate barely shifts — 233.8 MB → 234.0 MB — because the errors nearly cancel, which is exactly why nobody noticed.

## Live run

Commit 1 lands the canary red against the current plan; commit 2 fixes the sizes it named. After the fix, against real upstream:

```
ok: models/parakeet-tdt-v3/encoder-model.onnx (asr): 41770866 bytes
ok: models/parakeet-tdt-v3/encoder-model.onnx.data (asr): 2435420160 bytes
ok: models/parakeet-tdt-v3/decoder_joint-model.onnx (asr): 72520893 bytes
ok: models/parakeet-tdt-v3/nemo128.onnx (asr): 139764 bytes
ok: models/parakeet-tdt-v3/vocab.txt (asr): 93939 bytes
ok: models/lang-id-ecapa/lang-id-ecapa.onnx (langId): 759814 bytes
ok: models/lang-id-ecapa/lang-id-ecapa.onnx.data (langId): 85327872 bytes
ok: models/lang-id-ecapa/labels.json (langId): 646 bytes
ok: models/silero-vad/silero_vad.onnx (vad): 2327524 bytes
ok: models/g2p/byt5-tiny/encoder_model.onnx (g2pCharsiu): 57234020 bytes
ok: models/g2p/byt5-tiny/decoder_model.onnx (g2pCharsiu): 26118052 bytes
ok: models/g2p/byt5-tiny/decoder_with_past_model.onnx (g2pCharsiu): 22960684 bytes
ok: models/kokoro-82m/model.onnx (kokoroGraph): 325532387 bytes
ok: models/kokoro-82m/voices/am_michael.bin (kokoroVoices.en): 522240 bytes
ok: models/kokoro-82m/voices/em_alex.bin (kokoroVoices.es): 522240 bytes
ok: models/kokoro-82m/voices/ff_siwis.bin (kokoroVoices.fr): 522240 bytes
ok: models/kokoro-82m/voices/im_nicola.bin (kokoroVoices.it): 522240 bytes
ok: models/kokoro-82m/voices/pm_alex.bin (kokoroVoices.pt): 522240 bytes
ok: models/vosk-ru/model.onnx (voskRu): 179314533 bytes
ok: models/vosk-ru/dictionary (voskRu): 101431118 bytes
ok: models/vosk-ru/config.json (voskRu): 1518 bytes
ok: models/vosk-ru/bert/model.onnx (voskRu): 654361598 bytes
ok: models/vosk-ru/bert/vocab.txt (voskRu): 1780720 bytes
ok: models/diarize/SortformerNvidiaLow_v2.mlpackage/Manifest.json (diarize): 617 bytes
ok: models/diarize/SortformerNvidiaLow_v2.mlpackage/Data/com.apple.CoreML/model.mlmodel (diarize): 856521 bytes
ok: models/diarize/SortformerNvidiaLow_v2.mlpackage/Data/com.apple.CoreML/weights/0-weight.bin (diarize): 8948544 bytes
ok: models/diarize/SortformerNvidiaLow_v2.mlpackage/Data/com.apple.CoreML/weights/1-weight.bin (diarize): 235580992 bytes

All 27 recorded sizes match the bytes their pinned URLs serve.
```

## Failure paths, demonstrated

A doctored plan reproducing the #896 shape (`encoder_model.onnx` back to its wrong `12478704`):

```
DRIFT: models/g2p/byt5-tiny/encoder_model.onnx (g2pCharsiu): recorded 12478704 bytes (11.9 MB), live 57234020 bytes (54.6 MB), delta +44755316 bytes (+42.7 MB)

1 of 27 recorded sizes no longer match upstream:
  - models/g2p/byt5-tiny/encoder_model.onnx (g2pCharsiu): recorded 12478704 bytes (11.9 MB), live 57234020 bytes (54.6 MB), delta +44755316 bytes (+42.7 MB)

  Fix: correct sizeBytes in <plan> — the live length is the truth.
```

A plan entry pointed at a path no manifest carries, which stops the run before any request:

```
FAIL: 1 plan entry has no URL in rust/src/models.rs:
  - models/silero-vad/does-not-exist.onnx (vad)

  Either the manifest dropped the file, or this script stopped reading it.
```

## Two things the network taught the implementation

Both have tests standing on them, because both silently produce a wrong answer rather than an error:

- **The size is on the far side of the 302.** HF `resolve/` URLs redirect to a CDN; only the final response knows the length.
- **`accept-encoding: identity` is mandatory.** HF gzips small text files, and `vocab.txt` then answers with **no `Content-Length` at all** — 93939 with identity, absent without it. A compressed length would read as drift on every text file.

A third thing the network taught it, this time about the retry. Bun's `fetch` drops connections to `github.com` — "socket connection was closed unexpectedly" — and it does so **in bursts lasting tens of seconds**, not as isolated blips. My first retry (250 ms, then 500 ms) landed inside the same burst every time and reported the silero VAD entry `UNCHECKED` on three consecutive full runs, while `curl` succeeded against the same URL throughout and cold `bun` processes scored 4/6. Backing off in seconds instead (1 s, 2 s, 4 s) fixed it: three consecutive full runs green, ~10 s each. Worth knowing before someone "simplifies" that backoff.

`UNCHECKED` stays its own category — "this run proved nothing about those entries" — separate from drift, in both the output and the issue body, so a network failure can never be mistaken for a wrong size.

## Workflow

Mirrors the canary family: `schedule` + `workflow_dispatch`, SHA-pinned actions copied from the siblings, `shell: bash` on every `run:` (#850), `${{ }}` routed through `env:` (#291), and one issue upserted through `.github/scripts/upsert-audit-issue.sh` with the `pact-drift` label rather than a new issue each week. Cron `0 14 * * 1`, clear of the capability pact (05:00), mini-model pact (08:00) and real-model canary (11:00).

`model-plan.json` and `rust/src/models.rs` join ci.yml's `code` filter: the new unit test asserts every plan entry still resolves to a URL, and a change to either file alone would never have run it.

## Gates

- `just preflight` (TS gate; the diff touches no `rust/` source, so the Rust and CoreML gates skip by design) — exit 0
- `bun test` — 1338 pass, 6 skip, 0 fail; `bun run test:unit` after the last edit — 1162 pass, 0 fail
- `bunx tsc --noEmit` — clean
- `bun run check:workflows` — clean
- The canary itself, three consecutive live runs — 27/27 green, ~10 s each

## Review round (grok, no P1/P2)

Two P3s taken, both about the canary's own trustworthiness:

- **The real-manifest test asserted presence, not correctness.** `unresolved === []` passed as long as the parser emitted *a* string per `relPath`, so a wrong-host or truncated URL stayed green in PR CI. Three golden URLs are now byte-exact, one per construction `models.rs` uses. Proven by mutation: rewriting only the host and leaving every `relPath` intact fails this test **and nothing else** — the presence test alone did not notice.
- **`liveSize` spent no retries on a 200 with an unusable `Content-Length`.** A CDN omitting the header intermittently would have marked the entry `UNCHECKED` and filed the drift issue. It is now retried like a dropped connection. Retry over a Range-GET fallback because the observed failures are intermittent, and a host that *never* returns a length is a genuine "cannot check" that should say so rather than silently switch protocols.

The nit — ci.yml's "16 of these scripts have unit tests" — turned out to be stale in the other direction: the real count is **25**, so the comment now carries no number rather than a freshly wrong one.
