### PR TITLE
ci(homebrew): validate the formula against the working tree, not the pinned release

### DIFF
--- a/.github/scripts/stage-homebrew-worktree-formula.mjs
+++ b/.github/scripts/stage-homebrew-worktree-formula.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+// Stage the committed Homebrew formula against the WORKING TREE for CI.
+//
+// The published formula's `url` names a released tag, so `brew install
+// --build-from-source` on it compiles a released source tree, never the
+// checkout under review — the install block and the tree it ships with drift
+// silently (#924, surfaced by #915). This rewrites a throwaway tap copy to
+// build a `git archive` of HEAD instead, so the lane exercises the proposed
+// install block against the code it lands with. The committed formula keeps its
+// real release url/sha256; only this CI copy is rewritten.
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+
+const NAME = "kesha-voice-kit";
+const FORMULA_REL = `Formula/${NAME}.rb`;
+const SRC_FORMULA = `packaging/homebrew/${FORMULA_REL}`;
+
+function usage() {
+  console.error(
+    "usage: node .github/scripts/stage-homebrew-worktree-formula.mjs --tap-dir path --archive path",
+  );
+  process.exit(2);
+}
+
+function getArg(name) {
+  const i = process.argv.indexOf(name);
+  if (i === -1) return undefined;
+  const value = process.argv[i + 1];
+  if (!value || value.startsWith("--")) usage();
+  return value;
+}
+
+function replaceOne(source, pattern, replacement, label) {
+  if (!pattern.test(source)) throw new Error(`formula is missing ${label}`);
+  return source.replace(pattern, replacement);
+}
+
+const tapDir = getArg("--tap-dir");
+const archiveArg = getArg("--archive");
+if (!tapDir || !archiveArg) usage();
+
+const version = JSON.parse(readFileSync("package.json", "utf8")).version;
+if (!version) throw new Error("package.json is missing a version");
+
+const archivePath = resolve(archiveArg);
+mkdirSync(dirname(archivePath), { recursive: true });
+execFileSync(
+  "git",
+  ["archive", "--format=tar.gz", `--prefix=${NAME}-${version}/`, "-o", archivePath, "HEAD"],
+  { stdio: ["ignore", "ignore", "inherit"] },
+);
+
+const sha256 = createHash("sha256").update(readFileSync(archivePath)).digest("hex");
+
+let formula = readFileSync(SRC_FORMULA, "utf8");
+formula = replaceOne(
+  formula,
+  /^  url ".*"$/m,
+  // A file:// url gives Homebrew no version to parse, and the formula's `test do`
+  // asserts `version` matches `kesha --version`, so pin it from package.json.
+  `  url "file://${archivePath}"\n  version "${version}"`,
+  "url",
+);
+formula = replaceOne(
+  formula,
+  /^  sha256 "[a-f0-9]{64}"$/m,
+  `  sha256 "${sha256}"`,
+  "sha256",
+);
+
+const formulaPath = join(tapDir, FORMULA_REL);
+mkdirSync(dirname(formulaPath), { recursive: true });
+writeFileSync(formulaPath, formula);
+console.log(`Staged ${NAME} ${version} from the working tree`);
+console.log(`archive: ${archivePath}`);
+console.log(`sha256: ${sha256}`);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,15 +231,20 @@ jobs:
           brew trust oven-sh/bun
 
       - name: 🧪 Create local test tap
+        run: brew tap-new local/kesha
+
+      - name: 🔍 Audit formula (as published)
         run: |
-          brew tap-new local/kesha
           cp packaging/homebrew/Formula/kesha-voice-kit.rb "$(brew --repository local/kesha)/Formula/kesha-voice-kit.rb"
+          brew audit --strict --formula local/kesha/kesha-voice-kit
+
+      - name: 🌳 Stage formula against the working tree
+        # #924: build a git-archive of HEAD instead of the pinned release tarball, so the
+        # install block is exercised against the checkout under review, not a released tree.
+        run: node .github/scripts/stage-homebrew-worktree-formula.mjs --tap-dir "$(brew --repository local/kesha)" --archive "$RUNNER_TEMP/kesha-worktree.tar.gz"
 
       - name: 📦 Install formula
         run: brew install --build-from-source local/kesha/kesha-voice-kit
-
-      - name: 🔍 Audit formula
-        run: brew audit --strict --formula local/kesha/kesha-voice-kit
 
       - name: 🚬 Test formula
         run: brew test local/kesha/kesha-voice-kit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,7 @@ jobs:
               - 'packaging/homebrew/Formula/**'
               - 'docs/homebrew.md'
               - '.github/workflows/ci.yml'
