### PR TITLE
fix(cli): a reader that stops reading ends the run quietly

### DIFF
--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -1,6 +1,7 @@
 import { runMain, type CommandDef } from "citty";
 import { existsSync } from "fs";
 import { log } from "../log";
+import { guardStdoutWrites } from "../stdout-pipe";
 import { suggestCommand } from "../suggest-command";
 import { applyCliContext, resolveCliContext } from "./context";
 
@@ -89,6 +90,7 @@ export function unknownCommandMessages(token: string, subcommandKeys: string[]):
 }
 
 export async function runCli(argv = process.argv.slice(2)): Promise<void> {
+  guardStdoutWrites();
   const context = resolveCliContext(argv);
   applyCliContext(context);
 

--- a/src/stdout-pipe.ts
+++ b/src/stdout-pipe.ts
@@ -1,0 +1,26 @@
+import { errorMessage } from "./error-utils";
+import { log } from "./log";
+
+let guarded = false;
+
+/**
+ * Keeps a reader that stops reading — `kesha say | ffplay -` then quit, `| head -c 1000` for
+ * a preview — from reading as a crash. Bun delivers a stdout EPIPE asynchronously, past any
+ * try/catch around the write, so it escaped as an uncaught stack trace and turned a
+ * successful synthesis into exit 1 (#1001). EPIPE alone means the reader left; every other
+ * write failure still reports and exits non-zero.
+ */
+export function guardStdoutWrites(): void {
+  if (guarded) return;
+  guarded = true;
+  process.stdout.on("error", (err: NodeJS.ErrnoException) => {
+    if (err?.code === "EPIPE") {
+      log.debug("stdout closed by the reader; nothing left to write");
+      return;
+    }
+    log.error(
+      `failed writing to stdout: ${errorMessage(err)}. Check that the destination is writable and has free space.`,
+    );
+    process.exitCode = 1;
+  });
+}

--- a/tests/integration/cli-contracts.test.ts
+++ b/tests/integration/cli-contracts.test.ts
@@ -7,6 +7,7 @@ import {
   readFileSync,
   renameSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "fs";
 import { tmpdir } from "os";
@@ -113,6 +114,11 @@ if (args[0] === "transcribe") {
   } else {
     console.log(text);
   }
+  process.exit(0);
+}
+
+if (args[0] === "say") {
+  await Bun.write(Bun.stdout, new Uint8Array(Number(process.env.KESHA_FAKE_SAY_BYTES || "4096")));
   process.exit(0);
 }
 
@@ -262,6 +268,47 @@ process.exit(2);
   );
   chmodSync(enginePath, 0o755);
   return enginePath;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+/**
+ * Runs the CLI under a real shell so its stdout can be redirected or piped. `runCliScenario`
+ * drains stdout to completion, so it can never produce the reader-went-away case #1001 is
+ * about; `${PIPESTATUS[0]}` reports the CLI's own status rather than the consumer's.
+ */
+async function runCliWithShellStdout(
+  args: string[],
+  stdoutSuffix: string,
+  env: Record<string, string>,
+): Promise<{ exitCode: number; stderr: string }> {
+  const cli = [process.execPath, "run", "src/cli-entry.ts", ...args].map(shellQuote).join(" ");
+  const proc = Bun.spawn(["bash", "-c", `${cli} ${stdoutSuffix}; exit \${PIPESTATUS[0]}`], {
+    cwd: DEFAULT_CWD,
+    stdout: "ignore",
+    stderr: "pipe",
+    env: { ...process.env, NO_COLOR: "1", FORCE_COLOR: "0", ...env },
+  });
+  const [stderr, exitCode] = await Promise.all([new Response(proc.stderr).text(), proc.exited]);
+  return { exitCode, stderr };
+}
+
+async function runCliPipedTo(
+  args: string[],
+  consumer: string,
+  opts: { env: Record<string, string>; sinkPath: string },
+): Promise<{ exitCode: number; stderr: string; stdoutBytes: number }> {
+  const run = await runCliWithShellStdout(
+    args,
+    `| ${consumer} > ${shellQuote(opts.sinkPath)}`,
+    opts.env,
+  );
+  return {
+    ...run,
+    stdoutBytes: existsSync(opts.sinkPath) ? statSync(opts.sinkPath).size : 0,
+  };
 }
 
 function expectContract(
@@ -1370,5 +1417,66 @@ describe("CLI contracts", () => {
     });
 
     expect(existsSync(join(dir, "cache", "engine"))).toBe(false);
+  }, 30000);
+
+  // `kesha say | ffplay -` then quitting, or `| head -c N` for a preview, is ordinary use of
+  // a filter. Bun delivers the resulting EPIPE asynchronously, so it used to escape as an
+  // uncaught crash dump — absolute install paths, a Bun banner, exit 1 on a synthesis that
+  // in fact succeeded (#1001).
+  test("a reader that stops reading ends the run quietly, on say and on transcribe (#1001)", async () => {
+    const dir = makeTempDir("kesha-cli-contract-stdout-epipe-");
+    const enginePath = createFakeEngine(dir);
+    markFakeEngineInstalled(enginePath);
+    const mediaPath = join(dir, "clip.ogg");
+    writeFileSync(mediaPath, "fake media");
+    const env: Record<string, string> = {
+      ...isolatedEnv(dir),
+      KESHA_ENGINE_BIN: enginePath,
+      KESHA_FAKE_SAY_BYTES: "262144",
+    };
+
+    const dropped = await runCliPipedTo(["say", "--voice", "en-am_michael", "тест потока"], "true", {
+      env,
+      sinkPath: join(dir, "dropped.bin"),
+    });
+    expect(dropped.stderr).toBe("");
+    expect(dropped.exitCode).toBe(0);
+    expect(dropped.stdoutBytes).toBe(0);
+
+    const preview = await runCliPipedTo(
+      ["say", "--voice", "en-am_michael", "тест потока"],
+      "head -c 1000",
+      { env, sinkPath: join(dir, "preview.bin") },
+    );
+    expect(preview.stderr).toBe("");
+    expect(preview.exitCode).toBe(0);
+    expect(preview.stdoutBytes).toBe(1000);
+
+    // Same write path, so the guard belongs to stdout rather than to `say` (main.ts:399-407).
+    const transcript = await runCliPipedTo([mediaPath], "true", {
+      env,
+      sinkPath: join(dir, "transcript.txt"),
+    });
+    expect(transcript.stderr).not.toContain("EPIPE");
+    expect(transcript.exitCode).toBe(0);
+  }, 30000);
+
+  test("a stdout that fails for any other reason still fails loudly (#1001)", async () => {
+    const dir = makeTempDir("kesha-cli-contract-stdout-ebadf-");
+    const enginePath = createFakeEngine(dir);
+    markFakeEngineInstalled(enginePath);
+    const env: Record<string, string> = { ...isolatedEnv(dir), KESHA_ENGINE_BIN: enginePath };
+
+    // fd 1 opened read-only: every write fails EBADF. Not a reader leaving, so the run has to
+    // say what went wrong and exit non-zero rather than pretend the audio was delivered.
+    const run = await runCliWithShellStdout(
+      ["say", "--voice", "en-am_michael", "тест потока"],
+      "1</dev/null",
+      env,
+    );
+    expect(run.exitCode).not.toBe(0);
+    expect(run.stderr).toContain("failed writing to stdout");
+    expect(run.stderr).toContain("EBADF");
+    expect(run.stderr).not.toContain("at writeFast");
   }, 30000);
 });


