### PR TITLE
fix(install): a star-prompt failure no longer fails a completed install (#936)

### DIFF
--- a/openspec/specs/installation/spec.md
+++ b/openspec/specs/installation/spec.md
@@ -668,7 +668,7 @@ install proceeds without it.
 
 ### Requirement: The star prompt is gated to meaningful version bumps and bounded in time
 
-After a successful install the CLI MAY print an invitation to star the repository, and SHALL show it only on a first install or a major/minor bump — never on a patch-only bump — and SHALL bound how long it waits on any external probe before printing.
+After a successful install the CLI MAY print an invitation to star the repository, and SHALL show it only on a first install or a major/minor bump — never on a patch-only bump — and SHALL bound how long it waits on any external probe before printing. The prompt is cosmetic and SHALL never fail the install: any error it raises — a failed probe, spawn, or logger — is swallowed and the install still exits 0.
 
 #### Scenario: Maks installs for the first time
 
@@ -694,9 +694,17 @@ After a successful install the CLI MAY print an invitation to star the repositor
 #### Scenario: The marker cannot be written
 
 - GIVEN the engine directory is read-only, so the marker write fails
-- WHEN the invitation is shown
-- THEN the install still succeeds, and the next install for the same version
-  prompts again, because nothing recorded that it already asked
+- WHEN the invitation would be shown
+- THEN nothing is printed and the install still succeeds, because the prompt is
+  skipped when it cannot be recorded, so a read-only directory never nags
+
+#### Scenario: The star prompt throws after a completed install
+
+- GIVEN the engine and models are downloaded and verified on disk
+- AND the star prompt raises — `Bun.which`, either `gh` spawn, or the logger throws
+- WHEN `maybeAskForStar` runs
+- THEN the throw is swallowed to a warning, the install is recorded as
+  `success`, and the CLI exits 0
 
 #### Scenario: The repository is already starred
 
@@ -712,11 +720,12 @@ After a successful install the CLI MAY print an invitation to star the repositor
 > (`src/star.ts:16`) and is written *before* printing, so one run never prompts
 > twice and a write failure is non-fatal. `GH_PROBE_TIMEOUT_MS` is 2 000 ms
 > (`src/star.ts:6`), sized to clear a healthy `gh auth status` (0.77–1.21 s
-> measured) but not a wedged one that blocked install 11–25 s (#810). Only the
-> marker write is guarded (`src/star.ts:85`); the call sits inside
-> `performInstall`'s `try` (`src/cli/install.ts:239`), so anything else it
-> throws lands in the catch that exits 1 — see Open Issues. Covered by
-> `tests/unit/star.test.ts`.*
+> measured) but not a wedged one that blocked install 11–25 s (#810).
+> `maybeAskForStar` is total: its whole body sits in a try that swallows any
+> throw to `log.warn`, so a failing probe, spawn, or logger cannot escape into
+> `performInstall`'s catch (#936). A marker-write failure returns without
+> printing, so a read-only engine directory is silently skipped rather than
+> nagging every install. Covered by `tests/unit/star.test.ts`.*
 
 ### Requirement: Install cost is stated before download
 User-facing install documentation SHALL state the approximate download/disk cost of `kesha install` (~2.7 GB) and the quiet-progress behavior of the model step next to the command itself, and SHALL present `kesha install --plan` (exact sizes, downloads nothing) and `kesha status --disk` as the user-facing cost-inspection commands.
@@ -736,9 +745,3 @@ Interactive missing-model errors recommend `kesha init`; the Quick Start SHALL m
 
 - `kesha record` has no Windows or Linux microphone capture; `record.rs` gates capture on
   macOS and the README directs other platforms to pass an existing audio file.
-- **A star prompt failure can fail an install that already succeeded.**
-  `maybeAskForStar` runs inside `performInstall`'s `try` after the engine is on
-  disk, and only its marker write is guarded. A throw from `Bun.which`, either
-  `gh` spawn, or the logger reaches the catch, which reports the install as
-  `failed` and exits 1 — after every byte was downloaded and verified. The
-  prompt is cosmetic and should not be able to do that.

--- a/src/star.ts
+++ b/src/star.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, writeFileSync } from "fs";
 import { tryParseSemver } from "./semver.mjs";
+import { errorMessage } from "./error-utils";
 
 // Clears a healthy `gh auth status` (0.77-1.21 s measured) but not a wedged one, which
 // blocked install 11-25 s; Bun kills at the budget and reports exitCode null (#810).
@@ -55,59 +56,72 @@ export function hasStarMarker(binPath: string): boolean {
 
 /**
  * Prompt the user to star the repo on first install and major/minor bumps.
- * Marker is written before printing so a single run never prompts twice.
+ *
+ * Best-effort and never-throw: the prompt is cosmetic, so any failure — a
+ * throwing `Bun.which`, either `gh` probe, or the logger — is swallowed to a
+ * warning and never fails a completed install (#936). The marker is written
+ * before printing so a single run never prompts twice; when the marker cannot
+ * be written the prompt is skipped entirely, so a read-only engine directory
+ * never nags on every install.
  * `shims` injects deterministic `which`/`spawn` for tests — Bun.which()
  * caches PATH at process start, so env-swapping in tests doesn't work.
  */
 export async function maybeAskForStar(
   binPath: string,
   currentVersion: string | null,
-  log: { info: (msg: string) => void },
+  log: { info: (msg: string) => void; warn?: (msg: string) => void },
   shims?: {
     which?: (name: string) => string | null;
     spawn?: (cmd: string[]) => { exitCode: number | null };
   },
 ): Promise<void> {
-  const which = shims?.which ?? ((n: string) => Bun.which(n));
-  const spawn =
-    shims?.spawn ??
-    ((cmd: string[]) =>
-      Bun.spawnSync(cmd, {
-        stdout: "ignore",
-        stderr: "ignore",
-        timeout: GH_PROBE_TIMEOUT_MS,
-      }));
-  if (!currentVersion) return;
-  const seen = readStarSeen(binPath);
-  if (!shouldShowStarPrompt(currentVersion, seen)) {
-    return;
-  }
   try {
-    writeStarSeen(binPath, currentVersion);
-  } catch {
-    /* Non-fatal — falling through to the prompt is still OK. */
-  }
+    const which = shims?.which ?? ((n: string) => Bun.which(n));
+    const spawn =
+      shims?.spawn ??
+      ((cmd: string[]) =>
+        Bun.spawnSync(cmd, {
+          stdout: "ignore",
+          stderr: "ignore",
+          timeout: GH_PROBE_TIMEOUT_MS,
+        }));
+    if (!currentVersion) return;
+    const seen = readStarSeen(binPath);
+    if (!shouldShowStarPrompt(currentVersion, seen)) {
+      return;
+    }
+    try {
+      writeStarSeen(binPath, currentVersion);
+    } catch {
+      // Couldn't record that we asked — skip the prompt so a read-only engine
+      // directory never nags on every install (#936).
+      return;
+    }
 
-  // Marker recorded — every return below must print, except "already starred".
-  const printBasicPrompt = () => {
-    log.info("\nIf you enjoy Kesha Voice Kit, consider starring the repo:");
+    // Marker recorded — every return below must print, except "already starred".
+    const printBasicPrompt = () => {
+      log.info("\nIf you enjoy Kesha Voice Kit, consider starring the repo:");
+      log.info("  https://github.com/drakulavich/kesha-voice-kit");
+    };
+
+    const gh = which("gh");
+    if (!gh) {
+      printBasicPrompt();
+      return;
+    }
+    const authCheck = spawn([gh, "auth", "status"]);
+    if (authCheck.exitCode !== 0) {
+      // Unauthenticated — can't check star status; still print so the slot isn't silently consumed.
+      printBasicPrompt();
+      return;
+    }
+    const starred = spawn([gh, "api", "user/starred/drakulavich/kesha-voice-kit"]);
+    if (starred.exitCode === 0) return; // already starred — slot consumed by verification
+    log.info("\n⭐ If you enjoy Kesha Voice Kit, star it on GitHub:");
     log.info("  https://github.com/drakulavich/kesha-voice-kit");
-  };
-
-  const gh = which("gh");
-  if (!gh) {
-    printBasicPrompt();
-    return;
+    log.info('  Or run: gh api -X PUT /user/starred/drakulavich/kesha-voice-kit');
+  } catch (err) {
+    // A cosmetic prompt must never fail a completed, verified install (#936).
+    log.warn?.(`Skipping the star prompt: ${errorMessage(err)}`);
   }
-  const authCheck = spawn([gh, "auth", "status"]);
-  if (authCheck.exitCode !== 0) {
-    // Unauthenticated — can't check star status; still print so the slot isn't silently consumed.
-    printBasicPrompt();
-    return;
-  }
-  const starred = spawn([gh, "api", "user/starred/drakulavich/kesha-voice-kit"]);
-  if (starred.exitCode === 0) return; // already starred — slot consumed by verification
-  log.info("\n⭐ If you enjoy Kesha Voice Kit, star it on GitHub:");
-  log.info("  https://github.com/drakulavich/kesha-voice-kit");
-  log.info('  Or run: gh api -X PUT /user/starred/drakulavich/kesha-voice-kit');
 }

--- a/src/star.ts
+++ b/src/star.ts
@@ -121,7 +121,13 @@ export async function maybeAskForStar(
     log.info("  https://github.com/drakulavich/kesha-voice-kit");
     log.info('  Or run: gh api -X PUT /user/starred/drakulavich/kesha-voice-kit');
   } catch (err) {
-    // A cosmetic prompt must never fail a completed, verified install (#936).
-    log.warn?.(`Skipping the star prompt: ${errorMessage(err)}`);
+    // A cosmetic prompt must never fail a completed, verified install (#936) —
+    // and neither may its own failure-to-log: log.warn is process.stderr.write,
+    // which re-throws on a dying stderr (EPIPE), so the swallow is guarded too.
+    try {
+      log.warn?.(`Skipping the star prompt: ${errorMessage(err)}`);
+    } catch {
+      /* Nothing left to do — the prompt is cosmetic. */
+    }
   }
 }

--- a/tests/unit/star.test.ts
+++ b/tests/unit/star.test.ts
@@ -103,7 +103,12 @@ describe("star-seen marker file", () => {
 describe("maybeAskForStar — orchestration", () => {
   function captureLog() {
     const lines: string[] = [];
-    return { log: { info: (m: string) => lines.push(m) }, lines };
+    const warnings: string[] = [];
+    return {
+      log: { info: (m: string) => lines.push(m), warn: (m: string) => warnings.push(m) },
+      lines,
+      warnings,
+    };
   }
 
   // gh shim factory — `auth` is the first argv when checking auth status,
@@ -192,5 +197,64 @@ describe("maybeAskForStar — orchestration", () => {
     const out = lines.join("\n");
     expect(out).toContain("⭐ If you enjoy Kesha Voice Kit");
     expect(out).toContain("gh api -X PUT /user/starred");
+  });
+});
+
+describe("maybeAskForStar — cosmetic prompt never fails the install (#936)", () => {
+  function captureLog() {
+    const lines: string[] = [];
+    const warnings: string[] = [];
+    return {
+      log: { info: (m: string) => lines.push(m), warn: (m: string) => warnings.push(m) },
+      lines,
+      warnings,
+    };
+  }
+
+  test("a throwing `which` probe is swallowed to a warning, never propagated", async () => {
+    const binPath = mkTmpBinPath();
+    const { log, warnings } = captureLog();
+    const shims = {
+      which: () => {
+        throw new Error("which blew up");
+      },
+    };
+    await expect(maybeAskForStar(binPath, "1.2.0", log, shims)).resolves.toBeUndefined();
+    expect(warnings.join("\n")).toContain("which blew up");
+  });
+
+  test("a throwing `gh` spawn is swallowed, never propagated", async () => {
+    const binPath = mkTmpBinPath();
+    const { log } = captureLog();
+    const shims = {
+      which: () => "/fake/gh",
+      spawn: () => {
+        throw new Error("spawn blew up");
+      },
+    };
+    await expect(maybeAskForStar(binPath, "1.2.0", log, shims)).resolves.toBeUndefined();
+  });
+
+  test("a throwing logger is swallowed, never propagated", async () => {
+    const binPath = mkTmpBinPath();
+    const log = {
+      info: () => {
+        throw new Error("logger blew up");
+      },
+      warn: () => {},
+    };
+    const shims = { which: () => null };
+    await expect(maybeAskForStar(binPath, "1.2.0", log, shims)).resolves.toBeUndefined();
+  });
+
+  test("marker write failure skips the prompt entirely (no nag on a read-only dir)", async () => {
+    // Parent directory does not exist, so writeStarSeen throws. The prompt must
+    // not print as if the slot were consumed, and the call must not throw.
+    const binPath = join(tmpdir(), "kesha-star-nonexistent-dir-936", "kesha-engine");
+    const { log, lines, warnings } = captureLog();
+    const shims = { which: () => null };
+    await expect(maybeAskForStar(binPath, "1.2.0", log, shims)).resolves.toBeUndefined();
+    expect(lines).toEqual([]);
+    expect(warnings).toEqual([]);
   });
 });

--- a/tests/unit/star.test.ts
+++ b/tests/unit/star.test.ts
@@ -247,6 +247,24 @@ describe("maybeAskForStar — cosmetic prompt never fails the install (#936)", (
     await expect(maybeAskForStar(binPath, "1.2.0", log, shims)).resolves.toBeUndefined();
   });
 
+  test("a throwing warn in the swallow path is itself swallowed (dying stderr, EPIPE)", async () => {
+    // The catch is part of the never-throw contract: log.warn is
+    // process.stderr.write in production, which re-throws on a broken pipe.
+    const binPath = mkTmpBinPath();
+    const log = {
+      info: () => {},
+      warn: () => {
+        throw new Error("EPIPE");
+      },
+    };
+    const shims = {
+      which: () => {
+        throw new Error("which blew up");
+      },
+    };
+    await expect(maybeAskForStar(binPath, "1.2.0", log, shims)).resolves.toBeUndefined();
+  });
+
   test("marker write failure skips the prompt entirely (no nag on a read-only dir)", async () => {
     // Parent directory does not exist, so writeStarSeen throws. The prompt must
     // not print as if the slot were consumed, and the call must not throw.


### PR DESCRIPTION
## Problem

`maybeAskForStar` ran inside `performInstall`'s `try`, *after* the engine and models were downloaded and verified. Inside it only the marker write was guarded — `Bun.which("gh")`, both `Bun.spawnSync` probes, and the `log.info` calls were bare. Any throw there turned a completed, verified multi-GB install into `error: … exit 1`, logged it `failed` in the diagnostic, and a re-run re-verified everything only to hit the same throw (nothing changed).

Second, smaller problem: the marker-write guard fell through and printed the prompt anyway after recording nothing, so a read-only engine directory prompted on every install.

## Fix

1. **Never-throw contract.** `maybeAskForStar` is now total: its whole body sits in a `try` that swallows any throw to `log.warn`, so a failing `Bun.which`, `gh` probe, or logger cannot escape into `performInstall`'s catch. `performInstall` proceeds to `finishInstallDiagnostic(…, "success")` and exits 0. The contract is stated in a one-line doc comment. `#810`'s 2 s probe-timeout budget is untouched — that fixed a *hang*, this fixes a *throw*.
2. **Marker guard fallthrough.** A marker-write failure now `return`s without printing, instead of falling through to the prompt. A read-only engine directory is silently skipped rather than nagging every install — consistent with the "at most once per meaningful version" intent.
3. Scope kept minimal: no new prompt features, no refactor of the star flow beyond total-ing it and fixing the fallthrough.

## Tests (red → green)

Added to `tests/unit/star.test.ts`, driving throwing shims through the call site:
- throwing `which` → resolves (no throw), warning logged
- throwing `gh` spawn → resolves
- throwing logger → resolves
- marker-write failure (non-existent parent dir) → nothing printed, no throw

Committed red first (all 4 fail on the bare code), then the fix greens them.

## Spec

`openspec/specs/installation/spec.md`: the star requirement regains a never-fails-the-install clause; the marker-write scenario switches to skip-don't-nag; a "star prompt throws after a completed install" scenario is added; the Technical Note is corrected; and the Open Issue is resolved.

## Verification

- `bun run test` → 1348 pass, 6 skip, 0 fail
- `bunx tsc --noEmit` → clean

Closes #936