### PR TITLE
docs(nix): stop presenting the broken .#kesha CLI path as a working install

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ kesha audio.ogg                                 # transcript to stdout
 
 `kesha install` pulls ~2.5 GB on Linux/Windows and ~0.6 GB on Apple Silicon, whose CoreML engine reads a smaller model set. It is always explicit — nothing downloads behind your back — and the model step has no progress bar, so expect a few quiet minutes. If `bun --version` fails right after step 1, reload your PATH: `exec $SHELL -l`.
 
-Prefer Homebrew, Docker, or Nix? See [Other install methods](#other-install-methods).
+Prefer Homebrew or Docker? See [Other install methods](#other-install-methods).
 Air-gapped or behind a corporate mirror? See [docs/model-mirror.md](docs/model-mirror.md).
 
 ### Platform support
@@ -135,12 +135,12 @@ Full per-file breakdown (Russian + English): [BENCHMARK.md](BENCHMARK.md). The C
 
 ## Other install methods
 
-All of these install the Bun CLI wrapper; engine + models still download explicitly via `kesha install`.
+All of these install the Bun CLI wrapper; engine + models still download explicitly via `kesha install`. (Nix is the exception — it currently builds only the engine from source; see below.)
 
 - **Homebrew** — `brew install drakulavich/tap/kesha-voice-kit` · [docs/homebrew.md](docs/homebrew.md)
 - **Linux packages** (`.deb`/`.rpm`, x64) — published on CLI releases, see [docs/linux-packages.md](docs/linux-packages.md)
 - **Docker** (GHCR image) — [docs/docker.md](docs/docker.md)
-- **Nix** (`aarch64-darwin` / `x86_64-linux`) — `nix run github:drakulavich/kesha-voice-kit -- install` · [docs/nix-install.md](docs/nix-install.md)
+- **Nix** (`aarch64-darwin` / `x86_64-linux`) — builds the engine from source (`nix build github:drakulavich/kesha-voice-kit#kesha-engine`). The full `kesha` CLI via `nix run` / `nix profile install` is **not yet available** — it needs a maintainer with Nix to populate a build hash ([#946](https://github.com/drakulavich/kesha-voice-kit/issues/946)). · [docs/nix-install.md](docs/nix-install.md)
 - **Shell completions + manpage** — `kesha completions bash|zsh|fish` and `kesha manpage` print the packaged files to install wherever your shell expects them.
 
 ## Integrations

--- a/docs/nix-install.md
+++ b/docs/nix-install.md
@@ -4,25 +4,11 @@ Alternative reproducible-build path for Kesha Voice Kit. The Bun install (`bun a
 
 **Prerequisites:** [Nix](https://nixos.org/download/) with flakes enabled. Supported systems: `aarch64-darwin`, `x86_64-linux`.
 
-## One-liner run (no install)
-```bash
-nix run github:drakulavich/kesha-voice-kit -- install      # downloads models (engine is bundled)
-nix run github:drakulavich/kesha-voice-kit -- audio.ogg    # transcribe
-```
-
-`nix run` resolves to `apps.default` (the `kesha` Bun CLI), which has the engine binary baked in via `KESHA_ENGINE_BIN`, so there's no separate engine download.
-
-## Install to profile (persistent)
-```bash
-nix profile install github:drakulavich/kesha-voice-kit
-kesha install       # downloads models (~2.5 GB, speech-to-text only; engine is bundled)
-kesha audio.ogg     # transcript to stdout
-```
-
-`packages.default` ships the Bun CLI (`kesha`) wired to the Nix-built engine. After `nix profile install`, the `kesha` shim is on `PATH` and runs transcription, language detection, and TTS (including `macos-*` AVSpeech voices on darwin-arm64) identically to the npm install. Speaker diarization (`kesha install --diarize` / `--speakers`) is not yet wired into the Nix build — the `kesha-diarize` Swift sidecar needs network-fetched FluidAudio at build time, which the Nix sandbox forbids; use the Bun install path (`bun add -g @drakulavich/kesha-voice-kit`) on darwin-arm64 if you need that feature (tracked alongside [#199](https://github.com/drakulavich/kesha-voice-kit/issues/199)).
+> **Status:** only the engine derivation (`.#kesha-engine`) builds today. The full `kesha` CLI (`.#kesha`, `nix run`, `nix profile install`) is **not yet available** — see [The `kesha` CLI is not yet buildable via Nix](#the-kesha-cli-is-not-yet-buildable-via-nix) below. Until that is resolved, install the CLI with `bun add -g @drakulavich/kesha-voice-kit`.
 
 ## Engine only (no Bun, no Node)
-For users who just want the Rust binary:
+
+For users who just want the Rust binary — this is the supported Nix path:
 ```bash
 nix build github:drakulavich/kesha-voice-kit#kesha-engine
 ./result/bin/kesha-engine --help
@@ -33,6 +19,23 @@ nix build github:drakulavich/kesha-voice-kit#kesha-engine
 ```bash
 nix develop github:drakulavich/kesha-voice-kit
 # Now you have: pinned rustc/cargo (via rust-overlay), bun, protoc, cmake, pkg-config, libclang
+```
+
+## The `kesha` CLI is not yet buildable via Nix
+
+The flake defines `packages.kesha` / `apps.default` (the Bun CLI wired to the flake-built engine), but they **cannot build as committed**. The CLI's Bun dependency closure is a fixed-output derivation whose `outputHash` is a placeholder (`lib.fakeHash`), so `nix run` / `nix build .#kesha` / `nix profile install` all fail with a hash-mismatch error every time until a maintainer with Nix populates the real value:
+
+```bash
+nix build .#kesha 2>&1 | grep -A1 'hash mismatch'   # read the `got:` value
+# then paste it into keshaNodeModules.outputHash in flake.nix and rebuild
+```
+
+That is a maintainer workflow, not a user one — and it re-breaks whenever `bun.lock` changes, with nothing in CI to catch it (the flake is deliberately not a CI gate). Re-enabling the CLI Nix path (populating the hash, or adopting `bun2nix` so no fixed hash is needed, then re-documenting `nix run` here) is tracked in [#946](https://github.com/drakulavich/kesha-voice-kit/issues/946). Until then, use the Bun install:
+
+```bash
+bun add -g @drakulavich/kesha-voice-kit
+kesha install       # downloads models (~2.5 GB, speech-to-text only)
+kesha audio.ogg     # transcript to stdout
 ```
 
 ## Why Nix?

--- a/openspec/specs/cli-distribution/spec.md
+++ b/openspec/specs/cli-distribution/spec.md
@@ -215,7 +215,7 @@ The published container image SHALL run the CLI as a non-root user, resolve the 
 
 ### Requirement: The Nix flake is an alternate build path, and never a release gate
 
-The Nix flake SHALL define the CLI and a from-source Engine build for `aarch64-darwin` and `x86_64-linux`, with the CLI pointed at the Engine the same flake built. No published artifact SHALL depend on it, so a flake that does not build blocks nothing.
+The Nix flake SHALL define a from-source Engine build for `aarch64-darwin` and `x86_64-linux`, and MAY define the CLI pointed at the Engine the same flake built. Only the Engine derivation (`.#kesha-engine`) SHALL be presented as a usable Nix path; the CLI derivation (`.#kesha`) SHALL NOT be documented as a working install method while its dependency derivation's output hash is an unpopulated placeholder. No published artifact SHALL depend on the flake, so a flake that does not build blocks nothing.
 
 #### Scenario: Maks builds the Engine through Nix
 
@@ -224,13 +224,16 @@ The Nix flake SHALL define the CLI and a from-source Engine build for `aarch64-d
 - THEN the Engine is built from source, carrying the Pinned Engine version in
   a file beside the binary
 
-#### Scenario: The CLI derivation cannot build
+#### Scenario: The CLI Nix path is not presented as an install method
 
 - GIVEN the CLI's dependency derivation carries a placeholder output hash that
-  no one has populated
-- WHEN a user runs `nix run` or `nix build .#kesha`
-- THEN it fails with a hash mismatch, and the documented recovery is to read the
-  real hash out of that error and paste it in
+  no one has populated, so `nix run` / `nix build .#kesha` fail with a hash
+  mismatch
+- WHEN a user reads the README or `docs/nix-install.md`
+- THEN no doc presents `nix run` / `nix profile install .#kesha` as a working
+  install method — the only documented Nix path is `nix build .#kesha-engine`
+- AND the flake still exposes `.#kesha`, so a maintainer with Nix can populate
+  the hash (or adopt `bun2nix`) and re-document the CLI path
 - AND no release lane fails as a result
 
 > *Technical Note — `flake.nix` exposes `packages.kesha` and
@@ -239,9 +242,12 @@ The Nix flake SHALL define the CLI and a from-source Engine build for `aarch64-d
 > (`flake.nix:144-167`), and the `kesha` wrapper sets `KESHA_ENGINE_BIN` to it
 > (`flake.nix:280`). `keshaNodeModules.outputHash` is `lib.fakeHash`
 > (`flake.nix:230`), and the comment above it (`flake.nix:188-205`) states
-> plainly that `packages.default`, `apps.default`, and the README's `nix run` /
-> `nix profile install` snippets all fail until it is populated. Usage:
-> `docs/nix-install.md`. CLAUDE.md states the flake is not a CI gate.*
+> plainly that `packages.default`, `apps.default`, and any `nix run` /
+> `nix profile install .#kesha` invocation fail until it is populated — so the
+> docs (README "Other install methods", `docs/nix-install.md`) present only
+> `nix build .#kesha-engine` as usable and mark the CLI path as not yet
+> available (#946). CLAUDE.md states the flake is not a CI gate; `nix-build` in
+> `ci.yml` builds `.#kesha-engine` only, on push.*
 
 ### Requirement: The MCP registry manifest names a published CLI version
 
@@ -349,6 +355,10 @@ Whichever path put `kesha` on the machine, the Engine and models SHALL still arr
   covers tag grammar and channels; [installation](../installation/spec.md)
   covers what an install resolves; neither states the versioning contract
   itself, which is only in CLAUDE.md and the gate script.
-- `nix build .#kesha` cannot succeed as committed (`lib.fakeHash`), so the CLI
-  half of the flake is documented-but-unbuildable. `docs/nix-install.md` and the
-  README both present `nix run` as a working install path.
+- `nix build .#kesha` still cannot succeed as committed (`lib.fakeHash`), so the
+  CLI half of the flake remains unbuildable until a maintainer with Nix populates
+  the hash. The user-facing discrepancy is resolved (#946): neither the README
+  nor `docs/nix-install.md` presents `nix run` / `nix profile install .#kesha` as
+  a working install path anymore — both document only `nix build .#kesha-engine`
+  and mark the CLI path as not yet available. Populating the hash (or adopting
+  `bun2nix`) and re-documenting the CLI path is the remaining follow-up.


### PR DESCRIPTION
## Problem (#946)

`keshaNodeModules.outputHash` is `lib.fakeHash` (`flake.nix:230`), so `nix run` / `nix build .#kesha` / `nix profile install .#kesha` fail with a hash-mismatch error every time until a developer with `nix` populates the real value — a maintainer workflow, not a user one. Yet the README listed Nix under "Other install methods" with `nix run ... -- install`, and `docs/nix-install.md` documented `nix run` / `nix profile install` as usable. A user following a documented method hits an error they have no reason to expect. `nix build .#kesha-engine` (naersk) is unaffected.

## Route chosen + why

**Honest docs (issue Option 3), not hash population.** Nix is **not installed** in this environment (`which nix` → not found), so the real `outputHash` cannot be computed here, and a *wrong* hash is worse than `fakeHash` (it fails with a confusing mismatch pointing at a plausible-looking value). Git history confirms `outputHash` has always been `lib.fakeHash` — there is no prior real value to reuse. So the fix that can be completed and verified without Nix is to stop advertising the broken path.

## What changed vs kept

**Demoted / removed (user-facing docs only):**
- `README.md` — the Nix bullet under "Other install methods" now points at the working engine build (`nix build ...#kesha-engine`) and marks the CLI `nix run` / `nix profile install` path **not yet available** (with a #946 link); "Prefer Homebrew, Docker, or Nix?" teaser drops Nix; the "all of these install the CLI wrapper" intro notes the Nix exception.
- `docs/nix-install.md` — leads with the working engine build + dev shell; the `nix run` / `nix profile install .#kesha` snippets move under a clearly-marked **"The `kesha` CLI is not yet buildable via Nix"** section that explains the placeholder hash and the maintainer recovery workflow, and points users to `bun add -g` meanwhile.
- `openspec/specs/cli-distribution/spec.md` — the "The CLI derivation cannot build" (user-facing-failure) scenario is retired in favor of "The CLI Nix path is not presented as an install method"; requirement text and technical note updated; the Nix Open Issue resolved (the user-deception is gone; populating the hash remains a follow-up).

**Kept (works / dev-only):**
- `.#kesha-engine` docs and flake — untouched.
- The `flake.nix` `packages.kesha` / `apps.default` targets and the explanatory `keshaNodeModules` comment — untouched, so a nix-equipped maintainer can populate the hash and re-enable the CLI path.

## Follow-up

Populating `keshaNodeModules.outputHash` (or adopting `bun2nix` so no fixed hash is needed) and re-documenting the CLI `nix run` path is the remaining work — **only a maintainer with Nix can fully re-enable it**. Tracked in the flake comment, the new nix-install.md section, and the spec's remaining Open Issue, all referencing #946.

## CI impact

None. The `nix-build` job in `ci.yml` runs on **push only** (post-merge), is path-filtered to `flake.nix` (unchanged here), and builds **`.#kesha-engine` only** — it never built `.#kesha`. CLAUDE.md: the flake is not a CI gate.

## Verification

- `bun run check:specs` (openspec `--strict`) → 17 passed, 0 failed
- `bunx tsc --noEmit` → clean
- `bun test` → 1398 pass, 6 skip, 0 fail

Closes #946

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBTpJjqyYFW6W8LHJ2nwy