### PR TITLE
fix(engine): validate the capabilities `tts` block instead of casting it into existence

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -564,12 +564,38 @@ export async function getEngineCapabilities(
   }
 }
 
-// A non-null return must mean "it described itself" — callers reach straight for `.features.join()` (#647).
+function parseTtsLanguages(raw: unknown): TtsLanguageCapability[] | null {
+  const languages = (raw as { languages?: unknown } | null | undefined)?.languages;
+  if (!Array.isArray(languages)) return null;
+  const out: TtsLanguageCapability[] = [];
+  for (const entry of languages) {
+    const l = entry as Record<string, unknown> | null;
+    if (typeof l?.code !== "string") return null;
+    if (!Array.isArray(l.engines) || l.engines.some((e) => typeof e !== "string")) return null;
+    out.push({ code: l.code, engines: l.engines as string[] });
+  }
+  return out;
+}
+
+// A non-null return must mean "it described itself" — callers reach straight for `.features.join()` (#647)
+// and `.tts.languages.map()`, so every field is checked and rebuilt rather than cast. A `tts` key that is
+// present and malformed is an engine that failed to describe itself, not one without TTS (#928): the
+// engine omits the key entirely when the feature is absent, so dropping it would forge that answer.
 function parseCapabilities(parsed: unknown): EngineCapabilities | null {
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
-  const { protocolVersion, backend, features } = parsed as Record<string, unknown>;
+  const { protocolVersion, backend, features, tts } = parsed as Record<string, unknown>;
   if (typeof protocolVersion !== "number") return null;
   if (typeof backend !== "string") return null;
   if (!Array.isArray(features) || features.some((f) => typeof f !== "string")) return null;
-  return parsed as EngineCapabilities;
+  const capabilities: EngineCapabilities = {
+    protocolVersion,
+    backend,
+    features: features as string[],
+  };
+  if (tts !== undefined) {
+    const languages = parseTtsLanguages(tts);
+    if (!languages) return null;
+    capabilities.tts = { languages };
+  }
+  return capabilities;
 }

--- a/tests/unit/engine.test.ts
+++ b/tests/unit/engine.test.ts
@@ -3,6 +3,7 @@ import { chmodSync, mkdtempSync, mkdirSync, utimesSync, writeFileSync } from "fs
 import { homedir, tmpdir } from "os";
 import { join } from "path";
 import { waitForPidExit, waitForPidFile } from "../helpers/process";
