### PR TITLE
chore(ts): enable noUncheckedIndexedAccess and fix the 76 sites (#932 phase 2)

### DIFF
--- a/.github/scripts/alpha-publishable.ts
+++ b/.github/scripts/alpha-publishable.ts
@@ -18,12 +18,13 @@ export function parseNameStatus(diff: string): ChangedPath[] {
     .map((line) => line.trim())
     .filter(Boolean)
     .flatMap((line) => {
-      const [status, ...rest] = line.split(/\t+/);
-      const path = rest[rest.length - 1];
+      const [status = "", ...rest] = line.split(/\t+/);
+      const path = rest[rest.length - 1] ?? "";
+      const code = status[0] ?? "";
       // A rename is a delete plus an add to the tarball, and either side alone can ship.
-      return status[0] === "R"
-        ? [{ status: "D", path: rest[0] }, { status: "A", path }]
-        : [{ status: status[0], path }];
+      return code === "R"
+        ? [{ status: "D", path: rest[0] ?? "" }, { status: "A", path }]
+        : [{ status: code, path }];
     });
 }
 

--- a/.github/scripts/check-model-plan-sizes.ts
+++ b/.github/scripts/check-model-plan-sizes.ts
@@ -103,13 +103,14 @@ function expandModelFileMacros(source: string): string {
   let stripped = "";
   let at = 0;
   for (const decl of source.matchAll(/macro_rules!\s+(\w+)\s*\{/g)) {
+    const name = decl[1];
     const body = balanced(source, decl.index + decl[0].length - 1, "{", "}");
-    if (!body) continue;
+    if (!name || !body) continue;
     const arm = /\(([^)]*)\)\s*=>\s*\{/.exec(body.inner);
     const template = arm && balanced(body.inner, arm.index + arm[0].length - 1, "{", "}");
     if (arm && template && template.inner.includes("ModelFile")) {
-      macros.set(decl[1], {
-        params: [...arm[1].matchAll(/(\$\w+):/g)].map((p) => p[1]),
+      macros.set(name, {
+        params: [...(arm[1] ?? "").matchAll(/(\$\w+):/g)].map((p) => p[1] ?? ""),
         template: template.inner,
       });
     }
@@ -143,8 +144,8 @@ export function parseManifestUrls(source: string): Map<string, string> {
   const urls = new Map<string, string>();
   const modelFile = /ModelFile\s*\{\s*rel_path:\s*([\s\S]*?),\s*url:\s*([\s\S]*?),\s*sha256:/g;
   for (const match of expandModelFileMacros(source).matchAll(modelFile)) {
-    const relPath = literalValue(match[1]);
-    const url = literalValue(match[2]);
+    const relPath = literalValue(match[1] ?? "");
+    const url = literalValue(match[2] ?? "");
     if (relPath && url) urls.set(relPath, url);
   }
   return urls;

--- a/.github/scripts/check-recipes.ts
+++ b/.github/scripts/check-recipes.ts
@@ -72,7 +72,7 @@ function markdownCommands(lines: string[]): CommandLine[] {
       found.push({ line: at + 1, text: raw });
       continue;
     }
-    for (const span of raw.matchAll(/`([^`]+)`/g)) found.push({ line: at + 1, text: span[1] });
+    for (const span of raw.matchAll(/`([^`]+)`/g)) found.push({ line: at + 1, text: span[1] ?? "" });
   }
   return found;
 }
@@ -93,7 +93,7 @@ function yamlRunCommands(lines: string[]): CommandLine[] {
     }
     const step = raw.match(/^\s*(?:-\s+)?run:\s*(.*)$/);
     if (!step) continue;
-    const value = step[1].trim();
+    const value = (step[1] ?? "").trim();
     if (value === "" || /^[|>][-+\d]*$/.test(value)) blockIndent = raw.indexOf("run:");
     else found.push({ line: at + 1, text: value });
   }
@@ -109,8 +109,9 @@ export function referencedRecipes(path: string, contents: string): Reference[] {
   const found: Reference[] = [];
   for (const { line, text } of commandLines(path, contents)) {
     for (const match of text.matchAll(INVOCATION)) {
-      if (!RECIPE_NAME.test(match[2])) continue;
-      found.push({ line, recipe: match[2], text: text.trim() });
+      const recipe = match[2];
+      if (!recipe || !RECIPE_NAME.test(recipe)) continue;
+      found.push({ line, recipe, text: text.trim() });
     }
   }
   return found;

--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -30,7 +30,7 @@ function requirePinnedActions(path: string, contents: string): string[] {
 
   for (const match of contents.matchAll(actionPattern)) {
     const reference = match[1];
-    if (reference.startsWith("./") || reference.startsWith("docker://")) continue;
+    if (!reference || reference.startsWith("./") || reference.startsWith("docker://")) continue;
     if (!/@[0-9a-f]{40}$/i.test(reference)) {
       errors.push(`${path}: external action must be pinned to a full commit SHA: ${reference}`);
     }
@@ -103,7 +103,7 @@ export function requireDarwinSmokeCoversBothEngines(path: string, document: unkn
   if (!steps) return [`${path}: expected a \`${job}\` job with steps`];
 
   const smokes = runsMatching(steps, /^\s*bun\s+\S*smoke-synthesis\.ts\b/m);
-  const isAvspeech = (at: number) => /--voice\s+macos-/.test(String(steps[at].run));
+  const isAvspeech = (at: number) => /--voice\s+macos-/.test(String(steps[at]?.run));
   const avspeech = smokes.find(isAvspeech);
   const kokoro = smokes.some((at) => !isAvspeech(at));
 
@@ -111,14 +111,15 @@ export function requireDarwinSmokeCoversBothEngines(path: string, document: unkn
   if (!kokoro) {
     errors.push(`${path}: \`${job}\` must synthesise through Kokoro — a smoke-synthesis.ts run on a non-\`macos-*\` voice (#678)`);
   }
-  if (avspeech === undefined) {
+  const avspeechStep = avspeech === undefined ? undefined : steps[avspeech];
+  if (avspeechStep === undefined) {
     errors.push(`${path}: \`${job}\` must synthesise through the AVSpeech sidecar — a smoke-synthesis.ts run with \`--voice macos-*\` (#678)`);
     return errors;
   }
-  if (/--text\b/.test(String(steps[avspeech].run))) {
+  if (/--text\b/.test(String(avspeechStep.run))) {
     errors.push(`${path}: \`${job}\`'s AVSpeech arm must carry the default pangram, not a \`--text\` override — it is the only long-utterance darwin coverage (#678)`);
   }
-  if (!/!\s*cancelled\(\)/.test(condition(steps[avspeech]))) {
+  if (!/!\s*cancelled\(\)/.test(condition(avspeechStep))) {
     errors.push(`${path}: \`${job}\`'s AVSpeech arm needs \`if: \${{ !cancelled() }}\`, or a red Kokoro arm hides whether the sidecar works (#678)`);
   }
   return errors;
@@ -248,7 +249,7 @@ function valuesAt(node: unknown, path: string[]): string[] {
   if (Array.isArray(node)) return node.flatMap((item) => valuesAt(item, path));
   if (path.length === 0) return typeof node === "object" ? [] : [String(node)];
   if (typeof node !== "object") return [];
-  return valuesAt((node as Record<string, unknown>)[path[0]], path.slice(1));
+  return valuesAt((node as Record<string, unknown>)[path[0] ?? ""], path.slice(1));
 }
 
 /** The concrete labels a `runs-on` can resolve to, substituting the matrix keys it names. */
@@ -260,7 +261,7 @@ function runnerLabels(job: Job): string[] {
     if (references.length === 0) return [label];
     const matrix = job.strategy?.matrix;
     return references.flatMap((reference) => {
-      const key = reference[1].split(".");
+      const key = (reference[1] ?? "").split(".");
       return [...valuesAt(matrix, key), ...valuesAt((matrix as { include?: unknown })?.include, key)];
     });
   });
@@ -401,7 +402,9 @@ function collectTestedScripts(): string[] {
   const found = new Set<string>();
   for (const contents of tests) {
     for (const match of contents.matchAll(/\.github\/scripts\/([\w.-]+)/g)) {
-      for (const candidate of [match[1], `${match[1]}.ts`]) {
+      const name = match[1];
+      if (!name) continue;
+      for (const candidate of [name, `${name}.ts`]) {
         const file = join(".github/scripts", candidate);
         if (existsSync(file)) found.add(file);
       }

--- a/.github/scripts/derive-alpha-version.ts
+++ b/.github/scripts/derive-alpha-version.ts
@@ -66,9 +66,10 @@ export function assertBaseLeadsPublished(channel: Channel, base: string, tags: s
   let highest: { raw: string; version: ReturnType<typeof parseSemver> } | undefined;
   for (const tag of tags) {
     const match = shape.exec(tag.trim());
-    if (!match) continue;
-    const version = parseSemver(match[1], "published stable");
-    if (!highest || cmp(version, highest.version) > 0) highest = { raw: match[1], version };
+    const captured = match?.[1];
+    if (!captured) continue;
+    const version = parseSemver(captured, "published stable");
+    if (!highest || cmp(version, highest.version) > 0) highest = { raw: captured, version };
   }
   if (!highest) return;
   if (cmp(parseSemver(base, "alpha base"), highest.version) > 0) return;

--- a/src/__tests__/error-codes-drift.test.ts
+++ b/src/__tests__/error-codes-drift.test.ts
@@ -20,7 +20,7 @@ describeOrSkip("error-code drift", () => {
 
     const doc = readFileSync(join(import.meta.dir, "../../docs/errors.md"), "utf8");
     const documented = new Set<string>();
-    for (const m of doc.matchAll(/`(E_[A-Z0-9_]+)`/g)) documented.add(m[1]);
+    for (const m of doc.matchAll(/`(E_[A-Z0-9_]+)`/g)) if (m[1]) documented.add(m[1]);
 
     // Named both ways: a set-membership assertion only reports "false is not true".
     expect([...known].filter((c) => !documented.has(c)).sort()).toEqual([]);

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,8 +1,9 @@
 import type { TranscribeErrorRecord, TranscribeJsonOutput, TranscribeResult } from "./types";
 
 export function formatTextOutput(results: TranscribeResult[]): string {
-  if (results.length === 1) {
-    return results[0].text + "\n";
+  const [first] = results;
+  if (first && results.length === 1) {
+    return first.text + "\n";
   }
   return results
     .map((r, i) => (i > 0 ? "\n" : "") + `=== ${r.file} ===\n${r.text}\n`)

--- a/src/mcp/voices.ts
+++ b/src/mcp/voices.ts
@@ -64,8 +64,8 @@ function parseVoiceInfo(id: string): VoiceInfo {
 
   const kokoro = id.match(/^(es|fr|hi|it|ja|pt|zh)-([a-z][fm]_.+)$/);
   if (kokoro) {
-    const languageCode = kokoro[1];
-    const bareVoice = kokoro[2];
+    const languageCode = kokoro[1] ?? "";
+    const bareVoice = kokoro[2] ?? "";
     const genderChar = bareVoice[1];
     const gender: "male" | "female" = genderChar === "f" ? "female" : "male";
     return {

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -1139,7 +1139,7 @@ function elapsedMs(startedAt: string, finishedAt: string | null): number | null 
 function percentile(sortedDurations: number[], p: number): number {
   if (sortedDurations.length === 0) return 0;
   const index = Math.min(sortedDurations.length - 1, Math.max(0, Math.ceil((p / 100) * sortedDurations.length) - 1));
-  return sortedDurations[index];
+  return sortedDurations[index] ?? 0;
 }
 
 function sizeBucket(sizeBytes: number | null): string {

--- a/src/suggest-command.ts
+++ b/src/suggest-command.ts
@@ -7,7 +7,7 @@ export function suggestCommand(input: string, commands: string[]): string | null
   const lowerCommands = commands.map((c) => c.toLowerCase());
 
   const exactIdx = lowerCommands.indexOf(lowerInput);
-  if (exactIdx !== -1) return commands[exactIdx];
+  if (exactIdx !== -1) return commands[exactIdx] ?? null;
 
   const match = closest(lowerInput, lowerCommands);
   const dist = distance(lowerInput, match);
@@ -17,5 +17,5 @@ export function suggestCommand(input: string, commands: string[]): string | null
   if (dist > maxDist) return null;
 
   const idx = lowerCommands.indexOf(match);
-  return commands[idx];
+  return commands[idx] ?? null;
 }

--- a/src/voice-routing.ts
+++ b/src/voice-routing.ts
@@ -41,7 +41,7 @@ export function pickVoiceForLang(
   arch: NodeJS.Architecture = process.arch,
 ): string | undefined {
   if (!code || confidence < 0.5) return undefined;
-  const baseCode = code.toLowerCase().split(/[-_]/, 1)[0];
+  const baseCode = code.toLowerCase().split(/[-_]/, 1)[0] ?? "";
   switch (baseCode) {
     case "en":
       return "en-am_michael";

--- a/tests/integration/cli-contracts.test.ts
+++ b/tests/integration/cli-contracts.test.ts
@@ -42,7 +42,12 @@ function makeTempDir(prefix: string): string {
   return dir;
 }
 
-function isolatedEnv(dir = makeTempDir("kesha-cli-contract-")): Record<string, string> {
+function isolatedEnv(dir = makeTempDir("kesha-cli-contract-")): {
+  HOME: string;
+  KESHA_CACHE_DIR: string;
+  KESHA_LOG_DIR: string;
+  KESHA_STATS_DB: string;
+} {
   return {
     HOME: dir,
     KESHA_CACHE_DIR: join(dir, "cache"),
@@ -558,7 +563,7 @@ describe("CLI contracts", () => {
       errors: Array<Record<string, unknown>>;
     };
     expect(decoded.results).toHaveLength(1);
-    expect(decoded.results[0].file).toBe(mediaPath);
+    expect(decoded.results[0]?.file).toBe(mediaPath);
     expect(decoded.errors).toEqual([
       { file: "missing.wav", code: "E_INPUT_NOT_FOUND", message: "File not found" },
     ]);
@@ -766,8 +771,8 @@ describe("CLI contracts", () => {
     });
     const { decode: decodeToon } = await import("@toon-format/toon");
     const decoded = decodeToon(toon.stdout) as Array<Record<string, unknown>>;
-    expect(decoded[0].text).toBe("Привет с воркшопа");
-    expect(decoded[0].lang).toBe("ru");
+    expect(decoded[0]?.text).toBe("Привет с воркшопа");
+    expect(decoded[0]?.lang).toBe("ru");
 
     const noVadJson = await runCli([mediaPath, "--json", "--no-vad"], { env });
     expectContract(noVadJson, {
@@ -855,7 +860,7 @@ describe("CLI contracts", () => {
       command: "install",
       status: "success",
     });
-    expect(typeof events[1].durationMs).toBe("number");
+    expect(typeof events[1]?.durationMs).toBe("number");
   });
 
   test("install keeps progress on stderr while --plan's deliverable stays on stdout (#945)", async () => {

--- a/tests/integration/cli-contracts.test.ts
+++ b/tests/integration/cli-contracts.test.ts
@@ -405,7 +405,7 @@ describe("CLI contracts", () => {
   test("a directory positional is rejected before any progress output or engine spawn", async () => {
     const dir = makeTempDir("kesha-cli-contract-engine-");
     const enginePath = createFailingEngine(dir);
-    const env: Record<string, string> = {
+    const env = {
       ...isolatedEnv(dir),
       KESHA_ENGINE_BIN: enginePath,
     };
@@ -650,7 +650,7 @@ describe("CLI contracts", () => {
     writeFileSync(mediaPath, "fake media");
     const diarizeError =
       "speaker diarization failed\n\nCaused by:\n    kesha-diarize timed out after 600s for 12894s audio; try splitting the file or set KESHA_DIARIZE_TIMEOUT_SECS=1200 (or larger):";
-    const env: Record<string, string> = {
+    const env = {
       ...isolatedEnv(dir),
       KESHA_ENGINE_BIN: enginePath,
       KESHA_FAKE_TRANSCRIBE_ERROR: diarizeError,
@@ -686,7 +686,7 @@ describe("CLI contracts", () => {
     // E_DIARIZE_TIMEOUT is retryable — the CLI must not collapse it to E_TRANSCRIBE_FAILED.
     const codedError =
       "error [E_DIARIZE_TIMEOUT]: speaker diarization timed out after 30s for 4s of audio";
-    const env: Record<string, string> = {
+    const env = {
       ...isolatedEnv(dir),
       KESHA_ENGINE_BIN: enginePath,
       KESHA_FAKE_TRANSCRIBE_ERROR: codedError,
@@ -715,7 +715,7 @@ describe("CLI contracts", () => {
     const enginePath = createFakeEngine(dir);
     const mediaPath = join(dir, "workshop.mp4");
     writeFileSync(mediaPath, "fake media");
-    const env: Record<string, string> = {
+    const env = {
       ...isolatedEnv(dir),
       KESHA_ENGINE_BIN: enginePath,
     };
@@ -788,7 +788,7 @@ describe("CLI contracts", () => {
     const enginePath = createFakeEngine(dir);
     const mediaPath = join(dir, "recording");
     writeFileSync(mediaPath, "fake media");
-    const env: Record<string, string> = {
+    const env = {
       ...isolatedEnv(dir),
       KESHA_ENGINE_BIN: enginePath,
     };
@@ -828,7 +828,7 @@ describe("CLI contracts", () => {
     const enginePath = createFakeEngine(dir);
     markFakeEngineInstalled(enginePath);
     const installArgsPath = join(dir, "install-args.json");
-    const env: Record<string, string> = {
+    const env = {
       ...isolatedEnv(dir),
       KESHA_ENGINE_BIN: enginePath,
       KESHA_FAKE_INSTALL_ARGS_PATH: installArgsPath,
@@ -916,7 +916,7 @@ describe("CLI contracts", () => {
     const dir = makeTempDir("kesha-cli-contract-install-diagnostic-failure-");
     const enginePath = createFakeEngine(dir);
     markFakeEngineInstalled(enginePath);
-    const env: Record<string, string> = {
+    const env = {
       ...isolatedEnv(dir),
       KESHA_ENGINE_BIN: enginePath,
       KESHA_FAKE_INSTALL_ERROR: `fake model install failed in ${dir}`,
@@ -947,7 +947,7 @@ describe("CLI contracts", () => {
     const mediaPath = join(dir, "meeting.mp4");
     const detectLangMarker = join(dir, "detect-lang-called");
     writeFileSync(mediaPath, "fake media");
-    const env: Record<string, string> = {
+    const env = {
       ...isolatedEnv(dir),
       KESHA_ENGINE_BIN: enginePath,
       KESHA_FAKE_DETECT_LANG_MARKER: detectLangMarker,
@@ -1101,7 +1101,7 @@ describe("CLI contracts", () => {
   test("read-only planning and stats commands keep user data on stdout", async () => {
     const dir = makeTempDir("kesha-cli-contract-readonly-");
     const enginePath = createFailingEngine(dir);
-    const env: Record<string, string> = {
+    const env = {
       ...isolatedEnv(dir),
       KESHA_ENGINE_BIN: enginePath,
     };

--- a/tests/integration/mcp-e2e.test.ts
+++ b/tests/integration/mcp-e2e.test.ts
@@ -32,6 +32,6 @@ describe.skipIf(!engineInstalled)("mcp e2e", () => {
     const res = await cl.callTool({ name: "transcribe_audio", arguments: { path: FIXTURE_RU } });
     expect(res.isError).toBeUndefined();
     // Backend-stable word: CoreML and ONNX disagree on "сообщения"/"сообщение" for this clip.
-    expect((res.content as Array<{ text: string }>)[0].text).toContain("транскрипцией");
+    expect((res.content as Array<{ text: string }>)[0]?.text).toContain("транскрипцией");
   }, 60_000);
 });

--- a/tests/unit/diagnostic-log.test.ts
+++ b/tests/unit/diagnostic-log.test.ts
@@ -132,8 +132,8 @@ describe("diagnostic log storage", () => {
 
     const lines = readFileSync(resolveDiagnosticLogPath(), "utf8").trim().split("\n");
     expect(lines).toHaveLength(2);
-    expect(JSON.parse(lines[0]).event).toBe("command.start");
-    expect(JSON.parse(lines[1]).exitCode).toBe(42);
+    expect(JSON.parse(lines[0] ?? "").event).toBe("command.start");
+    expect(JSON.parse(lines[1] ?? "").exitCode).toBe(42);
   });
 
   test("retain-on-failure session finish is terminal", () => {
@@ -147,7 +147,7 @@ describe("diagnostic log storage", () => {
 
     const lines = readFileSync(resolveDiagnosticLogPath(), "utf8").trim().split("\n");
     expect(lines).toHaveLength(1);
-    expect(JSON.parse(lines[0]).runId).toBe("fail-once");
+    expect(JSON.parse(lines[0] ?? "").runId).toBe("fail-once");
 
     const success = createDiagnosticLogSession();
     expect(success.event("command.start", { command: "transcribe", runId: "success-first" })).toBe(true);

--- a/tests/unit/init.test.ts
+++ b/tests/unit/init.test.ts
@@ -141,7 +141,7 @@ describe("init onboarding", () => {
   test("init drives every prompt through @clack/prompts", async () => {
     // #677: a node:readline interface sharing stdin with clack deadlocks after clack closes.
     const source = await Bun.file(new URL("../../src/cli/init.ts", import.meta.url)).text();
-    const imported = [...source.matchAll(/^import .*?from "(.+?)";$/gm)].map((m) => m[1]);
+    const imported = [...source.matchAll(/^import .*?from "(.+?)";$/gm)].map((m) => m[1] ?? "");
 
     expect(imported).toContain("@clack/prompts");
     expect(imported.filter((m) => m.startsWith("node:readline"))).toEqual([]);

--- a/tests/unit/install-plan.test.ts
+++ b/tests/unit/install-plan.test.ts
@@ -219,7 +219,9 @@ describe("the plan's download economics", () => {
         "cached",
       );
 
-      seed(cacheRoot, modelPlan.langId[0]?.relPath ?? "", "");
+      const firstLangId = modelPlan.langId[0];
+      if (!firstLangId) throw new Error("model-plan.json langId is empty — fixture invariant broken");
+      seed(cacheRoot, firstLangId.relPath, "");
       expect(status(await renderInstallPlan({ backend: "onnx" }), "Audio language ID ECAPA")).toBe(
         "needed",
       );

--- a/tests/unit/install-plan.test.ts
+++ b/tests/unit/install-plan.test.ts
@@ -219,7 +219,7 @@ describe("the plan's download economics", () => {
         "cached",
       );
 
-      seed(cacheRoot, modelPlan.langId[0].relPath, "");
+      seed(cacheRoot, modelPlan.langId[0]?.relPath ?? "", "");
       expect(status(await renderInstallPlan({ backend: "onnx" }), "Audio language ID ECAPA")).toBe(
         "needed",
       );

--- a/tests/unit/mcp-list-voices.test.ts
+++ b/tests/unit/mcp-list-voices.test.ts
@@ -44,7 +44,7 @@ describe("list_voices / list_languages guard when the engine is missing", () => 
     await withMissingEngine(async () => {
       const res = await call("list_voices");
       expect(res.isError).toBe(true);
-      expect((res.content as Array<{ text: string }>)[0].text).toContain("kesha-engine not installed");
+      expect((res.content as Array<{ text: string }>)[0]?.text).toContain("kesha-engine not installed");
     });
   });
 
@@ -52,7 +52,7 @@ describe("list_voices / list_languages guard when the engine is missing", () => 
     await withMissingEngine(async () => {
       const res = await call("list_languages");
       expect(res.isError).toBe(true);
-      expect((res.content as Array<{ text: string }>)[0].text).toContain("kesha-engine not installed");
+      expect((res.content as Array<{ text: string }>)[0]?.text).toContain("kesha-engine not installed");
     });
   });
 });
@@ -69,7 +69,7 @@ describe("list_voices guard when the engine is present but not executable", () =
     try {
       const res = await call("list_voices");
       expect(res.isError).toBe(true);
-      const text = (res.content as Array<{ text: string }>)[0].text;
+      const text = (res.content as Array<{ text: string }>)[0]?.text;
       expect(text).toContain("E_ENGINE_SPAWN");
       expect(text).toContain(notExecutable);
     } finally {

--- a/tests/unit/mcp-say-errors.test.ts
+++ b/tests/unit/mcp-say-errors.test.ts
@@ -16,7 +16,7 @@ describe("synthesize_speech errors", () => {
   test("rate out of range or NaN is isError", async () => {
     const outOfRange = await call({ text: "hi", rate: 9 });
     expect(outOfRange.isError).toBe(true);
-    expect((outOfRange.content as Array<{ text: string }>)[0].text).toMatch(/rate/i);
+    expect((outOfRange.content as Array<{ text: string }>)[0]?.text).toMatch(/rate/i);
 
     const nanRate = await call({ text: "hi", rate: NaN });
     expect(nanRate.isError).toBe(true);
@@ -28,7 +28,7 @@ describe("synthesize_speech errors", () => {
     try {
       const res = await call({ text: "hello", voice: "en-am_michael" });
       expect(res.isError).toBe(true);
-      expect((res.content as Array<{ text: string }>)[0].text).toMatch(/install --tts|not installed|kesha-engine not installed/i);
+      expect((res.content as Array<{ text: string }>)[0]?.text).toMatch(/install --tts|not installed|kesha-engine not installed/i);
     } finally {
       if (prev === undefined) delete process.env.KESHA_CACHE_DIR;
       else process.env.KESHA_CACHE_DIR = prev;

--- a/tests/unit/mcp-transcribe-errors.test.ts
+++ b/tests/unit/mcp-transcribe-errors.test.ts
@@ -16,13 +16,13 @@ describe("transcribe_audio errors", () => {
   test("missing file returns isError, never throws protocol error", async () => {
     const res = await call("transcribe_audio", { path: "/no/such/file.wav" });
     expect(res.isError).toBe(true);
-    expect((res.content as Array<{ text: string }>)[0].text).toContain("File not found");
+    expect((res.content as Array<{ text: string }>)[0]?.text).toContain("File not found");
   });
 
   test("missing relative path explains cwd resolution and recommends absolute path", async () => {
     const res = await call("transcribe_audio", { path: "./no-such-file.wav" });
     expect(res.isError).toBe(true);
-    const text = (res.content as Array<{ text: string }>)[0].text;
+    const text = (res.content as Array<{ text: string }>)[0]?.text;
     expect(text).toContain("File not found");
     expect(text).toContain("relative paths resolve against the MCP server's working directory");
     expect(text).toContain(process.cwd());

--- a/tests/unit/mcp-voices.test.ts
+++ b/tests/unit/mcp-voices.test.ts
@@ -66,10 +66,10 @@ describe("parseVoiceLines", () => {
 
   test("malformed en- id falls through to unknown", () => {
     const [v] = parseVoiceLines("en-zzz");
-    expect(v.modelId).toBe("unknown");
-    expect(v.modelName).toBe("Unknown");
-    expect(v.gender).toBeNull();
-    expect(v.languageCode).toBe("");
+    expect(v?.modelId).toBe("unknown");
+    expect(v?.modelName).toBe("Unknown");
+    expect(v?.gender).toBeNull();
+    expect(v?.languageCode).toBe("");
   });
 
   test("maps multilingual Kokoro ids", () => {

--- a/tests/unit/stats.test.ts
+++ b/tests/unit/stats.test.ts
@@ -90,8 +90,8 @@ describe("stats storage", () => {
     expect(week.inputBytes).toBe(1024);
     expect(week.sttTimeMs).toBeGreaterThanOrEqual(0);
     expect(errors).toHaveLength(1);
-    expect(errors[0].message).not.toContain(statsDir());
-    expect(errors[0].message).not.toContain("secret.ogg");
+    expect(errors[0]?.message).not.toContain(statsDir());
+    expect(errors[0]?.message).not.toContain("secret.ogg");
   });
 
   test("recorder is a no-op when disabled", async () => {
@@ -488,8 +488,8 @@ describe("week summary aggregation", () => {
     const summary = getWeekSummary(NOW);
     expect(summary.slowestRuns).toHaveLength(1);
     const run = summary.slowestRuns[0];
-    expect(run.durationMs).toBe(0);
-    expect(run.stages).toEqual([
+    expect(run?.durationMs).toBe(0);
+    expect(run?.stages).toEqual([
       { stage: "transcribe", durationMs: 900, status: "failed" },
       { stage: "decode", durationMs: 200, status: "success" },
       { stage: "lang_id_audio", durationMs: 200, status: "success" },
@@ -973,7 +973,7 @@ describe("stats export contracts", () => {
     });
 
     const lines = exportStats("csv").trim().split("\n");
-    const header = lines[0].split(",");
+    const header = (lines[0] ?? "").split(",");
     const runRow = lines.find((line) => line.startsWith("runs,"))!.split(",");
 
     expect(runRow).toHaveLength(header.length);

--- a/tests/unit/status.test.ts
+++ b/tests/unit/status.test.ts
@@ -600,7 +600,7 @@ describe("collectStatus disk accounting (#647)", () => {
       const engineBytes = statSync(binPath).size + 32;
 
       expect(disk.components.map((c) => c.label)).toEqual(["Engine", "TTS (Kokoro)"]);
-      expect(disk.components[0].sizeBytes).toBe(engineBytes);
+      expect(disk.components[0]?.sizeBytes).toBe(engineBytes);
       expect(disk.componentTotalBytes).toBe(engineBytes + 64);
       // The engine lives under the cache, so its bytes are counted once, not twice.
       expect(disk.totalBytes).toBe(engineBytes + 64);

--- a/tests/unit/upload-flakiness.test.ts
+++ b/tests/unit/upload-flakiness.test.ts
@@ -39,7 +39,7 @@ describe("normaliseReport", () => {
   test("preserves the untruncated version in metadata", () => {
     const report = { environments: [macos("26.5.2")] };
     normaliseReport(report);
-    expect(report.environments[0].metadata).toEqual({ osVersionFull: "26.5.2" });
+    expect(report.environments[0]?.metadata).toEqual({ osVersionFull: "26.5.2" });
   });
 
   test("matches osName case-insensitively", () => {
@@ -57,7 +57,7 @@ describe("normaliseReport", () => {
     const { normalised, skipped } = normaliseReport(report, "linux");
     expect(normalised).toBe(0);
     expect(skipped).toBe(2);
-    expect(report.environments[1].systemData.osVersion).toBe("10.0.26100");
+    expect(report.environments[1]?.systemData.osVersion).toBe("10.0.26100");
   });
 
   test("throws when running on darwin but nothing was labelled macos", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "verbatimModuleSyntax": true,
     "isolatedModules": true,
     "noImplicitOverride": true,
+    "noUncheckedIndexedAccess": true,
     "skipLibCheck": true,
     "noEmit": true
   },


### PR DESCRIPTION
Phase 2 of #932: turn on `noUncheckedIndexedAccess` and fix every resulting error.

## Stack

**Based on PR #979** (`chore/issue-932-strict-flags`, phase 1). This PR's base is that branch, not `main` — review/merge #979 first, then this retargets to `main` automatically. The diff here is phase 2 only.

## Re-measured

`noUncheckedIndexedAccess` re-measures to **76 errors** on the current tree (the issue estimated 72 at `eb566a4`). The delta: `.github/scripts/*.ts` are pulled into the program via test imports, so they count too. Spread: 15 in `src/`+`.github/scripts/`, the rest in `tests/`.

## The one that mattered

`src/voice-routing.ts` `pickVoiceForLang` is declared `=> string | undefined`, and that is true at runtime — but indexing `Record<string, string>` was typed as `string`, so the compiler could not see the `undefined` the entire TTS auto-routing path depends on. After this change its return type is **genuinely** type-checked as `string | undefined` (verified: assigning the result to a `string` now raises TS2322).

## How the fixes were made

Per the issue guidance, no blanket `!`:
- **Root-cause structural fix** where one change closes many sites: `isolatedEnv()` in `cli-contracts.test.ts` gains a concrete key type, so all 13 `env.KESHA_*` reads are `string` again.
- **Guards / local bindings** in the `.github/scripts` parsers (`check-workflows`, `check-recipes`, `alpha-publishable`, …) where a captured regex group or split field could in principle be absent.
- **`?? <fallback>`** where an invariant is documented by the fallback (e.g. `voice-routing` `baseCode`, `suggest-command` returning its `null` sentinel, `percentile` returning `0`).
- **`?.`** in test assertions where the value flows straight into an `expect(...)` matcher after a length/content assertion.

## Gates

- `bunx tsc --noEmit` → exit 0
- `bun test` → 1407 pass, 6 skip, 0 fail
- `bun run check` → 1248 pass, 0 fail

## Phase 3 — deferred

`exactOptionalPropertyTypes` and `noPropertyAccessFromIndexSignature` are **not** in this stack. They stay open pending the citty `CommandContext` typing question (Refs #932). `noPropertyAccessFromIndexSignature` alone was ~421 errors and is judged not worth it.

Closes #932

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBTpJjqyYFW6W8LHJ2nwy