### PR TITLE
fix: manage every engine subprocess lifecycle

### DIFF
--- a/openspec/specs/process-lifecycle/spec.md
+++ b/openspec/specs/process-lifecycle/spec.md
@@ -7,12 +7,11 @@ those runs take minutes. This spec covers what happens when such a run is
 interrupted: which processes are terminated, how long they are given, what exit
 code the CLI reports, and what a caller who cancels programmatically observes.
 
-Every Engine subprocess started through the shared `spawnEngineProcess` helper
-registers itself, so this coverage is uniform across them: the two-hour
-transcription and the near-instant `--list-voices` listing are terminated the
-same way when interrupted. A few direct `Bun.spawn` paths outside that helper —
-the darwin Kokoro warmup, the model install, and the `--version` probe — do not,
-and are listed under Open Issues.
+Every Engine subprocess is started through `spawnEngineProcess` and registered
+for its lifetime, so this coverage is uniform across them: the two-hour
+transcription, the near-instant `--list-voices` listing, a darwin Kokoro warmup,
+model installation, and a `--version` health check are terminated the same way
+when interrupted.
 
 Ira runs batches in CI where a job cancellation must not leave a model-loading
 Engine holding a runner's CPU. Maks presses Ctrl-C on a long meeting
@@ -34,9 +33,9 @@ her agent and needs a distinguishable outcome rather than an empty transcript.
 
 ## Requirements
 
-### Requirement: An interrupted command terminates its registered Engine subprocess and reports the signal in its Exit code
+### Requirement: An interrupted command terminates its Engine subprocess and reports the signal in its Exit code
 
-When the CLI receives an interrupt or termination signal while a registered Engine subprocess is running, it SHALL terminate that subprocess and SHALL exit with the code conventionally derived from the signal — 130 for interrupt, 143 for termination — rather than with the command's own success or failure code. Every `spawnEngineProcess` call site registers, so this holds for transcription, Language detection, synthesis, recording, and both `--list-voices` listings — the CLI command's and the MCP server's — alike; the direct `Bun.spawn` warmup, install, and probe paths do not (see Open Issues).
+When the CLI receives an interrupt or termination signal while an Engine subprocess is running, it SHALL terminate that subprocess and SHALL exit with the code conventionally derived from the signal — 130 for interrupt, 143 for termination — rather than with the command's own success or failure code. This holds for transcription, Language detection, synthesis, recording, both `--list-voices` listings — the CLI command's and the MCP server's — alike, as well as the darwin Kokoro warmup, model installation, and executable health checks.
 
 #### Scenario: Maks interrupts a long transcription
 
@@ -173,20 +172,10 @@ When a caller of the Core API cancels an in-flight call, the call SHALL fail wit
   flag or timeout wires an `AbortSignal` into a run. The Raycast extension gets
   its cancellation by killing the CLI process instead, which lands on the signal
   path above rather than this one.
-- `waitForPendingSignalCleanup` is consulted only in the main transcription
-  command (`src/cli/main.ts`). `kesha say`, `kesha record`, and `kesha install`
-  rely on the handler's own `process.exit`, so their interrupted exit code is
-  set by the same handler but never awaited by the command — whether that can
-  race a command-owned `process.exit` is untested.
+- `waitForPendingSignalCleanup` is consulted by the main transcription command
+  and `kesha install`; `kesha say` and `kesha record` still rely on the
+  handler's own `process.exit`, so whether their command-owned exits can race
+  the signal cleanup is untested.
 - The Windows path spawns `taskkill` and does not wait for it, so on Windows the
   tree kill is fire-and-forget; nothing verifies it completed before the CLI
   exits.
