### PR TITLE
fix(mcp): synthesize_speech now actually auto-routes, and reports the voice that spoke (#942)

### DIFF
--- a/openspec/specs/mcp-server/spec.md
+++ b/openspec/specs/mcp-server/spec.md
@@ -125,6 +125,14 @@ The tool SHALL:
   voice, exactly as `kesha say` routes it
 - AND `structuredContent.voice` is that Voice id (`en-am_michael` here)
 
+#### Scenario: The auto-routed voice is not installed
+
+- GIVEN the detected language routes to a voice whose models are not installed
+- WHEN Sona calls `synthesize_speech` with no `voice`
+- THEN the call returns `isError: true` carrying the Engine's own message, the
+  same failure `kesha say` gives — rather than silently speaking a voice the
+  caller did not ask for
+
 #### Scenario: Voice omitted and the language does not route
 
 - GIVEN text-language detection is unavailable, or the detected language has no
@@ -133,12 +141,12 @@ The tool SHALL:
 - THEN synthesis uses the Engine's default voice
 - AND `structuredContent.voice` names that voice rather than a placeholder
 
-> *Technical Note — `synthesize_speech` registered at `src/mcp/tools.ts:36`.
+> *Technical Note — `synthesize_speech` registered at `src/mcp/tools.ts:37`.
 > Rate validation at `src/mcp/tools.ts:62`. `allocAudioPath` in
 > `src/mcp/audio-output.ts:25` creates `<tmpdir>/kesha-mcp/` with mode
 > `0o700` and names the file `<uuid>.<ext>`. `chmodSync(outPath, 0o600)` at
-> `src/mcp/tools.ts:73`. The voice is resolved before the engine is spawned by
-> `resolveSayVoice` (`src/voice-routing.ts`) — the same function `kesha say`
+> `src/mcp/tools.ts:71`. The voice is resolved before the engine is spawned by
+> `resolveSayVoice` (`src/voice-routing.ts:76`) — the same function `kesha say`
 > uses — falling back to `DEFAULT_VOICE_ID`, and passed to the engine
 > explicitly so the reported id is the one that spoke (#942).*
 

--- a/openspec/specs/mcp-server/spec.md
+++ b/openspec/specs/mcp-server/spec.md
@@ -97,7 +97,9 @@ The tool SHALL:
 3. Return a `resource_link` content item with URI `kesha-audio://<filename>`
    and a text summary of the synthesis.
 4. Return `structuredContent` with `uri`, `path`, `format`, `voice`, and
-   `bytes`.
+   `bytes`. `voice` SHALL be the Voice id that actually synthesized the audio —
+   the caller's when one was given, the auto-routed one otherwise — and SHALL be
+   valid input to a follow-up call, never a placeholder.
 
 `annotations.readOnlyHint` is `false`.
 
@@ -119,15 +121,26 @@ The tool SHALL:
 #### Scenario: Voice omitted — auto-route applies
 
 - WHEN Sona calls `synthesize_speech` with `{ text: "Hello" }` and no `voice`
-- THEN `structuredContent.voice` is `"(auto)"`
-- AND synthesis succeeds using the Default voice
+- THEN the text's language is detected and routed to that language's default
+  voice, exactly as `kesha say` routes it
+- AND `structuredContent.voice` is that Voice id (`en-am_michael` here)
 
-> *Technical Note — `synthesize_speech` registered at `src/mcp/tools.ts:35`.
-> Rate validation at `src/mcp/tools.ts:61`. `allocAudioPath` in
+#### Scenario: Voice omitted and the language does not route
+
+- GIVEN text-language detection is unavailable, or the detected language has no
+  voice on this build
+- WHEN Sona calls `synthesize_speech` with no `voice`
+- THEN synthesis uses the Engine's default voice
+- AND `structuredContent.voice` names that voice rather than a placeholder
+
+> *Technical Note — `synthesize_speech` registered at `src/mcp/tools.ts:36`.
+> Rate validation at `src/mcp/tools.ts:62`. `allocAudioPath` in
 > `src/mcp/audio-output.ts:25` creates `<tmpdir>/kesha-mcp/` with mode
 > `0o700` and names the file `<uuid>.<ext>`. `chmodSync(outPath, 0o600)` at
-> `src/mcp/tools.ts:69`. Resolved voice shows `"(auto)"` when `voice` was
-> omitted (`src/mcp/tools.ts:73`).*
+> `src/mcp/tools.ts:73`. The voice is resolved before the engine is spawned by
+> `resolveSayVoice` (`src/voice-routing.ts`) — the same function `kesha say`
+> uses — falling back to `DEFAULT_VOICE_ID`, and passed to the engine
+> explicitly so the reported id is the one that spoke (#942).*
 
 ### Requirement: `list_voices` returns installed voice metadata
 
@@ -252,10 +265,6 @@ The `transcribe_audio` tool SHALL document that paths resolve against the MCP se
 
 ## Open Issues
 
-- `synthesize_speech` returns `voice: "(auto)"` in `structuredContent` when no
-  voice is given, making it impossible for the caller to know which voice was
-  actually used; the engine could return the resolved Voice id in a future
-  protocol revision.
 - `transcribe_audio` does not expose a `lang` hint parameter; callers cannot
   influence language detection or trigger the expected-language mismatch warning
   via MCP.

--- a/openspec/specs/tts-synthesis/spec.md
+++ b/openspec/specs/tts-synthesis/spec.md
@@ -129,8 +129,9 @@ Voice id SHALL fail with `E_VOICE_UNKNOWN` and exit 1.
 - THEN the run fails with `E_VOICE_UNKNOWN` listing the supported prefixes
 - AND the process exits 1
 
-> *Technical Note — precedence: `src/cli/say.ts:27-35` (`resolveSayVoice`);
-> mapping: `src/voice-routing.ts:31-53` (`pickVoiceForLang`). The full map
+> *Technical Note — precedence: `src/voice-routing.ts:76-84` (`resolveSayVoice`,
+> shared with the MCP server since #942); mapping: `src/voice-routing.ts:42-60`
+> (`pickVoiceForLang`). The full map
 > (confidence < 0.5 → none; base code is lowercased and split on `-`/`_`):*
 >
 > | Detected/stated lang | darwin-arm64 | darwin-x64 (Intel macOS) | Linux / Windows |

--- a/src/cli/say.ts
+++ b/src/cli/say.ts
@@ -1,7 +1,6 @@
 import { defineCommand } from "citty";
 import { errorMessage } from "../error-utils";
 import {
-  detectTextLanguageEngine,
   getEngineBinPath,
   isEngineInstalled,
   spawnEngineProcess,
@@ -12,33 +11,9 @@ import { registerProcessTree } from "../process-tree";
 import { log } from "../log";
 import { say, SayError, type SayFormat } from "../synth";
 import { artifactFromBytes, artifactFromFile, type StatsRecorder } from "../stats";
-import { pickVoiceForLang } from "../voice-routing";
+import { resolveSayVoice } from "../voice-routing";
 import { diagnosticCharBucket, diagnosticSizeBucket } from "../diagnostic-events";
 import { runCommandSession, type CommandOutcome, type CommandSession } from "./command-session";
-
-async function autoRouteVoice(text: string): Promise<string | undefined> {
-  if (!text) return undefined;
-  const detected = await detectTextLanguageEngine(text);
-  return pickVoiceForLang(detected?.code, detected?.confidence ?? 0);
-}
-
-/**
- * Resolve the voice for `kesha say`. Precedence: explicit `--voice` > explicit
- * `--lang` (route by the stated language, skipping detection — also the path on
- * Linux/Windows where text-language detection is unavailable) > macOS
- * text-language auto-detection > engine default (`undefined`). A `--lang` the
- * build has no voice for resolves to `undefined` (engine default) rather than
- * re-running detection — the user stated the language explicitly.
- */
-export async function resolveSayVoice(
-  explicitVoice: string | undefined,
-  langHint: string | undefined,
-  text: string,
-): Promise<string | undefined> {
-  if (explicitVoice !== undefined) return explicitVoice;
-  if (langHint !== undefined) return pickVoiceForLang(langHint, 1);
-  return autoRouteVoice(text);
-}
 
 async function resolveText(inline: string | undefined): Promise<string> {
   if (inline !== undefined && inline.length > 0) return inline;

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -6,6 +6,7 @@ import { basename, isAbsolute, join } from "path";
 import { transcribe, transcribeWithTimestamps } from "../lib";
 import { listVoices, aggregateLanguages } from "./voices";
 import { say, type SayFormat } from "../synth";
+import { DEFAULT_VOICE_ID, resolveSayVoice } from "../voice-routing";
 import { allocAudioPath, audioDir } from "./audio-output";
 
 export function registerTools(server: McpServer): void {
@@ -64,13 +65,16 @@ export function registerTools(server: McpServer): void {
       const fmt: SayFormat = format ?? "wav";
       const outPath = allocAudioPath(fmt);
       try {
-        await say({ text, voice, rate, format: fmt, out: outPath });
+        // Resolve before spawning and pass the id explicitly: an MCP caller has no stderr to
+        // read, so the voice it is told is the only record of what spoke (#942). Naming the
+        // engine's own default is the same resolution it would make from a bare `say`.
+        const resolvedVoice = (await resolveSayVoice(voice, undefined, text)) ?? DEFAULT_VOICE_ID;
+        await say({ text, voice: resolvedVoice, rate, format: fmt, out: outPath });
         chmodSync(outPath, 0o600);
         const bytes = statSync(outPath).size;
         const file = basename(outPath);
         const uri = `kesha-audio://${file}`;
         const mimeType = mimeForExt(file);
-        const resolvedVoice = voice ?? "(auto)";
         return {
           content: [
             { type: "resource_link" as const, uri, name: file, mimeType },

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -65,9 +65,7 @@ export function registerTools(server: McpServer): void {
       const fmt: SayFormat = format ?? "wav";
       const outPath = allocAudioPath(fmt);
       try {
-        // Resolve before spawning and pass the id explicitly: an MCP caller has no stderr to
-        // read, so the voice it is told is the only record of what spoke (#942). Naming the
-        // engine's own default is the same resolution it would make from a bare `say`.
+        // An MCP caller has no stderr to read: the voice it is told is its only record (#942).
         const resolvedVoice = (await resolveSayVoice(voice, undefined, text)) ?? DEFAULT_VOICE_ID;
         await say({ text, voice: resolvedVoice, rate, format: fmt, out: outPath });
         chmodSync(outPath, 0o600);

--- a/src/voice-routing.ts
+++ b/src/voice-routing.ts
@@ -1,3 +1,13 @@
+import { detectTextLanguageEngine } from "./engine";
+
+/**
+ * The voice the engine falls back to when `say` is given no `--voice`
+ * (`tts::voices::DEFAULT_VOICE_ID`, rust/src/tts/voices.rs). Callers that must
+ * report the voice actually used name it explicitly rather than let the engine
+ * pick silently.
+ */
+export const DEFAULT_VOICE_ID = "en-am_michael";
+
 /**
  * Darwin defaults to AVSpeech Milena — zero install, no model download required.
  * Linux/Windows fall through to Vosk-TTS `ru-vosk-m02` (male, per CLAUDE.md
@@ -44,7 +54,7 @@ export function pickVoiceForLang(
   const baseCode = code.toLowerCase().split(/[-_]/, 1)[0] ?? "";
   switch (baseCode) {
     case "en":
-      return "en-am_michael";
+      return DEFAULT_VOICE_ID;
     case "ru":
       return platform === "darwin" ? RU_DARWIN_FALLBACK_VOICE : "ru-vosk-m02";
     default:
@@ -52,4 +62,31 @@ export function pickVoiceForLang(
       // ONNX: es/fr/it/pt via CharsiuG2P; hi/ja/zh have no ONNX pack → undefined.
       return ONNX_KOKORO_DEFAULTS[baseCode];
   }
+}
+
+async function autoRouteVoice(text: string): Promise<string | undefined> {
+  if (!text) return undefined;
+  const detected = await detectTextLanguageEngine(text);
+  return pickVoiceForLang(detected?.code, detected?.confidence ?? 0);
+}
+
+/**
+ * Resolve the voice for a synthesis request. Precedence: explicit voice >
+ * explicit language hint (route by the stated language, skipping detection —
+ * also the path on Linux/Windows where text-language detection is unavailable) >
+ * macOS text-language auto-detection > engine default (`undefined`). A language
+ * hint the build has no voice for resolves to `undefined` (engine default)
+ * rather than re-running detection — the user stated the language explicitly.
+ *
+ * Every caller that synthesizes routes through here; the MCP server reports what
+ * it returns as the voice used, so a second routing path would be a second answer.
+ */
+export async function resolveSayVoice(
+  explicitVoice: string | undefined,
+  langHint: string | undefined,
+  text: string,
+): Promise<string | undefined> {
+  if (explicitVoice !== undefined) return explicitVoice;
+  if (langHint !== undefined) return pickVoiceForLang(langHint, 1);
+  return autoRouteVoice(text);
 }

--- a/src/voice-routing.ts
+++ b/src/voice-routing.ts
@@ -1,11 +1,6 @@
 import { detectTextLanguageEngine } from "./engine";
 
-/**
- * The voice the engine falls back to when `say` is given no `--voice`
- * (`tts::voices::DEFAULT_VOICE_ID`, rust/src/tts/voices.rs). Callers that must
- * report the voice actually used name it explicitly rather than let the engine
- * pick silently.
- */
+/** The voice the Engine speaks with when `say` is given no `--voice` — mirrors `tts::voices::DEFAULT_VOICE_ID`. */
 export const DEFAULT_VOICE_ID = "en-am_michael";
 
 /**
@@ -77,9 +72,6 @@ async function autoRouteVoice(text: string): Promise<string | undefined> {
  * macOS text-language auto-detection > engine default (`undefined`). A language
  * hint the build has no voice for resolves to `undefined` (engine default)
  * rather than re-running detection — the user stated the language explicitly.
- *
- * Every caller that synthesizes routes through here; the MCP server reports what
- * it returns as the voice used, so a second routing path would be a second answer.
  */
 export async function resolveSayVoice(
   explicitVoice: string | undefined,

--- a/tests/unit/mcp-synthesize-voice.test.ts
+++ b/tests/unit/mcp-synthesize-voice.test.ts
@@ -5,6 +5,7 @@ import { join } from "path";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { createKeshaMcpServer } from "../../src/mcp/server";
+import { DEFAULT_VOICE_ID, pickVoiceForLang } from "../../src/voice-routing";
 
 const skipOnWin32 = process.platform === "win32" ? test.skip : test;
 
@@ -85,9 +86,13 @@ describe("synthesize_speech reports the voice it used (#942)", () => {
     const engine = synthesizingEngine({ code: "ru", confidence: 0.99 });
     const { voice } = await synthesize(engine, { text: "Совещание начинается." });
 
-    // Which Russian voice depends on the platform (AVSpeech on darwin, Vosk elsewhere);
-    // that it is a Russian one, and that the engine was told so, is the contract.
-    expect(voice).toMatch(/ru/i);
+    // The contract is "the same voice `kesha say` would use", so it is asserted against the
+    // routing function rather than a literal — which Russian voice is right depends on the
+    // platform, and darwin's AVSpeech Milena is a documented choice, not a defect (CLAUDE.md).
+    const routed = pickVoiceForLang("ru", 0.99);
+    expect(routed).toBeDefined();
+    expect(voice).toBe(routed as string);
+    expect(voice).not.toBe(DEFAULT_VOICE_ID);
     expect(engine.sayArgs()).toContain(voice);
   });
 

--- a/tests/unit/mcp-synthesize-voice.test.ts
+++ b/tests/unit/mcp-synthesize-voice.test.ts
@@ -1,0 +1,109 @@
+import { describe, test, expect } from "bun:test";
+import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { createKeshaMcpServer } from "../../src/mcp/server";
+
+const skipOnWin32 = process.platform === "win32" ? test.skip : test;
+
+interface SynthesizingEngine {
+  binPath: string;
+  /** Every argument the stub's last `say` invocation received. */
+  sayArgs(): string[];
+}
+
+/**
+ * A stub engine that answers `detect-text-lang` with `lang` (or fails detection when it is
+ * null, the Linux/Windows reality) and records the argv of the `say` it is then handed.
+ */
+function synthesizingEngine(lang: { code: string; confidence: number } | null): SynthesizingEngine {
+  const dir = mkdtempSync(join(tmpdir(), "kesha-mcp-synth-"));
+  const binPath = join(dir, "kesha-engine");
+  const argvPath = join(dir, "say-argv");
+  const detect = lang
+    ? `printf '%s\\n' '${JSON.stringify(lang)}'\n  exit 0`
+    : `printf '%s\\n' 'detect-text-lang: unsupported on this build' >&2\n  exit 2`;
+  writeFileSync(
+    binPath,
+    `#!/bin/sh
+if [ "$1" = "detect-text-lang" ]; then
+  ${detect}
+fi
+if [ "$1" = "say" ]; then
+  cat > /dev/null
+  : > '${argvPath}'
+  out=""
+  prev=""
+  for a in "$@"; do
+    printf '%s\\n' "$a" >> '${argvPath}'
+    if [ "$prev" = "--out" ]; then out="$a"; fi
+    prev="$a"
+  done
+  printf 'RIFF' > "$out"
+  exit 0
+fi
+exit 2
+`,
+  );
+  chmodSync(binPath, 0o755);
+  return {
+    binPath,
+    sayArgs: () => readFileSync(argvPath, "utf8").split("\n").filter(Boolean),
+  };
+}
+
+async function synthesize(engine: SynthesizingEngine, args: Record<string, unknown>) {
+  const prev = process.env.KESHA_ENGINE_BIN;
+  process.env.KESHA_ENGINE_BIN = engine.binPath;
+  try {
+    const server = createKeshaMcpServer();
+    const [c, s] = InMemoryTransport.createLinkedPair();
+    await server.connect(s);
+    const client = new Client({ name: "t", version: "0" });
+    await client.connect(c);
+    const res = await client.callTool({ name: "synthesize_speech", arguments: args });
+    return { res, voice: (res.structuredContent as { voice: string }).voice };
+  } finally {
+    if (prev === undefined) delete process.env.KESHA_ENGINE_BIN;
+    else process.env.KESHA_ENGINE_BIN = prev;
+  }
+}
+
+describe("synthesize_speech reports the voice it used (#942)", () => {
+  skipOnWin32("voice omitted: reports the auto-routed id, and hands the engine that same id", async () => {
+    const engine = synthesizingEngine({ code: "en", confidence: 0.99 });
+    const { res, voice } = await synthesize(engine, { text: "Meeting starts now." });
+
+    expect(res.isError).toBeUndefined();
+    expect(voice).toBe("en-am_michael");
+    expect(engine.sayArgs()).toContain(voice);
+  });
+
+  skipOnWin32("voice omitted, Russian text: routes away from the English default", async () => {
+    const engine = synthesizingEngine({ code: "ru", confidence: 0.99 });
+    const { voice } = await synthesize(engine, { text: "Совещание начинается." });
+
+    // Which Russian voice depends on the platform (AVSpeech on darwin, Vosk elsewhere);
+    // that it is a Russian one, and that the engine was told so, is the contract.
+    expect(voice).toMatch(/ru/i);
+    expect(engine.sayArgs()).toContain(voice);
+  });
+
+  skipOnWin32("detection unavailable: reports the default voice, never a placeholder", async () => {
+    const engine = synthesizingEngine(null);
+    const { voice } = await synthesize(engine, { text: "Meeting starts now." });
+
+    expect(voice).toBe("en-am_michael");
+    expect(engine.sayArgs()).toContain(voice);
+  });
+
+  skipOnWin32("explicit voice is echoed back verbatim", async () => {
+    const engine = synthesizingEngine({ code: "en", confidence: 0.99 });
+    const { voice } = await synthesize(engine, { text: "Привет", voice: "ru-vosk-m02" });
+
+    expect(voice).toBe("ru-vosk-m02");
+    expect(engine.sayArgs()).toContain(voice);
+  });
+});

--- a/tests/unit/say-cli.test.ts
+++ b/tests/unit/say-cli.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, test } from "bun:test";
-import { shouldRejectMissingSayText } from "../../src/cli/say";
+import { afterEach, describe, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { sayCommand, shouldRejectMissingSayText } from "../../src/cli/say";
+import { saveEngineEnv } from "../helpers/fake-engine";
 
 describe("say CLI input guard (#324 P1)", () => {
   test("rejects missing text only when stdin is a TTY", () => {
@@ -14,5 +18,91 @@ describe("say CLI input guard (#324 P1)", () => {
 
   test("allows explicit positional text even from a TTY", () => {
     expect(shouldRejectMissingSayText("Hello", true)).toBe(false);
+  });
+});
+
+class ExitCalled extends Error {
+  constructor(readonly code: number) {
+    super(`process.exit(${code})`);
+  }
+}
+
+const cleanups: Array<() => void> = [];
+
+afterEach(() => {
+  for (const undo of cleanups.splice(0).reverse()) undo();
+});
+
+function tempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  cleanups.push(() => rmSync(dir, { recursive: true, force: true }));
+  return dir;
+}
+
+/** A stub engine whose `say` fails the way the real one does: an `error [CODE]:` line and a status. */
+function failingEngine(exitCode: number, stderrLine: string): string {
+  const dir = tempDir("kesha-say-fail-");
+  const binPath = join(dir, "kesha-engine");
+  writeFileSync(
+    binPath,
+    `#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' '${stderrLine}' >&2\nexit ${exitCode}\n`,
+  );
+  chmodSync(binPath, 0o755);
+  cleanups.push(saveEngineEnv());
+  process.env.KESHA_ENGINE_BIN = binPath;
+  return binPath;
+}
+
+/** Runs `kesha say` in-process and returns the status it exits with plus everything it wrote to stderr. */
+async function runSay(args: Record<string, unknown>): Promise<{ exitCode: number; stderr: string }> {
+  const savedExit = process.exit;
+  const savedWrite = process.stderr.write;
+  let stderr = "";
+  process.stderr.write = ((chunk: unknown) => {
+    stderr += String(chunk);
+    return true;
+  }) as typeof process.stderr.write;
+  process.exit = ((code?: number) => {
+    throw new ExitCalled(code ?? 0);
+  }) as typeof process.exit;
+  try {
+    await sayCommand.run?.({ args } as never);
+    return { exitCode: 0, stderr };
+  } catch (err) {
+    if (err instanceof ExitCalled) return { exitCode: err.code, stderr };
+    throw err;
+  } finally {
+    process.exit = savedExit;
+    process.stderr.write = savedWrite;
+  }
+}
+
+const skipOnWin32 = process.platform === "win32" ? test.skip : test;
+
+// Nothing exercised this path: `say.test.ts` only ever hands the CLI an engine that succeeds,
+// so a failure flattened into "exit 1, generic message" would have gone unnoticed.
+describe("kesha say relays an engine failure", () => {
+  skipOnWin32("exits with the engine's own status and prints its stderr", async () => {
+    failingEngine(3, "error [E_VOICE_NOT_FOUND]: voice zz-nobody is not installed");
+
+    const { exitCode, stderr } = await runSay({
+      text: "Hello",
+      voice: "zz-nobody",
+      out: join(tempDir("kesha-say-out-"), "reply.wav"),
+      rate: "1.0",
+    });
+
+    expect(exitCode).toBe(3);
+    expect(stderr).toContain("E_VOICE_NOT_FOUND");
+    expect(stderr).toContain("voice zz-nobody is not installed");
+  });
+
+  skipOnWin32("does not swallow a failure into a success exit", async () => {
+    failingEngine(1, "error [E_INTERNAL]: synthesis aborted");
+
+    const { exitCode, stderr } = await runSay({ text: "Hello", voice: "en-am_michael", rate: "1.0" });
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("synthesis aborted");
   });
 });

--- a/tests/unit/say-routing.test.ts
+++ b/tests/unit/say-routing.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { resolveSayVoice } from "../../src/cli/say";
+import { resolveSayVoice } from "../../src/voice-routing";
 
 // resolveSayVoice precedence: --voice > --lang (route by stated language,
 // skip detection) > macOS auto-detect > engine default (undefined).

--- a/tests/unit/voice-routing.test.ts
+++ b/tests/unit/voice-routing.test.ts
@@ -3,10 +3,13 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { DEFAULT_VOICE_ID, pickVoiceForLang } from "../../src/voice-routing";
 
-const MODELS_RS = readFileSync(
-  join(import.meta.dir, "..", "..", "rust", "src", "models.rs"),
-  "utf8",
-).replace(/\r\n/g, "\n");
+const rustSource = (...parts: string[]) =>
+  readFileSync(join(import.meta.dir, "..", "..", "rust", "src", ...parts), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+
+const MODELS_RS = rustSource("models.rs");
 
 // Parsed, not copied: a language added to tts_languages() alone must turn these guards red (#769).
 function advertisedTtsLangs(): { systemKokoro: string[]; onnx: string[] } {
@@ -192,15 +195,20 @@ describe("pickVoiceForLang (auto-routing)", () => {
   });
 });
 
+// The MCP server names this voice when routing declines, and reports it as the one that
+// spoke (#942). Two things have to hold for that report to stay true, so both are parsed
+// out of the Rust source rather than copied: the constant's value, and the fact that
+// `kesha-engine say` still applies *that* constant when no --voice reaches it.
 describe("DEFAULT_VOICE_ID", () => {
-  // The MCP server names this voice when routing declines, and reports it as the one that
-  // spoke (#942). If the engine's own fallback moves, that report becomes a lie.
   it("matches the engine's fallback voice", () => {
-    const voicesRs = readFileSync(
-      join(import.meta.dir, "..", "..", "rust", "src", "tts", "voices.rs"),
-      "utf8",
-    );
-    const engineDefault = voicesRs.match(/DEFAULT_VOICE_ID:\s*&str\s*=\s*"([^"]+)"/)?.[1];
+    const engineDefault = rustSource("tts", "voices.rs").match(
+      /DEFAULT_VOICE_ID:\s*&str\s*=\s*"([^"]+)"/,
+    )?.[1];
     expect(engineDefault).toBe(DEFAULT_VOICE_ID);
+  });
+
+  it("is what the engine's own say applies when no voice reaches it", () => {
+    const fallback = rustSource("cli", "say.rs").match(/voice_id\.unwrap_or\(([^)]*)\)/)?.[1];
+    expect(fallback).toBe("tts::voices::DEFAULT_VOICE_ID");
   });
 });

--- a/tests/unit/voice-routing.test.ts
+++ b/tests/unit/voice-routing.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { pickVoiceForLang } from "../../src/voice-routing";
+import { DEFAULT_VOICE_ID, pickVoiceForLang } from "../../src/voice-routing";
 
 const MODELS_RS = readFileSync(
   join(import.meta.dir, "..", "..", "rust", "src", "models.rs"),
@@ -189,5 +189,18 @@ describe("pickVoiceForLang (auto-routing)", () => {
   it("returns undefined when code is missing", () => {
     expect(pickVoiceForLang(undefined, 0.95)).toBeUndefined();
     expect(pickVoiceForLang("", 0.95)).toBeUndefined();
+  });
+});
+
+describe("DEFAULT_VOICE_ID", () => {
+  // The MCP server names this voice when routing declines, and reports it as the one that
+  // spoke (#942). If the engine's own fallback moves, that report becomes a lie.
+  it("matches the engine's fallback voice", () => {
+    const voicesRs = readFileSync(
+      join(import.meta.dir, "..", "..", "rust", "src", "tts", "voices.rs"),
+      "utf8",
+    );
+    const engineDefault = voicesRs.match(/DEFAULT_VOICE_ID:\s*&str\s*=\s*"([^"]+)"/)?.[1];
+    expect(engineDefault).toBe(DEFAULT_VOICE_ID);
   });
 });


### PR DESCRIPTION
Closes #942

## ⚠️ Read this before merging: MCP synthesis sounds different after this PR

The first framing of this PR called it a reporting fix. It is not only that. Fixing the report required fixing the thing being reported, and **audible behaviour changes** for MCP callers that omit `voice`:

| Call | Before | After |
|---|---|---|
| Russian text, no `voice`, on darwin | spoke `en-am_michael` — an English voice reading Cyrillic | speaks AVSpeech **Milena**, the documented darwin zero-install route (CLAUDE.md) |
| es / fr / it / pt / hi / ja / zh, no `voice`, on darwin-arm64 | spoke `en-am_michael` | speaks that language's Kokoro default |
| Routed voice's models not installed | silently spoke `en-am_michael` anyway | **hard error** (`isError: true`) carrying the engine's own message |
| Any call with no `voice` | straight to the engine | one extra `detect-text-lang` engine call first |

`--voice`-bearing calls and `kesha say` are untouched. Nothing here is new *policy* — it is `kesha say`'s existing routing, which the MCP tool description and `openspec/specs/mcp-server/spec.md` both already promised. But an owner who reads "reporting fix" and merges will hear a different voice afterwards, so it is stated up front.

## Two bugs, not one

**Bug 1 — the report.** `synthesize_speech` returned `voice: "(auto)"` whenever the caller omitted `voice`. Not a Voice id: it could not be fed back into a follow-up call, keyed a cache, or told to a user.

**Bug 2 — the thing it was hiding.** Auto-routing *was never running*. Routing lived in `resolveSayVoice` in `src/cli/say.ts`; the MCP server calls `say()` from `src/synth.ts` directly and never passes through the CLI layer. So a voiceless MCP call — Russian text included — synthesized with the engine's English default, while the tool description and the spec both said it auto-routed. `"(auto)"` is exactly why nobody noticed: the response never named a voice that could be checked against the audio.

Fixing bug 1 honestly is not possible without fixing bug 2. Reporting a voice means knowing which one spoke, and the only way to know is to decide it here and say so explicitly.

## Option chosen: B, done as *reuse* rather than duplication

Issue #942 offered (A) a protocol change so the engine reports its resolved voice, or (B) resolving CLI-side before spawning. B, on this reasoning:

- The routing inputs *are* cleanly available at the MCP layer — routing needs the detected text language, and detection is an engine call (`detect-text-lang`) any caller can make, not something buried inside `say`.
- The real risk with B is a *second* routing path that drifts from the CLI's. That is avoided by moving `resolveSayVoice` out of `src/cli/say.ts` into `src/voice-routing.ts` and having both entry points call the one function. The MCP server no longer reaches into the CLI layer, and there is exactly one answer to "which voice for this text".
- The voice is then passed to the engine **explicitly**, so the reported id is not a prediction of what the engine will do — it is what the engine was told.
- A protocol change (A) would need a new engine release, a capability string and a version gate to report something the CLI already knows before it spawns.

**The one place the engine still holds knowledge we don't**: when routing declines (detection unavailable — Linux/Windows — or a language this build has no voice for), `say` with no `--voice` falls back to `tts::voices::DEFAULT_VOICE_ID`. `--capabilities-json` doesn't advertise it. So `src/voice-routing.ts` names it as `DEFAULT_VOICE_ID` and passes it explicitly. Two things must hold for that to stay true, and `tests/unit/voice-routing.test.ts` parses both out of the Rust source rather than copying them:

1. the constant's value in `rust/src/tts/voices.rs`;
2. that `rust/src/cli/say.rs` still applies *that* constant — `voice_id.unwrap_or(tts::voices::DEFAULT_VOICE_ID)` — and not some other literal.

If A ever lands, that constant is the only thing it removes.

## Red → green

`tests/unit/mcp-synthesize-voice.test.ts` drives the real MCP tool over `InMemoryTransport` against a stub engine (`KESHA_ENGINE_BIN`, the #985 pattern) that answers `detect-text-lang` and records the argv of the `say` it is then handed — so the assertion is "the id we reported is the id the engine got", not merely "not a placeholder". Runs in the fast lane; no models, no network.

```
# at fe0b5f0 (test only)
Expected: "en-am_michael"   Received: "(auto)"   ← voice omitted, English
Expected: a ru voice        Received: "(auto)"   ← voice omitted, Russian
Expected: "en-am_michael"   Received: "(auto)"   ← detection unavailable
 1 pass 3 fail                                   ← explicit voice already echoed; the regression guard

# at 4647d03 (fix)
 4 pass 0 fail
```

The Russian case asserts against `pickVoiceForLang("ru", …)` rather than a literal id: the contract is "the voice `kesha say` would use", which is platform-dependent, and darwin's AVSpeech Milena is a documented brand-rule exception rather than something to lock against.

## Coverage: what the `ts-coverage` gate caught, and why no floor moved

The first push turned `ts-coverage` red — `src/cli/say.ts` at **49.82%** against its 50% floor.

Nothing about the say CLI became less tested. Moving `resolveSayVoice` out of that file took eight fully-covered lines with it (150/293 → 142/285) and the floor is a percentage, so the file's untested remainder grew as a share. The floor was left alone and the honest gap was covered instead: **`kesha say` translating a `SayError` into an exit status and relaying the engine's stderr had no test anywhere.** `tests/integration/say.test.ts` only ever hands the CLI an engine that succeeds, and being subprocess-driven it credits no coverage either way. `tests/unit/say-cli.test.ts` now drives the command in-process against a stub engine that fails, asserting the engine's own status and stderr reach the caller unchanged.

`src/cli/say.ts` 49.82% → **78.55%**; total 80.27% → **81.30%**. Both new tests were verified to go red under a mutation of the exit-code path (`err.exitCode` → constant 4).

## Gates

- `bun test` → 1415 pass, 6 skip, 0 fail
- `bunx tsc --noEmit` → clean
- `bun run check` → 1256 pass, 0 fail
- `bun run coverage:check:ts` → **green** (was the failing check)
- `openspec validate --specs --strict` → 17/17
- TS-only; no engine change needed, so no Rust gate.

## Spec

`openspec/specs/mcp-server/spec.md`: the `"(auto)"` scenario is replaced by three real ones (routed; routed-voice-not-installed, which now fails loudly; and routing-declines), the `structuredContent` requirement states the id must be valid input to a follow-up call, and the Open Issue this closes is removed. `openspec/specs/tts-synthesis/spec.md`'s pointer to `resolveSayVoice` followed it to `src/voice-routing.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBTpJjqyYFW6W8LHJ2nwy
