### PR TITLE
fix(raycast): a quiet room gets the message written for a quiet room

### DIFF
--- a/openspec/specs/raycast-extension/spec.md
+++ b/openspec/specs/raycast-extension/spec.md
@@ -331,17 +331,16 @@ session rather than silently copying an empty string.
 
 - GIVEN Transcription succeeded but returned only whitespace
 - WHEN the Dictation session completes
-- THEN the view shows `No transcript returned.`
+- THEN the view shows `No speech was detected in the recording.`
 - AND the clipboard is left untouched
 
 > *Technical Note — the empty case is rejected by `normalizeTranscribeResult`
-> (`raycast/src/lib/dictation-controller.ts` lines 253–262), which trims stdout
-> and throws before the session sees a result; that is why the user-visible text
-> is `No transcript returned.` and not the friendlier
-> `No speech was detected in the recording.` at lines 158–160, which is
-> unreachable for exactly that reason (see Open Issues). Trim, copy and success
-> state: lines 157–169. Clipboard write is Raycast's own `Clipboard.copy`,
-> injected at
+> (`raycast/src/lib/dictation-controller.ts`), which trims stdout and throws
+> before the session sees a result. It is the only empty-transcript guard on the
+> path and so carries the user-facing wording; `deliverTranscript` used to repeat
+> the check unreachably behind it, and that duplicate is gone (#943). Copy and
+> success state: `deliverTranscript`, on the already-trimmed text. Clipboard
+> write is Raycast's own `Clipboard.copy`, injected at
 > `raycast/src/dictate-to-clipboard.tsx` lines 43–46; the result view's copy
 > action is at lines 115–118.*
 
@@ -568,14 +567,6 @@ When the signal meter delivers no sample within a short window (~8 s) of recordi
   `--max-seconds` — but it stops on meter silence, not on audio silence, so a
   monologue recorded while the meter is dead is cut at 45 s. That coupling is
   not obvious from the requirement text.
-- The friendlier empty-transcript message `No speech was detected in the
-  recording.` (`raycast/src/lib/dictation-controller.ts` lines 158–160) is
-  unreachable: `normalizeTranscribeResult` (lines 253–262) already trims and
-  throws `No transcript returned.` for the same input, so that is what Maks
-  actually sees. Either the outer guard should go or `normalizeTranscribeResult`
-  should carry the friendlier wording — changing it means diverging from the
-  version currently in the Raycast Store, so it is recorded here rather than
-  fixed in the sync.
 - Microphone permission is observed only indirectly, as digital silence. The
   extension cannot distinguish "permission denied" from "the wrong input device
   is selected" or "the mic is muted in hardware", so the error names all of

--- a/raycast/src/lib/dictation-controller.ts
+++ b/raycast/src/lib/dictation-controller.ts
@@ -266,19 +266,12 @@ export function startDictationSession(
   }
 
   async function deliverTranscript(result: TranscribeResult) {
-    const transcript = result.text.trim();
-    if (!transcript) {
-      throw new Error("No speech was detected in the recording.");
-    }
-    await deps.copyToClipboard(transcript);
+    await deps.copyToClipboard(result.text);
     await deps.showToast({
       style: "success",
       title: "Copied transcript",
     });
-    setState({
-      status: "ok",
-      result: { ...result, text: transcript },
-    });
+    setState({ status: "ok", result });
   }
 
   function releaseResources() {
@@ -458,8 +451,10 @@ export function normalizeTranscribeResult(
   stdout: string,
 ): TranscribeResult {
   const text = stdout.trim();
+  // The only empty-transcript guard on the path, so it carries the wording the
+  // user needs — talking too quietly is the common cause, not a broken CLI (#943).
   if (!text) {
-    throw new Error("No transcript returned.");
+    throw new Error("No speech was detected in the recording.");
   }
   return { file: audioPath, text };
 }

--- a/raycast/tests/dictation-controller.test.ts
+++ b/raycast/tests/dictation-controller.test.ts
@@ -909,7 +909,7 @@ describe("normalizeTranscribeResult", () => {
       text: "hello",
     });
     expect(() => normalizeTranscribeResult("/tmp/a.wav", " \n")).toThrow(
-      "No transcript returned.",
+      "No speech was detected in the recording.",
     );
   });
 });

--- a/raycast/tests/dictation-controller.test.ts
+++ b/raycast/tests/dictation-controller.test.ts
@@ -578,6 +578,21 @@ describe("dictation controller", () => {
     );
   });
 
