### PR TITLE
test: constrain the engine JSON parse seams against their surviving mutants

### DIFF
--- a/tests/unit/engine.test.ts
+++ b/tests/unit/engine.test.ts
@@ -370,18 +370,27 @@ describe("engine", () => {
     });
   });
 
-  /** An engine without the capability sends no key; the parser must not invent one. */
-  fakeEngineTest("transcribeEngineWithSegments leaves words undefined when absent", async () => {
+  /** An engine without the capability sends no key; the parser must not invent one — a
+   * `words: undefined` still counts as a column to TOON, which prints it as `words` / `null`. */
+  fakeEngineTest("transcribeEngineWithSegments leaves words absent, not undefined", async () => {
     await withEngineEnv(fakeEngine(["transcribe.segments"]), async () => {
       const out = await transcribeEngineWithSegments("audio.wav");
-      expect(out.segments[0]!.words).toBeUndefined();
+      expect(out.segments[0]).toStrictEqual({ start: 0, end: 1, text: "ok", speaker: 0 });
     });
   });
 
   /** A malformed `words` is a bad enrichment, not a bad transcript: drop it, keep the text.
-   * Throwing would make a garbled optional field cost the user their transcription. */
+   * Throwing would make a garbled optional field cost the user their transcription. Each
+   * of `word`/`start`/`end` is checked on its own, so each gets its own broken payload. */
   fakeEngineTest("transcribeEngineWithSegments drops malformed word timings", async () => {
-    for (const words of ['"not-an-array"', '[{"word":"hi","start":"0","end":1}]', "[{}]", "[null]"]) {
+    for (const words of [
+      '"not-an-array"',
+      '[{"word":7,"start":0,"end":1}]',
+      '[{"word":"hi","start":"0","end":1}]',
+      '[{"word":"hi","start":0,"end":"1"}]',
+      "[{}]",
+      "[null]",
+    ]) {
       const payload = `{"text":"hi","segments":[{"start":0,"end":1,"text":"hi","words":${words}}]}`;
       const engine = writeTranscribingEngine(
         "kesha-engine-badwords-",
@@ -391,7 +400,7 @@ describe("engine", () => {
       await withEngineEnv(engine, async () => {
         const out = await transcribeEngineWithSegments("audio.wav");
         expect(out.text).toBe("hi");
-        expect(out.segments[0]!.words).toBeUndefined();
+        expect(out.segments[0]).toStrictEqual({ start: 0, end: 1, text: "hi" });
       });
     }
   });
@@ -567,11 +576,11 @@ describe("the engine boundary refuses to pass a malformed reply through", () => 
     return writeTranscribingEngine("kesha-engine-malformed-", ["transcribe.segments"], `  printf '%s\\n' '${payload}'`);
   }
 
-  function capabilitiesEngine(payload: string): string {
+  function capabilitiesEngine(payload: string, exitCode = 0): string {
     const path = join(mkdtempSync(join(tmpdir(), "kesha-engine-caps-")), "kesha-engine");
     writeFileSync(
       path,
-      `#!/bin/sh\nif [ "$1" = "--capabilities-json" ]; then\n  printf '%s\\n' '${payload}'\n  exit 0\nfi\nexit 2\n`,
+      `#!/bin/sh\nif [ "$1" = "--capabilities-json" ]; then\n  printf '%s\\n' '${payload}'\n  exit ${exitCode}\nfi\nexit 2\n`,
     );
     chmodSync(path, 0o755);
     return path;
@@ -582,6 +591,9 @@ describe("the engine boundary refuses to pass a malformed reply through", () => 
     ["a non-string text", '{"text":7,"segments":[]}'],
     ["segments that are not an array", '{"text":"ok","segments":{}}'],
     ["no segments field", '{"text":"ok"}'],
+    // A bare `null` has no fields to inspect; it must still read as a malformed reply
+    // rather than as whatever TypeError reading through it would produce.
+    ["a bare null", "null"],
   ] as const) {
     fakeEngineTest(`${shape} is rejected, with the payload named`, async () => {
       await withEngineEnv(transcribingEngine(payload), async () => {
@@ -642,6 +654,24 @@ describe("the engine boundary refuses to pass a malformed reply through", () => 
       });
     });
   }
+
+  // The exit code is the engine's own verdict on what it just printed: a probe that failed
+  // must read as no capabilities even when the bytes on stdout happen to parse.
+  fakeEngineTest("capabilities printed by a failing probe are not trusted", async () => {
+    await withEngineEnv(
+      capabilitiesEngine('{"protocolVersion":3,"backend":"onnx","features":["tts"]}', 3),
+      async () => {
+        expect(await getEngineCapabilities()).toBeNull();
+      },
+    );
+  });
+
+  // Null, not undefined: callers branch on `caps === null` for the "could not read it" message.
+  fakeEngineTest("stdout that is not JSON at all reads as no capabilities", async () => {
+    await withEngineEnv(capabilitiesEngine("not json"), async () => {
+      expect(await getEngineCapabilities()).toBeNull();
+    });
+  });
 
   fakeEngineTest("well-formed capabilities are returned as they came", async () => {
     await withEngineEnv(


### PR DESCRIPTION
Closes #919

## What this measures

`just mutants-ts src/engine.ts` (the #897 one-command scoped run) on `origin/main@46b74e0`: **433 mutants, 277 killed, 90 survived, 64.20% score** — the audit's "high line coverage, low mutation score" reading, confirmed on the exact surface where #905's P1 landed.

Fifteen of those 90 survivors sit in the parse layer #919 names. Five are behaviour no test constrained; ten are equivalent under the outer `try`/`catch`, or memoisation-only. This PR kills the five and records why the ten stay.

No production code changes — `src/engine.ts` is untouched.

## Before / after, per function

| function | lines | survivors before | survivors after | killed |
| --- | --- | --- | --- | --- |
| `parseWordTimings` | 358–373 | 1 | 0 | 1 |
| `parseTranscriptionOutput` | 375–398 | 3 | 1 | 2 |
| `getEngineCapabilities` | 537–565 | 6 | 4 | 2 |
| `parseCapabilities` | 568–575 | 5 | 5 | 0 |
| **target scope** | | **15** | **10** | **5** |

File-wide for context: 64.20% → **64.90%** total, 75.54% → **76.36%** covered.

## The five kills

Each was verified twice: the scoped mutation run reports it dead, and hand-applying the same edit to `src/engine.ts` turns `tests/unit/engine.test.ts` red.

| line | mutant | what was unconstrained | the assertion that now holds it |
| --- | --- | --- | --- |
| 366 | `typeof w.end !== "number"` → `false` | `end` was never the deciding check — every malformed-words payload broke `word` or `start` first and short-circuited, so a word with a string `end` was forwarded to the caller | each of `word`/`start`/`end` gets its own broken payload in the drop-malformed table |
| 377 | `parsed?.text` → `parsed.text` | a bare `null` reply threw a raw `TypeError` instead of the named `Invalid transcription JSON returned by kesha-engine: null` | `a bare null` joins the malformed-shape table |
| 393 | `if (words)` → `if (true)` | assigning `words: undefined` is invisible to `toEqual`, but TOON counts the key as a column and prints `words` / `null` for an engine that sent no timings | `toStrictEqual` on the whole segment, so an absent key stays absent |
| 556 | `if (exitCode !== 0) return null` → `false` | capabilities printed by a probe that then *failed* were trusted; the exit code is the engine's own verdict on those bytes | a stub that prints valid capabilities JSON and exits 3 must read as `null` |
| 562 | `catch { return null }` → `catch {}` | unparseable stdout resolved `undefined`, not the `null` every caller branches on for the "could not read it" message | a stub that exits 0 with `not json` must read as `null` |

The 393 claim is measured, not assumed:

```
words: undefined  ->  segments[1]{start,end,text,words}:\n  0,1,hi,null
no words key      ->  segments[1]{start,end,text}:\n  0,1,hi
```

## Survivors left alive, with reasons

| line | mutant | why it stays |
| --- | --- | --- |
| 377 | `parsed?.segments` → `parsed.segments` | equivalent: `\|\|` short-circuits, so the right operand only runs when `parsed?.text` yielded a string — `parsed` is necessarily non-nullish there |
| 550, 552, 560 | cache-hit guard and cache write | memoisation only; the observable result is identical, and killing it needs a spawn-count spy — the kind of test the #161 audit retired |
| 559 | `if (!capabilities) return null` → `false` | equivalent: it caches `capabilities: null` and still returns `null`, on this call and every later one |
| 569 (×5) | the `!parsed \|\| typeof !== "object" \|\| isArray` shape guard | equivalent: every input this guard rejects already resolves to `null` via the per-field checks below it plus `getEngineCapabilities`'s own `catch` |

## Coordination with #927

#927 (open, `test/issue-917`) pacts *field presence* — that every field the Rust side records reaches the parsed result. This PR constrains *value handling* — type checks, drop-vs-throw semantics, and the exit-code/parse-failure contract on the capabilities probe. No assertion is duplicated, and this PR deliberately does **not** export `parseTranscriptionOutput`, so it does not touch the one line of `src/engine.ts` that #927 changes.

## Two out-of-scope survivors the diff did not cause

The file-wide count moved 90 → 87 rather than 90 → 85, because two mutants outside the parse layer read as "killed" in the baseline and "survived" after. Neither is a regression from this diff:

- **`105` `if (!envFd) return base` → `if (false)`** — an equivalent mutant (`Number(undefined)` is `NaN`, so `Number.isInteger` returns `base` anyway). Hand-applied against the **pre-PR** test file it is still green, so the baseline's "killed" was spurious. Stryker's Bun runner warns about exactly this id-collision hazard in its own log.
- **`158` `forceKillTimer ??=` → `&&=`** — a genuinely flaky killer. Against that mutant the `abort terminates the spawned engine process tree` test fails 2 runs in 3 (measured); the confirmation run happened to catch the passing arm. The test itself is **not** flaky against real code — 5/5 green on unmodified `src/engine.ts`. It is the process-tree teardown seam, not the parse layer, so it is reported rather than fixed here.

## Gates

| gate | result |
| --- | --- |
| `bun run test` | 1324 pass / 6 skip / **0 fail** (1330 across 92 files) |
| `bunx tsc --noEmit` | clean |
| `just mutants-ts src/engine.ts` | 280 killed / 87 survived, 64.90% (was 277 / 90, 64.20%) |

No Rust changes, so no Rust gate. `seam_long_form` stays excluded per the audit — this is the TS runner and never touches it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBTpJjqyYFW6W8LHJ2nwy
