### PR TITLE
refactor(core): remove ineffective TranscribeOptions.silent

### DIFF
--- a/openspec/specs/programmatic-api/spec.md
+++ b/openspec/specs/programmatic-api/spec.md
@@ -65,8 +65,7 @@ object. It SHALL:
 > `src/lib.ts:46`. The Engine's stderr never reaches the caller's stderr because
 > `runEngine` (`src/engine.ts:106`) spawns it with `stdio: ["ignore", "pipe",
 > "pipe"]` — stderr is captured into a string, surfaced only inside the thrown
-> Error on failure and discarded on success. `lib.ts` also passes `silent: true`,
-> but that option is currently never read downstream — see Open Issues.*
+> Error on failure and discarded on success.*
 
 ### Requirement: `transcribeWithTimestamps(path, opts?)` returns text and segments
 
@@ -267,8 +266,3 @@ message naming the `kesha install` command needed to fix the situation.
   surfaced in the type; it is documented only in the JSDoc comment.
 - `downloadTts` does not expose a progress callback; callers cannot observe
   download progress except via stderr parsing.
-- **`silent` is a dead option** — `lib.ts` passes `silent: true` to
-  `internalTranscribe`/`internalTranscribeWithSegments` (`src/lib.ts:52,66`), but
-  `TranscribeOptions.silent` (`src/transcribe.ts:15`) is never read; stderr
-  suppression for the Core API comes solely from `runEngine`'s piped stdio. The
-  flag should either be wired up or removed.

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -49,7 +49,7 @@ export async function transcribe(
     throw new Error(`File not found: ${audioPath}`);
   }
 
-  return internalTranscribe(audioPath, { ...options, silent: true });
+  return internalTranscribe(audioPath, options);
 }
 
 export async function transcribeWithTimestamps(
@@ -63,7 +63,6 @@ export async function transcribeWithTimestamps(
   return internalTranscribeWithSegments(audioPath, {
     ...options,
     timestamps: true,
-    silent: true,
   });
 }
 

--- a/src/transcribe.ts
+++ b/src/transcribe.ts
@@ -14,7 +14,6 @@ export type { VadMode };
 export type { TranscriptionOutput };
 
 export interface TranscribeOptions {
-  silent?: boolean;
   /** Silero VAD preprocessing selector. Defaults to `"auto"`. */
   vad?: VadMode;
   /** Cancel any in-flight engine subprocess for this transcription. */

--- a/tests/unit/transcribe-options.test.ts
+++ b/tests/unit/transcribe-options.test.ts
@@ -1,0 +1,6 @@
+import type { TranscribeOptions } from "../../src/lib";
+
+// @ts-expect-error `silent` is not a Core API option.
+const options: TranscribeOptions = { silent: false };
+
+void options;


### PR DESCRIPTION
| Before | After |
| --- | --- |
| Callers passing `silent` compile. | Callers passing `silent` fail TypeScript compilation. |
| Runtime behavior appears configurable. | Runtime behavior is unchanged: `silent` was never read. |

## Summary

- Remove the ineffective `TranscribeOptions.silent` field and Core API call-site overrides.
- Add a compile-time contract rejecting `silent`.
- Resolve the matching Programmatic API Open Issue.

## Validation

- `bunx tsc --noEmit` (RED before the change: unused `@ts-expect-error`; GREEN after)
- `bun run test`
- `bun run check`
- `bun run coverage:check:ts`
- `just preflight`

Closes #937
