### PR TITLE
refactor(tts): make SayOptions opus-safe

### DIFF
--- a/src/cli/say.ts
+++ b/src/cli/say.ts
@@ -9,7 +9,13 @@ import {
 import { installHint } from "../install-hint";
 import { registerProcessTree } from "../process-tree";
 import { log } from "../log";
-import { say, SayError, type SayFormat } from "../synth";
+import {
+  say,
+  SayError,
+  SUPPORTED_SAMPLE_RATES,
+  type SayFormat,
+  type SayOptions,
+} from "../synth";
 import { artifactFromBytes, artifactFromFile, type StatsRecorder } from "../stats";
 import { resolveSayVoice } from "../voice-routing";
 import { diagnosticCharBucket, diagnosticSizeBucket } from "../diagnostic-events";
@@ -68,12 +74,13 @@ function parseBitrateFlag(value: unknown): Parsed<number> {
   return bitrate;
 }
 
-const SUPPORTED_SAMPLE_RATES = [8000, 12000, 16000, 24000, 48000];
-
 function parseSampleRateFlag(value: unknown): Parsed<number> {
   const sampleRate = parseFiniteNumberFlag("--sample-rate", value);
   if (!sampleRate.ok || sampleRate.value === undefined) return sampleRate;
-  if (!Number.isInteger(sampleRate.value) || !SUPPORTED_SAMPLE_RATES.includes(sampleRate.value)) {
+  if (
+    !Number.isInteger(sampleRate.value) ||
+    !SUPPORTED_SAMPLE_RATES.includes(sampleRate.value as (typeof SUPPORTED_SAMPLE_RATES)[number])
+  ) {
     return {
       ok: false,
       error: `--sample-rate must be one of ${SUPPORTED_SAMPLE_RATES.join(", ")}.`,
@@ -189,7 +196,7 @@ async function synthesizeAndEmit(
       const voiceLabel = opts.voice ?? "default voice";
       log.status(`Synthesizing ${voiceLabel} -> ${opts.out}...`);
     }
-    const audio = await stats.timeStage("tts", () => say(opts));
+    const audio = await stats.timeStage("tts", () => say(opts as SayOptions));
     const ttsTimeMs = Math.round(performance.now() - startedAt);
     if (opts.out) {
       log.status(`Saved ${opts.out} (${ttsTimeMs}ms)`);

--- a/src/synth.ts
+++ b/src/synth.ts
@@ -20,9 +20,11 @@ import { registerProcessTree } from "./process-tree";
  *   Safari/iOS. Keeps the engine's native rate; no bitrate knob.
  */
 export type SayFormat = "wav" | "ogg-opus" | "flac";
+export const SUPPORTED_SAMPLE_RATES = [8000, 12000, 16000, 24000, 48000] as const;
+export type SupportedSampleRate = (typeof SUPPORTED_SAMPLE_RATES)[number];
 export const MAX_TEXT_CHARS = 5000;
 
-export interface SayOptions {
+type SayBase = {
   /**
    * Text to synthesize. Required for programmatic callers — `say()` does not
    * forward the host process's stdin. The CLI (`kesha say` with no positional
@@ -36,14 +38,6 @@ export interface SayOptions {
   /** Parse `text` as SSML (`<speak>…<break time="500ms"/>…</speak>`). See issue #122. */
   ssml?: boolean;
   /**
-   * Defaults to `wav`, or inferred from the `out` extension: `.wav` → wav, `.ogg`/`.opus` → ogg-opus.
-   */
-  format?: SayFormat;
-  /** Only valid with `format: "ogg-opus"`. Default 32000. */
-  bitrate?: number;
-  /** Only valid with `format: "ogg-opus"`. Must be one of 8000, 12000, 16000, 24000, 48000. Default 24000. */
-  sampleRate?: number;
-  /**
    * Disable acronym auto-expansion. Honored for `ru-vosk-*` voices and for
    * `en-*` on ONNX engine builds; a no-op on FluidAudio Kokoro (the released
    * darwin-arm64 binary), `macos-*` and non-English voices, where the engine
@@ -56,7 +50,21 @@ export interface SayOptions {
    * still works regardless of this flag.
    */
   noExpandAbbrev?: boolean;
-}
+};
+
+type OpusOpts = {
+  format: "ogg-opus";
+  bitrate?: number;
+  sampleRate?: SupportedSampleRate;
+};
+
+type PcmOpts = {
+  format?: "wav" | "flac";
+  bitrate?: never;
+  sampleRate?: never;
+};
+
+export type SayOptions = SayBase & (OpusOpts | PcmOpts);
 
 function applyNoExpandAbbrev(args: string[], capabilities: EngineCapabilities | null | undefined): void {
   const supportsAcronymExpansion =

--- a/tests/unit/synth.test.ts
+++ b/tests/unit/synth.test.ts
@@ -1,6 +1,42 @@
 import { describe, it, expect, spyOn } from "bun:test";
-import { buildSayArgs, engineCrashMessage, say, SayError } from "../../src/synth";
+import { buildSayArgs, engineCrashMessage, say, SayError, type SayOptions } from "../../src/synth";
 import { log } from "../../src/log";
+
+describe("SayOptions type contract", () => {
+  const oggOpusOptions: SayOptions = {
+    format: "ogg-opus",
+    bitrate: 32_000,
+    sampleRate: 24_000,
+  };
+  const wavOptions: SayOptions = { format: "wav" };
+
+  // @ts-expect-error bitrate is only valid with format: "ogg-opus"
+  const wavWithBitrate: SayOptions = {
+    format: "wav",
+    bitrate: 64_000,
+  };
+  const flacWithSampleRate: SayOptions = {
+    format: "flac",
+    // @ts-expect-error sampleRate is only valid with format: "ogg-opus"
+    sampleRate: 24_000,
+  };
+  // @ts-expect-error bitrate requires an explicit format: "ogg-opus"
+  const defaultFormatWithBitrate: SayOptions = {
+    bitrate: 64_000,
+  };
+  const opusWithUnsupportedSampleRate: SayOptions = {
+    format: "ogg-opus",
+    // @ts-expect-error 44100 is not an Opus sample rate supported by kesha-engine
+    sampleRate: 44_100,
+  };
+
+  void oggOpusOptions;
+  void wavOptions;
+  void wavWithBitrate;
+  void flacWithSampleRate;
+  void defaultFormatWithBitrate;
+  void opusWithUnsupportedSampleRate;
+});
 
 describe("buildSayArgs", () => {
   it("starts with the 'say' subcommand", () => {


### PR DESCRIPTION
| Before | After |
| --- | --- |
| `SayOptions` accepted bitrate/sampleRate with WAV, FLAC, or no explicit format, and any numeric sample rate. | Invalid combinations stop compiling; encoder options require `format: "ogg-opus"`, and sample rates are limited to the engine-supported literals. Valid calls produce unchanged argv and runtime behaviour. |

## Summary

- Model `SayOptions` as a discriminated union so Opus encoder settings cannot be supplied to PCM/default output.
- Derive `SupportedSampleRate` from one `SUPPORTED_SAMPLE_RATES` `as const` value, shared by the CLI parser.
- Add a red-to-green TypeScript contract for illegal and legal public option combinations.

## Compatibility

This is a compile-time narrowing of the exported `SayOptions` API. Consumers relying on formerly accepted invalid combinations must remove the encoder options or select `format: "ogg-opus"`. Valid runtime calls are unchanged.

## Verification

- `bun run test -- tests/unit/synth.test.ts tests/unit/say-flags.test.ts`
- `bun run test`
- `bunx tsc --noEmit`
- `bun run check`
- `bun run coverage:check:ts`
- `just preflight`

Closes #930
