### PR TITLE
test(mcp): run the list_voices/list_languages cases off a stub, not an installed engine

### DIFF
--- a/tests/unit/mcp-list-voices.test.ts
+++ b/tests/unit/mcp-list-voices.test.ts
@@ -9,6 +9,17 @@ import { listVoices } from "../../src/mcp/voices";
 
 const skipOnWin32 = process.platform === "win32" ? test.skip : test;
 
+async function withEngineBin<T>(bin: string, fn: () => Promise<T>): Promise<T> {
+  const prevBin = process.env.KESHA_ENGINE_BIN;
+  process.env.KESHA_ENGINE_BIN = bin;
+  try {
+    return await fn();
+  } finally {
+    if (prevBin === undefined) delete process.env.KESHA_ENGINE_BIN;
+    else process.env.KESHA_ENGINE_BIN = prevBin;
+  }
+}
+
 async function call(name: string, args: Record<string, unknown> = {}) {
   const server = createKeshaMcpServer();
   const [c, s] = InMemoryTransport.createLinkedPair();
@@ -64,78 +75,66 @@ describe("list_voices guard when the engine is present but not executable", () =
     writeFileSync(notExecutable, "not a binary");
     chmodSync(notExecutable, 0o644);
 
-    const prevBin = process.env.KESHA_ENGINE_BIN;
-    process.env.KESHA_ENGINE_BIN = notExecutable;
-    try {
+    await withEngineBin(notExecutable, async () => {
       const res = await call("list_voices");
       expect(res.isError).toBe(true);
       const text = (res.content as Array<{ text: string }>)[0]?.text;
       expect(text).toContain("E_ENGINE_SPAWN");
       expect(text).toContain(notExecutable);
-    } finally {
-      if (prevBin === undefined) delete process.env.KESHA_ENGINE_BIN;
-      else process.env.KESHA_ENGINE_BIN = prevBin;
-    }
+    });
   });
 });
 
