### PR TITLE
fix(cli): list init and mcp in the usage block and guard it against SUBCOMMANDS drift (#938)

### DIFF
--- a/openspec/specs/cli-shell-integration/spec.md
+++ b/openspec/specs/cli-shell-integration/spec.md
@@ -249,20 +249,23 @@ The CLI SHALL print usage to stdout with an empty stderr in both cases, exiting 
 - AND stderr is empty
 - AND the process exits 1
 
-#### Scenario: A subcommand exists but the usage block does not name it
+#### Scenario: The usage block names every dispatchable subcommand
 
-- GIVEN a subcommand the hard-coded usage block omits
-- WHEN Ira reads that block to discover the command set
-- THEN the subcommand is still dispatchable, and still absent from the listing
-  — the block is maintained by hand and drifts (see Open Issues)
+- GIVEN every subcommand `SUBCOMMANDS` dispatches
+- WHEN Ira reads the bare-invocation block to discover the command set
+- THEN each dispatchable subcommand — including `init` and `mcp` — is named in
+  the listing
+- AND adding a subcommand without listing it fails a unit test (#938)
 
-> *Technical Note — the no-argument usage block is a hand-maintained string at
-> `src/cli/main.ts:533-547`, printed with `log.info` (stdout) followed by
-> `process.exit(1)`; it lists ten subcommands and omits `init` and `mcp`, both
-> of which `SUBCOMMANDS` in `src/cli/dispatch.ts:10-23` dispatches. `--help` is
-> citty's own renderer over the main command's `meta` and `args`, so it shows
-> the transcription flags, not each subcommand's. Both stream contracts are
-> asserted in `tests/integration/cli-contracts.test.ts`.*
+> *Technical Note — the no-argument usage block is a hand-maintained string,
+> `USAGE_MESSAGE` in `src/cli/dispatch.ts`, co-located with the `SUBCOMMANDS`
+> registry it must mirror; `src/cli/main.ts` prints it with `log.info` (stdout)
+> followed by `process.exit(1)`. `tests/unit/dispatch.test.ts` iterates
+> `SUBCOMMAND_NAMES` and asserts each appears in `USAGE_MESSAGE`, so the two
+> lists can no longer drift apart (#938). `--help` is citty's own renderer over
+> the main command's `meta` and `args`, so it shows the transcription flags, not
+> each subcommand's. Both stream contracts are asserted in
+> `tests/integration/cli-contracts.test.ts`.*
 
 ### Requirement: Result-producing commands follow the stdout-purity principle
 
@@ -312,11 +315,6 @@ When the first positional token is not a file and not a known subcommand, the CL
 - There is no `--color` flag to force color on when stdout is not a TTY (e.g.
   inside tmux with `TERM=dumb`); `FORCE_COLOR` from picocolors is the current
   workaround.
-- The bare-invocation usage block omits `init` and `mcp` — two dispatchable
-  subcommands, one of them the command interactive missing-model errors
-  recommend ([installation](../installation/spec.md), "Documented install entry
-  points match interactive hints"). Nothing keeps the hand-written list and
-  `SUBCOMMANDS` in sync, so it will drift again.
 - `kesha completions` and `kesha manpage` both resolve their file relative to
   `import.meta.url`, which does not survive the `bun build --compile` step the
   `.deb`/`.rpm` are built with, so on that install path both crash with an

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -22,6 +22,25 @@ const SUBCOMMANDS: Record<string, CommandLoader> = {
   mcp: async () => (await import("./mcp")).mcpCommand,
 };
 
+export const SUBCOMMAND_NAMES = Object.keys(SUBCOMMANDS);
+
+// Hand-curated ordering and per-command argument hints; every key in SUBCOMMANDS
+// must appear here, guarded by tests/unit/dispatch.test.ts (#938).
+export const USAGE_MESSAGE =
+  "Usage: kesha <audio_file> [audio_file ...]\n" +
+  "       kesha completions <bash|zsh|fish>\n" +
+  "       kesha doctor [--json] [--redact]\n" +
+  "       kesha init [--yes]\n" +
+  "       kesha install [--no-cache]\n" +
+  "       kesha logs [enable|disable|mode|status|path|reset]\n" +
+  "       kesha manpage\n" +
+  "       kesha mcp\n" +
+  "       kesha record --out path.wav [--max-seconds 120]\n" +
+  "       kesha status\n" +
+  "       kesha say <text>\n" +
+  "       kesha stats [enable|disable|status|week|errors|export|reset|vacuum|retention]\n" +
+  "       kesha support-bundle [--output path.tar.gz]";
+
 function isPathLike(arg: string): boolean {
   return arg.includes(".") || arg.includes("/") || existsSync(arg);
 }
@@ -73,7 +92,7 @@ export async function runCli(argv = process.argv.slice(2)): Promise<void> {
   applyCliContext(context);
 
   const [firstArg, ...restArgs] = context.rawArgs;
-  const subcommandKeys = Object.keys(SUBCOMMANDS);
+  const subcommandKeys = SUBCOMMAND_NAMES;
 
   switch (classifyFirstArg(firstArg, subcommandKeys)) {
     case "subcommand":

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -25,7 +25,8 @@ const SUBCOMMANDS: Record<string, CommandLoader> = {
 export const SUBCOMMAND_NAMES = Object.keys(SUBCOMMANDS);
 
 // Hand-curated ordering and per-command argument hints; every key in SUBCOMMANDS
-// must appear here, guarded by tests/unit/dispatch.test.ts (#938).
+// must appear here, guarded at the observable layer by the bare-invocation case in
+// tests/integration/cli-contracts.test.ts (#938).
 export const USAGE_MESSAGE =
   "Usage: kesha <audio_file> [audio_file ...]\n" +
   "       kesha completions <bash|zsh|fish>\n" +

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -430,6 +430,7 @@ export function createMainCommand(context: CliContext = { quiet: false, disableC
         "  install    Download engine and models.\n" +
         "  logs       Manage local privacy-safe diagnostic logs.\n" +
         "  manpage    Print the kesha(1) manpage.\n" +
+        "  mcp        Run an MCP server over stdio.\n" +
         "  record     Record microphone audio to a WAV file.\n" +
         "  status     Inspect installed backend.\n" +
         "  say        Synthesize speech from text.\n" +

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -21,6 +21,7 @@ import { getPendingSignalExitCode, waitForPendingSignalCleanup } from "../proces
 import type { TranscriptionSegment } from "../types";
 import { diagnosticSizeBucket } from "../diagnostic-events";
 import { runCommandSession, type CommandSession } from "./command-session";
+import { USAGE_MESSAGE } from "./dispatch";
 import type { CliContext } from "./context";
 import { ENGINE_CODES, extractEngineErrorCode, TS_NATIVE_CODES } from "../error-codes";
 
@@ -531,19 +532,7 @@ export function createMainCommand(context: CliContext = { quiet: false, disableC
       const { vadMode, outputFormat } = validated;
 
       if (files.length === 0) {
-        log.info(
-          "Usage: kesha <audio_file> [audio_file ...]\n" +
-            "       kesha completions <bash|zsh|fish>\n" +
-            "       kesha doctor [--json] [--redact]\n" +
-            "       kesha install [--no-cache]\n" +
-            "       kesha logs [enable|disable|mode|status|path|reset]\n" +
-            "       kesha manpage\n" +
-            "       kesha record --out path.wav [--max-seconds 120]\n" +
-            "       kesha status\n" +
-            "       kesha say <text>\n" +
-            "       kesha stats [enable|disable|status|week|errors|export|reset|vacuum|retention]\n" +
-            "       kesha support-bundle [--output path.tar.gz]",
-        );
+        log.info(USAGE_MESSAGE);
         process.exit(1);
       }
 

--- a/tests/integration/cli-contracts.test.ts
+++ b/tests/integration/cli-contracts.test.ts
@@ -12,6 +12,7 @@ import {
 import { tmpdir } from "os";
 import { delimiter, dirname, join } from "path";
 import { engineVersion } from "../../src/package-info";
+import { SUBCOMMAND_NAMES } from "../../src/cli/dispatch";
 import { waitForPidExit, waitForPidFile } from "../helpers/process";
 import {
   DEFAULT_TIMEOUT_MS,
@@ -291,9 +292,17 @@ describe("CLI contracts", () => {
     const empty = await runCli([]);
     expectContract(empty, {
       exitCode: 1,
-      stdoutContains: ["Usage: kesha <audio_file>", "kesha logs", "kesha stats", "kesha support-bundle"],
+      stdoutContains: ["Usage: kesha <audio_file>"],
       stderrEmpty: true,
     });
+    // #938 drift guard, at the observable layer: every dispatchable subcommand must
+    // surface in the bare-invocation usage the user actually sees. Coupling the loop
+    // to SUBCOMMAND_NAMES makes adding a command without listing it fail here; the
+    // per-name line anchor (leading whitespace, then `kesha <name>` followed by a
+    // space or end of line) stops a shorter name from prefix-matching a longer one.
+    for (const name of SUBCOMMAND_NAMES) {
+      expect(empty.stdout).toMatch(new RegExp(`^\\s+kesha ${name}( |$)`, "m"));
+    }
   });
 
   test("validation errors are stderr-only and exit with the documented codes", async () => {

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -251,6 +251,7 @@ Commands:
   install    Download engine and models.
   logs       Manage local privacy-safe diagnostic logs.
   manpage    Print the kesha(1) manpage.
+  mcp        Run an MCP server over stdio.
   record     Record microphone audio to a WAV file.
   status     Inspect installed backend.
   say        Synthesize speech from text.

--- a/tests/unit/dispatch.test.ts
+++ b/tests/unit/dispatch.test.ts
@@ -1,10 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import {
-  classifyFirstArg,
-  unknownCommandMessages,
-  SUBCOMMAND_NAMES,
-  USAGE_MESSAGE,
-} from "../../src/cli/dispatch";
+import { classifyFirstArg, unknownCommandMessages } from "../../src/cli/dispatch";
 
 // ---------------------------------------------------------------------------
 // classifyFirstArg
@@ -53,12 +48,6 @@ describe("classifyFirstArg — unknown (typo detection)", () => {
 
   test("empty string → 'main' (falsy guard at top of function)", () => {
     expect(classifyFirstArg("", KNOWN)).toBe("main");
-  });
-});
-
-describe("bare-invocation usage block names every dispatchable subcommand (#938)", () => {
-  test.each(SUBCOMMAND_NAMES)("usage block lists 'kesha %s'", (name) => {
-    expect(USAGE_MESSAGE).toContain(`kesha ${name}`);
   });
 });
 

--- a/tests/unit/dispatch.test.ts
+++ b/tests/unit/dispatch.test.ts
@@ -1,5 +1,10 @@
 import { describe, test, expect } from "bun:test";
-import { classifyFirstArg, unknownCommandMessages } from "../../src/cli/dispatch";
+import {
+  classifyFirstArg,
+  unknownCommandMessages,
+  SUBCOMMAND_NAMES,
+  USAGE_MESSAGE,
+} from "../../src/cli/dispatch";
 
 // ---------------------------------------------------------------------------
 // classifyFirstArg
@@ -48,6 +53,12 @@ describe("classifyFirstArg — unknown (typo detection)", () => {
 
   test("empty string → 'main' (falsy guard at top of function)", () => {
     expect(classifyFirstArg("", KNOWN)).toBe("main");
+  });
+});
+
+describe("bare-invocation usage block names every dispatchable subcommand (#938)", () => {
+  test.each(SUBCOMMAND_NAMES)("usage block lists 'kesha %s'", (name) => {
+    expect(USAGE_MESSAGE).toContain(`kesha ${name}`);
   });
 });
 


### PR DESCRIPTION
## What

The bare-invocation usage block (`kesha` with no args) was a hand-written string in `src/cli/main.ts` listing ten subcommands. Two dispatchable ones were missing — `init` (the command interactive missing-model errors tell users to run) and `mcp` (the whole MCP integration). Nothing kept the block in sync with the `SUBCOMMANDS` registry in `src/cli/dispatch.ts`.

## Approach — Option B (hand-written block + drift-guard test)

The issue offered generation from `SUBCOMMANDS` (Option A) or keeping the curated block and adding a sync test (Option B). Chose **B**:

- `SUBCOMMANDS` is a `Record<string, CommandLoader>` with **no** description/usage field. Option A would need a new field on every entry (a bigger, speculative-field-adjacent change) and would still not naturally carry the per-command argument hints (`record --out path.wav [--max-seconds 120]`, `stats [enable|disable|...]`) or the curated ordering, nor the `kesha <audio_file>` main form that is not a subcommand.
- Option B is the lower-risk change the issue itself endorses ("a three-line unit test and catches the next drift too") and preserves the hints and ordering.

## Changes

- Moved the usage string to `USAGE_MESSAGE` in `dispatch.ts`, **co-located with `SUBCOMMANDS`** so the two lists sit next to each other and drift is obvious to future editors; `main.ts` now imports and prints it. Added the `kesha init [--yes]` and `kesha mcp` lines.
- Exported `SUBCOMMAND_NAMES` (also now used by `runCli` in place of an inline `Object.keys`).
- **Drift guard** in `tests/unit/dispatch.test.ts`: `test.each(SUBCOMMAND_NAMES)` asserts each name appears in `USAGE_MESSAGE`. It is structure-insensitive — it asserts the observable contract (every dispatchable command is named in the usage text), not the string's construction. Red-check: removing the `mcp` line makes the test fail with `Expected to contain: "kesha mcp"`; restored and green.

## Spec

`openspec/specs/cli-shell-integration/spec.md`:
- Retired the "A subcommand exists but the usage block does not name it" drift scenario; replaced it with "The usage block names every dispatchable subcommand" (asserts `init`/`mcp` present and that adding an unlisted subcommand fails a test).
- Updated the Technical Note to the new location and the guarding test.
- Removed the now-resolved Open Issue bullet about the block omitting `init`/`mcp`.

## Gates

- `bunx tsc --noEmit` — clean
- `bun test tests/unit/dispatch.test.ts` — 22 pass (incl. red-check evidence above)
- `bun test tests/integration/cli-contracts.test.ts` — 31 pass (bare-invocation stream contract intact: stdout, empty stderr, exit 1)
- `bun run check:specs` — 17 passed, 0 failed
- `bun run check` + full `bun test` — 1255 pass, 0 fail

Closes #938

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBTpJjqyYFW6W8LHJ2nwy