### PR TITLE
fix(errors): an unresolvable home is E_INTERNAL at the ASR gates, not a missing model

### DIFF
--- a/rust/src/lang_id.rs
+++ b/rust/src/lang_id.rs
@@ -16,14 +16,7 @@ const MAX_SECONDS: f32 = 10.0;
 pub fn detect_audio_language(audio_path: &str) -> Result<LangDetectResult> {
     audio::ensure_audio_track(audio_path)?;
 
-    if !models::is_cached(models::ModelKind::LangId) {
-        coded_bail!(
-            ErrorCode::ModelMissing,
-            "Lang-ID model not installed. Run: kesha install"
-        );
-    }
-
-    let dir = models::model_dir(models::ModelKind::LangId)?;
+    let dir = lang_id_model_dir(models::cache_dir())?;
 
     // Load ONNX session
     let mut session = ort::session::Session::builder()
@@ -72,9 +65,25 @@ pub fn detect_audio_language(audio_path: &str) -> Result<LangDetectResult> {
     })
 }
 
+/// The lang-id model dir, or the reason there isn't one. Takes the cache-root
+/// resolution rather than reading it, so the null-home failure #953 coded as
+/// `E_INTERNAL` stays an environment error instead of being reported as a
+/// missing model (#969) — and so that ordering is testable.
+fn lang_id_model_dir(cache: Result<std::path::PathBuf>) -> Result<std::path::PathBuf> {
+    let dir = models::model_dir_at(models::ModelKind::LangId, &cache?);
+    if !models::is_cached_in(models::ModelKind::LangId, &dir) {
+        coded_bail!(
+            ErrorCode::ModelMissing,
+            "Lang-ID model not installed. Run: kesha install"
+        );
+    }
+    Ok(dir)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::errors::code_of;
 
     #[test]
     fn missing_audio_fails_before_model_lookup() {
@@ -86,6 +95,24 @@ mod tests {
         assert!(
             !msg.contains("Lang-ID model not installed"),
             "input validation must happen before model lookup, got: {msg}"
+        );
+    }
+
+    // #969: no resolvable home means we cannot tell whether the model is there,
+    // so the verdict is the environment failure, never "install the model".
+    #[test]
+    fn unresolvable_home_is_coded_internal_not_model_missing() {
+        let err = lang_id_model_dir(models::cache_dir_from(None, None))
+            .expect_err("a null home cannot yield a lang-id model dir");
+        assert_eq!(code_of(&err), ErrorCode::Internal);
+        let msg = format!("{err:#}");
+        assert!(
+            !msg.contains("not installed"),
+            "a home failure must not be reported as a missing model: {msg}"
+        );
+        assert!(
+            msg.contains("KESHA_CACHE_DIR"),
+            "message must name the escape hatch: {msg}"
         );
     }
 }

--- a/rust/src/lang_id.rs
+++ b/rust/src/lang_id.rs
@@ -115,4 +115,19 @@ mod tests {
             "message must name the escape hatch: {msg}"
         );
     }
