### PR TITLE
fix(record): propagate cache_dir()'s Result through recovery_dir (#982)

### DIFF
--- a/rust/src/record.rs
+++ b/rust/src/record.rs
@@ -238,7 +238,13 @@ fn deliver_and_settle(
 /// failure here is loud but not fatal.
 #[cfg(all(feature = "coreml", target_os = "macos"))]
 fn open_recovery_spill(sample_rate: u32) -> Option<spill::SpillWav> {
-    let dir = spill::recovery_dir();
+    let dir = match spill::recovery_dir() {
+        Ok(dir) => dir,
+        Err(err) => {
+            eprintln!("warning: this session has no recovery audio: {err:#}");
+            return None;
+        }
+    };
     spill::prune_stale_spills(&dir, spill::RETENTION);
     match spill::SpillWav::create(&spill::spill_path(&dir), sample_rate) {
         Ok(spill) => {
@@ -670,8 +676,8 @@ mod spill {
 
     /// Under the Kesha cache, so `KESHA_CACHE_DIR` relocates recovery audio with
     /// everything else the tool owns.
-    pub(super) fn recovery_dir() -> PathBuf {
-        crate::models::cache_dir().join("recordings")
+    pub(super) fn recovery_dir() -> Result<PathBuf> {
+        Ok(crate::models::cache_dir()?.join("recordings"))
     }
 
     pub(super) fn spill_path(dir: &Path) -> PathBuf {
@@ -863,7 +869,7 @@ mod tests {
         let _guard =
             crate::util::test_env::EnvGuard::set("KESHA_CACHE_DIR", "/tmp/kesha-962-cache");
         assert_eq!(
-            spill::recovery_dir(),
+            spill::recovery_dir().unwrap(),
             std::path::PathBuf::from("/tmp/kesha-962-cache/recordings")
         );
     }


### PR DESCRIPTION
## P0 hotfix — main is RED on the Rust test target

Semantic merge conflict between **#965** and **#967** (no textual conflict; both PRs' CI missed it because `record.rs`'s `spill` mod only fully compiles under `test`/`coreml`):

- **#967** changed `models::cache_dir()` → `Result<PathBuf>` (was `PathBuf`).
- **#965** added `spill::recovery_dir()` = `cache_dir().join("recordings")` — now `.join()` on a `Result<PathBuf>`, which does not compile.

The break only surfaces on the full target:

```
error[E0599]: no method named `join` found for enum `Result<PathBuf, anyhow::Error>`
   --> src/record.rs:674:36
```

## Fix

- `recovery_dir()` now returns `anyhow::Result<PathBuf>` → `Ok(cache_dir()?.join("recordings"))`, propagating the Result honestly (no `unwrap`/`expect` in the production path — that would reintroduce the panic #967 removed).
- `open_recovery_spill` handles the `Err`: prints a loud stderr warning and returns `None`, so a cache-dir failure never crashes the session — consistent with the existing "loud but not fatal" contract on that function.
- Test `recovery_audio_lives_under_the_kesha_cache` unwraps the Result (test code).

Surgical — only what's needed to compile and stay non-fatal.

## Gates run

- `cargo clippy --all-targets -- -D warnings` (rust/) — **clean** (before: the E0599 above; after: `Finished`).
- `just verify-darwin-full` (`cargo clippy --all-targets --features coreml,tts,system_tts,system_kokoro,system_diarize,system_text_lang --no-default-features -- -D warnings`) — **exit 0**, proving the coreml path (`open_recovery_spill`) compiles.
- `just rust-test` (nextest) — **582 passed, 0 skipped**, incl. `record::` / `recovery_audio_lives_under_the_kesha_cache`.
- `cargo fmt --check` — clean.

Unblocks every red Rust PR (incl. #981).

Closes #982

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBTpJjqyYFW6W8LHJ2nwy
