### PR TITLE
fix(diarize): let the model load report itself while it is loading

### DIFF
--- a/openspec/specs/speaker-diarization/spec.md
+++ b/openspec/specs/speaker-diarization/spec.md
@@ -258,6 +258,12 @@ The Engine SHALL report diarization progress on stderr — never stdout — nami
 the compute units at the start, the model load time once the binding reports the
 model ready, and the percentage of audio processed at intervals thereafter.
 
+The CLI SHALL relay each of those lines as the Engine writes it, not once the run
+is over. Progress that arrives only after the wait it described cannot tell a slow
+run from a hung one, which is what a silent 51 s model load was taken for (#1002).
+Progress relayed this way SHALL NOT be repeated in the failure report, which keeps
+naming the file and the Engine's own error.
+
 The Engine SHALL supervise the run with a budget per phase rather than one
 wall-clock timeout, each phase delimited by a signal from the binding rather than
 inferred: 300 s for the model load (up to the model-ready marker), 60 s plus
@@ -278,6 +284,14 @@ can only shorten a run — never widen a phase budget.
   `diarize: model ready in 4.0s; reading the audio`, then percentage lines, then
   `diarize: done in 39.5s (20 spans)`
 - AND stdout carries only the JSON result
+
+#### Scenario: Maks watches the model load rather than a still bar
+
+- GIVEN a cold ANE cache, so the model load runs for ~105 s
+- WHEN Maks runs `kesha --json --speakers meeting.ogg`
+- THEN `diarize: loading the CoreML model on all` reaches his terminal before the
+  load begins, and the cold-cache explanation while it is still going
+- AND neither waits for the run to finish to be printed
 
 #### Scenario: The first run after an ANE cache eviction
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -324,6 +324,13 @@ async function processFile(
 
   const startedAt = performance.now();
   let progress: ReturnType<typeof createPercentProgress> | null = null;
+  // #1002: the bar sitting at 0% through a ~100 s diarization model load reads as a hang,
+  // so the engine's progress has to land while it happens, not once the run is over.
+  const showProgressLine = (line: string) => {
+    const write = () => process.stderr.write(`${line}\n`);
+    if (progress) progress.interrupt(write);
+    else write();
+  };
   try {
     await preflightTranscribeWithSegments({ vad: vadMode, timestamps, speakers, itn });
     progress = reportProgress
@@ -332,7 +339,13 @@ async function processFile(
         })
       : null;
     const transcript = await stats.timeStage("transcribe", () =>
-      transcribeWithSegments(file, { vad: vadMode, timestamps, speakers, itn }),
+      transcribeWithSegments(file, {
+        vad: vadMode,
+        timestamps,
+        speakers,
+        itn,
+        onProgressLine: showProgressLine,
+      }),
     );
     const { text, segments } = transcript;
     const transcriptDurationSeconds = estimateTranscriptDurationSeconds(segments);

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -113,6 +113,51 @@ export function spawnStdioWithDebugFd(
 
 export interface RunEngineOptions {
   signal?: AbortSignal;
+  /** Receives each progress line as the engine writes it, rather than once the run is
+   *  over (#1002). Progress the caller takes delivery of this way is dropped from the
+   *  returned `stderr`, so it is never shown a second time in the failure report. */
+  onProgressLine?: (line: string) => void;
+}
+
+/**
+ * Whether `line` is the engine reporting on work in flight rather than on its outcome.
+ *
+ * Diarization is the only phase slow enough to need it: its CoreML model load alone
+ * costs ~100 s on a first run and ~5 s warm, and it prefixes every line it emits
+ * (#443/#721). Errors carry no such prefix, so they stay with the failure report.
+ */
+function isProgressLine(line: string): boolean {
+  return line.startsWith("diarize: ");
+}
+
+/** Reads `stream` to EOF, handing progress lines to `onProgress` as they arrive and
+ *  returning everything else. */
+async function partitionProgress(
+  stream: ReadableStream<Uint8Array>,
+  onProgress: (line: string) => void,
+): Promise<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let rest = "";
+  let pending = "";
+  const take = (line: string) => {
+    if (isProgressLine(line)) onProgress(line);
+    else rest += `${line}\n`;
+  };
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    pending += decoder.decode(value, { stream: true });
+    let nl = pending.indexOf("\n");
+    while (nl !== -1) {
+      take(pending.slice(0, nl));
+      pending = pending.slice(nl + 1);
+      nl = pending.indexOf("\n");
+    }
+  }
+  pending += decoder.decode();
+  if (pending.length > 0) take(pending);
+  return rest;
 }
 
 /**
@@ -168,9 +213,12 @@ async function runEngine(
   let stderr: string;
   let exitCode: number;
   try {
+    const onProgress = opts.onProgressLine;
     [stdout, stderr, exitCode] = await Promise.all([
       new Response(stdoutStream).text(),
-      new Response(stderrStream).text(),
+      onProgress
+        ? partitionProgress(stderrStream, onProgress)
+        : new Response(stderrStream).text(),
       proc.exited,
     ]);
   } finally {
@@ -209,6 +257,8 @@ export interface TranscribeEngineOptions {
   /** Rewrite spoken-form numbers to written form. Requires the engine to
    * advertise `transcribe.itn` (#710). */
   itn?: boolean;
+  /** See {@link RunEngineOptions.onProgressLine}. */
+  onProgressLine?: (line: string) => void;
 }
 
 /** #768: speakers force VAD windowing, so `vad: "off"` is an invalid pair. Callers
@@ -343,7 +393,10 @@ export async function transcribeEngine(
   await preflightTranscribeEngineItn(opts);
 
   const args = buildTranscribeArgs(audioPath, opts);
-  const { stdout, stderr, exitCode } = await runEngine(args, { signal: opts.signal });
+  const { stdout, stderr, exitCode } = await runEngine(args, {
+    signal: opts.signal,
+    onProgressLine: opts.onProgressLine,
+  });
   if (exitCode !== 0) {
     throw new Error(stderr || `kesha-engine exited with code ${exitCode}`);
   }
@@ -405,7 +458,10 @@ export async function transcribeEngineWithSegments(
   await preflightTranscribeEngineWithSegments(opts);
 
   const args = buildTranscribeArgs(audioPath, opts, true);
-  const { stdout, stderr, exitCode } = await runEngine(args, { signal: opts.signal });
+  const { stdout, stderr, exitCode } = await runEngine(args, {
+    signal: opts.signal,
+    onProgressLine: opts.onProgressLine,
+  });
   if (exitCode !== 0) {
     throw new Error(stderr || `kesha-engine exited with code ${exitCode}`);
   }

--- a/src/transcribe.ts
+++ b/src/transcribe.ts
@@ -30,6 +30,10 @@ export interface TranscribeOptions {
    * through unchanged. Throws when the engine doesn't advertise
    * `transcribe.itn`. */
   itn?: boolean;