-// Skip the full tool test if the engine is not installed (unit environment).
-// The integration path (tests/integration/) covers the full round-trip with a
-// real engine binary.
-// Guarding on "any voice" let a Russian-only `--tts ru` install run the English assertions.
-let engineAvailable = false;
-try {
-  engineAvailable = (await listVoices()).some((v) => v.voiceId === "en-am_michael");
-} catch {
-  engineAvailable = false;
+// A stub, because gating on an installed engine skipped these in every CI lane (#984).
+function voiceListingEngine(voiceIds: string[]): string {
+  const dir = mkdtempSync(join(tmpdir(), "kesha-mcp-voices-"));
+  const path = join(dir, "kesha-engine");
+  const args = voiceIds.map((id) => `'${id}'`).join(" ");
+  writeFileSync(
+    path,
+    `#!/bin/sh\nif [ "$1" = "say" ] && [ "$2" = "--list-voices" ]; then\n  printf '%s\\n' ${args}\n  exit 0\nfi\nexit 2\n`,
+  );
+  chmodSync(path, 0o755);
+  return path;
 }
 
+const STUB_VOICES = ["en-am_michael", "en-bf_emma", "ru-vosk-m02"];
+
 describe("list_voices tool", () => {
-  test.skipIf(!engineAvailable)("returns structured voices with new schema", async () => {
-    const server = createKeshaMcpServer();
-    const [c, s] = InMemoryTransport.createLinkedPair();
-    await server.connect(s);
-    const client = new Client({ name: "t", version: "0" });
-    await client.connect(c);
-    const res = await client.callTool({ name: "list_voices", arguments: {} });
-    expect(res.isError).toBeUndefined();
-    const sc = res.structuredContent as {
-      voices: Array<{ voiceId: string; modelId: string; modelName: string; languageCode: string; languageName: string; gender: string | null }>;
-    };
-    // The English default is a brand contract; naming it pins every field, BCP-47 tag included.
-    expect(sc.voices.find((v) => v.voiceId === "en-am_michael")).toEqual({
-      voiceId: "en-am_michael",
-      modelId: "kokoro",
-      modelName: "Kokoro-82M",
-      languageCode: "en-US",
-      languageName: "American English",
-      gender: "male",
+  skipOnWin32("returns structured voices with new schema", async () => {
+    await withEngineBin(voiceListingEngine(STUB_VOICES), async () => {
+      const res = await call("list_voices");
+      expect(res.isError).toBeUndefined();
+      const sc = res.structuredContent as {
+        voices: Array<{ voiceId: string; modelId: string; modelName: string; languageCode: string; languageName: string; gender: string | null }>;
+      };
+      // The English default is a brand contract; naming it pins every field, BCP-47 tag included.
+      expect(sc.voices.find((v) => v.voiceId === "en-am_michael")).toEqual({
+        voiceId: "en-am_michael",
+        modelId: "kokoro",
+        modelName: "Kokoro-82M",
+        languageCode: "en-US",
+        languageName: "American English",
+        gender: "male",
+      });
+      expect(sc.voices.map((v) => v.voiceId)).toEqual(STUB_VOICES);
     });
   });
 });
 
 describe("list_languages tool", () => {
-  test.skipIf(!engineAvailable)("returns structured languages", async () => {
-    const server = createKeshaMcpServer();
-    const [c, s] = InMemoryTransport.createLinkedPair();
-    await server.connect(s);
-    const client = new Client({ name: "t", version: "0" });
-    await client.connect(c);
-    const res = await client.callTool({ name: "list_languages", arguments: {} });
-    expect(res.isError).toBeUndefined();
-    const sc = res.structuredContent as {
-      languages: Array<{ languageCode: string; languageName: string; voiceCount: number }>;
-    };
-    expect(sc.languages.find((l) => l.languageCode === "en-US")).toMatchObject({
-      languageCode: "en-US",
-      languageName: "American English",
+  skipOnWin32("returns structured languages", async () => {
+    await withEngineBin(voiceListingEngine(STUB_VOICES), async () => {
+      const res = await call("list_languages");
+      expect(res.isError).toBeUndefined();
+      const sc = res.structuredContent as {
+        languages: Array<{ languageCode: string; languageName: string; voiceCount: number }>;
+      };
+      expect(sc.languages).toEqual([
+        { languageCode: "en-GB", languageName: "British English", voiceCount: 1 },
+        { languageCode: "en-US", languageName: "American English", voiceCount: 1 },
+        { languageCode: "ru", languageName: "Russian", voiceCount: 1 },
+      ]);
     });
-
-    // Cross-tool agreement, not a re-implementation; the maths has its oracle in mcp-voices.
-    const voicesRes = await client.callTool({ name: "list_voices", arguments: {} });
-    const listed = (voicesRes.structuredContent as { voices: Array<{ languageCode: string }> }).voices;
-    for (const lang of sc.languages) {
-      expect(lang.voiceCount).toBe(listed.filter((v) => v.languageCode === lang.languageCode).length);
-    }
   });
 });


### PR DESCRIPTION
Closes #984

Found while auditing the suite through Flakiness.io. Two cases report `skipped` on **all three** CI environments — win 10.0.26100, ubuntu 24.04, macos 26.5:

- `list_voices tool > returns structured voices with new schema`
- `list_languages tool > returns structured languages`

Both live in `tests/unit/mcp-list-voices.test.ts` behind `test.skipIf(!engineAvailable)`, where the probe is a real engine call. No lane runs `tests/unit/` with an engine present — `test:unit` installs none, `integration-tests-full` runs `tests/integration/` only — so the gate is always false in CI. They passed on a developer laptop that happened to have `kesha install --tts` done, and nowhere else.

The coverage was genuinely absent rather than duplicated: `tests/integration/` never mentions either tool (`mcp-e2e.test.ts` exercises `transcribe_audio` only), so nothing asserted their `structuredContent` schema.

## Why a stub and not a real engine

The engine half of the contract — `say --list-voices` printing one `en-<stem>` id per line — is already pinned by `rust/tests/tts_smoke.rs::list_voices_shows_installed`, which runs in the rust lanes on all three OSes. Only the TS half (engine stdout → `structuredContent`) was uncovered, and a stub covers it with no models, no staging, and no ci.yml change. The cases now run on every PR on ubuntu and macOS, POSIX-gated like the fake-engine cases already in this file.

Feeding a fixed three-voice list (`en-am_michael`, `en-bf_emma`, `ru-vosk-m02`) also lets the language assertion be an exact array. The old cross-tool loop re-derived its own oracle from whatever happened to be installed, so its `voiceCount` check could not fail.

Dropping the probe additionally removes a top-level `await` that spawned the engine on every import of this file, in every unit run.

## Evidence

With no engine in the cache — i.e. what the `unit-tests` job sees:

```
BEFORE: 4 pass, 2 skip
AFTER:  6 pass, 0 skip
```

`just preflight`: 1407 pass / 0 fail across 98 files, `tsc --noEmit` clean. Rust gate correctly skipped (TS-only diff).

## Considered and rejected

Extending #921's `model-suite-guards` meta-test to scan `tests/unit/` as well. It would misfire on two existing files — `engine.test.ts` imports `getEngineBinPath` but drives only fakes, and `model-suite-guards.test.ts` matches its own inline fixtures — *and* would still have missed this case, since the probe went through `listVoices` from `src/mcp/voices`, which is in none of the seams. `tests/helpers/suite-guards.ts` argues the point itself: "A guard lint that misfires teaches people to ignore it." Left alone deliberately.
