### PR TITLE
refactor(core): expose transcription error output guard

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -28,6 +28,7 @@ export type {
   TranscribeJsonOutput,
   TranscribeResult,
 } from "./types";
+export { hasErrorRecords } from "./types";
 
 /**
  * Install TTS models for the given languages (default: English only, matching

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,4 +31,10 @@ export type TranscribeJsonOutput =
       errors: TranscribeErrorRecord[];
     };
 
+export function hasErrorRecords(
+  output: TranscribeJsonOutput,
+): output is { results: TranscribeResult[]; errors: TranscribeErrorRecord[] } {
+  return !Array.isArray(output);
+}
+
 export type { LangDetectResult, TranscriptionSegment };

--- a/tests/unit/format.test.ts
+++ b/tests/unit/format.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import {
+  formatJsonOutput,
   formatTextOutput,
   formatTranscriptOutput,
   formatVerboseOutput,
   humanBytes,
 } from "../../src/format";
-import type { TranscribeResult } from "../../src/types";
+import { hasErrorRecords } from "../../src/lib";
+import type { TranscribeJsonOutput, TranscribeResult } from "../../src/types";
 
 function result(overrides: Partial<TranscribeResult>): TranscribeResult {
   return { file: "a.ogg", text: "hello", ...overrides } as TranscribeResult;
@@ -91,5 +93,24 @@ describe("formatVerboseOutput", () => {
       result({ file: "b.ogg", text: "two" }),
     ]);
     expect(out).toBe("=== a.ogg ===\n---\none\n\n=== b.ogg ===\n---\ntwo\n");
+  });
+});
+
+describe("formatJsonOutput", () => {
+  test("keeps the bare result array recognizable after serialization", () => {
+    const output = JSON.parse(formatJsonOutput([result({})])) as TranscribeJsonOutput;
+
+    expect(hasErrorRecords(output)).toBe(false);
+    expect(output).toEqual([result({})]);
+  });
+
+  test("keeps the results-and-errors envelope recognizable after serialization", () => {
+    const errors = [{ file: "missing.ogg", code: "E_INPUT_NOT_FOUND", message: "File not found" }];
+    const output = JSON.parse(formatJsonOutput([result({})], errors)) as TranscribeJsonOutput;
+
+    expect(hasErrorRecords(output)).toBe(true);
+    if (hasErrorRecords(output)) {
+      expect(output).toEqual({ results: [result({})], errors });
+    }
   });
 });


### PR DESCRIPTION
## Summary

- expose `hasErrorRecords` from `@drakulavich/kesha-voice-kit/core` to narrow `TranscribeJsonOutput`
- keep the existing bare-array and `{ results, errors }` JSON wire formats unchanged
- verify the guard against parsed output from both `formatJsonOutput` variants

## Test plan

- RED: `bun run test tests/unit/format.test.ts` failed before implementation with `SyntaxError: Export named 'hasErrorRecords' not found in module 'src/lib.ts'` (0 pass, 1 fail, 1 error)
- GREEN: `bun run test tests/unit/format.test.ts`
- `bun run test`
- `bunx tsc --noEmit`
- `bun run check`
- `bun run coverage:check:ts`
- `just preflight`

Closes #929