+  /** Receives the engine's progress lines as it writes them, rather than once the run
+   * is over. The diarization model load alone can take ~100 s on a first run, and a
+   * caller with no way to show that in flight looks like it has hung (#1002). */
+  onProgressLine?: (line: string) => void;
 }
 
 export async function transcribe(audioPath: string, opts: TranscribeOptions = {}): Promise<string> {
@@ -73,6 +77,7 @@ export async function transcribeWithSegments(
       signal: opts.signal,
       speakers: opts.speakers,
       itn: opts.itn,
+      onProgressLine: opts.onProgressLine,
     });
   }
 
@@ -80,6 +85,7 @@ export async function transcribeWithSegments(
     vad: opts.vad,
     signal: opts.signal,
     itn: opts.itn,
+    onProgressLine: opts.onProgressLine,
   });
   return { text, segments: [] };
 }

--- a/tests/unit/engine.test.ts
+++ b/tests/unit/engine.test.ts
@@ -482,6 +482,72 @@ describe("engine", () => {
       expect(await waitForPidExit(helperPid)).toBe(true);
     });
   });
+
+  /**
+   * #1002: a 51 s diarization model load read as a hang because the engine's stderr was
+   * collected to EOF before any of it was forwarded, so the lines announcing the wait
+   * only landed once the wait was over. The stub blocks until the caller acknowledges
+   * the line and reports in its own transcript whether that happened, so the contract —
+   * progress reaches the caller while the engine still works — is asserted with no
+   * wall-clock comparison to go flaky.
+   */
+  fakeEngineTest("progress reaches the caller while the engine is still running", async () => {
+    const ack = join(mkdtempSync(join(tmpdir(), "kesha-live-progress-")), "ack");
+    const engine = writeTranscribingEngine(
+      "kesha-engine-live-progress-",
+      ["transcribe.segments"],
+      `  echo 'diarize: loading the CoreML model on all' >&2
+  i=0
+  while [ "$i" -lt 20 ]; do
+    if [ -e '${ack}' ]; then
+      printf '%s\\n' '{"text":"streamed","segments":[]}'
+      exit 0
+    fi
+    sleep 0.05
+    i=$((i + 1))
+  done
+  printf '%s\\n' '{"text":"buffered","segments":[]}'`,
+    );
+
+    const seen: string[] = [];
+    const out = await withEngineEnv(engine, () =>
+      transcribeEngineWithSegments("audio.wav", {
+        onProgressLine: (line) => {
+          seen.push(line);
+          writeFileSync(ack, "");
+        },
+      }),
+    );
+
+    expect(out.text).toBe("streamed");
+    expect(seen).toEqual(["diarize: loading the CoreML model on all"]);
+  });
+
+  /** The other half of that contract: a failure still arrives whole through the thrown
+   *  error, and the progress already shown live is not replayed inside it. */
+  fakeEngineTest("a failure keeps its own report and does not repeat live progress", async () => {
+    const engine = writeTranscribingEngine(
+      "kesha-engine-progress-failure-",
+      ["transcribe.segments"],
+      `  echo 'diarize: loading the CoreML model on all' >&2
+  echo 'error [E_DIARIZE_TIMEOUT]: speaker diarization stalled while loading the model' >&2
+  exit 1`,
+    );
+
+    const seen: string[] = [];
+    const failure = await withEngineEnv(engine, () =>
+      transcribeEngineWithSegments("audio.wav", {
+        onProgressLine: (line) => seen.push(line),
+      }).then(
+        () => null,
+        (err: unknown) => String(err),
+      ),
+    );
+
+    expect(seen).toEqual(["diarize: loading the CoreML model on all"]);
+    expect(failure).toContain("error [E_DIARIZE_TIMEOUT]: speaker diarization stalled");
+    expect(failure).not.toContain("loading the CoreML model");
+  });
 });
 
 describe("spawnStdioWithDebugFd", () => {


### PR DESCRIPTION
Closes #1002

## The engine was never silent — the CLI was

The reported symptom is a 51 s diarization model load with nothing on stderr, then both `diarize:` lines at once. Reading `rust/src/transcribe/diarize.rs` first: the engine has printed `diarize: loading the CoreML model on all` **before** the load since #806, plus a cold-cache explanation at 15 s and `still loading (Ns)` ticks after that. All of it is in the reporter's own engine build:

```console
$ git show v1.24.10-alpha.2:rust/src/transcribe/diarize.rs | grep -n "loading the CoreML model"
292:    eprintln!("diarize: loading the CoreML model on {}", units.as_str());
```

So the fix direction in the issue (emit a line before the wait) was already implemented. The defect is one layer up, in `src/engine.ts::runEngine`, which collected the engine's stderr to EOF before writing any of it:

```ts
[stdout, stderr, exitCode] = await Promise.all([
  new Response(stdoutStream).text(),
  new Response(stderrStream).text(),   // resolves only at EOF
  proc.exited,
]);
...
if (exitCode === 0 && stderr.length > 0) process.stderr.write(stderr);
```

Every progress line the engine wrote therefore landed *after* the wait it described. Measured against a stub that writes one stderr line at t≈0 and then sleeps 3 s: the line surfaced at **+3085 ms**, on process exit.

## What changed

`runEngine` now splits the stderr stream as it arrives. Lines carrying the engine's `diarize: ` progress prefix — the same channel `tests/integration/e2e-engine.test.ts:196` already filters on — go straight to the caller; everything else is retained and handled exactly as before. `processFile` renders them through the progress bar's existing `interrupt`, so they print above the bar instead of being drawn over.

Wording emitted is unchanged and comes from the engine, not from new CLI text. Only its timing changed:

```console
[+0.6s] Transcribing clip.wav  [░░░░░░░░░░░░░░░░░░░░] 0%
[+0.6s] diarize: loading the CoreML model on all      <-- was +3.6s
[+3.6s] diarize: model ready in 3.0s; reading the audio
[+3.6s] diarize: done in 3.1s (1 spans)
```

**First run vs warm run** needs no new text and no invented number. The engine already distinguishes them honestly and only speaks when the load is actually slow: `slow_phase_hint` fires after 15 s of quiet with *"the model is still loading after 15s — a cold Neural Engine cache makes this take ~105s, once (#443)"*. A warm ~5 s load finishes before that ever fires. Both are `diarize: `-prefixed, so both now stream.

**Failure reports stay intact and unrepeated.** Retaining only the non-progress lines means the thrown error and the `--include-errors` envelope still carry the engine's own message, attributed to the file, minus progress the user already watched arrive:

```console
diarize: loading the CoreML model on all
diarize: still loading (30s)
clip.wav: error [E_DIARIZE_TIMEOUT]: speaker diarization stalled after 300s while loading the model
```

Untouched paths (`install`, `detect-lang`, `--capabilities-json`) pass no handler and take the byte-identical original branch.

## The 0% bar — left alone, deliberately

The bar is a time estimate (`estimatePercent` against a 60-minute assumption for `--speakers`), not a phase indicator. Making it name the load phase means mapping engine phases onto percentages, which is the full phased progress bar the issue explicitly does not ask for. With the engine's lines now landing during the wait, the bar is no longer the only thing on screen — the phase is stated in words above it. Starting the bar only after the load would be worse: it would restore the silence this fixes.

## Red → green

Two tests in `tests/unit/engine.test.ts`, landed in `bb06532` before the fix in `fb3204b`. The stub blocks until the caller acknowledges the line it wrote and reports in its own transcript whether that happened, so the contract is asserted with no wall-clock comparison to go flaky.

Verified red against the pre-fix source, green after:

```
(fail) progress reaches the caller while the engine is still running
       Expected: "streamed"   Received: "buffered"
(fail) a failure keeps its own report and does not repeat live progress
       expect(seen).toEqual(["diarize: loading the CoreML model on all"])
```

The red run also takes 2.0 s to the green run's 0.8 s, because the stub waits out its handshake.

## Gates

- `bun run lint` (tsc --noEmit) — clean
- `just preflight` — 1446 pass, 6 skip, 0 fail
- `openspec validate --specs --strict` — 17 passed, 0 failed
- Rust gates (`rust-test`, `fmt`, `clippy`, `--features system_diarize`): **not applicable — `rust/` is untouched.** The root cause was TypeScript; `just preflight` gates the Rust suite on a `rust/**` diff for exactly this reason.

One earlier full-suite run had `cli-contracts > diagnostic logs record successful install events without content` time out at 15 s. It passes in isolation (7.4 s), passes with its whole file (35/35), and passed on the re-run (0 fail). `kesha install` never passes a progress handler, so it takes the unchanged branch of `runEngine`.

## Spec

`openspec/specs/speaker-diarization/spec.md` gained the relay guarantee on the existing progress requirement plus a scenario, since the requirement described what the Engine writes without saying when the CLI must show it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBTpJjqyYFW6W8LHJ2nwy
