### PR TITLE
fix(diarize): a clip below the model's window keeps its transcript (#999)

### DIFF
--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -45,6 +45,8 @@ jobs:
               - 'rust/src/backend/fluidaudio.rs'
               # The lane's diagnostics ride KESHA_DEBUG's sink selection (#841).
               - 'rust/src/fluid_stdout.rs'
+              # The only lane that *runs* diarize's tests; everything else stops at clippy (#999).
+              - 'rust/src/transcribe/diarize.rs'
               - 'rust/build.rs'
               - 'rust/Cargo.toml'
               - 'rust/Cargo.lock'
@@ -481,11 +483,13 @@ jobs:
           cd rust
           # Without this nextest swallows a passing test's output, and the ANE gate's
           # "this guard did not run" line is exactly that (#841).
+          # `system_diarize` rides along because `transcribe::diarize` compiles under no other
+          # lane, so its tests only ever got clippy'd; they are pure and cost 0.14 s (#999).
           cargo nextest run \
-            --no-default-features --features coreml \
+            --no-default-features --features coreml,system_diarize \
             --run-ignored all \
             --success-output immediate \
-            -E 'test(transcribe_samples_is_stateless_across_calls) + test(debug_routes_silenced_chatter_to_stderr) + test(a_sub_second_file_transcribes_instead_of_erroring)'
+            -E 'test(transcribe_samples_is_stateless_across_calls) + test(debug_routes_silenced_chatter_to_stderr) + test(a_sub_second_file_transcribes_instead_of_erroring) + test(transcribe::diarize::)'
 
       - name: 📤 Upload JUnit
         if: always()

--- a/openspec/specs/speaker-diarization/spec.md
+++ b/openspec/specs/speaker-diarization/spec.md
@@ -143,7 +143,23 @@ The percentage check SHALL be skipped when there is exactly one ASR Segment: the
 ratio can then only be 0 % or 100 % depending on whether that Segment's midpoint
 lands in a speaker-change gap, which measures absent segmentation rather than
 partial labeling. Diarization returning no spans at all SHALL still fail closed
-at any Segment count.
+at any Segment count, with one exception: when the audio file is shorter than the
+1.04 s the Sortformer chunker needs before it can emit its first chunk, an empty
+result is the clip being too short rather than labels going missing. There the
+Engine SHALL return the transcript without `speaker` fields and exit 0, and SHALL
+say on stderr that the clip is below the floor and that the labels the user asked
+for are not in the output. Both halves of that exception are required — a run that
+dropped labels still has spans, and a clip long enough to diarize is judged by the
+checks above unchanged.
+
+#### Scenario: Ira diarizes a voice command shorter than the model's window
+
+- GIVEN a 0.9 s recording and the VAD + diarize models installed
+- WHEN Ira runs `kesha --json --speakers short.wav`
+- THEN stderr says no speaker spans came back, that the clip is 0.90 s against a
+  1.04 s floor, and that the transcript is returned without speaker labels
+- AND stdout carries the transcript, whose Segments omit `speaker` entirely
+- AND the process exits 0
 
 #### Scenario: A single whole-file Segment does not fail closed
 
@@ -166,10 +182,15 @@ at any Segment count.
 - AND the process exits 1
 
 > *Technical Note — constants: `MIN_DIARIZE_SEGMENT_COVERAGE = 0.95`,
-> `MAX_DIARIZE_TAIL_GAP_SECONDS = 30.0`.
-> Source: `rust/src/transcribe/diarize.rs` lines 20–21.
-> Validation function: `validate_coverage` in
-> `rust/src/transcribe/diarize.rs` lines 212–265.*
+> `MAX_DIARIZE_TAIL_GAP_SECONDS = 30.0`, `MIN_DIARIZABLE_SECONDS = 1.04`.
+> Source: `rust/src/transcribe/diarize.rs`.
+> Validation function: `validate_coverage`; the short-clip exception is
+> `below_diarizer_floor`, which runs before it. The floor derives from
+> `SortformerConfig.balancedV2`: `(chunkLen 6 + chunkRightContext 7) *
+> subsamplingFactor 8 * melStride 160 / sampleRate 16 000`. Measured on a cut of
+> `01-ne-nuzhno-slat-soobshcheniya.ogg`, the step is at ~1.023 s — 16 360 samples
+> return 0 spans, 16 380 return 1 — so the derived value sits just above the
+> observed one. Closes #999.*
 
 ### Requirement: Speaker ids are cluster indices stable within one call only
 

