### PR TITLE
test(stats): anchor the export fixtures to a relative clock

### DIFF
--- a/tests/unit/stats.test.ts
+++ b/tests/unit/stats.test.ts
@@ -42,6 +42,18 @@ function useTempStatsDb(prefix: string): () => string {
   return () => dir;
 }
 
+/**
+ * A run window inside the retention horizon. #1005: `exportStats` prunes rows older than the
+ * 90-day default as it reads, so a literal date here fails the day it ages out — keep it relative.
+ */
+function recentRunWindow(durationMs = 1_000): { startedAt: string; finishedAt: string } {
+  const startedAt = Date.now() - 60 * 60 * 1000;
+  return {
+    startedAt: new Date(startedAt).toISOString(),
+    finishedAt: new Date(startedAt + durationMs).toISOString(),
+  };
+}
+
 describe("stats storage", () => {
   const statsDir = useTempStatsDb("kesha-stats-test-");
 
@@ -186,8 +198,7 @@ describe("stats storage", () => {
     seedStatsRun({
       command: "transcribe",
       status: "failed",
-      startedAt: "2026-05-16T10:00:00.000Z",
-      finishedAt: "2026-05-16T10:00:01.000Z",
+      ...recentRunWindow(),
       itemCount: 1,
       stages: [{ stage: "transcribe", durationMs: 100, status: "failed" }],
       inputArtifacts: [{ format: "wav", sizeBytes: 1234, durationMs: 2000 }],
@@ -966,8 +977,7 @@ describe("stats export contracts", () => {
     seedStatsRun({
       command: "transcribe",
       status: "failed",
-      startedAt: "2026-05-16T10:00:00.000Z",
-      finishedAt: "2026-05-16T10:00:01.000Z",
+      ...recentRunWindow(),
       itemCount: 1,
       stages: [],
     });
@@ -989,8 +999,7 @@ describe("stats export contracts", () => {
     seedStatsRun({
       command: "transcribe",
       status: "failed",
-      startedAt: "2026-05-16T10:00:00.000Z",
-      finishedAt: "2026-05-16T10:00:01.000Z",
+      ...recentRunWindow(),
       itemCount: 1,
       stages: [],
       error: new Error('one, two "three"'),


### PR DESCRIPTION
Closes #1005

Three tests in `tests/unit/stats.test.ts` went red today on **main and every open PR**, with no code change behind it:

- `stats storage > exports content-free JSON and CSV` — `expect(parsed.runs).toHaveLength(1)` sees 0
- `stats export contracts > every row carries one cell per column…` — `TypeError: undefined is not an object (evaluating 'lines.find((line) => line.startsWith("runs,")).split')`
- `stats export contracts > a cell containing a comma or a quote is quoted…`

## The arithmetic

Every fixture in the export suite was hardcoded at `2026-05-16T10:00:00.000Z`. `exportStats()` → `readStatsExport()` → `applyStatsRetention(db)` (`src/stats.ts:776`, delete at `:983`) purges runs older than `retentionDays` — default **90** — relative to wall-clock now.

`2026-05-16 + 90d = 2026-08-14`, today. Measured while diagnosing:

```
now 2026-08-14T10:14:39Z  cutoff 2026-05-16T10:14:39Z  seed 2026-05-16T10:00:00Z → deleted: true
```

The seeded run is deleted **by the export call under test**, so `runs` comes back empty and the CSV has no `runs,` row — which is exactly the `lines.find(...)` TypeError rather than a clean assertion failure.

Only these three fail because `exportStats` is the only public entry that applies retention *after* seeding: `getWeekSummary` takes an explicit `now`, and `enableStats` / `setStatsRetentionDays` run before the seeds.

## Why main looked green

main's last `🧪 CI` ran at **05:22 UTC**, before the cutoff crossed at 10:00 UTC. It was green because the bomb had not gone off yet, not because main was healthy. Re-running that same SHA now goes red.

Verified independently in **two unrelated worktrees** (a rust-only lane and an install-lock lane) where `src/stats.ts` and `tests/unit/stats.test.ts` are byte-identical to `origin/main` — same three failures, and the stats suite fails when run entirely alone, which rules out cross-test pollution.

## Classification

**Test defect, not a production defect.** Retention deleting rows older than 90 days is the documented contract working as intended, so `src/stats.ts` is untouched here. The suite violated the *deterministic* desideratum in CLAUDE.md: fixtures pinned to an absolute date, asserted against a wall-clock-relative purge. It was always going to fail exactly 90 days after someone typed that date.

Deliberately **not** fixed by raising or stubbing the default retention — `KESHA_STATS_RETENTION_DAYS=3650` turns these three green but flips two others red (`status is disabled before the database exists`, `an export from an untouched install…`), because the default of 90 is itself an asserted contract. That lever was a diagnostic, never a candidate fix.

## The change

One helper, three seeds re-anchored:

```ts
function recentRunWindow(durationMs = 1_000): { startedAt: string; finishedAt: string }
```

It carries a why-comment naming this issue so nobody tidies it back to a literal date. The retention-*boundary* tests keep their explicit dates on purpose — `retention prunes old runs before recording new stats` needs a run that must be pruned (`2020-01-01`), and `retention off keeps runs older than any window` needs one that must survive. The boundary is their contract; making those relative would delete the thing they test.

## Verification

- **Full `bun run test`: 1424 pass, 6 skip, 0 fail** across 99 files. (Use `bun run test`, not bare `bun test` — the script passes `--timeout 30000` while bare `bun test` caps at 5 s, which makes `doctor … a working sidecar still reports as installed` fail at ~5002 ms. That is the cap, not a defect; the full run is green apart from the time bomb this PR removes.)
- `bunx tsc --noEmit` → exit 0
- `bun run check` → exit 0 (1265 pass, 0 fail)
- **Recurrence proof**: re-ran the three export tests under `KESHA_STATS_RETENTION_DAYS=1`, which is equivalent to jumping 89 days into the future against the default window. All three pass. The old literal fixture would have been purged.
