### PR TITLE
fix(engine): coded E_INTERNAL for null home_dir, not a panic (#953)

### DIFF
--- a/rust/src/backend/fluidaudio.rs
+++ b/rust/src/backend/fluidaudio.rs
@@ -26,7 +26,7 @@ pub struct FluidAudioBackend {
 
 impl FluidAudioBackend {
     pub fn new() -> Result<Self> {
-        let audio = crate::models::fluidaudio_bridge(&crate::models::fluidaudio_asr_location())
+        let audio = crate::models::fluidaudio_bridge(&crate::models::fluidaudio_asr_location()?)
             .context("failed to initialize FluidAudio bridge")?;
         audio
             .init_asr()
@@ -123,8 +123,14 @@ mod tests {
     }
 
     fn render_diagnostics(first_call: Option<&str>) -> String {
-        let loc = crate::models::fluidaudio_asr_location();
         let mut out = String::from("\n──── #841 coreml-regression diagnostics ────\n");
+        let loc = match crate::models::fluidaudio_asr_location() {
+            Ok(loc) => loc,
+            Err(e) => {
+                let _ = writeln!(out, "bundle dir : unavailable ({e:#})");
+                return out;
+            }
+        };
         let _ = writeln!(out, "bundle dir : {}", loc.dir.display());
         let _ = writeln!(
             out,

--- a/rust/src/cli/install.rs
+++ b/rust/src/cli/install.rs
@@ -66,7 +66,7 @@ pub fn run(args: InstallArgs) -> Result<()> {
     // first real `kesha audio.ogg` is fast. CoreML cache is keyed by (model bytes, signing
     // identity) and survives process exit; survives re-runs until next `kesha install` re-signs (#295).
     if !no_warmup {
-        let asr_dir = models::model_dir(models::ModelKind::Asr)
+        let asr_dir = models::model_dir(models::ModelKind::Asr)?
             .to_string_lossy()
             .into_owned();
         let cost_hint = if cfg!(feature = "coreml") {
@@ -92,13 +92,14 @@ pub fn run(args: InstallArgs) -> Result<()> {
     // Non-fatal: matches ASR warm-up above.
     #[cfg(feature = "system_diarize")]
     if diarize && !no_warmup && models::is_cached(models::ModelKind::Diarize) {
-        let diarize_pkg = models::model_dir(models::ModelKind::Diarize);
+        let diarize_pkg = models::model_dir(models::ModelKind::Diarize)?;
+        let diarize_loc = models::fluidaudio_diarize_location()?;
         eprintln!(
             "Warming up diarization model (one-time compile ~1-2 min on first install, ~4 s after)..."
         );
         let t = std::time::Instant::now();
         let result = crate::fluid_stdout::with_silenced_stdout_oneshot(|| {
-            models::fluidaudio_bridge(&models::fluidaudio_diarize_location())
+            models::fluidaudio_bridge(&diarize_loc)
                 .and_then(|fa| fa.compile_diarization_model(&diarize_pkg))
         });
         match result {

--- a/rust/src/cli/say.rs
+++ b/rust/src/cli/say.rs
@@ -213,7 +213,11 @@ fn resolve_voice(
         }
         (None, None) => {
             let id = voice_id.unwrap_or(tts::voices::DEFAULT_VOICE_ID);
-            tts::voices::resolve_voice(&models::cache_dir(), id).map_err(|err| {
+            let cache = models::cache_dir().map_err(|err| {
+                eprintln!("error [{}]: {err:#}", crate::errors::code_of(&err).as_str());
+                1
+            })?;
+            tts::voices::resolve_voice(&cache, id).map_err(|err| {
                 eprintln!("error [{}]: {err:#}", crate::errors::code_of(&err).as_str());
                 1
             })
@@ -277,7 +281,13 @@ fn write_output(out: Option<&std::path::Path>, bytes: &[u8]) -> Result<(), i32> 
 
 pub fn run(a: SayArgs) -> i32 {
     if a.list_voices {
-        let cache = models::cache_dir();
+        let cache = match models::cache_dir() {
+            Ok(c) => c,
+            Err(err) => {
+                eprintln!("error [{}]: {err:#}", crate::errors::code_of(&err).as_str());
+                return 1;
+            }
+        };
         let mut voice_ids: Vec<String> = list_kokoro_voices(&cache)
             .into_iter()
             .chain(list_vosk_ru_voices(&cache))

--- a/rust/src/lang_id.rs
+++ b/rust/src/lang_id.rs
@@ -23,7 +23,7 @@ pub fn detect_audio_language(audio_path: &str) -> Result<LangDetectResult> {
         );
     }
 
-    let dir = models::model_dir(models::ModelKind::LangId);
+    let dir = models::model_dir(models::ModelKind::LangId)?;
 
     // Load ONNX session
     let mut session = ort::session::Session::builder()

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -1089,8 +1089,8 @@ pub const FLUIDAUDIO_ROOT_DIR: &str = "fluidaudio";
 /// FluidAudio's repo folder for the Parakeet bundle, mirrored TS-side the same way (#684).
 pub const FLUID_ASR_REPO_DIR: &str = "parakeet-tdt-0.6b-v3";
 
-pub fn fluidaudio_models_root() -> PathBuf {
-    cache_dir().join(FLUIDAUDIO_ROOT_DIR)
+pub fn fluidaudio_models_root() -> Result<PathBuf> {
+    Ok(cache_dir()?.join(FLUIDAUDIO_ROOT_DIR))
 }
 
 /// Resolve one subsystem, preferring a legacy location that already holds a usable bundle.
@@ -1107,18 +1107,18 @@ pub fn fluidaudio_location(
     legacy: &Path,
     legacy_ready: bool,
     repo_subpath: &str,
-) -> FluidAudioLocation {
+) -> Result<FluidAudioLocation> {
     if legacy_ready {
-        return FluidAudioLocation {
+        return Ok(FluidAudioLocation {
             dir: legacy.to_path_buf(),
             root: None,
-        };
+        });
     }
-    let root = fluidaudio_models_root();
-    FluidAudioLocation {
+    let root = fluidaudio_models_root()?;
+    Ok(FluidAudioLocation {
         dir: root.join(repo_subpath),
         root: Some(root),
-    }
+    })
 }
 
 /// Open a FluidAudio bridge honouring `at`. Routing every construction site through this
@@ -1166,10 +1166,11 @@ pub fn stale_legacy_notice(
     if legacy_ready || !dir_has_entries(legacy) || latched.swap(true, Ordering::Relaxed) {
         return None;
     }
+    let root = fluidaudio_models_root().ok()?;
     Some(format!(
         "warning: legacy FluidAudio bundle at {} is no longer read (incomplete, or superseded by a model-set change); models now load from {}, so the old directory can be deleted",
         legacy.display(),
-        fluidaudio_models_root().display()
+        root.display()
     ))
 }
 
@@ -1181,8 +1182,8 @@ pub fn stale_legacy_notice(
     target_os = "macos",
     target_arch = "aarch64"
 ))]
-pub fn fluidaudio_kokoro_cache_dir() -> PathBuf {
-    fluidaudio_kokoro_location().dir
+pub fn fluidaudio_kokoro_cache_dir() -> Result<PathBuf> {
+    Ok(fluidaudio_kokoro_location()?.dir)
 }
 
 /// FluidAudio's Kokoro ANE voice-pack cache directory. FluidAudio 0.15.5 reads voice packs
@@ -1195,8 +1196,8 @@ pub fn fluidaudio_kokoro_cache_dir() -> PathBuf {
     target_os = "macos",
     target_arch = "aarch64"
 ))]
-pub fn fluidaudio_ane_kokoro_dir() -> PathBuf {
-    fluidaudio_kokoro_cache_dir().join("ANE")
+pub fn fluidaudio_ane_kokoro_dir() -> Result<PathBuf> {
+    Ok(fluidaudio_kokoro_cache_dir()?.join("ANE"))
 }
 
 /// FluidAudio's Mandarin (`ANE-zh/`) bundle directory, the Kokoro sibling of
@@ -1206,8 +1207,8 @@ pub fn fluidaudio_ane_kokoro_dir() -> PathBuf {
     target_os = "macos",
     target_arch = "aarch64"
 ))]
-pub fn fluidaudio_ane_zh_kokoro_dir() -> PathBuf {
-    fluidaudio_kokoro_cache_dir().join("ANE-zh")
+pub fn fluidaudio_ane_zh_kokoro_dir() -> Result<PathBuf> {
+    Ok(fluidaudio_kokoro_cache_dir()?.join("ANE-zh"))
 }
 
 /// Where the shared BART G2P bundle and the Misaki lexicon must be staged.
@@ -1222,13 +1223,12 @@ pub fn fluidaudio_ane_zh_kokoro_dir() -> PathBuf {
     target_os = "macos",
     target_arch = "aarch64"
 ))]
-pub fn fluidaudio_kokoro_g2p_dir() -> PathBuf {
-    dirs::home_dir()
-        .expect("cannot determine home directory")
+pub fn fluidaudio_kokoro_g2p_dir() -> Result<PathBuf> {
+    Ok(require_home_dir()?
         .join(".cache")
         .join("fluidaudio")
         .join("Models")
-        .join("kokoro")
+        .join("kokoro"))
 }
 
 /// Where FluidAudio's Kokoro CoreML bundles live, and the root that puts them there.
@@ -1237,8 +1237,8 @@ pub fn fluidaudio_kokoro_g2p_dir() -> PathBuf {
     target_os = "macos",
     target_arch = "aarch64"
 ))]
-pub fn fluidaudio_kokoro_location() -> FluidAudioLocation {
-    let legacy = legacy_fluidaudio_kokoro_cache_dir();
+pub fn fluidaudio_kokoro_location() -> Result<FluidAudioLocation> {
+    let legacy = legacy_fluidaudio_kokoro_cache_dir()?;
     let staged = dir_has_entries(&legacy);
     fluidaudio_location(&legacy, staged, "kokoro-82m-coreml")
 }
@@ -1250,27 +1250,26 @@ pub fn fluidaudio_kokoro_location() -> FluidAudioLocation {
     target_os = "macos",
     target_arch = "aarch64"
 ))]
-fn legacy_fluidaudio_kokoro_cache_dir() -> PathBuf {
-    dirs::home_dir()
-        .expect("cannot determine home directory")
+fn legacy_fluidaudio_kokoro_cache_dir() -> Result<PathBuf> {
+    Ok(require_home_dir()?
         .join(".cache")
         .join("fluidaudio")
         .join("Models")
-        .join("kokoro-82m-coreml")
+        .join("kokoro-82m-coreml"))
 }
 
 /// FluidAudio's ASR bundle directory — the one `AsrModels` loads from, wherever that
 /// currently is. See [`fluidaudio_asr_location`] for which of the two it can be.
 #[cfg(feature = "coreml")]
-pub fn fluidaudio_asr_dir() -> PathBuf {
-    fluidaudio_asr_location().dir
+pub fn fluidaudio_asr_dir() -> Result<PathBuf> {
+    Ok(fluidaudio_asr_location()?.dir)
 }
 
 /// Where the Parakeet bundle lives, and the root that puts it there.
 #[cfg(feature = "coreml")]
-pub fn fluidaudio_asr_location() -> FluidAudioLocation {
+pub fn fluidaudio_asr_location() -> Result<FluidAudioLocation> {
     static ANNOUNCED: AtomicBool = AtomicBool::new(false);
-    let legacy = legacy_fluidaudio_asr_dir();
+    let legacy = legacy_fluidaudio_asr_dir()?;
     let complete = fluidaudio_asr_ready_in(&legacy);
     if let Some(notice) = stale_legacy_notice(&legacy, complete, &ANNOUNCED) {
         with_stderr(|| eprintln!("{notice}"));
@@ -1285,34 +1284,32 @@ pub fn fluidaudio_asr_location() -> FluidAudioLocation {
 /// Keying on the `…-v3-coreml` sibling that also exists on disk would report a healthy
 /// install as broken (#684).
 #[cfg(feature = "coreml")]
-fn legacy_fluidaudio_asr_dir() -> PathBuf {
-    dirs::home_dir()
-        .expect("cannot determine home directory")
+fn legacy_fluidaudio_asr_dir() -> Result<PathBuf> {
+    Ok(require_home_dir()?
         .join("Library")
         .join("Application Support")
         .join("FluidAudio")
         .join("Models")
-        .join(FLUID_ASR_REPO_DIR)
+        .join(FLUID_ASR_REPO_DIR))
 }
 
 /// Where `fluidaudio-rs` keeps compiled Sortformer `.mlmodelc` bundles, and the root that
 /// puts them there. Relocating this costs a ~100 s ANE recompile rather than a download, but
 /// the fallback rule is the same: an existing cache stays where it is.
 #[cfg(feature = "system_diarize")]
-pub fn fluidaudio_diarize_location() -> FluidAudioLocation {
-    let legacy = legacy_sortformer_compiled_dir();
+pub fn fluidaudio_diarize_location() -> Result<FluidAudioLocation> {
+    let legacy = legacy_sortformer_compiled_dir()?;
     let compiled = dir_has_entries(&legacy);
     fluidaudio_location(&legacy, compiled, "fluidaudio-rs/SortformerCompiled")
 }
 
 #[cfg(feature = "system_diarize")]
-fn legacy_sortformer_compiled_dir() -> PathBuf {
-    dirs::home_dir()
-        .expect("cannot determine home directory")
+fn legacy_sortformer_compiled_dir() -> Result<PathBuf> {
+    Ok(require_home_dir()?
         .join("Library")
         .join("Application Support")
         .join("fluidaudio-rs")
-        .join("SortformerCompiled")
+        .join("SortformerCompiled"))
 }
 
 /// What FluidAudio's own `modelsExist` requires. The encoder is pinned to int8
@@ -1336,7 +1333,7 @@ const FLUID_ASR_REQUIRED: &[&str] = &[
 /// no-auto-download rule exists to prevent (#684).
 #[cfg(feature = "coreml")]
 pub fn fluidaudio_asr_ready() -> bool {
-    fluidaudio_asr_ready_in(&fluidaudio_asr_dir())
+    fluidaudio_asr_dir().is_ok_and(|d| fluidaudio_asr_ready_in(&d))
 }
 
 #[cfg(feature = "coreml")]
@@ -1360,7 +1357,7 @@ pub fn stage_ane_kokoro_voices(langs: &[&str], no_cache: bool) -> Result<()> {
     if manifest.is_empty() {
         return Ok(());
     }
-    let ane_dir = fluidaudio_ane_kokoro_dir();
+    let ane_dir = fluidaudio_ane_kokoro_dir()?;
     fs::create_dir_all(&ane_dir)
         .with_context(|| format!("create FluidAudio ANE dir {}", ane_dir.display()))?;
     parallel_download(&ane_dir, &manifest, no_cache)
@@ -1392,11 +1389,11 @@ const ANE_ENGLISH_VARIANT_LANGS: &[&str] = &["en", "es", "fr", "hi", "it", "ja",
 ))]
 pub fn stage_fluidaudio_kokoro_assets(langs: &[&str], no_cache: bool) -> Result<()> {
     if langs.iter().any(|l| ANE_ENGLISH_VARIANT_LANGS.contains(l)) {
-        stage_into(&fluidaudio_ane_kokoro_dir(), ANE_EN_FILES, no_cache)?;
-        stage_into(&fluidaudio_kokoro_g2p_dir(), KOKORO_G2P_FILES, no_cache)?;
+        stage_into(&fluidaudio_ane_kokoro_dir()?, ANE_EN_FILES, no_cache)?;
+        stage_into(&fluidaudio_kokoro_g2p_dir()?, KOKORO_G2P_FILES, no_cache)?;
     }
     if langs.contains(&"zh") {
-        let zh = fluidaudio_ane_zh_kokoro_dir();
+        let zh = fluidaudio_ane_zh_kokoro_dir()?;
         stage_into(&zh, ANE_ZH_FILES, no_cache)?;
         stage_into(&zh, ANE_ZH_G2P_ASSETS, no_cache)?;
     }
@@ -1422,15 +1419,15 @@ pub fn stage_fluidaudio_kokoro_assets(langs: &[&str], no_cache: bool) -> Result<
 ))]
 pub fn missing_kokoro_assets(lang: &str, voice: &str) -> Vec<PathBuf> {
     if lang == "zh" {
-        let zh = fluidaudio_ane_zh_kokoro_dir();
+        let Ok(zh) = fluidaudio_ane_zh_kokoro_dir() else {
+            return Vec::new();
+        };
         missing_kokoro_assets_in(&zh, &zh, lang, voice)
     } else {
-        missing_kokoro_assets_in(
-            &fluidaudio_ane_kokoro_dir(),
-            &fluidaudio_kokoro_g2p_dir(),
-            lang,
-            voice,
-        )
+        let (Ok(ane), Ok(g2p)) = (fluidaudio_ane_kokoro_dir(), fluidaudio_kokoro_g2p_dir()) else {
+            return Vec::new();
+        };
+        missing_kokoro_assets_in(&ane, &g2p, lang, voice)
     }
 }
 
@@ -1593,7 +1590,7 @@ fn purge_incomplete_ane_bundles_in(kokoro_dir: &Path) -> Result<()> {
     target_arch = "aarch64"
 ))]
 pub fn purge_incomplete_ane_bundles() -> Result<()> {
-    purge_incomplete_ane_bundles_in(&fluidaudio_kokoro_cache_dir())
+    purge_incomplete_ane_bundles_in(&fluidaudio_kokoro_cache_dir()?)
 }
 
 /// Names of the incomplete bundles currently in the cache, for the hint
@@ -1605,7 +1602,10 @@ pub fn purge_incomplete_ane_bundles() -> Result<()> {
     target_arch = "aarch64"
 ))]
 pub fn incomplete_ane_bundle_names() -> Vec<String> {
-    incomplete_ane_bundles_in(&fluidaudio_kokoro_cache_dir())
+    let Ok(dir) = fluidaudio_kokoro_cache_dir() else {
+        return Vec::new();
+    };
+    incomplete_ane_bundles_in(&dir)
         .unwrap_or_default()
         .iter()
         .filter_map(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
@@ -1652,19 +1652,87 @@ pub const VOSK_RU_FILES: &[ModelFile] = &[
     // removed in PR #214 — Russian uses vosk-tts internal G2P now.
 ];
 
-pub fn cache_dir() -> PathBuf {
+pub fn cache_dir() -> Result<PathBuf> {
     cache_dir_from(std::env::var("KESHA_CACHE_DIR").ok(), dirs::home_dir())
-        .expect("cannot determine home directory")
 }
 
 /// The cache root from its two inputs, split out so the null-home path is
-/// unit-testable without an unsettable process environment (#953).
-fn cache_dir_from(env_cache: Option<String>, home: Option<PathBuf>) -> anyhow::Result<PathBuf> {
+/// unit-testable without an unsettable process environment (#953). A set
+/// `KESHA_CACHE_DIR` wins even with no resolvable home; otherwise a missing
+/// home is a coded `E_INTERNAL` naming the escape hatch, never a panic past
+/// the `error [CODE]:` contract.
+fn cache_dir_from(env_cache: Option<String>, home: Option<PathBuf>) -> Result<PathBuf> {
     if let Some(p) = env_cache {
         return Ok(PathBuf::from(p));
     }
-    let home = home.expect("cannot determine home directory");
+    let Some(home) = home else {
+        coded_bail!(
+            ErrorCode::Internal,
+            "cannot determine home directory; set $HOME, or set KESHA_CACHE_DIR to an explicit cache path"
+        );
+    };
     Ok(home.join(".cache").join("kesha"))
+}
+
+/// The home directory, or a coded `E_INTERNAL` naming the `$HOME` remedy. The
+/// FluidAudio caches below hardcode `~/.cache/fluidaudio` / `~/Library/...`, so
+/// `KESHA_CACHE_DIR` cannot relocate them — the hint must not offer it (#953).
+#[cfg(any(
+    feature = "coreml",
+    feature = "system_kokoro",
+    feature = "system_diarize"
+))]
+fn require_home_dir() -> Result<PathBuf> {
+    require_home(dirs::home_dir())
+}
+
+#[cfg(any(
+    feature = "coreml",
+    feature = "system_kokoro",
+    feature = "system_diarize"
+))]
+fn require_home(home: Option<PathBuf>) -> Result<PathBuf> {
+    let Some(home) = home else {
+        coded_bail!(
+            ErrorCode::Internal,
+            "cannot determine home directory; set $HOME"
+        );
+    };
+    Ok(home)
+}
+
+#[cfg(all(
+    test,
+    any(
+        feature = "coreml",
+        feature = "system_kokoro",
+        feature = "system_diarize"
+    )
+))]
+mod require_home_tests {
+    use super::*;
+
+    // #953: the FluidAudio caches are not KESHA_CACHE_DIR-relocatable, so a null
+    // home is coded E_INTERNAL whose hint names only $HOME.
+    #[test]
+    fn require_home_null_is_coded_internal_without_cache_dir_hint() {
+        let err = require_home(None).unwrap_err();
+        assert_eq!(code_of(&err), ErrorCode::Internal);
+        let msg = format!("{err:#}");
+        assert!(msg.contains("$HOME"), "message must name $HOME: {msg}");
+        assert!(
+            !msg.contains("KESHA_CACHE_DIR"),
+            "these paths are not KESHA_CACHE_DIR-relocatable: {msg}"
+        );
+    }
+
+    #[test]
+    fn require_home_passes_through_a_resolved_home() {
+        assert_eq!(
+            require_home(Some(PathBuf::from("/home/u"))).unwrap(),
+            PathBuf::from("/home/u")
+        );
+    }
 }
 
 /// Optional HuggingFace mirror base URL. Respects `KESHA_MODEL_MIRROR` (#121).
@@ -1756,8 +1824,8 @@ impl ModelKind {
 
 /// Absolute path to a kind's directory under the active cache (honours
 /// `KESHA_CACHE_DIR`).
-pub fn model_dir(kind: ModelKind) -> PathBuf {
-    model_dir_at(kind, &cache_dir())
+pub fn model_dir(kind: ModelKind) -> Result<PathBuf> {
+    Ok(model_dir_at(kind, &cache_dir()?))
 }
 
 /// Same as [`model_dir`] but with a caller-supplied cache root — for the
@@ -1769,7 +1837,7 @@ pub fn model_dir_at(kind: ModelKind, cache_root: &Path) -> PathBuf {
 
 /// True iff `kind`'s required files are present under the active cache.
 pub fn is_cached(kind: ModelKind) -> bool {
-    is_cached_in(kind, &model_dir(kind))
+    model_dir(kind).is_ok_and(|d| is_cached_in(kind, &d))
 }
 
 /// True iff `kind` is usable. `dir` is the Kesha cache location; the coreml `Asr`
@@ -1833,7 +1901,7 @@ fn has_all_files(dir: &Path, files: &[ModelFile]) -> bool {
 }
 
 pub fn install(no_cache: bool) -> Result<()> {
-    let cache = cache_dir();
+    let cache = cache_dir()?;
 
     // Every install repairs the ANE cache, not just `--tts`: a user who already had
     // TTS and only upgrades the engine still carries the incomplete bundle (#709).
@@ -1852,7 +1920,7 @@ pub fn install(no_cache: bool) -> Result<()> {
     let manifest: Vec<&ModelFile> = LANG_ID_FILES.iter().collect();
     parallel_download(&cache, &manifest, no_cache)?;
 
-    cleanup_legacy();
+    cleanup_legacy(&cache);
     Ok(())
 }
 
@@ -2743,7 +2811,7 @@ mod tts_tests {
     fn cache_dir_honors_env_var() {
         let _lock = crate::util::test_env::lock();
         let guard = EnvGuard::set("KESHA_CACHE_DIR", "/tmp/kesha-test-xyz");
-        assert_eq!(cache_dir(), PathBuf::from("/tmp/kesha-test-xyz"));
+        assert_eq!(cache_dir().unwrap(), PathBuf::from("/tmp/kesha-test-xyz"));
         drop(guard);
     }
 
@@ -2910,7 +2978,7 @@ pub fn download_diarize(no_cache: bool) -> Result<()> {
 
 /// Hash-verified parallel download of a static manifest into the cache dir.
 fn download_manifest(files: &[ModelFile], no_cache: bool) -> Result<()> {
-    let cache = cache_dir();
+    let cache = cache_dir()?;
     let refs: Vec<&ModelFile> = files.iter().collect();
     parallel_download(&cache, &refs, no_cache)
 }
@@ -2990,7 +3058,7 @@ pub fn download_tts(langs: &[&str], no_cache: bool) -> Result<()> {
         target_arch = "aarch64"
     )))]
     {
-        let cache = cache_dir();
+        let cache = cache_dir()?;
         let mut manifest = kokoro_manifest_for(langs);
         if langs.contains(&"ru") {
             manifest.extend_from_slice(VOSK_RU_FILES);
@@ -3526,8 +3594,7 @@ fn compute_sha256(path: &Path) -> Result<String> {
     Ok(format!("{:x}", hasher.finalize()))
 }
 
-fn cleanup_legacy() {
-    let cache = cache_dir();
+fn cleanup_legacy(cache: &Path) {
     let old_onnx = cache.join("v3");
     if old_onnx.exists() {
         eprintln!("Cleaning up legacy ONNX models...");
@@ -3539,7 +3606,7 @@ fn cleanup_legacy() {
         let _ = fs::remove_file(&old_swift);
     }
     #[cfg(unix)]
-    cleanup_orphan_staging(&cache);
+    cleanup_orphan_staging(cache);
 }
 
 /// Age threshold for orphaned download staging. A SIGKILLed download leaves
@@ -3653,7 +3720,7 @@ mod characterization_tests {
     #[test]
     #[cfg(feature = "coreml")]
     fn fluidaudio_asr_dir_is_the_directory_fluidaudio_loads_from() {
-        let dir = legacy_fluidaudio_asr_dir();
+        let dir = legacy_fluidaudio_asr_dir().unwrap();
         assert!(dir.ends_with("parakeet-tdt-0.6b-v3"), "{dir:?}");
         assert!(
             dir.to_string_lossy()
@@ -3675,7 +3742,7 @@ mod characterization_tests {
         );
 
         let legacy = PathBuf::from("/nonexistent/FluidAudio/Models/parakeet-tdt-0.6b-v3");
-        let at = fluidaudio_location(&legacy, false, "parakeet-tdt-0.6b-v3");
+        let at = fluidaudio_location(&legacy, false, "parakeet-tdt-0.6b-v3").unwrap();
 
         let root = at
             .root
@@ -3701,7 +3768,7 @@ mod characterization_tests {
         );
 
         let legacy = PathBuf::from("/somewhere/FluidAudio/Models/parakeet-tdt-0.6b-v3");
-        let at = fluidaudio_location(&legacy, true, "parakeet-tdt-0.6b-v3");
+        let at = fluidaudio_location(&legacy, true, "parakeet-tdt-0.6b-v3").unwrap();
 
         assert_eq!(at.dir, legacy);
         assert!(
@@ -3722,9 +3789,10 @@ mod characterization_tests {
         );
 
         let missing = PathBuf::from("/nonexistent");
-        let asr = fluidaudio_location(&missing, false, "parakeet-tdt-0.6b-v3");
-        let kokoro = fluidaudio_location(&missing, false, "kokoro-82m-coreml");
-        let sortformer = fluidaudio_location(&missing, false, "fluidaudio-rs/SortformerCompiled");
+        let asr = fluidaudio_location(&missing, false, "parakeet-tdt-0.6b-v3").unwrap();
+        let kokoro = fluidaudio_location(&missing, false, "kokoro-82m-coreml").unwrap();
+        let sortformer =
+            fluidaudio_location(&missing, false, "fluidaudio-rs/SortformerCompiled").unwrap();
 
         assert_eq!(asr.root, kokoro.root);
         assert_eq!(kokoro.root, sortformer.root);

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -1653,13 +1653,18 @@ pub const VOSK_RU_FILES: &[ModelFile] = &[
 ];
 
 pub fn cache_dir() -> PathBuf {
-    if let Ok(p) = std::env::var("KESHA_CACHE_DIR") {
-        return PathBuf::from(p);
-    }
-    dirs::home_dir()
+    cache_dir_from(std::env::var("KESHA_CACHE_DIR").ok(), dirs::home_dir())
         .expect("cannot determine home directory")
-        .join(".cache")
-        .join("kesha")
+}
+
+/// The cache root from its two inputs, split out so the null-home path is
+/// unit-testable without an unsettable process environment (#953).
+fn cache_dir_from(env_cache: Option<String>, home: Option<PathBuf>) -> anyhow::Result<PathBuf> {
+    if let Some(p) = env_cache {
+        return Ok(PathBuf::from(p));
+    }
+    let home = home.expect("cannot determine home directory");
+    Ok(home.join(".cache").join("kesha"))
 }
 
 /// Optional HuggingFace mirror base URL. Respects `KESHA_MODEL_MIRROR` (#121).
@@ -2740,6 +2745,30 @@ mod tts_tests {
         let guard = EnvGuard::set("KESHA_CACHE_DIR", "/tmp/kesha-test-xyz");
         assert_eq!(cache_dir(), PathBuf::from("/tmp/kesha-test-xyz"));
         drop(guard);
+    }
+
+    // #953: a null home must surface as a coded E_INTERNAL naming KESHA_CACHE_DIR,
+    // not a panic past the `error [CODE]:` contract.
+    #[test]
+    fn cache_dir_from_null_home_is_coded_internal() {
+        let err = cache_dir_from(None, None).unwrap_err();
+        assert_eq!(code_of(&err), ErrorCode::Internal);
+        assert!(
+            format!("{err:#}").contains("KESHA_CACHE_DIR"),
+            "message must name the escape hatch: {err:#}"
+        );
+    }
+
+    #[test]
+    fn cache_dir_from_env_wins_without_home() {
+        let dir = cache_dir_from(Some("/tmp/x".into()), None).unwrap();
+        assert_eq!(dir, PathBuf::from("/tmp/x"));
+    }
+
+    #[test]
+    fn cache_dir_from_derives_under_home() {
+        let dir = cache_dir_from(None, Some(PathBuf::from("/home/u"))).unwrap();
+        assert_eq!(dir, PathBuf::from("/home/u/.cache/kesha"));
     }
 
     use crate::util::test_env::EnvGuard;

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -1418,6 +1418,12 @@ pub fn stage_fluidaudio_kokoro_assets(langs: &[&str], no_cache: bool) -> Result<
     target_arch = "aarch64"
 ))]
 pub fn missing_kokoro_assets(lang: &str, voice: &str) -> Vec<PathBuf> {
+    // The empty returns below ("nothing missing") are safe ONLY because the same
+    // null-home that unresolves these dirs also unresolves fluidaudio_kokoro_location,
+    // so synthesis bails with E_INTERNAL before this preflight's result is trusted. A
+    // future path that reached here with a resolvable bundle dir but no home would turn
+    // "couldn't find the dir" into "no missing assets" — a silent auto-download, the
+    // exact thing the no-auto-download rule forbids. Keep the home requirement upstream (#953).
     if lang == "zh" {
         let Ok(zh) = fluidaudio_ane_zh_kokoro_dir() else {
             return Vec::new();

--- a/rust/src/say_loop.rs
+++ b/rust/src/say_loop.rs
@@ -186,7 +186,8 @@ fn handle(req: &LoopRequest, state: &mut LoopState) -> Result<Vec<u8>, String> {
         None,
     )?;
     let resolved =
-        tts::voices::resolve_voice(&models::cache_dir(), &req.voice).map_err(|e| e.to_string())?;
+        tts::voices::resolve_voice(&models::cache_dir().map_err(|e| e.to_string())?, &req.voice)
+            .map_err(|e| e.to_string())?;
     let espeak_lang: &str = req
         .lang
         .as_deref()

--- a/rust/src/streaming_asr.rs
+++ b/rust/src/streaming_asr.rs
@@ -41,7 +41,7 @@ impl StreamingAsrSession {
             .ok()
             .map(OwnedFd::from);
 
-        let audio = crate::models::fluidaudio_bridge(&crate::models::fluidaudio_asr_location())
+        let audio = crate::models::fluidaudio_bridge(&crate::models::fluidaudio_asr_location()?)
             .context("failed to initialize FluidAudio bridge")?;
         with_silenced_stdout(devnull.as_ref(), || audio.init_streaming_asr()).context(
             "failed to initialize FluidAudio streaming ASR \

--- a/rust/src/transcribe/diarize.rs
+++ b/rust/src/transcribe/diarize.rs
@@ -401,9 +401,10 @@ fn spawn_worker(
         // handled by `StdoutShield` at the CLI layer (fd 1 stays redirected past exit). (#259/#397/#434)
         let result = crate::fluid_stdout::with_silenced_stdout_oneshot(
             || -> Result<Option<Vec<DiarizeSpan>>> {
-                let audio =
-                    crate::models::fluidaudio_bridge(&crate::models::fluidaudio_diarize_location())
-                        .context("failed to initialize FluidAudio bridge")?;
+                let audio = crate::models::fluidaudio_bridge(
+                    &crate::models::fluidaudio_diarize_location()?,
+                )
+                .context("failed to initialize FluidAudio bridge")?;
                 let mut on_event = |event: DiarizeEvent| {
                     let _ = progress_tx.send(match event {
                         DiarizeEvent::ModelReady => WorkerEvent::ModelReady,

--- a/rust/src/transcribe/mod.rs
+++ b/rust/src/transcribe/mod.rs
@@ -311,7 +311,7 @@ pub fn transcribe_with_options(
         );
     }
 
-    let vad_dir = models::model_dir(models::ModelKind::Vad)
+    let vad_dir = models::model_dir(models::ModelKind::Vad)?
         .to_string_lossy()
         .into_owned();
     let vad_installed = models::is_cached(models::ModelKind::Vad);
@@ -1004,7 +1004,7 @@ fn resolve_diarize_model_path() -> Result<std::path::PathBuf> {
         );
     }
 
-    let default = crate::models::model_dir(crate::models::ModelKind::Diarize);
+    let default = crate::models::model_dir(crate::models::ModelKind::Diarize)?;
     if crate::models::is_cached(crate::models::ModelKind::Diarize) {
         return Ok(default);
     }
@@ -1024,7 +1024,7 @@ fn ensure_asr_installed() -> Result<String> {
              Please run: kesha install"
         );
     }
-    Ok(models::model_dir(models::ModelKind::Asr)
+    Ok(models::model_dir(models::ModelKind::Asr)?
         .to_string_lossy()
         .into_owned())
 }
@@ -2196,6 +2196,7 @@ mod seam_long_form {
             return None;
         }
         let dir = models::model_dir(models::ModelKind::Asr)
+            .expect("resolve ASR model dir")
             .to_string_lossy()
             .into_owned();
         Some(backend::create_backend(&dir).expect("create ASR backend"))

--- a/rust/src/tts/fluid_kokoro.rs
+++ b/rust/src/tts/fluid_kokoro.rs
@@ -276,7 +276,7 @@ fn with_kokoro<R>(voice_id: &str, f: impl FnOnce(&FluidAudio) -> Result<R>) -> R
         return Err(missing_assets_error(lang, &missing));
     }
     crate::fluid_stdout::with_silenced_stdout_oneshot(|| {
-        let audio = crate::models::fluidaudio_bridge(&crate::models::fluidaudio_kokoro_location())
+        let audio = crate::models::fluidaudio_bridge(&crate::models::fluidaudio_kokoro_location()?)
             .context("init FluidAudio bridge")?;
         audio
             .init_kokoro_with_compute_units(voice_id, lang, compute_units)
@@ -579,7 +579,10 @@ mod tests {
     /// exists after `kesha install --tts`.
     #[test]
     fn the_ane_vocab_agrees_with_the_onnx_fixture() {
-        let staged = crate::models::fluidaudio_ane_kokoro_dir().join("vocab.json");
+        let Ok(ane_dir) = crate::models::fluidaudio_ane_kokoro_dir() else {
+            return;
+        };
+        let staged = ane_dir.join("vocab.json");
         let Ok(ane_json) = std::fs::read_to_string(&staged) else {
             return;
         };

--- a/rust/src/tts/g2p.rs
+++ b/rust/src/tts/g2p.rs
@@ -30,7 +30,7 @@ pub fn text_to_ipa_cached(
     let base = crate::tts::charsiu::base_lang(&lower);
     if matches!(base, "es" | "fr" | "it" | "pt") {
         crate::dtrace!("g2p::route lang={lang} backend=charsiu text_chars={text_chars}");
-        let dir = crate::models::cache_dir().join("models/g2p/byt5-tiny");
+        let dir = crate::models::cache_dir()?.join("models/g2p/byt5-tiny");
         check_charsiu_files(&dir)?;
         let ipa = charsiu.to_ipa(&dir, text, &lower)?;
         crate::dtrace!("g2p::result ipa_chars={}", ipa.chars().count());

--- a/rust/src/tts/vosk.rs
+++ b/rust/src/tts/vosk.rs
@@ -102,7 +102,8 @@ mod tests {
         if !ci_true_or_skip("synth_short_phrase_produces_audio") {
             return;
         }
-        let dir = crate::models::model_dir(crate::models::ModelKind::VoskRu);
+        let dir = crate::models::model_dir(crate::models::ModelKind::VoskRu)
+            .expect("resolve vosk model dir");
         if !crate::models::is_cached(crate::models::ModelKind::VoskRu) {
             // This is the only consumer of the ~935 MB bundle, so a silent skip
             // here is how CI would lose Russian synthesis coverage without any

--- a/rust/tests/kokoro_rate_e2e.rs
+++ b/rust/tests/kokoro_rate_e2e.rs
@@ -47,7 +47,9 @@ use std::process::Command;
 /// skip rather than fail. The model graph is a `.mlmodelc` bundle; the voice
 /// pack is the flat `<voice>.bin` `stage_ane_kokoro_voices` writes.
 fn ane_kokoro_ready() -> bool {
-    let ane = kesha_engine::models::fluidaudio_ane_kokoro_dir();
+    let Ok(ane) = kesha_engine::models::fluidaudio_ane_kokoro_dir() else {
+        return false;
+    };
     let model_graph = ane.join("KokoroVocoder.mlmodelc");
     let voice = ane.join("am_michael.bin");
     model_graph.exists() && voice.exists()

--- a/tests/unit/kokoro-ane.test.ts
+++ b/tests/unit/kokoro-ane.test.ts
@@ -173,8 +173,8 @@ describe("Rust/TS Kokoro ANE manifest agreement", () => {
 
   // Both groups are staged by the same call; a rename there would strand the probe.
   test("both groups are still what `kesha install --tts` stages", () => {
-    expect(rust).toContain("stage_into(&fluidaudio_ane_kokoro_dir(), ANE_EN_FILES, no_cache)?;");
-    expect(rust).toContain("stage_into(&fluidaudio_kokoro_g2p_dir(), KOKORO_G2P_FILES, no_cache)?;");
-    expect(rust).toContain(`fluidaudio_kokoro_cache_dir().join("ANE")`);
+    expect(rust).toContain("stage_into(&fluidaudio_ane_kokoro_dir()?, ANE_EN_FILES, no_cache)?;");
+    expect(rust).toContain("stage_into(&fluidaudio_kokoro_g2p_dir()?, KOKORO_G2P_FILES, no_cache)?;");
+    expect(rust).toContain(`fluidaudio_kokoro_cache_dir()?.join("ANE")`);
   });
 });


### PR DESCRIPTION
## What & why

`rust/src/errors.rs` promises an uncoded error falls back to `E_INTERNAL` so the `error [CODE]:` stderr contract holds. Five `models.rs` sites broke it by resolving the home directory with `dirs::home_dir().expect(...)`: a box with no resolvable home (daemon context, stripped container, some CI images) got a Rust panic + backtrace that unwound *past* `report()`, and the TS wrapper — which parses `error [CODE]:` off stderr — could not classify it.

Closes #953

## Boundary decision (the propagation map)

Removing a panic from a `-> PathBuf` fn forces `-> Result<PathBuf>`; returning a bogus path or re-panicking downstream is worse and was explicitly disallowed. So the propagation is fundamental. Boundary chosen (architect-reviewed): **propagate `anyhow::Result` from each home-reading leaf to the nearest already-fallible caller, and absorb into the natural "absent" value at the `bool`/`Vec`/`Option`/diagnostics predicates** rather than flipping those to `Result`.

Signatures now returning `Result`:
- **Always-compiled cache chain:** `cache_dir`, `model_dir`, `fluidaudio_models_root`, `fluidaudio_location` (the `FluidAudioLocation` struct is unchanged).
- **darwin FluidAudio resolvers:** `fluidaudio_kokoro_g2p_dir`, `legacy_fluidaudio_kokoro_cache_dir`, `fluidaudio_kokoro_location`, `fluidaudio_kokoro_cache_dir`, `fluidaudio_ane_kokoro_dir`, `fluidaudio_ane_zh_kokoro_dir` (`system_kokoro`); `legacy_fluidaudio_asr_dir`, `fluidaudio_asr_location`, `fluidaudio_asr_dir` (`coreml`); `legacy_sortformer_compiled_dir`, `fluidaudio_diarize_location` (`system_diarize`).

Absorbed (kept their type, swallow to absent — home failure is process-invariant and the real use still fails loudly):
- `is_cached` / `fluidaudio_asr_ready` → `bool` via `is_ok_and`; `stale_legacy_notice`/`missing_kokoro_assets`/`incomplete_ane_bundle_names` → `None`/empty; `render_diagnostics` → partial string.

`cleanup_legacy` now takes the cache path `install()` already resolved, removing a sixth latent home read. Every leaf caller across `lang_id`, `transcribe`, `cli/{install,say}`, `say_loop`, `tts/{g2p,fluid_kokoro}`, `backend/fluidaudio`, `streaming_asr`, `transcribe/diarize` was an already-`Result`/`i32`/`String` context — a `?` or an explicit map.

## Per-site hint wording

- `cache_dir` (env-overridable): `cannot determine home directory; set $HOME, or set KESHA_CACHE_DIR to an explicit cache path` — true, `KESHA_CACHE_DIR` short-circuits above the home read.
- The four FluidAudio dirs hardcode `~/.cache/fluidaudio` / `~/Library/Application Support/...`, which `KESHA_CACHE_DIR` cannot relocate, so the hint names only `$HOME`.

All use `E_INTERNAL`, not `E_UNSUPPORTED_PLATFORM` — the latter's title ("Feature unsupported on this platform") would misdirect a Linux user with an unset `$HOME`.

## Tests (red → green)

`dirs::home_dir()==None` isn't drivable from a test (unix falls back to `getpwuid_r`; mutating `$HOME` breaks isolation), so the seam is extracted:
- `cache_dir_from(env, home)` — commit 1 lands the test with the seam still panicking (**red**, genuine panic), commit 2 swaps `expect`→`coded_bail!` (**green**). Asserts `code_of == Internal` + hint names `KESHA_CACHE_DIR`.
- `require_home(home)` (darwin) — asserts `Internal` + hint names `$HOME` and **omits** `KESHA_CACHE_DIR`.
- One source-string staging test updated to the new `?`-carrying form (same files staged).

## Gates (all green, run locally)

- `cargo nextest run --features tts` → 569 passed, 0 skipped
- `cargo clippy --all-targets -- -D warnings` → clean
- `cargo check --features coreml --no-default-features --all-targets` → clean
- `verify-darwin-full` (`clippy` over `coreml,tts,system_tts,system_kokoro,system_diarize,system_text_lang`) → clean
- `bunx tsc --noEmit` → clean; `bun test` → 1344 pass, 6 skip, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review round 2 (grok: NO P1/P2)

- **Taken:** added a load-bearing comment on `missing_kokoro_assets`'s empty-return arms locking the invariant grok flagged — the empty ("nothing missing") result is safe only because the same null home that unresolves these dirs also unresolves `fluidaudio_kokoro_location`, so synthesis surfaces `E_INTERNAL` before this preflight is trusted (ad4a3fe).
- **Deferred (follow-up):** grok's optional note that `detect_audio_language` / `ensure_asr_installed` still phrase a null home as "model not installed" rather than `E_INTERNAL`. It is **not** a clean 2-line reorder: on the coreml build `is_cached(Asr)` reads `fluidaudio_asr_dir` while `model_dir(Asr)` reads `cache_dir` — two different home-gated paths — so resolve-then-probe would need care on that branch. Left for a small follow-up per the reviewer's call. (Also note `ensure_asr_installed`'s `anyhow::bail!` is already uncoded and thus classifies as `E_INTERNAL` today — only the *message* is misleading, not the code.)