--- a/openspec/specs/speaker-diarization/spec.md
+++ b/openspec/specs/speaker-diarization/spec.md
@@ -143,14 +143,17 @@ The percentage check SHALL be skipped when there is exactly one ASR Segment: the
 ratio can then only be 0 % or 100 % depending on whether that Segment's midpoint
 lands in a speaker-change gap, which measures absent segmentation rather than
 partial labeling. Diarization returning no spans at all SHALL still fail closed
-at any Segment count, with one exception: when the audio file is shorter than the
-1.04 s the Sortformer chunker needs before it can emit its first chunk, an empty
-result is the clip being too short rather than labels going missing. There the
-Engine SHALL return the transcript without `speaker` fields and exit 0, and SHALL
-say on stderr that the clip is below the floor and that the labels the user asked
-for are not in the output. Both halves of that exception are required — a run that
-dropped labels still has spans, and a clip long enough to diarize is judged by the
-checks above unchanged.
+at any Segment count, with one exception: when the clip is shorter than the 1.04 s
+the Sortformer chunker needs before it can emit its first chunk, an empty result is
+the clip being too short rather than labels going missing. There the Engine SHALL
+return the transcript without `speaker` fields and exit 0, and SHALL say on stderr
+that the clip is below the floor and that the labels the user asked for are not in
+the output. A clip long enough to diarize is judged by the checks above unchanged,
+whether it lost some of its labels or all of them. Because a container can
+under-report its own duration, the Engine SHALL believe a below-floor measurement
+only when the transcript agrees: an ASR timeline reaching 1.04 s or beyond means the
+measurement is wrong, and the Engine SHALL fail closed rather than degrade — so the
+stderr notice never claims a length the transcript contradicts.
 
 #### Scenario: Ira diarizes a voice command shorter than the model's window
 
@@ -160,6 +163,13 @@ checks above unchanged.
   1.04 s floor, and that the transcript is returned without speaker labels
 - AND stdout carries the transcript, whose Segments omit `speaker` entirely
 - AND the process exits 0
+
+#### Scenario: A container that under-reports its own length does not open the exception
+
+- GIVEN a file whose header claims 0.3 s, diarization returning no spans, and an ASR
+  transcript running to 60 s
+- THEN the Engine reports the coverage error naming `labeled 0/1 segments` rather
+  than degrading, and the process exits 1
 
 #### Scenario: A single whole-file Segment does not fail closed
 
