### PR TITLE
fix(release): install dependencies before the alpha lane's derivation gate

### DIFF
--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -372,6 +372,34 @@ export function requireRestoreOnlyCachesHaveAWriter(
  * `check:versions` and the unit tests run inside `unit-tests`, which that filter gates,
  * so an uncovered script means edits to a gate skip the tests that prove it works.
  */
+/**
+ * A job that runs `bun test` without installing dependencies first passes until a test reaches
+ * for one — `tests/helpers/repo.ts` importing `yaml` broke the alpha lane's derivation gate long
+ * after the step was written, and only on the runs that actually cut an alpha (#993).
+ */
+export function requireDepsBeforeBunTest(path: string, document: unknown): string[] {
+  const jobs = (document as { jobs?: Record<string, Job> })?.jobs;
+  if (!jobs || typeof jobs !== "object") return [];
+
+  const installs = (step: Step) =>
+    (typeof step?.run === "string" && /\bbun install\b/.test(step.run)) ||
+    (typeof step?.uses === "string" && step.uses.endsWith("/actions/setup-bun"));
+
+  const errors: string[] = [];
+  for (const [name, job] of Object.entries(jobs)) {
+    const steps = Array.isArray(job?.steps) ? (job.steps as Step[]) : [];
+    let installed = false;
+    for (const step of steps) {
+      if (installs(step)) installed = true;
+      else if (!installed && runsMatching([step], /^\s*bun (test|run test)\b/m).length > 0) {
+        errors.push(`${path}: job \`${name}\` runs \`bun test\` without installing dependencies first`);
+        break;
+      }
+    }
+  }
+  return errors;
+}
+
 export function requireTestedScriptsInCodeFilter(
   path: string,
   document: unknown,
@@ -433,6 +461,7 @@ function checkFile(path: string, testedScripts: string[], cacheWriters: CacheEnt
       ...requireNpmPublishAfterPackaging(path, document),
       ...requirePactVerificationCoversEveryTarget(path, document),
       ...requireBashOnWindowsRunSteps(path, document),
+      ...requireDepsBeforeBunTest(path, document),
       ...requireRestoreOnlyCachesHaveAWriter(path, document, cacheWriters),
       ...requireTestedScriptsInCodeFilter(path, document, testedScripts),
     ];

--- a/.github/workflows/prune-alpha-releases.yml
+++ b/.github/workflows/prune-alpha-releases.yml
@@ -18,9 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.0.2
-        with:
-          bun-version: latest
+      # The composite installs dependencies: the `bun test` gate below needs them (#993).
+      - uses: ./.github/actions/setup-bun
 
       - name: Test the selection before trusting it
         run: bun test tests/unit/prune-alpha-releases.test.ts

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -48,9 +48,8 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.0.2
-        with:
-          bun-version: latest
+      # The composite installs dependencies: the `bun test` gate below needs them (#993).
+      - uses: ./.github/actions/setup-bun
 
       - name: Changed paths
         env:

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -6,6 +6,7 @@ import {
   requireBashOnWindowsRunSteps,
   requireRestoreOnlyCachesHaveAWriter,
   requireDarwinSmokeCoversBothEngines,
+  requireDepsBeforeBunTest,
   requireNpmPublishAfterPackaging,
   requirePactVerificationCoversEveryTarget,
   requirePreUploadSynthesisSmoke,
@@ -419,5 +420,44 @@ describe("requireRestoreOnlyCachesHaveAWriter", () => {
   test("a restore step is not a writer", () => {
     const restore = job("seed", [{ uses: "actions/cache/restore@55cc834", with: { path: "x", key: "models-v3" } }]);
     expect(collectCacheWriters(restore)).toEqual([]);
+  });
+});
+
+describe("requireDepsBeforeBunTest", () => {
+  const TEST = { name: "test", run: "bun test tests/unit/derive-alpha-version.test.ts" };
+  const INSTALL = { name: "install", run: "bun install --frozen-lockfile" };
+  const SETUP = { uses: "./.github/actions/setup-bun" };
+
+  test("passes on every workflow in the repo", () => {
+    for (const path of readdirSync(repoPath(".github/workflows")).map((f) => `.github/workflows/${f}`)) {
+      expect(requireDepsBeforeBunTest(path, parseRepoYaml(path))).toEqual([]);
+    }
+  });
+
+  test("fails when a job runs bun test without installing dependencies", () => {
+    const errors = requireDepsBeforeBunTest(PATH, job("decide", [TEST]));
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("runs `bun test` without installing dependencies first");
+  });
+
+  test("fails when the install runs after the tests", () => {
+    expect(requireDepsBeforeBunTest(PATH, job("decide", [TEST, INSTALL]))).toHaveLength(1);
+  });
+
+  test("accepts a bun install step before it", () => {
+    expect(requireDepsBeforeBunTest(PATH, job("decide", [INSTALL, TEST]))).toEqual([]);
+  });
+
+  test("accepts the setup-bun composite, which installs", () => {
+    expect(requireDepsBeforeBunTest(PATH, job("decide", [SETUP, TEST]))).toEqual([]);
+  });
+
+  test("an install in another job does not count", () => {
+    const document = { jobs: { setup: { steps: [INSTALL] }, decide: { steps: [TEST] } } };
+    expect(requireDepsBeforeBunTest(PATH, document)).toHaveLength(1);
+  });
+
+  test("ignores a mention that is not a run", () => {
+    expect(requireDepsBeforeBunTest(PATH, job("decide", [{ name: "x", run: 'echo "bun test"' }]))).toEqual([]);
   });
 });


### PR DESCRIPTION
Cutting a CLI alpha today fails in `release-alpha.yml`'s `decide` job ([run 31710186939](https://github.com/drakulavich/kesha-voice-kit/actions/runs/31710186939)):

```
error: Cannot find package 'yaml' from '…/tests/helpers/repo.ts'
```

The "Test the derivation" step runs `bun test` after a bare `oven-sh/setup-bun`, with no `bun install`. That held while those tests imported nothing outside `bun:test` — #789 moved them onto `tests/helpers/repo.ts`, which imports the `yaml` devDependency at module level. The step is guarded by `if: publish == 'true'`, so only a run that actually cuts an alpha executes it; nothing since #789 did.

`prune-alpha-releases.yml` has the same shape and would die the same way on its weekly schedule.

## Changes

- Both jobs now use the in-repo `./.github/actions/setup-bun` composite, which installs dependencies (and pins bun from `.bun-version` instead of `latest`).
- New `check-workflows.ts` lint `requireDepsBeforeBunTest`: a job running `bun test` without a preceding `bun install` (or the composite) fails the workflow lint. Both breaks are caught by it — verified by reverting each fix.

Test-first: the lint and its unit tests landed red against the real workflows, then the two workflows went green.

Closes #993