### PR DESCRIPTION
Closes #1001

`kesha say "тест потока" | true` printed a Bun crash dump — absolute
`~/.bun/install/global/…` paths, a version banner — and exited 1 on a synthesis
that had in fact succeeded.

## Why the existing try/catch never saw it

`synthesizeAndEmit` already wraps the write. It cannot help: Bun delivers the
stdout EPIPE **asynchronously**, after the `try` block has returned. Measured
directly:

```
process.stdout.write(bigBuffer)   →  returns normally, "sync-write-ok"
…200 ms later                     →  EPIPE dump on stderr, exit 1
```

So the only place that can observe it is an `error` listener on the stream, and
that is what this PR adds — once, in `runCli`.

## Exit code: 0

A reader that leaves is not our failure. Unix filters either die by SIGPIPE or
exit 0; `kesha say … | head -c 1000` already exited 0 before this change, so 0 is
also the consistent answer across the two shapes the issue tabulates. 141
(SIGPIPE emulation) would be a lie — we are not killed by a signal — and would
still break `kesha say | player` scripts.

The run is not aborted mid-flight, it just stops caring about stdout. That keeps
the `command.finish` diagnostic event and the stats row intact, which an
immediate `process.exit` would truncate.

## EPIPE vs. a genuine write failure

Only `err.code === "EPIPE"` is treated as the reader leaving. Everything else
(ENOSPC, EIO, EBADF …) still reports and exits non-zero, now as a message rather
than a stack trace, per CLAUDE.md → ERROR HANDLING:

```
failed writing to stdout: EBADF: bad file descriptor, write. Check that the
destination is writable and has free space.
```

That branch is covered by a test, not just asserted: `1</dev/null` opens fd 1
read-only, so every write fails EBADF portably.

## Scope: shared primitive, not say.ts

`say` is one of six `process.stdout.write` sites — `src/cli/main.ts:399-407`
(`--json` / `--toon` / transcript / verbose / text), `src/cli/action-result.ts`,
`src/cli/completions.ts`, `src/cli/manpage.ts` all share it. Measured: the size
of the write does not matter (a 13-byte `process.stdout.write` crashes the same
way), so `kesha audio.ogg | true` was broken too. `console.log` is **not**
affected — Bun swallows EPIPE on its buffered writer, verified up to 2 MB — which
is why this only ever surfaced on the raw-write paths.

The guard therefore lives in `runCli` (2 lines) rather than in `say.ts`. `--out`
never touches stdout and is unaffected.

## Red → green

Both new tests fail on `main` and pass with the fix. Red output, with the guard
call removed:

```
(fail) a reader that stops reading ends the run quietly, on say and on transcribe (#1001)
  - ""
  + "EPIPE: broken pipe, write
  +       at writeFast (internal:fs/streams:345:38)
  +       at synthesizeAndEmit (…/src/cli/say.ts:267:9)
  +       at runCommandSession (…/src/cli/command-session.ts:51:21)
  +       at run (…/src/cli/say.ts:338:27)
  + Bun v1.3.13 (macOS arm64)"

(fail) a stdout that fails for any other reason still fails loudly (#1001)
  Expected to contain: "failed writing to stdout"
  Received: "EBADF: bad file descriptor, write … at writeFast …"

 0 pass, 2 fail
```

— the first is the issue's stack trace reproduced line for line, down to
`say.ts:267`. Green after: `2 pass, 0 fail`.

The tests run the CLI as the left side of a real `bash` pipeline;
`runCliScenario` drains stdout to completion and so can never produce this case.
Fast lane only — the fake engine gained a `say` branch that emits
`KESHA_FAKE_SAY_BYTES` of audio, no model download.

## Gates

- `bun run test` → 1426 pass, 6 skip, 0 fail
- `bunx tsc --noEmit` → clean
- `bun run check` → 1267 pass, 0 fail
- `bun run coverage:check:ts` → total 81.20%; `src/cli/say.ts` 78.55% (floor 50%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBTpJjqyYFW6W8LHJ2nwy