+
+    // The other half of #969: a cache root that resolves fine but holds no
+    // weights is still the user's missing model, not an environment failure.
+    #[test]
+    fn resolved_cache_without_model_stays_model_missing() {
+        let tmp = tempfile::tempdir().expect("temp cache root");
+        let err = lang_id_model_dir(Ok(tmp.path().to_path_buf()))
+            .expect_err("an empty cache root holds no lang-id model");
+        assert_eq!(code_of(&err), ErrorCode::ModelMissing);
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("kesha install"),
+            "message must keep the install hint: {msg}"
+        );
+    }
 }

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -1667,7 +1667,7 @@ pub fn cache_dir() -> Result<PathBuf> {
 /// `KESHA_CACHE_DIR` wins even with no resolvable home; otherwise a missing
 /// home is a coded `E_INTERNAL` naming the escape hatch, never a panic past
 /// the `error [CODE]:` contract.
-fn cache_dir_from(env_cache: Option<String>, home: Option<PathBuf>) -> Result<PathBuf> {
+pub(crate) fn cache_dir_from(env_cache: Option<String>, home: Option<PathBuf>) -> Result<PathBuf> {
     if let Some(p) = env_cache {
         return Ok(PathBuf::from(p));
     }

--- a/rust/src/transcribe/mod.rs
+++ b/rust/src/transcribe/mod.rs
@@ -321,7 +321,7 @@ pub fn transcribe_with_options(
         mode
     };
 
-    let model_dir = ensure_asr_installed()?;
+    let model_dir = ensure_asr_installed(models::cache_dir())?;
 
     // `Auto` needs a duration probe for routing. `Off` probes too so explicit
     // full-file ASR can fail before loading a backend for media beyond the
@@ -1016,17 +1016,18 @@ fn resolve_diarize_model_path() -> Result<std::path::PathBuf> {
     )
 }
 
-/// Returns the cached ASR model dir or bails with the install hint.
-fn ensure_asr_installed() -> Result<String> {
-    if !models::is_cached(models::ModelKind::Asr) {
+/// Returns the cached ASR model dir or bails with the install hint. Takes the
+/// cache-root resolution rather than reading it, so a null home surfaces as the
+/// coded `E_INTERNAL` #953 established instead of "no models installed" (#969).
+fn ensure_asr_installed(cache: Result<std::path::PathBuf>) -> Result<String> {
+    let dir = models::model_dir_at(models::ModelKind::Asr, &cache?);
+    if !models::is_cached_in(models::ModelKind::Asr, &dir) {
         anyhow::bail!(
             "Error: No transcription models installed\n\n\
              Please run: kesha install"
         );
     }
-    Ok(models::model_dir(models::ModelKind::Asr)?
-        .to_string_lossy()
-        .into_owned())
+    Ok(dir.to_string_lossy().into_owned())
 }
 
 #[cfg(test)]
@@ -1808,6 +1809,24 @@ mod tests {
         assert!(
             !msg.contains("No transcription models installed"),
             "diarization preflight must happen before ASR install lookup, got: {msg}"
+        );
+    }
+
+    // #969: with no resolvable home the ASR gate cannot know whether the models
+    // are installed — reporting them missing sends the user to a fix that isn't one.
+    #[test]
+    fn asr_gate_reports_unresolvable_home_as_internal() {
+        let err = ensure_asr_installed(models::cache_dir_from(None, None))
+            .expect_err("a null home cannot yield an ASR model dir");
+        assert_eq!(crate::errors::code_of(&err), ErrorCode::Internal);
+        let msg = format!("{err:#}");
+        assert!(
+            !msg.contains("No transcription models installed"),
+            "a home failure must not be reported as a missing model: {msg}"
+        );
+        assert!(
+            msg.contains("KESHA_CACHE_DIR"),
+            "message must name the escape hatch: {msg}"
         );
     }
 

--- a/rust/src/transcribe/mod.rs
+++ b/rust/src/transcribe/mod.rs
@@ -1830,6 +1830,27 @@ mod tests {
         );
     }
 
+    // The other half of #969: a cache root that resolves fine but holds no
+    // weights is still the install hint, not an environment failure. CoreML is
+    // excluded because there `is_cached_in(Asr, …)` ignores the dir and probes
+    // FluidAudio's own cache, so a staged ANE machine would see no error at all.
+    #[cfg(not(feature = "coreml"))]
+    #[test]
+    fn asr_gate_reports_resolved_cache_without_model_as_missing() {
+        let tmp = tempfile::tempdir().expect("temp cache root");
+        let err = ensure_asr_installed(Ok(tmp.path().to_path_buf()))
+            .expect_err("an empty cache root holds no ASR model");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("No transcription models installed") && msg.contains("kesha install"),
+            "an absent model must keep the install hint: {msg}"
+        );
+        assert!(
+            !msg.contains("KESHA_CACHE_DIR"),
+            "a resolved cache must not be reported as a home failure: {msg}"
+        );
+    }
+
     // ── seam splice: one test per failure shape upstream FluidAudio hit ─────
 
     /// Budget for a 5 s overlap, matching the production chunker.


### PR DESCRIPTION
## The wrong code

`models::is_cached(kind)` is `model_dir(kind).is_ok_and(...)` — it swallows `cache_dir()`'s error into `false`. So with no resolvable home and no `KESHA_CACHE_DIR`, both ASR-side gates blamed the model:

- `detect_audio_language` → `error [E_MODEL_MISSING]: Lang-ID model not installed. Run: kesha install` — telling a user whose `$HOME` is unreadable to install a model that may well already be there, and that could not be found *because* of the home failure.
- `ensure_asr_installed` → `Error: No transcription models installed` (uncoded, so E_INTERNAL by `code_of`'s fallback) — right code by accident, misleading message.

Repro before the fix, both asserted directly against the gates:

```
lang_id::tests::unresolvable_home_is_coded_internal_not_model_missing
  assertion `left == right` failed
    left: ModelMissing
   right: Internal

transcribe::tests::asr_gate_reports_unresolvable_home_as_internal
  a home failure must not be reported as a missing model:
  Error: No transcription models installed
```

After: both PASS (584/584 in the full suite).

## The two-path trap, and how `is_cached` semantics stayed put

#969 flagged why this was not folded into #953: `is_cached(Asr)` under `coreml` reads `fluidaudio_asr_dir` (home-gated, no `KESHA_CACHE_DIR` escape) while `model_dir(Asr)` reads `cache_dir` — two different home-gated paths. A resolve-then-probe reorder that pushed the FluidAudio path through `?` would turn a missing ANE bundle into an E_INTERNAL and flip the bool absorption #953 deliberately chose.

The reorder here only moves the **cache-root** resolution ahead of the probe:

```rust
let dir = models::model_dir_at(models::ModelKind::Asr, &cache?);
if !models::is_cached_in(models::ModelKind::Asr, &dir) { /* install hint */ }
```

`is_cached_in`'s `coreml` `Asr` arm ignores `dir` entirely and still calls `fluidaudio_asr_ready()`, which keeps absorbing its own home failure into `false`. Untouched — verified by running both new tests against the full darwin feature set, not just the default build.

`E_MODEL_MISSING` is now reachable only when the cache root resolved and the files are genuinely absent.

## Testability

`dirs::home_dir()` cannot be forced to `None` from the process environment (dirs-sys 0.5 falls back to `getpwuid` when `$HOME` is unset), which is why #953 split out `cache_dir_from(env, home)` in the first place. Same shape here: each gate takes the cache-root `Result` instead of reading it, so the ordering contract is what the test exercises. `cache_dir_from` becomes `pub(crate)` so the tests feed the real null-home error rather than a hand-rolled one. Both tests are env-independent — they pass with and without `KESHA_CACHE_DIR` set.

## Gates

- `just rust-test` → 584/584 passed. (One earlier run had `models::retry_tests::the_receive_deadline_caps_the_whole_body_not_just_a_stall` fail — a wall-clock deadline test starved by a concurrent mutation-testing run on the same machine; 3/3 in isolation and green in the clean full run, and untouched by this diff.)
- `cargo fmt --check` → clean
- `cargo clippy --all-targets -- -D warnings` → clean
- `cargo check --features coreml --no-default-features --all-targets` → clean
- `just verify-darwin-full` → clean
- TS untouched.

Closes #969
