### PR TITLE
ci(homebrew): assert the working-tree invariant with a tripwire + fixture test (grok P2 on #975)

### DIFF
--- a/.github/scripts/stage-homebrew-worktree-formula.d.mts
+++ b/.github/scripts/stage-homebrew-worktree-formula.d.mts
@@ -1,0 +1,4 @@
+export function rewriteFormula(
+  formula: string,
+  fields: { url: string; version: string; sha256: string },
+): string;

--- a/.github/scripts/stage-homebrew-worktree-formula.mjs
+++ b/.github/scripts/stage-homebrew-worktree-formula.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Stage the committed Homebrew formula against the WORKING TREE for CI.
+// Stage the committed Homebrew formula against HEAD for CI.
 //
 // The published formula's `url` names a released tag, so `brew install
 // --build-from-source` on it compiles a released source tree, never the
@@ -12,67 +12,74 @@ import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
+import { isEntry } from "./script-entry.mjs";
 
 const NAME = "kesha-voice-kit";
 const FORMULA_REL = `Formula/${NAME}.rb`;
 const SRC_FORMULA = `packaging/homebrew/${FORMULA_REL}`;
-
-function usage() {
-  console.error(
-    "usage: node .github/scripts/stage-homebrew-worktree-formula.mjs --tap-dir path --archive path",
-  );
-  process.exit(2);
-}
-
-function getArg(name) {
-  const i = process.argv.indexOf(name);
-  if (i === -1) return undefined;
-  const value = process.argv[i + 1];
-  if (!value || value.startsWith("--")) usage();
-  return value;
-}
 
 function replaceOne(source, pattern, replacement, label) {
   if (!pattern.test(source)) throw new Error(`formula is missing ${label}`);
   return source.replace(pattern, replacement);
 }
 
-const tapDir = getArg("--tap-dir");
-const archiveArg = getArg("--archive");
-if (!tapDir || !archiveArg) usage();
+export function rewriteFormula(formula, { url, version, sha256 }) {
+  const withUrl = replaceOne(
+    formula,
+    /^  url ".*"$/m,
+    // A file:// url gives Homebrew no version to parse, and the formula's `test do`
+    // asserts `version` matches `kesha --version`, so pin it from package.json.
+    `  url "${url}"\n  version "${version}"`,
+    "url",
+  );
+  return replaceOne(withUrl, /^  sha256 "[a-f0-9]{64}"$/m, `  sha256 "${sha256}"`, "sha256");
+}
 
-const version = JSON.parse(readFileSync("package.json", "utf8")).version;
-if (!version) throw new Error("package.json is missing a version");
+if (isEntry(import.meta.url)) {
+  const usage = () => {
+    console.error(
+      "usage: node .github/scripts/stage-homebrew-worktree-formula.mjs --tap-dir path --archive path",
+    );
+    process.exit(2);
+  };
 
-const archivePath = resolve(archiveArg);
-mkdirSync(dirname(archivePath), { recursive: true });
-execFileSync(
-  "git",
-  ["archive", "--format=tar.gz", `--prefix=${NAME}-${version}/`, "-o", archivePath, "HEAD"],
-  { stdio: ["ignore", "ignore", "inherit"] },
-);
+  const getArg = (name) => {
+    const i = process.argv.indexOf(name);
+    if (i === -1) return undefined;
+    const value = process.argv[i + 1];
+    if (!value || value.startsWith("--")) usage();
+    return value;
+  };
 
-const sha256 = createHash("sha256").update(readFileSync(archivePath)).digest("hex");
+  const tapDir = getArg("--tap-dir");
+  const archiveArg = getArg("--archive");
+  if (!tapDir || !archiveArg) usage();
 
-let formula = readFileSync(SRC_FORMULA, "utf8");
-formula = replaceOne(
-  formula,
-  /^  url ".*"$/m,
-  // A file:// url gives Homebrew no version to parse, and the formula's `test do`
-  // asserts `version` matches `kesha --version`, so pin it from package.json.
-  `  url "file://${archivePath}"\n  version "${version}"`,
-  "url",
-);
-formula = replaceOne(
-  formula,
-  /^  sha256 "[a-f0-9]{64}"$/m,
-  `  sha256 "${sha256}"`,
-  "sha256",
-);
+  const version = JSON.parse(readFileSync("package.json", "utf8")).version;
+  if (!version) throw new Error("package.json is missing a version");
 
-const formulaPath = join(tapDir, FORMULA_REL);
-mkdirSync(dirname(formulaPath), { recursive: true });
-writeFileSync(formulaPath, formula);
-console.log(`Staged ${NAME} ${version} from the working tree`);
-console.log(`archive: ${archivePath}`);
-console.log(`sha256: ${sha256}`);
+  const archivePath = resolve(archiveArg);
+  mkdirSync(dirname(archivePath), { recursive: true });
+  execFileSync(
+    "git",
+    ["archive", "--format=tar.gz", `--prefix=${NAME}-${version}/`, "-o", archivePath, "HEAD"],
+    { stdio: ["ignore", "ignore", "inherit"] },
+  );
+
+  const sha256 = createHash("sha256").update(readFileSync(archivePath)).digest("hex");
+
+  // rewriteFormula validates both pins before returning, so the tap formula is
+  // written only once a complete rewrite exists — never a partial one.
+  const formula = rewriteFormula(readFileSync(SRC_FORMULA, "utf8"), {
+    url: `file://${archivePath}`,
+    version,
+    sha256,
+  });
+
+  const formulaPath = join(tapDir, FORMULA_REL);
+  mkdirSync(dirname(formulaPath), { recursive: true });
+  writeFileSync(formulaPath, formula);
+  console.log(`Staged ${NAME} ${version} from HEAD`);
+  console.log(`archive: ${archivePath}`);
+  console.log(`sha256: ${sha256}`);
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,7 +239,7 @@ jobs:
           cp packaging/homebrew/Formula/kesha-voice-kit.rb "$(brew --repository local/kesha)/Formula/kesha-voice-kit.rb"
           brew audit --strict --formula local/kesha/kesha-voice-kit
 
-      - name: 🌳 Stage formula against the working tree
+      - name: 🌳 Stage the HEAD archive as the tap formula
         # #924: build a git-archive of HEAD instead of the pinned release tarball, so the
         # install block is exercised against the checkout under review, not a released tree.
         run: node .github/scripts/stage-homebrew-worktree-formula.mjs --tap-dir "$(brew --repository local/kesha)" --archive "$RUNNER_TEMP/kesha-worktree.tar.gz"
@@ -249,8 +249,8 @@ jobs:
         # rewrite landed so a silently-skipped stage can't false-green the lane (#924).
         run: |
           formula="$(brew --repository local/kesha)/Formula/kesha-voice-kit.rb"
-          grep -q 'url "file://' "$formula" || { echo "staged formula missing file:// url"; exit 1; }
-          ! grep -q 'archive/refs/tags' "$formula" || { echo "staged formula still names the release tag"; exit 1; }
+          grep -qE '^  url "file://' "$formula" || { echo "staged formula missing file:// url"; exit 1; }
+          ! grep -qE '^  url ".*archive/refs/tags' "$formula" || { echo "staged formula still names the release tag"; exit 1; }
 
       - name: 📦 Install formula
         run: brew install --build-from-source local/kesha/kesha-voice-kit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,6 +244,14 @@ jobs:
         # install block is exercised against the checkout under review, not a released tree.
         run: node .github/scripts/stage-homebrew-worktree-formula.mjs --tap-dir "$(brew --repository local/kesha)" --archive "$RUNNER_TEMP/kesha-worktree.tar.gz"
 
+      - name: 🔒 Assert brew loads the staged HEAD copy, not the release tag
+        # brew test can't tell HEAD from the pinned tag once their versions coincide; assert the
+        # rewrite landed so a silently-skipped stage can't false-green the lane (#924).
+        run: |
+          formula="$(brew --repository local/kesha)/Formula/kesha-voice-kit.rb"
+          grep -q 'url "file://' "$formula" || { echo "staged formula missing file:// url"; exit 1; }
+          ! grep -q 'archive/refs/tags' "$formula" || { echo "staged formula still names the release tag"; exit 1; }
+
       - name: 📦 Install formula
         run: brew install --build-from-source local/kesha/kesha-voice-kit
 

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -31,16 +31,22 @@ contract used by the Bun and Docker install paths.
 ## Maintainer Validation
 
 The source formula remains in this repository and is mirrored into
-`drakulavich/homebrew-tap` for users. To validate formula edits before a
-release:
+`drakulavich/homebrew-tap` for users. Its committed `url`/`sha256` name the real
+release tarball. CI's `homebrew-formula` lane does **not** trust that pin: it
+stages a throwaway tap copy whose `url` is a `git archive` of HEAD, so the
+install block is exercised against the checkout under review rather than a
+released tree (#924). To validate formula edits against HEAD locally the same
+way CI does:
 
 ```bash
 brew tap oven-sh/bun
 brew tap-new local/tap
-cp packaging/homebrew/Formula/kesha-voice-kit.rb "$(brew --repository local/tap)/Formula/"
-brew install local/tap/kesha-voice-kit
+node .github/scripts/stage-homebrew-worktree-formula.mjs \
+  --tap-dir "$(brew --repository local/tap)" \
+  --archive "$(mktemp -d)/kesha-worktree.tar.gz"
+brew install --build-from-source local/tap/kesha-voice-kit
 brew test local/tap/kesha-voice-kit
-brew audit --strict --formula local/tap/kesha-voice-kit
+brew audit --strict --formula "$(brew --repository local/tap)/Formula/kesha-voice-kit.rb"
 ```
 
 The public tap itself can be validated with:

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -41,12 +41,16 @@ way CI does:
 ```bash
 brew tap oven-sh/bun
 brew tap-new local/tap
+# Audit the committed pin first — --strict rejects the file:// url the stage step
+# writes, so it must run before staging, exactly as CI does.
+cp packaging/homebrew/Formula/kesha-voice-kit.rb \
+  "$(brew --repository local/tap)/Formula/kesha-voice-kit.rb"
+brew audit --strict --formula local/tap/kesha-voice-kit
 node .github/scripts/stage-homebrew-worktree-formula.mjs \
   --tap-dir "$(brew --repository local/tap)" \
   --archive "$(mktemp -d)/kesha-worktree.tar.gz"
 brew install --build-from-source local/tap/kesha-voice-kit
 brew test local/tap/kesha-voice-kit
-brew audit --strict --formula "$(brew --repository local/tap)/Formula/kesha-voice-kit.rb"
 ```
 
 The public tap itself can be validated with:

--- a/openspec/specs/cli-distribution/spec.md
+++ b/openspec/specs/cli-distribution/spec.md
@@ -327,15 +327,19 @@ Whichever path put `kesha` on the machine, the Engine and models SHALL still arr
   `drakulavich/homebrew-tap`, updated by `.github/workflows/homebrew-tap.yml`
   on `release: published`. The in-repo copy pins an older version than the
   current CLI, and nothing fails when it goes stale — there is no check that the
-  in-repo template and the published tap agree. This is not cosmetic: the
-  `homebrew-formula` CI lane builds **the pinned tarball**, not the working
-  tree, so it reviews a released tree while the formula around it is the
-  proposed one. #915 hit exactly that — an install block staging `completions`
-  and `man` against a pin (`v1.18.0`) predating both directories (added in
-  v1.18.4, #388) — and had to repin to `v1.24.7`, the newest tag that carries
-  them *and* whose `package.json#version` equals its tag name, which the
-  formula's own `--version` assertion requires. The repin fixes that instance
-  and nothing structural; tracked as #924.
+  in-repo template and the published tap agree. #915 surfaced this: an install
+  block staging `completions` and `man` against a pin (`v1.18.0`) predating both
+  directories (added in v1.18.4, #388) went green because the `homebrew-formula`
+  CI lane built the *pinned tarball*, not the working tree — it reviewed a
+  released tree while the formula around it was the proposed one. #924 fixed the
+  structure: the lane now stages a throwaway tap copy whose `url` is a
+  `git archive` of HEAD (`.github/scripts/stage-homebrew-worktree-formula.mjs`),
+  so `brew install --build-from-source` exercises the install block against the
+  checkout under review; a guard step asserts the staged `url` is `file://` and
+  no longer names the release tag. The committed formula keeps its real release
+  `url`/`sha256`; only the CI copy is rewritten, its `version` pinned from
+  `package.json#version` because a `file://` url gives Homebrew nothing to parse
+  and the formula's own `--version` assertion requires it.
 - `homebrew-tap.yml` fires on every published release, including Engine
   releases that publish no CLI version (see CLAUDE.md, "un-drafting an engine
   tag still fires 🍺 Homebrew Tap"). The lane's own skip logic is the only thing

--- a/packaging/homebrew/Formula/kesha-voice-kit.rb
+++ b/packaging/homebrew/Formula/kesha-voice-kit.rb
@@ -2,7 +2,7 @@ class KeshaVoiceKit < Formula
   desc "Local speech-to-text, text-to-speech, and language detection toolkit"
   homepage "https://github.com/drakulavich/kesha-voice-kit"
   # Release rewrites this pin; CI's homebrew-formula lane instead builds a git-archive of HEAD,
-  # so `install` must stage only paths that exist in the working tree (#924).
+  # so `install` must stage only paths that exist at HEAD (#924).
   url "https://github.com/drakulavich/kesha-voice-kit/archive/refs/tags/v1.24.7.tar.gz"
   sha256 "92531aaad3537b8e27322f425d8af9fa3fc8cb9592796893155c6bed0ef90b67"
   license "MIT"

--- a/tests/unit/stage-homebrew-worktree-formula.test.ts
+++ b/tests/unit/stage-homebrew-worktree-formula.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { rewriteFormula } from "../../.github/scripts/stage-homebrew-worktree-formula.mjs";
+import { readRepoFile } from "../helpers/repo";
+
+const FORMULA = readRepoFile("packaging/homebrew/Formula/kesha-voice-kit.rb");
+const VERSION = JSON.parse(readRepoFile("package.json")).version;
+
+const archive = Buffer.from("a throwaway git-archive of HEAD");
+const SHA256 = createHash("sha256").update(archive).digest("hex");
+const URL = "file:///tmp/kesha-worktree.tar.gz";
+
+describe("rewriteFormula", () => {
+  test("points url at the file:// archive and drops the release tag", () => {
+    const out = rewriteFormula(FORMULA, { url: URL, version: VERSION, sha256: SHA256 });
+
+    expect(out).toContain(`url "${URL}"`);
+    expect(out).not.toContain("archive/refs/tags");
+  });
+
+  test("pins sha256 to the staged archive", () => {
+    const out = rewriteFormula(FORMULA, { url: URL, version: VERSION, sha256: SHA256 });
+
+    expect(out).toContain(`sha256 "${SHA256}"`);
+  });
+
+  test("pins version to package.json so the formula's --version test can match", () => {
+    const out = rewriteFormula(FORMULA, { url: URL, version: VERSION, sha256: SHA256 });
+
+    expect(out).toContain(`version "${VERSION}"`);
+  });
+
+  // The CLI writes the tap formula only with rewriteFormula's return value, so a
+  // formula it rejects can never leave a partial file behind.
+  test("refuses a formula with no url before returning a rewrite", () => {
+    const noUrl = FORMULA.replace(/^  url ".*"$/m, "  # url removed");
+
+    expect(() => rewriteFormula(noUrl, { url: URL, version: VERSION, sha256: SHA256 })).toThrow(
+      /missing url/,
+    );
+  });
+
+  test("refuses a formula with no sha256 before returning a rewrite", () => {
+    const noSha = FORMULA.replace(/^  sha256 "[a-f0-9]{64}"$/m, "  # sha256 removed");
+
+    expect(() => rewriteFormula(noSha, { url: URL, version: VERSION, sha256: SHA256 })).toThrow(
+      /missing sha256/,
+    );
+  });
+});


### PR DESCRIPTION
Follow-up to #975, which landed the working-tree homebrew build mechanism but — per grok's adversarial review — left the #924 invariant **working but not asserted**. #975 was merged before these fixes landed; this PR completes them off fresh main.

**P2 #1 — post-stage tripwire.** Once the pinned tag's version coincides with `package.json#version` (after the next pin bump both print the same), `brew test`/`kesha --version` cannot distinguish HEAD from the pinned tag, silently reviving #924 with a green tick. Added a guard step in the `homebrew-formula` job (after stage, before install) that fails if the staged tap formula lacks `url "file://` or still contains `archive/refs/tags`. No `${{ }}` in `run:` (#291-clean).

**P2 #2 — fixture test for the rewrite.** The rewrite is the entire #924 invariant and shipped with zero tests. Extracted a pure `rewriteFormula()` (CLI orchestration now behind an `isEntry` guard so importing is side-effect-free) with a `.d.mts`, and added `tests/unit/stage-homebrew-worktree-formula.test.ts` — 5 tests: `file://` url + no release tag, sha256 from the written archive, version from `package.json`, and throws **before any write** on missing `url` / missing `sha256`.

**P3 (accuracy).**
- Script comment + log line now say **HEAD** (the tarball is `git archive HEAD`), not "working tree".
- `docs/homebrew.md` + `openspec/specs/cli-distribution/spec.md` now describe the lane building the HEAD archive, not the pinned tarball.

The committed `packaging/homebrew/Formula/*.rb` keeps its real release url/sha256; `homebrew-tap.yml` is untouched. Only the CI tap copy is rewritten.

Gates: `bun test` (new fixture 5 pass/0 fail); `bunx tsc --noEmit` exit 0; `bun run check` green incl `check:workflows`.

Closes #924