-- Three Engine spawns bypass `spawnEngineProcess` and so never register:
-  `warmDarwinKokoro` (`src/engine-install.ts:214`, a darwin Kokoro warmup that
-  can run for up to 180 s and is not detached), `runEngineModelInstall`
-  (`src/engine-install.ts:548`, a `spawnSync` install in the CLI's own process
-  group) and `probeExecutable` (`src/engine-health.ts:23`, a short `--version`
-  probe with its own kill timer). Interrupting during one leaves that Engine to
-  the shell rather than the CLI. #939 fixed the two `spawnEngineProcess` bypasses
-  (`--list-voices`, CLI and MCP); these direct-`Bun.spawn` paths are a separate,
-  unaddressed gap.

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -9,6 +9,7 @@ import { log } from "../log";
 import { packageVersion } from "../package-info";
 import { isSemver } from "../semver.mjs";
 import { createDiagnosticLogSession, type DiagnosticLogSession } from "../diagnostic-log";
+import { getPendingSignalExitCode, waitForPendingSignalCleanup } from "../process-tree";
 import type { SharedInstallArgs } from "./types";
 
 export interface InstallCommandArgs extends SharedInstallArgs {
@@ -239,6 +240,11 @@ export async function performInstall(options: PerformInstallOptions) {
     await maybeAskForStar(getEngineBinPath(), packageVersion, log);
     finishInstallDiagnostic(diagnosticLog, startedAt, "success");
   } catch (err: unknown) {
+    const signalExitCode = getPendingSignalExitCode();
+    if (signalExitCode !== null) {
+      await waitForPendingSignalCleanup();
+      process.exit(signalExitCode);
+    }
     const message = errorMessage(err);
     finishInstallDiagnostic(diagnosticLog, startedAt, "failed", errorKind);
     log.error(message);

--- a/src/engine-health.ts
+++ b/src/engine-health.ts
@@ -1,6 +1,13 @@
 import { existsSync } from "fs";
 import { errorMessage } from "./error-utils";
-import { getEngineBinPath, getEngineCapabilities, type EngineCapabilities } from "./engine";
+import {
+  getEngineBinPath,
+  getEngineCapabilities,
+  spawnEngineProcess,
+  spawnStdioWithDebugFd,
+  type EngineCapabilities,
+} from "./engine";
+import { registerProcessTree } from "./process-tree";
 
 export type ExecutableHealth =
   | { status: "ok" }
@@ -28,27 +35,25 @@ export async function probeExecutable(
 
   let proc: ReturnType<typeof Bun.spawn>;
   try {
-    proc = Bun.spawn([binPath, ...args], {
-      stdin: "ignore",
-      stdout: "ignore",
-      stderr: "ignore",
-      // Nothing this probe runs reads a `KESHA_*` today; it is passed so every engine spawn
-      // resolves env the same way and the #874/#876 class cannot come back here (#876).
-      env: process.env,
-    });
+    proc = spawnEngineProcess(binPath, args, spawnStdioWithDebugFd(["ignore", "ignore", "ignore"]));
   } catch (err) {
     return { status: "unusable", detail: errorMessage(err) };
   }
+  const tree = registerProcessTree(proc);
 
   let timedOut = false;
+  let forceKillTimer: Timer | undefined;
   const timer = setTimeout(() => {
     timedOut = true;
-    proc.kill();
+    tree.terminate();
+    forceKillTimer = tree.forceKillAfterGrace();
   }, PROBE_TIMEOUT_MS);
   try {
     await proc.exited;
   } finally {
     clearTimeout(timer);
+    tree.dispose();
+    if (!timedOut && forceKillTimer) clearTimeout(forceKillTimer);
   }
 
   if (timedOut) {
@@ -73,17 +78,23 @@ export async function readExecutableVersion(
 
   let proc: ReturnType<typeof Bun.spawn>;
   try {
-    proc = Bun.spawn([binPath, "--version"], {
-      stdin: "ignore",
-      stdout: "pipe",
-      stderr: "ignore",
-      env: process.env,
-    });
+    proc = spawnEngineProcess(
+      binPath,
+      ["--version"],
+      spawnStdioWithDebugFd(["ignore", "pipe", "ignore"]),
+    );
   } catch {
     return null;
   }
+  const tree = registerProcessTree(proc);
 
-  const timer = setTimeout(() => proc.kill(), timeoutMs);
+  let timedOut = false;
+  let forceKillTimer: Timer | undefined;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    tree.terminate();
+    forceKillTimer = tree.forceKillAfterGrace();
+  }, timeoutMs);
   let stdout: string;
   try {
     [stdout] = await Promise.all([
@@ -92,6 +103,8 @@ export async function readExecutableVersion(
     ]);
   } finally {
     clearTimeout(timer);
+    tree.dispose();
+    if (!timedOut && forceKillTimer) clearTimeout(forceKillTimer);
   }
   return /(\d+\.\d+\.\d+[0-9A-Za-z.+-]*)/.exec(stdout)?.[1] ?? null;
 }

--- a/src/engine-install.ts
+++ b/src/engine-install.ts
@@ -5,6 +5,8 @@ import { existsSync, mkdirSync, chmodSync, accessSync, constants, rmSync } from 
 import {
   getEngineBinPath,
   getEngineCapabilities,
+  spawnEngineProcess,
+  spawnStdioWithDebugFd,
   TRANSCRIBE_DIARIZE_FEATURE,
   type EngineCapabilities,
 } from "./engine";
@@ -16,6 +18,7 @@ import { log } from "./log";
 import { engineVersion } from "./package-info";
 import { keshaCacheDir } from "./paths";
 import { streamResponseToFile } from "./progress";
+import { registerProcessTree } from "./process-tree";
 import {
   readInstalledEngineVersion,
   writeInstalledEngineVersion,
@@ -224,24 +227,12 @@ async function warmDarwinKokoro(binPath: string): Promise<void> {
   log.progress("Warming FluidAudio Kokoro CoreML cache...");
 
   const startedAt = performance.now();
-  const proc = Bun.spawn(
-    [
-      binPath,
-      "say",
-      "--voice",
-      "en-am_michael",
-      "--out",
-      outPath,
-      "Kesha warmup.",
-    ],
-    {
-      stdout: "ignore",
-      stderr: "pipe",
-      // Resolves the voice from the Model cache, so it needs the same runtime
-      // `KESHA_CACHE_DIR` the install itself was given (#876).
-      env: process.env,
-    },
+  const proc = spawnEngineProcess(
+    binPath,
+    ["say", "--voice", "en-am_michael", "--out", outPath, "Kesha warmup."],
+    spawnStdioWithDebugFd(["ignore", "pipe", "pipe"]),
   );
+  const tree = registerProcessTree(proc);
 
   let timedOut = false;
   const timer = setTimeout(() => {
@@ -280,6 +271,7 @@ async function warmDarwinKokoro(binPath: string): Promise<void> {
     );
   } finally {
     clearTimeout(timer);
+    tree.dispose();
     try {
       rmSync(outPath, { force: true });
     } catch {
@@ -547,11 +539,11 @@ export function validateDiarize(caps: EngineCapabilities | null): void {
  * Runs `kesha-engine install` to download/verify models.
  * Inherits stdio so per-file progress reaches the user live, and throws on non-zero exit.
  */
-function runEngineModelInstall(
+async function runEngineModelInstall(
   binPath: string,
   noCache: boolean,
   options: InstallOptions,
-): void {
+): Promise<void> {
   log.progress("Installing models...");
   const installArgs = buildEngineInstallArgs({
     noCache,
@@ -563,15 +555,22 @@ function runEngineModelInstall(
   // `env` is load-bearing, not tidiness: this child resolves the model destination from
   // `KESHA_CACHE_DIR`, and without it Bun's startup snapshot sends a redirected install
   // to the real `~/.cache/kesha` anyway (#876).
-  const proc = Bun.spawnSync([binPath, ...installArgs], {
-    stdout: "inherit",
-    stderr: "inherit",
-    env: process.env,
-  });
+  const proc = spawnEngineProcess(
+    binPath,
+    installArgs,
+    spawnStdioWithDebugFd(["inherit", "inherit", "inherit"]),
+  );
+  const tree = registerProcessTree(proc);
+  let exitCode: number;
+  try {
+    exitCode = await proc.exited;
+  } finally {
+    tree.dispose();
+  }
 
-  if (proc.exitCode !== 0) {
+  if (exitCode !== 0) {
     throw new Error(
-      `Failed to install models: kesha-engine install exited with code ${proc.exitCode}. ` +
+      `Failed to install models: kesha-engine install exited with code ${exitCode}. ` +
         "See the engine output above for the failing file.",
     );
   }
@@ -777,7 +776,7 @@ async function installLockedEngine(
     if (options.diarize) validateDiarize(caps);
   }
 
-  runEngineModelInstall(binPath, noCache, options);
+  await runEngineModelInstall(binPath, noCache, options);
 
   // Warm the FluidAudio Kokoro CoreML cache only when a Kokoro language is
   // requested. Russian (`ru`) routes through Vosk-TTS, not Kokoro, so a

--- a/tests/helpers/process.ts
+++ b/tests/helpers/process.ts
@@ -5,8 +5,11 @@ const PID_FILE_POLL_INTERVAL_MS = 25;
 const PID_FILE_POLL_ATTEMPTS = 400;
 const PID_EXIT_POLL_ATTEMPTS = 400;
 
-export async function waitForPidFile(path: string): Promise<number> {
-  for (let i = 0; i < PID_FILE_POLL_ATTEMPTS; i++) {
+export async function waitForPidFile(
+  path: string,
+  attempts: number = PID_FILE_POLL_ATTEMPTS,
+): Promise<number> {
+  for (let i = 0; i < attempts; i++) {
     if (existsSync(path)) return Number(readFileSync(path, "utf8"));
     await Bun.sleep(PID_FILE_POLL_INTERVAL_MS);
   }

--- a/tests/integration/cli-contracts.test.ts
+++ b/tests/integration/cli-contracts.test.ts
@@ -14,7 +14,7 @@ import { tmpdir } from "os";
 import { delimiter, dirname, join } from "path";
 import { engineVersion } from "../../src/package-info";
 import { SUBCOMMAND_NAMES } from "../../src/cli/dispatch";
-import { waitForPidExit, waitForPidFile } from "../helpers/process";
+import { pidIsAlive, waitForPidExit, waitForPidFile } from "../helpers/process";
 import {
   DEFAULT_TIMEOUT_MS,
   installFakeDiarizeModel,
@@ -250,6 +250,76 @@ process.exit(2);
   );
   chmodSync(enginePath, 0o755);
   return enginePath;
+}
+
+function createLifecycleEngine(
+  dir: string,
+  enginePidPath: string,
+  hangsDuring: "probe" | "model-install" | "warmup" | "version-check",
+): string {
+  const enginePath = join(dir, `kesha-engine-${hangsDuring}`);
+  const capabilities = hangsDuring === "probe"
+    ? ""
+    : "console.log(JSON.stringify({ protocolVersion: 1, backend: \"fake\", features: [] }));";
+  const hang = `
+  await Bun.write(${JSON.stringify(enginePidPath)}, String(process.pid));
+  await new Promise(() => {});
+`;
+  writeFileSync(
+    enginePath,
+    `#!${process.execPath}
+const args = Bun.argv.slice(2);
+if (args[0] === "--capabilities-json") {
+  ${capabilities}
+  process.exit(0);
+}
+if (args[0] === "--version" && ${JSON.stringify(hangsDuring)} !== "probe" && ${JSON.stringify(hangsDuring)} !== "version-check") {
+  console.log("kesha-engine ${engineVersion}");
+  process.exit(0);
+}
+if (
+  (${JSON.stringify(hangsDuring)} === "probe" && args[0] === "--version") ||
+  (${JSON.stringify(hangsDuring)} === "model-install" && args[0] === "install") ||
+  (${JSON.stringify(hangsDuring)} === "warmup" && args[0] === "say") ||
+  (${JSON.stringify(hangsDuring)} === "version-check" && args[0] === "--version")
+) {${hang}}
+if (args[0] === "install") process.exit(0);
+console.error("unexpected fake engine args: " + JSON.stringify(args));
+process.exit(2);
+`,
+  );
+  chmodSync(enginePath, 0o755);
+  return enginePath;
+}
+
+async function interruptInstallAndReadExit(
+  args: readonly string[],
+  env: Record<string, string>,
+  enginePidPath: string,
+): Promise<{ exitCode: number | null; engineStopped: boolean }> {
+  const proc = Bun.spawn([process.execPath, "run", "src/cli-entry.ts", ...args], {
+    cwd: DEFAULT_CWD,
+    stdout: "ignore",
+    stderr: "ignore",
+    env: { ...process.env, NO_COLOR: "1", FORCE_COLOR: "0", ...env },
+  });
+  const enginePid = await waitForPidFile(enginePidPath, 800);
+  proc.kill("SIGINT");
+  const exitCode = await Promise.race([
+    proc.exited,
+    Bun.sleep(5_000).then(() => null),
+  ]);
+  let engineStopped = false;
+  for (let attempt = 0; attempt < 60; attempt++) {
+    if (!pidIsAlive(enginePid)) {
+      engineStopped = true;
+      break;
+    }
+    await Bun.sleep(25);
+  }
+  if (exitCode === null) proc.kill("SIGKILL");
+  if (!engineStopped) process.kill(enginePid, "SIGKILL");
+  return { exitCode, engineStopped };
 }
 
 function createListVoicesHangEngine(dir: string, enginePidPath: string): string {
@@ -1139,6 +1209,46 @@ describe("CLI contracts", () => {
       expect(await waitForPidExit(enginePid)).toBe(true);
     });
   }
+
+  for (const [phase, args] of [
+    ["probe", ["install"]],
+    ["model-install", ["install"]],
+    ["version-check", ["install"]],
+  ] as const) {
+    test(`Ctrl+C during ${phase} terminates the engine and exits 130 (#971)`, async () => {
+      if (process.platform === "win32") return;
+      const dir = makeTempDir(`kesha-cli-contract-${phase}-signal-`);
+      const enginePidPath = join(dir, "engine.pid");
+      const enginePath = createLifecycleEngine(dir, enginePidPath, phase);
+      markFakeEngineInstalled(enginePath);
+
+      const result = await interruptInstallAndReadExit(
+        args,
+        { ...isolatedEnv(dir), KESHA_ENGINE_BIN: enginePath },
+        enginePidPath,
+      );
+
+      expect(result.exitCode).toBe(130);
+      expect(result.engineStopped).toBe(true);
+    });
+  }
+
+  test("Ctrl+C during the darwin Kokoro warmup terminates the engine and exits 130 (#971)", async () => {
+    if (process.platform !== "darwin" || process.arch !== "arm64") return;
+    const dir = makeTempDir("kesha-cli-contract-warmup-signal-");
+    const enginePidPath = join(dir, "engine.pid");
+    const enginePath = createLifecycleEngine(dir, enginePidPath, "warmup");
+    markFakeEngineInstalled(enginePath);
+
+    const result = await interruptInstallAndReadExit(
+      ["install", "--tts", "en"],
+      { ...isolatedEnv(dir), KESHA_ENGINE_BIN: enginePath },
+      enginePidPath,
+    );
+
+    expect(result.exitCode).toBe(130);
+    expect(result.engineStopped).toBe(true);
+  });
 
   test("early transcription failure does not start audio language detection", async () => {
     if (process.platform === "win32") return;


### PR DESCRIPTION
## Summary

- Route warmup, install, and health/version Engine subprocesses through the registered lifecycle boundary.
- Preserve signal exit codes for interrupted installs and document the universal guarantee.
- Add PID-based interruption regressions for each lifecycle phase.

Closes #971

## Validation

- `bun test tests/integration/cli-contracts.test.ts --test-name-pattern '#971'`
- `bun test tests/integration/cli-contracts.test.ts --test-name-pattern 'install keeps progress on stderr while --plan'`
- `bun test tests/unit/engine-repair.test.ts`
- `bun test tests/unit/engine-install.test.ts`
- `bun run coverage:ts && bun run coverage:check:ts`
- `just preflight`
