### PR TITLE
docs+test: exit codes 130 and 143 for an interrupted run

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -66,6 +66,11 @@ status that lets scripts branch without parsing stderr:
 | `2` | Invalid arguments or usage (mutually-exclusive flags, a bad `--format`, empty `say` text, …). |
 | `4` | Unexpected/uncoded internal failure. |
 | `5` | `kesha say` text exceeds the length limit. |
+| `130` | Interrupted — Ctrl-C (`SIGINT`) reached the CLI mid-run; the engine subprocess was terminated. |
+| `143` | Terminated — a `SIGTERM` reached the CLI mid-run (a cancelled CI job, a stopped container); the engine subprocess was terminated. |
+
+`130` and `143` mean the run was **cancelled**, not that it failed: a wrapper
+that treats every non-zero status as a crash will misreport a cancellation.
 
 `kesha say` and other engine-backed commands may also exit with the **engine's
 own** non-zero status when the engine itself fails. For fine-grained handling,

--- a/openspec/specs/process-lifecycle/spec.md
+++ b/openspec/specs/process-lifecycle/spec.md
@@ -51,6 +51,7 @@ When the CLI receives an interrupt or termination signal while a registered Engi
 - GIVEN Ira's pipeline sends a termination signal to `kesha` mid-batch
 - WHEN the signal arrives
 - THEN the Engine subprocess is terminated and the CLI exits 143
+- AND no Engine process is left running
 
 #### Scenario: A signal arrives when nothing is running
 
@@ -65,7 +66,9 @@ When the CLI receives an interrupt or termination signal while a registered Engi
 > `terminateActiveProcessTrees` (`:109`) sets `process.exitCode`, signals every
 > registered process, then schedules the actual `process.exit`. With no active
 > processes the delay is `SIGNAL_EXIT_BUFFER_MS` (50 ms) instead of the full