+              - '.github/scripts/stage-homebrew-worktree-formula.mjs'
 
   workflow-lint:
     needs: changes

--- a/packaging/homebrew/Formula/kesha-voice-kit.rb
+++ b/packaging/homebrew/Formula/kesha-voice-kit.rb
@@ -1,7 +1,8 @@
 class KeshaVoiceKit < Formula
   desc "Local speech-to-text, text-to-speech, and language detection toolkit"
   homepage "https://github.com/drakulavich/kesha-voice-kit"
-  # Release rewrites this pin, but ci.yml's homebrew-formula lane builds it — it must carry every path install stages.
+  # Release rewrites this pin; CI's homebrew-formula lane instead builds a git-archive of HEAD,
+  # so `install` must stage only paths that exist in the working tree (#924).
   url "https://github.com/drakulavich/kesha-voice-kit/archive/refs/tags/v1.24.7.tar.gz"
   sha256 "92531aaad3537b8e27322f425d8af9fa3fc8cb9592796893155c6bed0ef90b67"
   license "MIT"


### PR DESCRIPTION
## Problem

The `homebrew-formula` job copied `packaging/homebrew/Formula/kesha-voice-kit.rb` into a local tap and ran `brew install --build-from-source`, so Homebrew fetched the tarball the formula's `url` names — a **published tag** — not the checkout under review. The lane reviewed the *proposed formula* against a *released source tree*; they drift independently and the gate could not see it.

`#915` hit the red side: the formula started staging `completions`/`man`, but the pin (`v1.18.0`) predated them, so the build failed with `Errno::ENOENT` on a tree ten minor versions behind the branch. The repin to `v1.24.7` fixed that instance and nothing structural. The silent inverse — a formula change correct for the pin but wrong for the tree — passed undetected.

## Fix

Split the lane into two concerns:

1. **Audit as published** — copy the committed formula unchanged into the tap and run `brew audit --strict` on it, so the released artifact's own url/sha/style stay gated.
2. **Build the working tree** — `.github/scripts/stage-homebrew-worktree-formula.mjs` writes a throwaway tap copy whose `url` points at a `git archive` of `HEAD` (`file://` path), with the matching `sha256` and an explicit `version` from `package.json#version` (a `file://` url gives Homebrew no version to parse, and the formula's `test do` asserts `version` matches `kesha --version`). `brew install --build-from-source` + `brew test` then run against that.

The install block now runs against the checkout under review. The pinned tag is **never fetched**, so version skew with it is structurally impossible — the `#915` failure class cannot recur.

The committed formula keeps its **real** release `url`/`sha256`; only the CI tap copy is rewritten. The comment above the pin is updated to describe the new mechanism.

## Drift-caught proof (real `brew` on macOS, run locally)

- **No false red (path present in tree, absent from pin):** committed a marker file `NEWFILE-issue924.txt` to `HEAD` and added it to the install block. `git cat-file -e v1.24.7:NEWFILE-issue924.txt` → **ABSENT from v1.24.7**, yet `brew install --build-from-source` → **exit 0**. Under the old mechanism this would have failed (the pinned tarball has no such file). The real working tree — which stages `completions`/`man`, the exact files that broke `#915` under a stale pin — also installs and `brew test`s clean (exit 0).
- **Real drift caught (path absent from tree):** added `"this-path-does-not-exist"` to the install block, staged, `brew install` → **`Errno::ENOENT: No such file or directory - this-path-does-not-exist`**, non-zero. The lane now fails on a formula that references a path the working tree lacks.

Both scratch edits were reverted; only the three files below ship.

## Release-path safety

- `homebrew-formula` runs on **PR CI only** (`if: needs.changes.outputs.homebrew == 'true'`), not on `release/*`.
- The published tap `drakulavich/homebrew-tap` is updated by `.github/workflows/homebrew-tap.yml` → `update-homebrew-tap.mjs` on `release: published`, which rewrites `url`/`sha256` from the real tag. **Untouched.**
- The committed formula still names the release tag; nothing in the release/tap path reads the CI-only stage script.

## Gates

- `bun run check:workflows` → pass (pinned SHAs, valid YAML)
- `bun run check:recipes` → pass
- `bunx tsc --noEmit` → pass
- `bun run check` → 1239 pass, 0 fail
- Full `brew tap-new` → audit → stage → install → test flow exercised end-to-end on this M2.

Closes #924

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBTpJjqyYFW6W8LHJ2nwy