+  it("tells the user no speech was detected when the transcript is empty (#943)", async () => {
+    const deps = createDeps({
+      startTranscriber: vi.fn(() => resolvedTask(Promise.resolve("  \n"))),
+    });
+
+    const session = startDictationSession({}, deps.setState, deps);
+    await session.done;
+
+    expect(deps.copyToClipboard).not.toHaveBeenCalled();
+    expect(deps.states.at(-1)).toMatchObject({
+      status: "error",
+      message: "No speech was detected in the recording.",
+    });
+  });
+
   it("keeps the recording when the user cancels transcription after capture (#944)", async () => {
     const transcriber = deferred<string>();
     const deps = createDeps({


### PR DESCRIPTION
After recording into a quiet room the Raycast extension showed
`No transcript returned.` — developer-facing wording. The message written for
exactly that case, `No speech was detected in the recording.`, sat in
`deliverTranscript` behind a guard no user could reach: `normalizeTranscribeResult`
had already trimmed the same stdout and thrown first.

This is the extension's most common non-error failure (talking too quietly, wrong
input device), and it cannot diagnose the cause — the spec records that limitation
separately — so the wording is the entire remedy.

Closes #943

## Fix direction — (a), the smaller one

The issue offered two. I took (a): move the friendlier wording onto
`normalizeTranscribeResult` and delete the now-provably-dead outer guard.

(b) — having `normalizeTranscribeResult` return an empty result so the outer guard
becomes reachable — would have turned a total function into one with a
"valid but empty" state that every caller must re-check, to keep two guards where
one suffices. Net diff: `-9 / +5` in the controller, one guard on the path.

The trim in `deliverTranscript` went with it: `normalizeTranscribeResult` already
returns trimmed text, so `result.text.trim()` and the `{ ...result, text: transcript }`
rebuild were both no-ops. The happy-path test still asserts `" hello world\n"`
reaches the clipboard as `"hello world"`.

## No other caller depended on the old behaviour

`grep -rn TranscribeResult raycast/src raycast/tests` — `normalizeTranscribeResult`
is the sole producer of a `TranscribeResult`, it has exactly one call site
(`transcribePhase`), and `deliverTranscript` is only ever handed that value. The
string `No transcript returned.` appeared in exactly three places repo-wide: the
throw, its unit test, and the spec — all updated here. Nothing outside `raycast/`
references it.

## Red → green

Red (before the fix), `raycast/tests/dictation-controller.test.ts`, commit b0aafaa:

```
FAIL  tests/dictation-controller.test.ts > dictation controller >
      tells the user no speech was detected when the transcript is empty (#943)
- Expected
+ Received
  {
-   "message": "No speech was detected in the recording.",
+   "message": "No transcript returned.",
    "status": "error",
  }
 Test Files  1 failed | 8 passed (9)
      Tests  1 failed | 108 passed (109)
```

The test drives a whole session through `startDictationSession` with a transcriber
that returns `"  \n"` and asserts the state the user sees, not which function threw.

Green after 0771d30: `Test Files 9 passed (9) · Tests 109 passed (109)`.

## Deliberate divergence from the Raycast Store copy

`raycast/` here and the published copy in `raycast/extensions` are reconciled
manually at mirror-sync time, and the issue flagged this change as one that
*widens* that gap. Landing it anyway, stated rather than silent:

- **What diverges:** one user-visible string. Empty-transcript now reads
  `No speech was detected in the recording.`; the Store build still says
  `No transcript returned.`
- **Why now:** the fix is three lines and the bug is the extension's most frequent
  user-facing failure. Waiting for the next sync would have kept the worse wording
  in front of users for an unbounded interval, for no reduction in sync effort —
  the sync copies the file either way.
- **What the next mirror-sync must carry over:**
  1. `raycast/src/lib/dictation-controller.ts` — the moved guard and the trimmed-down
     `deliverTranscript`.
  2. `raycast/tests/dictation-controller.test.ts` — both tests.
  3. A `raycast/CHANGELOG.md` entry, written at sync time as this repo does it
     (recent extension fixes — #966, #765, #670 — added none per-PR); suggested
     line: *"Say that no speech was detected when a recording is silent, instead
     of reporting an empty transcript."*

## Stale line numbers

`openspec/specs/raycast-extension/spec.md` cited lines 158–160 and 253–262 for this
code; the real ones were ~228 and ~336, and would have drifted again. The Technical
Note now names the symbols (`normalizeTranscribeResult`, `deliverTranscript`) and
carries no line numbers, and the Open Issue is resolved and removed. The scenario's
expected text was updated to the new wording. Unrelated line references elsewhere in
the spec were left alone.

## Gates

| Gate | Command | Result |
| --- | --- | --- |
| Raycast tests | `npm test` (in `raycast/`) | 109 passed / 9 files |
| Raycast lint (incl. `tsc --noEmit`) | `npm run lint` | clean — ESLint + Prettier |
| Root suite | `bun run test` | 1436 pass, 6 skip, 0 fail |
| Root types | `bunx tsc --noEmit` | exit 0 |
| Spec corpus | `bun run check:specs` | 17 passed, 0 failed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBTpJjqyYFW6W8LHJ2nwy