@@ -190,7 +200,9 @@ checks above unchanged.
 > subsamplingFactor 8 * melStride 160 / sampleRate 16 000`. Measured on a cut of
 > `01-ne-nuzhno-slat-soobshcheniya.ogg`, the step is at ~1.023 s — 16 360 samples
 > return 0 spans, 16 380 return 1 — so the derived value sits just above the
-> observed one. Closes #999.*
+> observed one, and a clip in that 17 ms band degrades where it could still have
+> been labeled. The duration cross-check is `max_asr_end`, the same clock
+> `validate_coverage` uses. Closes #999.*
 
 ### Requirement: Speaker ids are cluster indices stable within one call only
 

--- a/rust/src/transcribe/diarize.rs
+++ b/rust/src/transcribe/diarize.rs
@@ -143,7 +143,7 @@ pub(crate) fn run(
     };
     let spans: Vec<DiarizeSpan> = run_supervised(job, total_deadline, load_budget, audio_secs)?;
 
-    if let Some(secs) = below_diarizer_floor(&spans, audio_path, duration) {
+    if let Some(secs) = below_diarizer_floor(&spans, asr_segments, audio_path, duration) {
         eprintln!(
             "diarize: no speaker spans — the clip is {secs:.2}s and the model needs \
              {MIN_DIARIZABLE_SECONDS:.2}s of audio before it can label anything; \
@@ -786,16 +786,21 @@ pub(crate) struct DiarizeCoverage {
     pub max_span_end: f32,
 }
 
-/// `Some(secs)` for the one shape the model cannot serve: nothing came back *and* the file
-/// is shorter than [`MIN_DIARIZABLE_SECONDS`]. Both halves are load-bearing — a run that
-/// dropped labels still has spans, and a clip long enough to diarize still answers to
-/// [`validate_coverage`] (#999).
+/// `Some(secs)` for the one shape the model cannot serve: nothing came back *and* the clip
+/// is shorter than [`MIN_DIARIZABLE_SECONDS`] on both clocks available here. Every conjunct
+/// is load-bearing — a partial label drop still has spans, a total drop on a long clip still
+/// answers to [`validate_coverage`], and a container can under-report its own length, so the
+/// transcript's own end time has to agree before the probe is believed (#999).
 fn below_diarizer_floor(
     spans: &[DiarizeSpan],
+    asr_segments: &[TranscriptionSegment],
     audio_path: &Path,
     hint: Option<f32>,
 ) -> Option<f32> {
     if !spans.is_empty() {
+        return None;
+    }
+    if max_asr_end(asr_segments).is_some_and(|end| end >= MIN_DIARIZABLE_SECONDS) {
         return None;
     }
     clip_seconds(audio_path, hint).filter(|secs| *secs < MIN_DIARIZABLE_SECONDS)
@@ -1075,32 +1080,69 @@ mod tests {
         ))
     }
 
+    fn tone_3s() -> &'static Path {
+        Path::new(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../tests/fixtures/tone-3s.wav"
+        ))
+    }
+
     #[test]
     fn a_clip_below_the_floor_degrades_instead_of_failing() {
         assert_eq!(
-            below_diarizer_floor(&[], tone_150ms(), Some(0.2)),
+            below_diarizer_floor(&[], &[seg(0.0, 0.2, "hi")], tone_150ms(), Some(0.2)),
             Some(0.2)
         );
     }
 
     #[test]
     fn an_empty_result_on_a_full_length_clip_still_fails_closed() {
-        assert_eq!(below_diarizer_floor(&[], tone_150ms(), Some(60.0)), None);
+        let asr = [seg(0.0, 60.0, "a long take")];
+        assert_eq!(
+            below_diarizer_floor(&[], &asr, tone_150ms(), Some(60.0)),
+            None
+        );
 
-        let err = validate_coverage(&[seg(0.0, 60.0, "a long take")], &[])
+        let err = validate_coverage(&asr, &[])
             .expect_err("a minute of audio with no spans is dropped labels, not a short clip");
+        assert!(format!("{err}").contains("labeled 0/1 segments"), "{err}");
+    }
+
+    #[test]
+    fn an_empty_result_still_fails_closed_on_the_path_that_probes_the_file() {
+        let asr = [seg(0.0, 3.0, "a long take")];
+        assert_eq!(below_diarizer_floor(&[], &asr, tone_3s(), None), None);
+
+        let err = validate_coverage(&asr, &[])
+            .expect_err("three seconds with no spans is dropped labels, not a short clip");
+        assert!(format!("{err}").contains("labeled 0/1 segments"), "{err}");
+    }
+
+    #[test]
+    fn a_container_that_under_reports_its_length_still_fails_closed() {
+        let asr = [seg(0.0, 60.0, "a long take")];
+        assert_eq!(
+            below_diarizer_floor(&[], &asr, tone_150ms(), Some(0.3)),
+            None
+        );
+
+        let err = validate_coverage(&asr, &[])
+            .expect_err("a header claiming 0.3 s over a minute of speech must not buy a degrade");
         assert!(format!("{err}").contains("labeled 0/1 segments"), "{err}");
     }
 
     #[test]
     fn a_short_clip_the_model_did_label_is_still_judged_by_coverage() {
         let spans = vec![span(0.0, 0.1, 0)];
-        assert_eq!(below_diarizer_floor(&spans, tone_150ms(), Some(0.2)), None);
+        assert_eq!(
+            below_diarizer_floor(&spans, &[seg(0.0, 0.2, "hi")], tone_150ms(), Some(0.2)),
+            None
+        );
     }
 
     #[test]
     fn the_clip_is_measured_from_the_file_when_the_caller_probed_none() {
-        let secs = below_diarizer_floor(&[], tone_150ms(), None)
+        let secs = below_diarizer_floor(&[], &[], tone_150ms(), None)
             .expect("a 0.15 s file is below the floor");
         assert!((secs - 0.15).abs() < 0.01, "{secs}");
     }

--- a/rust/src/transcribe/diarize.rs
+++ b/rust/src/transcribe/diarize.rs
@@ -23,6 +23,15 @@ use super::TranscriptionSegment;
 const MIN_DIARIZE_SEGMENT_COVERAGE: f32 = 0.95;
 const MAX_DIARIZE_TAIL_GAP_SECONDS: f32 = 30.0;
 
+/// Audio the Sortformer chunker needs before it can emit its first chunk: one core chunk
+/// plus full right context, `(chunkLen + chunkRightContext) * subsamplingFactor * melStride
+/// / sampleRate` = (6 + 7) * 8 * 160 / 16 000 for `balancedV2`. Below it the model returns
+/// no spans for any input, so an empty result there is the clip being too short rather than
+/// labels going missing. The step measured on a real clip is 1.023 s (16 360 samples give
+/// 0 spans, 16 380 give 1); the derived value sits just above it so nothing genuinely below
+/// the floor is left failing (#999).
+const MIN_DIARIZABLE_SECONDS: f32 = 1.04;
+
 /// Default budget for the model load — the span before the binding's model-ready
 /// marker, which is one synchronous CoreML call and nothing else. Cold that is the
 /// ANE program compile, measured at 107.3 s on an M2 (0.3 s of it