-> grace window. These codes extend the Exit code taxonomy in the Glossary.*
+> grace window. These codes extend the Exit code taxonomy in the Glossary, and
+> `docs/errors.md` lists them for callers scripting the CLI. Both signals are
+> asserted end to end in `tests/integration/cli-contracts.test.ts` (#940).*
 
 ### Requirement: Termination targets the whole process tree, not just the direct child
 
@@ -166,9 +169,6 @@ When a caller of the Core API cancels an in-flight call, the call SHALL fail wit
 
 ## Open Issues
 
-- Exit codes 130 and 143 are not documented in `docs/errors.md` alongside 0/1/2
-  (and `say`'s 4/5), and the Glossary's Exit code entry did not list them before
-  this spec. Nothing tests them end to end.
 - The abort path (`opts.signal`) is reachable only from the Core API; no CLI
   flag or timeout wires an `AbortSignal` into a run. The Raycast extension gets
   its cancellation by killing the CLI process instead, which lands on the signal

--- a/tests/integration/cli-contracts.test.ts
+++ b/tests/integration/cli-contracts.test.ts
@@ -228,6 +228,24 @@ process.exit(2);
   return enginePath;
 }
 
+function createHangingTranscribeEngine(dir: string, enginePidPath: string): string {
+  const enginePath = join(dir, "kesha-engine-transcribe-hang");
+  writeFileSync(
+    enginePath,
+    `#!${process.execPath}
+const args = Bun.argv.slice(2);
+if (args[0] === "transcribe") {
+  await Bun.write(${JSON.stringify(enginePidPath)}, String(process.pid));
+  await new Promise(() => {});
+}
+console.error("unexpected fake engine args: " + JSON.stringify(args));
+process.exit(2);
+`,
+  );
+  chmodSync(enginePath, 0o755);
+  return enginePath;
+}
+
 function createListVoicesHangEngine(dir: string, enginePidPath: string): string {
   const enginePath = join(dir, "kesha-engine-listvoices-hang");
   writeFileSync(
@@ -1031,6 +1049,43 @@ describe("CLI contracts", () => {
     expect(exitCode).toBe(130);
     expect(await waitForPidExit(enginePid)).toBe(true);
   });
+
+  // The interrupted file counts as a failure, so the signal's code has to beat the batch's
+  // own exit(1) (src/cli/main.ts) for these to hold — that ordering is what they measure.
+  for (const [signal, exitCode] of [["SIGINT", 130], ["SIGTERM", 143]] as const) {
+    test(`${signal} mid-transcription exits ${exitCode} and leaves no engine running`, async () => {
+      if (process.platform === "win32") return;
+      const dir = makeTempDir(`kesha-cli-contract-${signal.toLowerCase()}-exit-`);
+      const enginePidPath = join(dir, "engine.pid");
+      const enginePath = createHangingTranscribeEngine(dir, enginePidPath);
+      const mediaPath = join(dir, "meeting.ogg");
+      writeFileSync(mediaPath, "fake media");
+
+      const proc = Bun.spawn([process.execPath, "run", "src/cli-entry.ts", mediaPath], {
+        cwd: DEFAULT_CWD,
+        stdout: "pipe",
+        stderr: "pipe",
+        env: {
+          ...process.env,
+          NO_COLOR: "1",
+          FORCE_COLOR: "0",
+          ...isolatedEnv(dir),
+          KESHA_ENGINE_BIN: enginePath,
+        },
+      });
+      const drained = Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+      ]);
+      const enginePid = await waitForPidFile(enginePidPath);
+
+      proc.kill(signal);
+
+      const [, actualExitCode] = await Promise.all([drained, proc.exited]);
+      expect(actualExitCode).toBe(exitCode);
+      expect(await waitForPidExit(enginePid)).toBe(true);
+    });
+  }
 
   test("early transcription failure does not start audio language detection", async () => {
     if (process.platform === "win32") return;


### PR DESCRIPTION
Closes #940

`kesha` exits 130 on SIGINT and 143 on SIGTERM (`src/process-tree.ts:106-107`), but `docs/errors.md` documented only 0/1/2 and `say`'s 4/5, and SIGTERM was asserted nowhere.

## Docs

Two rows in the process-exit-code table, plus one sentence saying what the numbers mean for a caller: `130`/`143` are a **cancellation**, not a failure. That is the table's whole purpose — a caller should not need Unix convention to script the CLI, and a CI wrapper that treats "not 0, not 2" as a crash misreports a cancelled job.

## Tests

`tests/integration/cli-contracts.test.ts:1057-1090` — one case per signal, table-driven, next to the existing signal tests. Each starts a transcription against a stub engine that writes its pid and hangs, waits for that pid file so the signal always lands mid-run, signals the CLI, then asserts the exit code is exactly 130/143 and that the engine process is gone (`waitForPidExit`). win32-skipped, matching the neighbouring signal tests; the stub is a fake engine, so this stays in the fast lane and needs no model gate (`cli-contracts` is asserted as fake-engine in `tests/unit/model-suite-guards.test.ts:39`).

Ctrl-C was already asserted at `:973` and `:1006`, but both tests are named for — and exist because of — something else (the grandchild helper tree; the `--list-voices` relay). The documented contract now has a test named after it, symmetric across both signals, matching the two spec scenarios.

### Red-check (the tests are not vacuous)

This is a coverage ticket, so the cases pass on arrival. To prove they exercise the ordering rather than passing by luck, `src/cli/main.ts:602-609` was temporarily reduced to a bare `process.exit(1)` — dropping the branch that prefers a pending signal's code over the batch's own failure code:

```
(fail) SIGINT  mid-transcription exits 130 …  Expected: 130  Received: 1
(fail) SIGTERM mid-transcription exits 143 …  Expected: 143  Received: 1
```

Sabotage reverted (`git checkout src/cli/main.ts`); both pass again. The interrupted file is recorded as a failure, so without that branch the batch's `exit(1)` wins the race against the 1 050 ms cleanup timer.

## Spec

`openspec/specs/process-lifecycle/spec.md`: the Open Issue bullet ("not documented … Nothing tests them end to end") is removed as resolved; the Technical Note now points at `docs/errors.md` and the tests; Ira's cancellation scenario gains `AND no Engine process is left running`, which is what the SIGTERM case asserts.

## Gates

- `bun test` → 1409 pass, 6 skip, 0 fail
- `bunx tsc --noEmit` → clean
- `bun run check` → 1250 pass, 0 fail
- `bun run check:specs` → 17 passed, 0 failed

TS/docs/spec only; no Rust gates apply.