+import { readRepoFile } from "../helpers/repo";
 import { envEchoEngine, saveEngineEnv, writeTranscribingEngine } from "../helpers/fake-engine";
 import { applyColorEnv } from "../../src/cli/context";
 import {
@@ -635,6 +636,30 @@ describe("the engine boundary refuses to pass a malformed reply through", () => 
     ["a non-string backend", '{"protocolVersion":3,"backend":3,"features":[]}'],
     ["features that are not an array", '{"protocolVersion":3,"backend":"onnx","features":"tts"}'],
     ["a non-string among the features", '{"protocolVersion":3,"backend":"onnx","features":["tts",7]}'],
+    // #928: `.tts.languages` is dereferenced as an array by init and install, so a present-but-
+    // wrong tts is an engine that failed to describe itself, not one without TTS.
+    ["a tts key that is not an object", '{"protocolVersion":3,"backend":"onnx","features":[],"tts":"yes"}'],
+    ["an explicitly null tts key", '{"protocolVersion":3,"backend":"onnx","features":[],"tts":null}'],
+    [
+      "tts languages that are not an array",
+      '{"protocolVersion":3,"backend":"onnx","features":[],"tts":{"languages":{}}}',
+    ],
+    [
+      "a tts language with no code",
+      '{"protocolVersion":3,"backend":"onnx","features":[],"tts":{"languages":[{}]}}',
+    ],
+    [
+      "a non-string code on a tts language",
+      '{"protocolVersion":3,"backend":"onnx","features":[],"tts":{"languages":[{"code":123,"engines":["kokoro"]}]}}',
+    ],
+    [
+      "a tts language with no engines",
+      '{"protocolVersion":3,"backend":"onnx","features":[],"tts":{"languages":[{"code":"en"}]}}',
+    ],
+    [
+      "a non-string among a tts language's engines",
+      '{"protocolVersion":3,"backend":"onnx","features":[],"tts":{"languages":[{"code":"en","engines":[7]}]}}',
+    ],
   ] as const) {
     fakeEngineTest(`capabilities carrying ${shape} read as no capabilities`, async () => {
       await withEngineEnv(capabilitiesEngine(payload), async () => {
@@ -655,6 +680,34 @@ describe("the engine boundary refuses to pass a malformed reply through", () => 
       },
     );
   });
+
+  fakeEngineTest("an advertised tts language list survives the probe", async () => {
+    const payload =
+      '{"protocolVersion":3,"backend":"onnx","features":["tts"],"tts":{"languages":[{"code":"en","engines":["kokoro"]},{"code":"ru","engines":["vosk"]}]}}';
+    await withEngineEnv(capabilitiesEngine(payload), async () => {
+      const caps = await getEngineCapabilities();
+      expect(caps?.tts?.languages).toEqual([
+        { code: "en", engines: ["kokoro"] },
+        { code: "ru", engines: ["vosk"] },
+      ]);
+    });
+  });
+
+  // Validation strict enough to reject a published binary would take init's language list with it (#928).
+  for (const key of ["darwin-arm64", "linux-x64", "win32-x64"] as const) {
+    fakeEngineTest(`the recorded ${key} pact still reads as capabilities`, async () => {
+      const recorded = JSON.parse(readRepoFile(`tests/fixtures/capabilities/${key}.json`));
+      await withEngineEnv(capabilitiesEngine(JSON.stringify(recorded)), async () => {
+        const caps = await getEngineCapabilities();
+        expect(caps).toMatchObject({
+          protocolVersion: recorded.protocolVersion,
+          backend: recorded.backend,
+          features: recorded.features,
+        });
+        expect(caps?.tts?.languages).toEqual(recorded.tts?.languages);
+      });
+    });
+  }
 });
 
 describe("the capability probe stays in step with the installed binary", () => {


### PR DESCRIPTION
`parseCapabilities` validated `protocolVersion`, `backend` and `features`, then cast the whole reply to `EngineCapabilities` — promising a `tts?: { languages: TtsLanguageCapability[] }` it never looked at. An engine answering `{"protocolVersion":3,"backend":"onnx","features":[],"tts":{"languages":{}}}` therefore reached `src/cli/init.ts:46`, where `caps?.tts?.languages.map(...)` threw a bare `TypeError` and killed `kesha init` — past the `?? installableTtsLangs()` fallback that exists for exactly this case (#770). The fallback covers an *absent* `tts`; the corruption arrived as a well-typed lie.

## Semantics: a malformed `tts` makes the whole reply unparseable (`null`)

`tts` is now validated to the same standard as the other three fields, and the function returns a **constructed** object rather than a cast, so no field is promised that was not checked. A `tts` key that is present but wrong reads as malformed, not as absent:

- The Rust side (`rust/src/capabilities.rs`) serializes `tts` with `skip_serializing_if = "Option::is_none"`, so a real engine **omits** the key when the `tts` feature is not compiled in. "Absent" is therefore a meaningful answer an honest engine already gives — stripping a malformed `tts` would forge that answer and make a corrupt engine indistinguishable from a genuine non-TTS build.
- `null` is the one return every consumer already handles, and it is what #647's contract comment demands: a non-null return must mean "it described itself".
- `"tts": null` is treated as malformed for the same reason: our engine never emits it, so it is not "absent", it is wrong.

Validated per language entry: `code` must be a string and `engines` an array of strings — the full declared shape of `TtsLanguageCapability`, not just the `.code` today's consumers dereference, since the constructed object promises both.

## Consumer audit (every reader of `caps.tts` and of `getEngineCapabilities()`)

| Consumer | Behaviour on `null` |
| --- | --- |
| `src/cli/init.ts:46` | `?? installableTtsLangs()` — the fallback the crash was defeating now fires. Correct. |
| `src/cli/install.ts:307` | same `?? installableTtsLangs()`; codes go unvalidated locally and the engine rejects unsupported ones at download time, which `probeCapabilitiesForInstall`'s doc comment already names as authoritative (#770). Correct. |
| `src/status.ts:119` | prints `Capabilities … probe failed` instead of a backend line derived from a reply we could not trust. Correct. |
| `src/doctor.ts:211`, `src/engine-install.ts` (`validateBackend`, `validateDiarize`), `src/engine.ts` (`assertItnSupported`, `assertSpeakersSupported`), `src/synth.ts:61`, `src/install-plan.ts:165` | all already typed `EngineCapabilities \| null` and take the tolerant path. |

`src/mcp/voices.ts` (named in the issue) does not exist on `main`; there is no MCP consumer of `.tts`. No consumer reads `engines` in TS today — the field is only exercised by the pact fixtures.

Well-formed input is unaffected: the constructed object carries the same four fields the engine emits (the recorded pacts have exactly `protocolVersion`, `backend`, `features`, `tts`).

## Tests (red first)

`tests/unit/engine.test.ts` — the malformed-payload table that covered the other three fields now covers `tts`, 7 new rows, all failing before the fix (`expect(...).toBeNull()` receiving the cast object):

- `tts` not an object (`"yes"`), `tts` explicitly `null`
- `languages: {}` (the exact payload from the issue), `languages: [{}]`, `[{"code":123,…}]`
- a language with no `engines`, and `engines: [7]`

Two positive tests guard the other direction — validation strict enough to reject a published binary would take init's language list with it:

- an advertised two-language list survives the probe intact;
- each recorded pact (`darwin-arm64`, `linux-x64`, `win32-x64`) still reads as capabilities with its `tts.languages` unchanged.

## Verification

- `bun test` (via `bun run test`, 30 s timeout): **1336 pass, 6 skip, 0 fail**, 93 files.
- `bunx tsc --noEmit`: clean.
- `tests/unit/capabilities-pact.test.ts` re-run explicitly: 93 pass across the two files.

Closes #928