@@ -133,6 +142,17 @@ pub(crate) fn run(
         units,
     };
     let spans: Vec<DiarizeSpan> = run_supervised(job, total_deadline, load_budget, audio_secs)?;
+
+    if let Some(secs) = below_diarizer_floor(&spans, audio_path, duration) {
+        eprintln!(
+            "diarize: no speaker spans — the clip is {secs:.2}s and the model needs \
+             {MIN_DIARIZABLE_SECONDS:.2}s of audio before it can label anything; \
+             returning the transcript without speaker labels"
+        );
+        dtrace!("diarize::below_floor clip_secs={secs:.3}");
+        dtrace_json!("diarize.below_floor", { "clip_secs": secs });
+        return Ok(spans);
+    }
 
     let coverage = validate_coverage(asr_segments, &spans)?;
     dtrace!(
@@ -766,6 +786,35 @@ pub(crate) struct DiarizeCoverage {
     pub max_span_end: f32,
 }
 
+/// `Some(secs)` for the one shape the model cannot serve: nothing came back *and* the file
+/// is shorter than [`MIN_DIARIZABLE_SECONDS`]. Both halves are load-bearing — a run that
+/// dropped labels still has spans, and a clip long enough to diarize still answers to
+/// [`validate_coverage`] (#999).
+fn below_diarizer_floor(
+    spans: &[DiarizeSpan],
+    audio_path: &Path,
+    hint: Option<f32>,
+) -> Option<f32> {
+    if !spans.is_empty() {
+        return None;
+    }
+    clip_seconds(audio_path, hint).filter(|secs| *secs < MIN_DIARIZABLE_SECONDS)
+}
+
+/// `--speakers` forces VAD, which skips the `Auto` duration probe, so the caller normally
+/// has none: fall back to the cheap header probe, then a decode for containers it cannot
+/// answer. `None` — an unmeasurable file — keeps the coverage check closed.
+fn clip_seconds(audio_path: &Path, hint: Option<f32>) -> Option<f32> {
+    if hint.is_some() {
+        return hint;
+    }
+    let path = audio_path.to_str()?;
+    match crate::audio::probe_duration_seconds(path) {
+        Ok(Some(secs)) => Some(secs),
+        _ => crate::audio::measure_duration_seconds(path).ok(),
+    }
+}
+
 pub(crate) fn validate_coverage(
     asr_segments: &[TranscriptionSegment],
     diarize_spans: &[DiarizeSpan],
@@ -1017,6 +1066,43 @@ mod tests {
             .expect_err("spans stopping 480s before the transcript end should fail closed");
 
         assert!(format!("{err}").contains("speaker diarization coverage incomplete"));
+    }
+
+    fn tone_150ms() -> &'static Path {
+        Path::new(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/fixtures/tone-150ms.wav"
+        ))
+    }
+
+    #[test]
+    fn a_clip_below_the_floor_degrades_instead_of_failing() {
+        assert_eq!(
+            below_diarizer_floor(&[], tone_150ms(), Some(0.2)),
+            Some(0.2)
+        );
+    }
+
+    #[test]
+    fn an_empty_result_on_a_full_length_clip_still_fails_closed() {
+        assert_eq!(below_diarizer_floor(&[], tone_150ms(), Some(60.0)), None);
+
+        let err = validate_coverage(&[seg(0.0, 60.0, "a long take")], &[])
+            .expect_err("a minute of audio with no spans is dropped labels, not a short clip");
+        assert!(format!("{err}").contains("labeled 0/1 segments"), "{err}");
+    }
+
+    #[test]
+    fn a_short_clip_the_model_did_label_is_still_judged_by_coverage() {
+        let spans = vec![span(0.0, 0.1, 0)];
+        assert_eq!(below_diarizer_floor(&spans, tone_150ms(), Some(0.2)), None);
+    }
+
+    #[test]
+    fn the_clip_is_measured_from_the_file_when_the_caller_probed_none() {
+        let secs = below_diarizer_floor(&[], tone_150ms(), None)
+            .expect("a 0.15 s file is below the floor");
+        assert!((secs - 0.15).abs() < 0.01, "{secs}");
     }
 
     #[test]

