### PR TITLE
chore(ts): adopt the six zero-cost strict flags (#932 phase 1)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,12 @@
     "resolveJsonModule": true,
     "types": ["bun-types"],
     "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "useUnknownInCatchVariables": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "noImplicitOverride": true,
     "skipLibCheck": true,
     "noEmit": true
   },


### PR DESCRIPTION
Phase 1 of #932: enable the strict flags that require **zero source changes** on today's tree. Config-only — green `bun run lint` is the whole proof.

## Re-measured per-flag error counts (current tree, each flag individually)

Measured with `bunx tsc -p tsconfig.json --<flag> --noEmit`. The issue's counts were taken at `eb566a4`; these are re-measured against the current `main`.

| Flag | Errors now | Enabled here |
|---|---|---|
| `noImplicitReturns` | 0 | ✅ |
| `noFallthroughCasesInSwitch` | 0 | ✅ |
| `useUnknownInCatchVariables` | 0 | ✅ |
| `verbatimModuleSyntax` | 0 | ✅ |
| `isolatedModules` | 0 | ✅ |
| `noImplicitOverride` | 0 | ✅ |

All six re-measure to zero. None excluded.

For reference (Phase 2 / 3, not in this PR): `noUncheckedIndexedAccess` re-measures to **76** (issue said 72 — the delta is that `.github/scripts/*.ts` get pulled into the program via test imports).

## Gates

- `bunx tsc --noEmit` → exit 0
- `bun test` → 1407 pass, 6 skip, 0 fail
- `bun run check` → 1248 pass, 0 fail

## Stack

This is PR 1 of a 2-PR stack. **PR 2** (`chore/issue-932-unchecked-index`, based on this branch) enables `noUncheckedIndexedAccess` and fixes its sites, and carries `Closes #932`.

Refs #932

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBTpJjqyYFW6W8LHJ2nwy