### PR TITLE
refactor(engine): generate ErrorCode + ALL from one macro so a new variant can't vanish from --error-codes-json (#949)

### DIFF
--- a/rust/src/errors.rs
+++ b/rust/src/errors.rs
@@ -9,27 +9,50 @@
 
 use serde::Serialize;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ErrorCode {
-    InputNotFound,
-    BadAudio,
-    ModelMissing,
-    ModelDownload,
-    CacheCorrupt,
-    ModelLoad,
-    UnsupportedPlatform,
-    SidecarMissing,
-    NoBackend,
-    TextEmpty,
-    TextTooLong,
-    VoiceUnknown,
-    SsmlInvalid,
-    SsmlUnsupported,
-    ScriptUnsupported,
-    TranscribeFailed,
-    DiarizeTimeout,
-    InvalidArg,
-    Internal,
+/// Declare the `ErrorCode` enum, its `ALL` slice, and `as_str` from one
+/// variant→code-string list so a new variant cannot silently vanish from
+/// `ALL` (and thus from `--error-codes-json`, `kesha doctor`, and the
+/// docs-drift check). `title`/`category`/`retryable` stay ordinary exhaustive
+/// matches below — the compiler already forces those updated.
+macro_rules! error_codes {
+    ($($variant:ident => $code:literal),+ $(,)?) => {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        pub enum ErrorCode {
+            $($variant),+
+        }
+
+        impl ErrorCode {
+            pub const ALL: &'static [ErrorCode] = &[$(ErrorCode::$variant),+];
+
+            pub fn as_str(self) -> &'static str {
+                match self {
+                    $(ErrorCode::$variant => $code),+
+                }
+            }
+        }
+    };
+}
+
+error_codes! {
+    InputNotFound => "E_INPUT_NOT_FOUND",
+    BadAudio => "E_BAD_AUDIO",
+    ModelMissing => "E_MODEL_MISSING",
+    ModelDownload => "E_MODEL_DOWNLOAD",
+    CacheCorrupt => "E_CACHE_CORRUPT",
+    ModelLoad => "E_MODEL_LOAD",
+    UnsupportedPlatform => "E_UNSUPPORTED_PLATFORM",
+    SidecarMissing => "E_SIDECAR_MISSING",
+    NoBackend => "E_NO_BACKEND",
+    TextEmpty => "E_TEXT_EMPTY",
+    TextTooLong => "E_TEXT_TOO_LONG",
+    VoiceUnknown => "E_VOICE_UNKNOWN",
+    SsmlInvalid => "E_SSML_INVALID",
+    SsmlUnsupported => "E_SSML_UNSUPPORTED",
+    ScriptUnsupported => "E_SCRIPT_UNSUPPORTED",
+    TranscribeFailed => "E_TRANSCRIBE_FAILED",
+    DiarizeTimeout => "E_DIARIZE_TIMEOUT",
+    InvalidArg => "E_INVALID_ARG",
+    Internal => "E_INTERNAL",
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -44,52 +67,6 @@ pub enum Category {
 }
 
 impl ErrorCode {
-    pub const ALL: [ErrorCode; 19] = [
-        ErrorCode::InputNotFound,
-        ErrorCode::BadAudio,
-        ErrorCode::ModelMissing,
-        ErrorCode::ModelDownload,
-        ErrorCode::CacheCorrupt,
-        ErrorCode::ModelLoad,
-        ErrorCode::UnsupportedPlatform,
-        ErrorCode::SidecarMissing,
-        ErrorCode::NoBackend,
-        ErrorCode::TextEmpty,
-        ErrorCode::TextTooLong,
-        ErrorCode::VoiceUnknown,
-        ErrorCode::SsmlInvalid,
-        ErrorCode::SsmlUnsupported,
-        ErrorCode::ScriptUnsupported,
-        ErrorCode::TranscribeFailed,
-        ErrorCode::DiarizeTimeout,
-        ErrorCode::InvalidArg,
-        ErrorCode::Internal,
-    ];
-
-    pub fn as_str(self) -> &'static str {
-        match self {
-            ErrorCode::InputNotFound => "E_INPUT_NOT_FOUND",
-            ErrorCode::BadAudio => "E_BAD_AUDIO",
-            ErrorCode::ModelMissing => "E_MODEL_MISSING",
-            ErrorCode::ModelDownload => "E_MODEL_DOWNLOAD",
-            ErrorCode::CacheCorrupt => "E_CACHE_CORRUPT",
-            ErrorCode::ModelLoad => "E_MODEL_LOAD",
-            ErrorCode::UnsupportedPlatform => "E_UNSUPPORTED_PLATFORM",
-            ErrorCode::SidecarMissing => "E_SIDECAR_MISSING",
-            ErrorCode::NoBackend => "E_NO_BACKEND",
-            ErrorCode::TextEmpty => "E_TEXT_EMPTY",
-            ErrorCode::TextTooLong => "E_TEXT_TOO_LONG",
-            ErrorCode::VoiceUnknown => "E_VOICE_UNKNOWN",
-            ErrorCode::SsmlInvalid => "E_SSML_INVALID",
-            ErrorCode::SsmlUnsupported => "E_SSML_UNSUPPORTED",
-            ErrorCode::ScriptUnsupported => "E_SCRIPT_UNSUPPORTED",
-            ErrorCode::TranscribeFailed => "E_TRANSCRIBE_FAILED",
-            ErrorCode::DiarizeTimeout => "E_DIARIZE_TIMEOUT",
-            ErrorCode::InvalidArg => "E_INVALID_ARG",
-            ErrorCode::Internal => "E_INTERNAL",
-        }
-    }
-
     pub fn title(self) -> &'static str {
         match self {
             ErrorCode::InputNotFound => "Input file not found",


### PR DESCRIPTION
Closes #949

## Problem

`rust/src/errors.rs` declared the variant list **twice**: once as `enum ErrorCode`, and again by hand as `pub const ALL: [ErrorCode; 19] = [ … ]`. `as_str`/`title`/`category`/`retryable` are exhaustive `match`es, so the compiler forces them updated when a variant is added — but `ALL` is a plain array with no such enforcement. Add a variant and `ALL` silently stays at 19, the crate compiles, and the new code vanishes from:

- `--error-codes-json` (`error_codes_json()` maps over `ALL`) — a **published CLI contract**,
- `kesha doctor`,
- the docs-drift check against `docs/errors.md`.

All six module tests iterate `ALL`, so they go blind together — including `error_codes_json_covers_all_variants`, which compares `arr.len()` to `ALL.len()` and therefore agrees with itself.

## Fix

A single `error_codes!` macro generates the enum, `ALL`, and `as_str` from one `variant => code-string` list. There is now no second place to forget. `title`/`category`/`retryable` stay ordinary exhaustive `match`es — the compiler already forces those, and they carry per-variant data that doesn't belong in the list.

### Preserved contract
- **Derive set unchanged:** `#[derive(Debug, Clone, Copy, PartialEq, Eq)]`.
- **Every code string byte-identical:** `E_INPUT_NOT_FOUND` … `E_INTERNAL`, all 19, same order. Verified by diff (the strings moved verbatim into the macro list) and by the unchanged `error_codes_docs` / `code_strings_are_stable_unique_and_prefixed` tests.
- **`error_codes_json()` output unchanged.**

### `ALL`: `[ErrorCode; 19]` → `&'static [ErrorCode]`
Retires the hand-counted array length. Every consumer uses `.iter()` / `.len()` / `IntoIterator for &[T]`, all of which a slice supports unchanged. Consumers checked (`grep -rn 'ErrorCode::ALL' rust/src rust/tests`): `error_codes_json()`, the six `errors::tests`, and `tests/error_codes_docs.rs::every_code_is_documented` — all pass.

## Drift-proof (ran locally, then reverted)

Added a throwaway `ZzDriftProof => "E_ZZ_DRIFT_PROOF"` to the macro list only:
- The **only** compile errors were `title` and `category` (the hand-written exhaustive matches). `ALL` and `as_str` regenerated with zero manual edits — the old failure mode (stale `ALL`, silent) is now structurally impossible.
- After adding the two forced match arms, `error_codes_json_covers_all_variants` passed with `ALL.len() == 20` — `ALL` and `--error-codes-json` picked up the new variant without touching any `ALL` array (there no longer is one).

Then removed the throwaway variant. `error_codes_json_covers_all_variants` is now effectively tautological, which is fine: drift is impossible via the macro, so it's left as-is rather than over-engineered.

## Gates
- `cargo fmt --check` — clean
- `cargo build` — passes
- `cargo clippy --lib -- -D warnings` — clean (macro-generated code is clippy-clean)
- `cargo nextest run --features tts errors error_codes` — all 9 `errors::tests` + `every_code_is_documented` pass

> [!WARNING]
> **`main` is currently broken on the Rust test target, independent of this PR.** `src/record.rs:674` (`recovery_dir`, from #965) calls `.join()` on `cache_dir()`, which #967 changed to return `Result<PathBuf>` — a semantic merge conflict that leaves `cargo clippy --all-targets` / `cargo nextest` red on every branch off current `main`. This PR touches only `errors.rs`; the full test-target gates were validated with a temporary local `record.rs` patch (reverted, not in this diff). Rust CI here will stay red until `main`'s `record.rs` is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)