--- a/rust/tests/diarize_e2e.rs
+++ b/rust/tests/diarize_e2e.rs
@@ -197,7 +197,11 @@ fn a_clip_below_the_diarizer_floor_keeps_its_transcript() {
         .unwrap();
 
     let spoken = tmp.path().join("spoken.wav");
-    if !say("Hello everyone, this is the call.", "en-am_michael", &spoken) {
+    if !say(
+        "Hello everyone, this is the call.",
+        "en-am_michael",
+        &spoken,
+    ) {
         eprintln!("skipping: TTS voices not installed (run `kesha install --tts`)");
         return;
     }

--- a/rust/tests/diarize_e2e.rs
+++ b/rust/tests/diarize_e2e.rs
@@ -15,6 +15,8 @@
 //!
 //! A second case covers the other end of the range: a clip too short for the
 //! Sortformer chunker to emit anything must still return its transcript (#999).
+//! It cuts a committed fixture rather than synthesizing, so it does not inherit
+//! the TTS skip — Sortformer and VAD are the only prerequisites it needs.
 
 #![cfg(feature = "system_diarize")]
 
@@ -59,25 +61,23 @@ fn concat_wavs(inputs: &[PathBuf], out: &Path) {
     writer.finalize().expect("finalize combined wav");
 }
 
-/// Copy the leading `seconds` of `input` into `out`, keeping the source spec.
-fn truncate_wav(input: &Path, out: &Path, seconds: f32) {
-    let mut reader = hound::WavReader::open(input).expect("read wav to truncate");
-    let spec = reader.spec();
-    let keep = (seconds * spec.sample_rate as f32) as usize * spec.channels as usize;
-    let mut writer = hound::WavWriter::create(out, spec).expect("create truncated wav");
-    match spec.sample_format {
-        hound::SampleFormat::Float => {
-            for s in reader.samples::<f32>().take(keep) {
-                writer.write_sample(s.expect("read f32 sample")).unwrap();
-            }
-        }
-        hound::SampleFormat::Int => {
-            for s in reader.samples::<i32>().take(keep) {
-                writer.write_sample(s.expect("read int sample")).unwrap();
-            }
-        }
+/// Write mono 16 kHz samples as 16-bit PCM. Paired with `load_audio_truncated`, whose
+/// output is already the engine's decode target, so the file's duration is exactly the
+/// cut length — which the assertion on the stderr notice depends on.
+fn write_wav_16k(samples: &[f32], out: &Path) {
+    let spec = hound::WavSpec {
+        channels: 1,
+        sample_rate: 16_000,
+        bits_per_sample: 16,
+        sample_format: hound::SampleFormat::Int,
+    };
+    let mut writer = hound::WavWriter::create(out, spec).expect("create short wav");
+    for s in samples {
+        writer
+            .write_sample((s.clamp(-1.0, 1.0) * f32::from(i16::MAX)) as i16)
+            .expect("write sample");
     }
-    writer.finalize().expect("finalize truncated wav");
+    writer.finalize().expect("finalize short wav");
 }
 
 #[test]
@@ -196,18 +196,14 @@ fn a_clip_below_the_diarizer_floor_keeps_its_transcript() {
         .tempdir()
         .unwrap();
 
-    let spoken = tmp.path().join("spoken.wav");
-    if !say(
-        "Hello everyone, this is the call.",
-        "en-am_michael",
-        &spoken,
-    ) {
-        eprintln!("skipping: TTS voices not installed (run `kesha install --tts`)");
-        return;
-    }
-
+    let fixture = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../tests/fixtures/benchmark-en/01-check-email.ogg"
+    );
+    let samples = kesha_engine::audio::load_audio_truncated(fixture, 0.9)
+        .expect("committed fixture must decode — run `git lfs pull` in a fresh checkout");
     let short = tmp.path().join("short.wav");
-    truncate_wav(&spoken, &short, 0.9);
+    write_wav_16k(&samples, &short);
 
     let out = Command::new(&exe)
         .args([
@@ -222,10 +218,13 @@ fn a_clip_below_the_diarizer_floor_keeps_its_transcript() {
 
     let stderr = String::from_utf8_lossy(&out.stderr);
     if !out.status.success() {
+        // The ASR models are on this list where the sibling test leaves them off: cutting a
+        // fixture instead of synthesizing means no TTS gate runs first to catch a bare machine.
         if stderr.contains("diarization model not found")
             || stderr.contains("kesha-diarize sidecar not found")
             || stderr.contains("VAD model")
             || stderr.contains("silero-vad")
+            || stderr.contains("No transcription models installed")
         {
             eprintln!(
                 "skipping: prerequisite missing (run `kesha install --vad --diarize`):\n{stderr}"
@@ -247,7 +246,9 @@ fn a_clip_below_the_diarizer_floor_keeps_its_transcript() {
         "a clip the diarizer cannot read must not carry invented labels: {segments:#?}"
     );
     assert!(
-        stderr.contains("without speaker labels"),
-        "the user asked for labels and did not get them — stderr must say so: {stderr}"
+        stderr.contains("the clip is 0.90s")
+            && stderr.contains("needs 1.04s")
+            && stderr.contains("without speaker labels"),
+        "stderr must name the clip length, the floor, and that labels are missing: {stderr}"
     );
 }

--- a/rust/tests/diarize_e2e.rs
+++ b/rust/tests/diarize_e2e.rs
@@ -12,6 +12,9 @@
 //!   * or the engine binary is missing.
 //!
 //! Closes #199.
+//!
+//! A second case covers the other end of the range: a clip too short for the
+//! Sortformer chunker to emit anything must still return its transcript (#999).
 
 #![cfg(feature = "system_diarize")]
 
@@ -54,6 +57,27 @@ fn concat_wavs(inputs: &[PathBuf], out: &Path) {
         }
     }
     writer.finalize().expect("finalize combined wav");
+}
+
+/// Copy the leading `seconds` of `input` into `out`, keeping the source spec.
+fn truncate_wav(input: &Path, out: &Path, seconds: f32) {
+    let mut reader = hound::WavReader::open(input).expect("read wav to truncate");
+    let spec = reader.spec();
+    let keep = (seconds * spec.sample_rate as f32) as usize * spec.channels as usize;
+    let mut writer = hound::WavWriter::create(out, spec).expect("create truncated wav");
+    match spec.sample_format {
+        hound::SampleFormat::Float => {
+            for s in reader.samples::<f32>().take(keep) {
+                writer.write_sample(s.expect("read f32 sample")).unwrap();
+            }
+        }
+        hound::SampleFormat::Int => {
+            for s in reader.samples::<i32>().take(keep) {
+                writer.write_sample(s.expect("read int sample")).unwrap();
+            }
+        }
+    }
+    writer.finalize().expect("finalize truncated wav");
 }
 
 #[test]
@@ -152,5 +176,74 @@ fn two_speaker_dialogue_yields_two_clusters() {
         labeled_ratio >= 0.80,
         "expected ≥ 80% of segments to have a speaker label, got {:.0}%",
         labeled_ratio * 100.0
+    );
+}
+
+/// #999: Sortformer needs 1.04 s before it can emit its first chunk, so every shorter
+/// clip comes back with no spans at all — which the coverage check turned into a hard
+/// `E_INTERNAL`, discarding a transcript the engine had already produced. `kesha record`
+/// plus `--speakers` for a voice command is exactly that length.
+#[test]
+fn a_clip_below_the_diarizer_floor_keeps_its_transcript() {
+    let exe = PathBuf::from(common::engine_bin());
+    if !exe.exists() {
+        eprintln!("skipping: engine binary not found at {}", exe.display());
+        return;
+    }
+
+    let tmp = tempfile::Builder::new()
+        .prefix("kesha-diarize-floor-")
+        .tempdir()
+        .unwrap();
+
+    let spoken = tmp.path().join("spoken.wav");
+    if !say("Hello everyone, this is the call.", "en-am_michael", &spoken) {
+        eprintln!("skipping: TTS voices not installed (run `kesha install --tts`)");
+        return;
+    }
+
+    let short = tmp.path().join("short.wav");
+    truncate_wav(&spoken, &short, 0.9);
+
+    let out = Command::new(&exe)
+        .args([
+            "transcribe",
+            "--json",
+            "--vad",
+            "--speakers",
+            short.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    if !out.status.success() {
+        if stderr.contains("diarization model not found")
+            || stderr.contains("kesha-diarize sidecar not found")
+            || stderr.contains("VAD model")
+            || stderr.contains("silero-vad")
+        {
+            eprintln!(
+                "skipping: prerequisite missing (run `kesha install --vad --diarize`):\n{stderr}"
+            );
+            return;
+        }
+        panic!("a 0.9 s clip must transcribe rather than fail closed: {stderr}");
+    }
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("engine output is not valid JSON");
+    let segments = json["segments"].as_array().expect("segments is an array");
+    assert!(
+        !segments.is_empty(),
+        "the transcript is what degrading exists to preserve; got {json}"
+    );
+    assert!(
+        segments.iter().all(|s| s.get("speaker").is_none()),
+        "a clip the diarizer cannot read must not carry invented labels: {segments:#?}"
+    );
+    assert!(
+        stderr.contains("without speaker labels"),
+        "the user asked for labels and did not get them — stderr must say so: {stderr}"
     );
 }


### PR DESCRIPTION
Closes #999

`--speakers` failed closed on every clip of 1 second or less. The ASR emitted one
segment, the diarizer found zero spans, and the #397 coverage check turned the pair
into `E_INTERNAL` with an empty stdout — discarding a transcript the engine had
already produced correctly.

## The measured floor

FluidAudio's `SortformerDiarizer` cannot emit its first chunk until the audio covers
one core chunk plus full right context (`getNextChunkFeaturesLocked`'s
`guard endFeat + rightContextFrames <= featLength`). For the `balancedV2` config the
engine uses that is:

```
(chunkLen 6 + chunkRightContext 7) * subsamplingFactor 8 * melStride 160 / 16 000 Hz = 1.04 s
```

Measured against the fixture the issue names, cutting at sample granularity from
`tests/fixtures/benchmark/01-ne-nuzhno-slat-soobshcheniya.ogg`:

| samples | seconds | spans | exit (before) |
| --- | --- | --- | --- |
| 3 200 / 9 600 / 14 400 / 16 000 | 0.2 / 0.6 / 0.9 / 1.00 | 0 | 1, `E_INTERNAL` |
| 16 360 | 1.0225 | 0 | 1, `E_INTERNAL` |
| 16 380 | 1.02375 | 1 | 0 |
| 16 480 / 17 600 / 24 000 | 1.03 / 1.10 / 1.50 | 1 | 0 |

So the observed step is ~1.023 s and the derived value is 1.04 s. `MIN_DIARIZABLE_SECONDS`
takes the derived one, which sits just above the step, so nothing genuinely below the
floor is left failing.

Same speech content padded with silence to 2.9 s returns 1 span and labels normally —
the floor is about file length, not content.

## The gating condition

`below_diarizer_floor` returns `Some(secs)` only when **both** hold:

1. `spans.is_empty()` — the diarizer returned nothing at all, and
2. the **measured file duration** is `< 1.04 s`.

Only then does `run` skip `validate_coverage`, print one stderr line and return the
transcript unlabeled. Every other path reaches `validate_coverage` byte-for-byte
unchanged.

### Why it cannot swallow a real coverage regression

- **A run that drops labels still has spans.** The 60 s clip that loses 90 % of its
  labels has a non-empty span list, so condition 1 fails on the first line of the
  function and the ratio check fires exactly as loudly as today. Likewise the tail-gap
  check (`spans end at 10s while transcript ends at 110s`) — spans exist, so it is
  untouched.
- **A clip long enough to diarize is judged as before.** A 60 s take that returns zero
  spans fails condition 2 and still errors. That is asserted directly in
  `an_empty_result_on_a_full_length_clip_still_fails_closed`, which checks both the
  gate returning `None` *and* `validate_coverage` still producing `labeled 0/1 segments`.
- **The two conditions can only coincide below 1.04 s.** The widest thing this can
  absorb is a ~1-second clip whose diarization legitimately failed — at that length
  "the model needs more audio" is the overwhelmingly likelier explanation, and the
  degradation is announced on stderr rather than silent.
- **An unmeasurable file keeps failing closed.** `clip_seconds` returns `None` when
  neither the header probe nor a decode can answer, and `Option::filter` on `None`
  yields `None` — the gate never opens on a guess.

`--speakers` forces VAD, which skips the `Auto` duration probe, so the caller passes
`duration: None` on this path; the probe is paid only when the span list came back
empty, i.e. never on a healthy run.

## Mirroring #996 (`bbfd098`)

The ASR side of the same class of bug landed today and this follows its shape:

| | #996 / `bbfd098` (ASR) | this PR (diarize) |
| --- | --- | --- |
| Trigger | FluidAudio refuses a file below ~0.25 s | Sortformer emits no spans below 1.04 s |
| Old behaviour | `E_INTERNAL` | `E_INTERNAL` |
| New behaviour | falls back to the padding path, transcribes | returns the transcript, unlabeled |
| Floor as a named constant | `MIN_TRANSCRIBABLE_SAMPLES` + `ensure_transcribable` | `MIN_DIARIZABLE_SECONDS` + `below_diarizer_floor` |
| Where it still errors | a file no backend can read → coded `E_BAD_AUDIO` | a real coverage shortfall → unchanged error |
| Tests | pure unit tests on the new seam + a gated real-model test, added to the `coreml-regression` filter | same, plus the e2e |

The one deliberate divergence: #996 turned its floor into a *coded input error*, because
audio below the ASR floor cannot be transcribed at all. Here the transcript exists and is
correct, so the floor is not an error — it is a degradation, which is what #999's Expected
asked for. The remaining `E_INTERNAL` on a genuine coverage shortfall is left alone: that
one really is an engine fault (labels went missing), so it is not the #935/#972/#995
misclassification family. The misclassified case was the short clip, and it is no longer
an error at all.

## Honesty

stderr, one line, in the existing `diarize:` style:

```
diarize: no speaker spans — the clip is 0.90s and the model needs 1.04s of audio
before it can label anything; returning the transcript without speaker labels
```

The structured output needs no new field. `TranscriptionSegment.speaker` is already
`Option<u32>` with `skip_serializing_if = "Option::is_none"`, and the spec already
contracts an unlabeled Segment as one that **omits** the key — "there is no `null` or
`"unknown"` value". So `--json` / `--toon` emit segments with no `speaker` key at all,
which is the same shape a consumer already handles for a midpoint that falls in a gap.
No schema change, no spec-breaking addition.

Before / after on the issue's own repro:

```console
$ kesha-engine transcribe --json --speakers cut-0.2.wav      # before
error [E_INTERNAL]: speaker diarization failed: speaker diarization coverage incomplete:
labeled 0/1 segments (0.0%), spans end at 0.0s while transcript ends at 0.2s
# exit 1, stdout empty

$ kesha-engine transcribe --json --speakers cut-0.2.wav      # after
diarize: no speaker spans — the clip is 0.20s and the model needs 1.04s ...   (stderr)
{"text":"Yeah..","segments":[{"start":0.0,"end":0.2,"text":"Yeah..", ...}]}   (stdout)
# exit 0
```

## Red → green

`0cf6835` lands the failing e2e test on its own. Against that commit's source, on
macOS arm64 with the VAD + Sortformer models staged:

```
thread 'a_clip_below_the_diarizer_floor_keeps_its_transcript' panicked at tests/diarize_e2e.rs:231:9:
a 0.9 s clip must transcribe rather than fail closed: diarize: done in 6.0s (0 spans)
error [E_INTERNAL]: speaker diarization failed: speaker diarization coverage incomplete:
labeled 0/1 segments (0.0%), spans end at 0.0s while transcript ends at 0.9s

Summary [12.450s] 1 test run: 0 passed, 1 failed
```

With `9d6f188` on top:

```
PASS [14.905s] kesha-engine::diarize_e2e a_clip_below_the_diarizer_floor_keeps_its_transcript
Summary [17.128s] 2 tests run: 2 passed, 0 skipped
```

Plus four unit tests on the seam: the sub-floor clip degrades, an empty result on a
full-length clip still fails closed (both halves), a short clip the model *did* label
is still judged by coverage, and the length is measured from the file when the caller
has no duration.

## CI visibility

`rust/src/transcribe/diarize.rs` is `#[cfg(all(feature = "system_diarize", target_os = "macos"))]`,
so it compiles under no PR lane — `verify-darwin-full` clippy'd its 44 unit tests but
nothing ever *ran* them. `coreml-regression` now carries `system_diarize` and adds
`test(transcribe::diarize::)` to its filter (44 pure tests, 0.135 s), and `diarize.rs`
joins that lane's path filter so a future diarize change actually triggers it. The exact
lane command was run locally: 47 tests, all passing. The `diarize_e2e` bodies still
cannot run in CI (no Sortformer model on the runner) — unchanged, and stated in the
lane's existing comment.

## Gates

- `just rust-test --all-targets` (nextest, `--features tts`): 588 passed
- `cargo fmt --check`: clean
- `cargo clippy --all-targets --no-default-features --features onnx,tts,system_diarize -- -D warnings`: clean
- `just verify-darwin-full` (clippy over `coreml,tts,system_tts,system_kokoro,system_diarize,system_text_lang`): clean
- `cargo nextest run --no-default-features --features coreml,system_diarize …` (the edited lane, verbatim): 47 passed
- `openspec validate --specs --strict`: 17 passed, 0 failed
- `just preflight`: green

One caveat reported rather than hidden: the first `just preflight` run failed on
`models::retry_tests::the_receive_deadline_caps_the_whole_body_not_just_a_stall`, a
wall-clock test that drips a 6.4 KB body against a 500 ms deadline. It passed 5/5 in
isolation and green on a re-run of the full suite. It cannot be caused by this branch —
`just rust-test` builds `--features tts`, under which `diarize.rs` is not compiled at
all, and the only other files touched here are a workflow and a spec. Pre-existing
load-sensitive flake in `models.rs`, filed as #1013 rather than fixed here.

## Spec

`openspec/specs/speaker-diarization/spec.md` — the "Coverage validation prevents
silently partial labels" requirement gains the exception with both of its conditions
spelled out, a scenario for the sub-floor voice command, and the derivation +
measurement in the Technical Note.
