### PR TITLE
fix(cli): route install progress to stderr, keeping stdout result-only (#945)

### DIFF
--- a/openspec/specs/cli-shell-integration/spec.md
+++ b/openspec/specs/cli-shell-integration/spec.md
@@ -278,12 +278,13 @@ filtering.
 - THEN `jq` receives clean JSON on stdin with no interleaved progress text
 - AND stderr carries any spinner or warning lines
 
-> *Technical Note — `log.info`, `log.success`, and `log.progress` use
-> `console.log` (stdout); `log.warn`, `log.error`, and `log.status` use
+> *Technical Note — `log.info` and `log.success` use `console.log` (stdout);
+> `log.warn`, `log.error`, `log.status`, and `log.progress` use
 > `process.stderr.write` to avoid Bun's startup-frozen TTY auto-red that
-> `console.error` would apply. `log.progress` (stdout) is used only in install
-> flows (`src/progress.ts:146`, `src/engine-install.ts`), which produce no
-> machine-readable stdout result. Source: `src/log.ts:46-68`.*
+> `console.error` would apply. `log.progress` is used only in install flows
+> (`src/progress.ts`, `src/engine-install.ts`); it writes to stderr (#945) so
+> that no non-result output reaches stdout even once install grows a
+> machine-readable mode. Source: `src/log.ts:46-68`.*
 
 ### Requirement: Directory arguments are rejected before work starts
 When a positional argument is a directory, the CLI SHALL print `<path>: is a directory (expected an audio file)` and exit 1 before any progress output or engine spawn.
@@ -308,10 +309,6 @@ When the first positional token is not a file and not a known subcommand, the CL
 - `--no-color` is not forwarded to the Engine subprocess explicitly; it relies
   on `process.env.NO_COLOR` propagation. If the Engine is spawned via a shell
   wrapper that resets the environment, the Engine may still produce ANSI codes.
-- Install-flow progress lines (`log.progress`) print to stdout, not stderr.
-  Harmless today because install has no machine-readable stdout, but it breaks
-  the corpus-wide "progress goes to stderr" intuition — candidate for moving to
-  `log.status` (stderr).
 - There is no `--color` flag to force color on when stdout is not a TTY (e.g.
   inside tmux with `TERM=dumb`); `FORCE_COLOR` from picocolors is the current
   workaround.

--- a/src/log.ts
+++ b/src/log.ts
@@ -47,9 +47,11 @@ export const log = {
   success: (msg: string) => console.log(colors.green(msg)),
   // `--quiet` (#526) silences status/progress chatter; warnings and errors
   // always print, and results are written straight to stdout (not via log.*).
+  // STDERR, not stdout: progress is not a result — the install flow's only
+  // caller must not collide with a future `install --json` deliverable (#945).
   progress: (msg: string) => {
     if (log.quietEnabled) return;
-    console.log(colors.cyan(msg));
+    process.stderr.write(colors.cyan(msg) + "\n");
   },
   // stderr via process.stderr.write (not console.error): Bun auto-colors
   // console.error red in a TTY, and that decision is frozen at startup — it

--- a/tests/integration/cli-contracts.test.ts
+++ b/tests/integration/cli-contracts.test.ts
@@ -808,7 +808,7 @@ describe("CLI contracts", () => {
       exitCode: 0,
       stdoutContains: ["Engine binary already installed", "Backend installed successfully"],
       stdoutNotContains: [dir],
-      stderrEmpty: true,
+      stderrContains: ["Installing models..."],
     });
     expect(JSON.parse(readFileSync(installArgsPath, "utf8"))).toEqual(["--vad"]);
 
@@ -829,6 +829,34 @@ describe("CLI contracts", () => {
       status: "success",
     });
     expect(typeof events[1].durationMs).toBe("number");
+  });
+
+  test("install keeps progress on stderr while --plan's deliverable stays on stdout (#945)", async () => {
+    const dir = makeTempDir("kesha-cli-contract-install-stdout-purity-");
+    const enginePath = createFakeEngine(dir);
+    markFakeEngineInstalled(enginePath);
+    const env: Record<string, string> = {
+      ...isolatedEnv(dir),
+      KESHA_ENGINE_BIN: enginePath,
+      KESHA_FAKE_INSTALL_ARGS_PATH: join(dir, "install-args.json"),
+    };
+
+    // Progress chatter ("Installing models...") is not a result; it must not ride
+    // stdout, where a future `install --json` would collide with it.
+    const install = await runCli(["install", "--vad"], { env });
+    expectContract(install, {
+      exitCode: 0,
+      stdoutContains: ["Backend installed successfully"],
+      stdoutNotContains: ["Installing models..."],
+      stderrContains: ["Installing models..."],
+    });
+
+    // `--plan` *is* a deliverable and stays on stdout.
+    const plan = await runCli(["install", "--plan", "--tts"], { env });
+    expectContract(plan, {
+      exitCode: 0,
+      stdoutContains: ["Kesha install plan"],
+    });
   });
 
   test("install finishes even when gh on PATH never answers (#810)", async () => {

--- a/tests/unit/log.test.ts
+++ b/tests/unit/log.test.ts
@@ -60,18 +60,19 @@ describe("log routing", () => {
     expect(stdout).not.toContain("status-msg");
   });
 
-  test("progress writes to stdout, not stderr", () => {
-    const stderr = captureStderr(() => {
-      const stdout = captureStdout(() => log.progress("progress-msg"));
-      expect(stdout).toContain("progress-msg");
+  test("progress writes to stderr, not stdout", () => {
+    const stdout = captureStdout(() => {
+      const stderr = captureStderr(() => log.progress("progress-msg"));
+      expect(stderr).toContain("progress-msg");
     });
-    expect(stderr).not.toContain("progress-msg");
+    expect(stdout).not.toContain("progress-msg");
   });
 
   test("stderr lines end with a newline", () => {
     expect(captureStderr(() => log.warn("w"))).toMatch(/\n$/);
     expect(captureStderr(() => log.error("e"))).toMatch(/\n$/);
     expect(captureStderr(() => log.status("s"))).toMatch(/\n$/);
+    expect(captureStderr(() => log.progress("p"))).toMatch(/\n$/);
   });
 });
 
@@ -82,13 +83,13 @@ describe("log.quietEnabled level gating (#526)", () => {
 
   test("progress is suppressed when quietEnabled", () => {
     log.quietEnabled = true;
-    const out = captureStdout(() => log.progress("quiet-progress"));
+    const out = captureStderr(() => log.progress("quiet-progress"));
     expect(out).not.toContain("quiet-progress");
   });
 
   test("progress is emitted when quietEnabled is false", () => {
     log.quietEnabled = false;
-    const out = captureStdout(() => log.progress("loud-progress"));
+    const out = captureStderr(() => log.progress("loud-progress"));
     expect(out).toContain("loud-progress");
   });
 

--- a/tests/unit/progress.test.ts
+++ b/tests/unit/progress.test.ts
@@ -302,19 +302,31 @@ describe("the live bar cleans up after itself", () => {
   });
 });
 
-/** The sizeless fallback reports through `log`, which splits across console.log/error. */
+/** The sizeless fallback reports the "Downloading" line via `log.progress`
+ * (process.stderr.write) and the "Downloaded" line via `log.success`
+ * (console.log), so capture both sinks. */
 function withCapturedLog(fn: () => void): string {
-  const saved = { log: console.log, error: console.error, isTTY: process.stderr.isTTY };
+  const saved = {
+    log: console.log,
+    error: console.error,
+    write: process.stderr.write,
+    isTTY: process.stderr.isTTY,
+  };
   const lines: string[] = [];
   const collect = (...args: unknown[]) => void lines.push(args.join(" "));
   try {
     Object.defineProperty(process.stderr, "isTTY", { value: false, configurable: true });
     console.log = collect;
     console.error = collect;
+    process.stderr.write = ((chunk: string) => {
+      lines.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write;
     fn();
   } finally {
     console.log = saved.log;
     console.error = saved.error;
+    process.stderr.write = saved.write;
     Object.defineProperty(process.stderr, "isTTY", { value: saved.isTTY, configurable: true });
   }
   return lines.join("\n");


### PR DESCRIPTION
Closes #945

## Problem

`log.progress` wrote to **stdout** (`console.log`), while every other non-result sink — `log.warn`, `log.error`, `log.status` — goes to stderr. The install flow is its only caller (`src/progress.ts`, `src/engine-install.ts`), so `Installing models...`, `Downloading ...`, `Replacing engine ...`, and the spawn-lock notice all leaked onto stdout. Harmless today because install has no machine-readable stdout, but a landmine the moment `install --json` exists — and `install --plan` is arguably already that command.

## Decision: fix the primitive, not the call sites

I grepped every `log.progress` caller: all of them are in the install flow, and none is a legitimate stdout-result use. A "progress" function on stdout is the defect itself, so I fixed the primitive — `log.progress` now writes via `process.stderr.write` (identical to `log.status`). This corrects all callers in one place and keeps the `progress`/`status` vocabulary the spec already documents, rather than churning five call sites. No caller relies on progress landing on stdout.

## `--plan` stays on stdout (confirmed)

`--plan` is a deliverable and renders through `log.info` (stdout) at `src/cli/install.ts:206`, which this change does not touch. The existing `read-only planning and stats commands keep user data on stdout` contract test still asserts `install --plan --tts` → stdout contains `Kesha install plan`, and the new #945 test re-confirms it.

## Tests (red → green)

- **Red** (`57eaf52`): flipped the three `log.progress` unit assertions to expect stderr, added a `cli-contracts` test asserting `kesha install` keeps `Installing models...` off stdout / on stderr and `install --plan` keeps its deliverable on stdout, and updated the diagnostic-log install test whose incidental `stderrEmpty` no longer holds. All failed against the old `console.log` implementation.
- **Green** (`2af178b`): the one-line primitive fix. `withCapturedLog` in `progress.test.ts` now also captures `process.stderr.write` so the non-TTY download-line coverage survives the stream move.

Evidence:
- `bun test`: 1345 pass, 6 skip, 0 fail
- `bunx tsc --noEmit`: clean
- `bun run check`: pass
- `bun run check:specs` (openspec --strict): 17 passed, 0 failed

## Spec

Resolved the corresponding Open Issue and moved `log.progress` into the stderr group of the stdout-purity Technical Note in `openspec/specs/cli-shell-integration/spec.md`; the fix makes reality match the "result → stdout, progress → stderr" requirement, so no requirement text changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)