### PR TITLE
refactor(cli): model output and VAD modes explicitly

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -32,6 +32,7 @@ interface MainCommandArgs {
   verbose: boolean;
   debug: boolean;
   vad: boolean;
+  "no-vad": boolean;
   timestamps: boolean;
   speakers: boolean;
   itn: boolean;
@@ -148,13 +149,16 @@ export type ValidatedTranscribeArgs = {
   outputFormat: "json" | "toon" | "transcript" | "text";
 };
 
-type NormalizedMainCommandArgs = MainCommandArgs & { noVad: boolean };
+type MainVadArgs = Pick<MainCommandArgs, "vad" | "no-vad">;
 
-function normalizeMainCommandArgs(args: MainCommandArgs, rawArgs: string[]): NormalizedMainCommandArgs {
+export function normalizeMainCommandArgs<T extends MainVadArgs>(
+  args: T,
+  rawArgs: string[],
+): T & { noVad: boolean } {
   return {
     ...args,
     vad: rawArgs.includes("--vad") || args.vad,
-    noVad: rawArgs.includes("--no-vad"),
+    noVad: rawArgs.includes("--no-vad") || args["no-vad"] === true,
   };
 }
 
@@ -164,10 +168,12 @@ export type TranscribeArgsValidation =
 
 /** Validates cross-flag consistency that citty can't express. */
 export function validateTranscribeArgs(
-  args: NormalizedMainCommandArgs,
+  args: MainCommandArgs,
+  rawArgs: string[],
   fmt: ResolvedOutputFormat & { ok: true },
 ): TranscribeArgsValidation {
-  const { vad, noVad } = args;
+  const normalizedArgs = normalizeMainCommandArgs(args, rawArgs);
+  const { vad, noVad } = normalizedArgs;
 
   if (vad && noVad) {
     return { ok: false, error: "--vad and --no-vad are mutually exclusive." };
@@ -402,6 +408,21 @@ function writeOutput(
 }
 
 /** The transcribe command, bound to the global flags dispatch resolved before citty. */
+export const MAIN_VAD_ARGS = {
+  vad: {
+    type: "boolean",
+    description:
+      "Force Silero VAD preprocessing (kesha install --vad first). Without this, VAD auto-engages on audio ≥ 120s.",
+    default: false,
+  },
+  "no-vad": {
+    type: "boolean",
+    description:
+      "Force full-file ASR for short/medium files; long audio fails early. Incompatible with --speakers",
+    default: false,
+  },
+} as const;
+
 export function createMainCommand(context: CliContext = { quiet: false, disableColor: false }) {
   return defineCommand({
     meta: {
@@ -479,16 +500,7 @@ export function createMainCommand(context: CliContext = { quiet: false, disableC
         description: "Trace engine subprocess calls on stderr (or KESHA_DEBUG=1)",
         default: false,
       },
-      vad: {
-        type: "boolean",
-        description: "Force Silero VAD preprocessing (kesha install --vad first). Without this, VAD auto-engages on audio ≥ 120s.",
-        default: false,
-      },
-      "no-vad": {
-        type: "boolean",
-        description: "Force full-file ASR for short/medium files; long audio fails early. Incompatible with --speakers",
-        default: false,
-      },
+      ...MAIN_VAD_ARGS,
       // quiet and no-color are resolved before citty in dispatch.ts (so they
       // apply to every command, not just transcribe); declared here only so they
       // appear in `kesha --help`.
@@ -518,7 +530,7 @@ export function createMainCommand(context: CliContext = { quiet: false, disableC
         process.exit(2);
       }
 
-      const validated = validateTranscribeArgs(normalizeMainCommandArgs(args, rawArgs), fmt);
+      const validated = validateTranscribeArgs(args, rawArgs, fmt);
       if (!validated.ok) {
         log.error(validated.error);
         process.exit(2);

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -32,9 +32,6 @@ interface MainCommandArgs {
   verbose: boolean;
   debug: boolean;
   vad: boolean;
-  "no-vad": boolean;
-  noVad?: boolean;
-  no_vad?: boolean;
   timestamps: boolean;
   speakers: boolean;
   itn: boolean;
@@ -65,31 +62,31 @@ export function isDirectoryPath(path: string): boolean {
  * with its own clearer error first.
  */
 export type ResolvedOutputFormat =
-  | {
-      ok: true;
-      wantsJson: boolean;
-      wantsToon: boolean;
-      wantsTranscript: boolean;
-    }
+  | { ok: true; format: "json" | "toon" | "transcript" | "text" }
   | { ok: false; error: string };
 
 const SUPPORTED_FORMATS = ["transcript", "json", "toon"] as const;
+
+function isSupportedFormat(format: string): format is (typeof SUPPORTED_FORMATS)[number] {
+  return SUPPORTED_FORMATS.some((supported) => supported === format);
+}
 
 export function resolveOutputFormat(input: {
   json?: boolean;
   toon?: boolean;
   format?: string;
 }): ResolvedOutputFormat {
-  if (input.format !== undefined && !SUPPORTED_FORMATS.includes(input.format as never)) {
+  if (input.format !== undefined && !isSupportedFormat(input.format)) {
     return {
       ok: false,
       error: `unknown --format '${input.format}'. supported: ${SUPPORTED_FORMATS.join(", ")}`,
     };
   }
-  const wantsJson = !!input.json || input.format === "json";
-  const wantsToon = !!input.toon || input.format === "toon";
-  const wantsTranscript = input.format === "transcript";
-  if (wantsJson && wantsToon) {
+  if (
+    (input.json && input.toon) ||
+    (input.json && input.format === "toon") ||
+    (input.toon && input.format === "json")
+  ) {
     return {
       ok: false,
       error: "--json and --toon are mutually exclusive (pick one output format).",
@@ -100,7 +97,7 @@ export function resolveOutputFormat(input: {
   // dispatch checked wantsJson/wantsToon first). Greptile P2 on #300
   // flagged the silent override. Fail loudly with the same shape as
   // the json/toon mutex — symmetric across all three formats.
-  if (wantsTranscript && (wantsJson || wantsToon)) {
+  if (input.format === "transcript" && (input.json || input.toon)) {
     return {
       ok: false,
       error:
@@ -108,7 +105,7 @@ export function resolveOutputFormat(input: {
         "(pick one output format).",
     };
   }
-  return { ok: true, wantsJson, wantsToon, wantsTranscript };
+  return { ok: true, format: input.json ? "json" : input.toon ? "toon" : (input.format ?? "text") };
 }
 
 export function checkLanguageMismatch(expected: string | undefined, detected: string): string | null {
@@ -151,30 +148,34 @@ export type ValidatedTranscribeArgs = {
   outputFormat: "json" | "toon" | "transcript" | "text";
 };
 
+type NormalizedMainCommandArgs = MainCommandArgs & { noVad: boolean };
+
+function normalizeMainCommandArgs(args: MainCommandArgs, rawArgs: string[]): NormalizedMainCommandArgs {
+  return {
+    ...args,
+    vad: rawArgs.includes("--vad") || args.vad,
+    noVad: rawArgs.includes("--no-vad"),
+  };
+}
+
 export type TranscribeArgsValidation =
   | ({ ok: true } & ValidatedTranscribeArgs)
   | { ok: false; error: string };
 
 /** Validates cross-flag consistency that citty can't express. */
 export function validateTranscribeArgs(
-  args: MainCommandArgs,
-  rawArgs: string[],
+  args: NormalizedMainCommandArgs,
   fmt: ResolvedOutputFormat & { ok: true },
 ): TranscribeArgsValidation {
-  const { wantsJson, wantsToon, wantsTranscript } = fmt;
-
-  // citty treats --no-vad as the negated form of --vad, so read rawArgs
-  // to distinguish "off" from the default auto mode and to catch both flags.
-  const vad = rawArgs.includes("--vad") || Boolean(args.vad);
-  const noVad = rawArgs.includes("--no-vad") || Boolean(args["no-vad"] ?? args.noVad ?? args.no_vad);
+  const { vad, noVad } = args;
 
   if (vad && noVad) {
     return { ok: false, error: "--vad and --no-vad are mutually exclusive." };
   }
-  if (args.timestamps && !(wantsJson || wantsToon)) {
+  if (args.timestamps && fmt.format !== "json" && fmt.format !== "toon") {
     return { ok: false, error: "--timestamps requires --json, --toon, or --format {json,toon}." };
   }
-  if (args.speakers && !(wantsJson || wantsToon)) {
+  if (args.speakers && fmt.format !== "json" && fmt.format !== "toon") {
     return { ok: false, error: "--speakers requires --json, --toon, or --format {json,toon}." };
   }
   // #768: diarization labels VAD-windowed segments, so --no-vad leaves nothing to label.
@@ -187,20 +188,12 @@ export function validateTranscribeArgs(
         "(VAD engages automatically for --speakers), or drop --speakers.",
     };
   }
-  if (args["include-errors"] && !(wantsJson || wantsToon)) {
+  if (args["include-errors"] && fmt.format !== "json" && fmt.format !== "toon") {
     return { ok: false, error: "--include-errors requires --json, --toon, or --format {json,toon}." };
   }
 
   const vadMode: ValidatedTranscribeArgs["vadMode"] = vad ? "on" : noVad ? "off" : "auto";
-  const outputFormat: ValidatedTranscribeArgs["outputFormat"] = wantsJson
-    ? "json"
-    : wantsToon
-      ? "toon"
-      : wantsTranscript
-        ? "transcript"
-        : "text";
-
-  return { ok: true, vadMode, outputFormat };
+  return { ok: true, vadMode, outputFormat: fmt.format };
 }
 
 async function detectLanguages(
@@ -525,7 +518,7 @@ export function createMainCommand(context: CliContext = { quiet: false, disableC
         process.exit(2);
       }
 
-      const validated = validateTranscribeArgs(args, rawArgs, fmt);
+      const validated = validateTranscribeArgs(normalizeMainCommandArgs(args, rawArgs), fmt);
       if (!validated.ok) {
         log.error(validated.error);
         process.exit(2);

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -3,6 +3,7 @@ import { parseArgs, renderUsage } from "citty";
 import { decode as decodeToon } from "@toon-format/toon";
 import { createMainCommand, completionsCommand, doctorCommand, initCommand, installCommand, logsCommand, manpageCommand, recordCommand, statusCommand, statsCommand, supportBundleCommand, sayCommand, formatJsonOutput, formatToonOutput, detectLanguage, checkLanguageMismatch, estimateTranscriptDurationSeconds, isDirectoryPath, noRecordingBackendMessage, resolveOutputFormat, resolveRecordArgs, shouldReportTranscribeProgress, shouldRunAudioLanguageDetection, validateTranscribeArgs } from "../../src/cli";
 import type { ResolvedOutputFormat } from "../../src/cli";
+import { MAIN_VAD_ARGS, normalizeMainCommandArgs } from "../../src/cli/main";
 
 function normalizeUsage(usage: string): string {
   return usage
@@ -19,7 +20,9 @@ function normalizeUsage(usage: string): string {
     .trim();
 }
 
-function defaultMainArgs(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+type MainCommandArgs = Parameters<typeof validateTranscribeArgs>[0];
+
+function defaultMainArgs(overrides: Partial<MainCommandArgs> = {}): MainCommandArgs {
   return {
     _: [],
     json: false,
@@ -30,19 +33,26 @@ function defaultMainArgs(overrides: Record<string, unknown> = {}): Record<string
     "no-vad": false,
     timestamps: false,
     speakers: false,
+    itn: false,
     "include-errors": false,
+    quiet: false,
+    "no-color": false,
     ...overrides,
   };
 }
 
 describe("citty negated flags", () => {
-  test("--no-vad is represented as vad: false, not a no-vad key", () => {
-    const args: Record<string, unknown> = parseArgs(["--no-vad"], {
-      vad: { type: "boolean", default: false },
-    });
+  test("production VAD args distinguish exact and camel-case no-vad spellings", () => {
+    const exactRawArgs = ["--no-vad"];
+    const exact = parseArgs<typeof MAIN_VAD_ARGS>(exactRawArgs, MAIN_VAD_ARGS);
+    const camelRawArgs = ["--noVad"];
+    const camel = parseArgs<typeof MAIN_VAD_ARGS>(camelRawArgs, MAIN_VAD_ARGS);
 
-    expect(args.vad).toBe(false);
-    expect(args["no-vad"]).toBeUndefined();
+    expect(exact.vad).toBe(false);
+    expect(exact["no-vad"]).toBe(false);
+    expect(normalizeMainCommandArgs(exact, exactRawArgs).noVad).toBe(true);
+    expect(camel["no-vad"]).toBe(true);
+    expect(normalizeMainCommandArgs(camel, camelRawArgs).noVad).toBe(true);
   });
 });
 
@@ -638,18 +648,24 @@ function okFmt(format: "json" | "toon" | "transcript" | "text" = "text"): Resolv
 
 describe("validateTranscribeArgs guards", () => {
   function validate(
-    argsOverrides: Partial<ReturnType<typeof defaultMainArgs>>,
+    argsOverrides: Partial<MainCommandArgs>,
     rawArgs: string[],
     fmt: ResolvedOutputFormat & { ok: true },
   ) {
+    const parsedVadArgs = parseArgs<typeof MAIN_VAD_ARGS>(rawArgs, MAIN_VAD_ARGS);
     return validateTranscribeArgs(
-      { ...defaultMainArgs(argsOverrides), noVad: rawArgs.includes("--no-vad") } as never,
+      defaultMainArgs({
+        vad: parsedVadArgs.vad,
+        "no-vad": parsedVadArgs["no-vad"],
+        ...argsOverrides,
+      }),
+      rawArgs,
       fmt,
     );
   }
 
   function expectRejected(
-    argsOverrides: Partial<ReturnType<typeof defaultMainArgs>>,
+    argsOverrides: Partial<MainCommandArgs>,
     rawArgs: string[],
     fmt: ResolvedOutputFormat & { ok: true },
   ): string {
@@ -660,7 +676,7 @@ describe("validateTranscribeArgs guards", () => {
   }
 
   function expectAccepted(
-    argsOverrides: Partial<ReturnType<typeof defaultMainArgs>>,
+    argsOverrides: Partial<MainCommandArgs>,
     rawArgs: string[],
     fmt: ResolvedOutputFormat & { ok: true },
   ) {
@@ -720,15 +736,19 @@ describe("validateTranscribeArgs guards", () => {
   });
 
   test("--vad and --no-vad are mutually exclusive", () => {
-    expect(expectRejected({ vad: true }, ["--vad", "--no-vad"], okFmt())).toContain(
+    expect(expectRejected({}, ["--vad", "--no-vad"], okFmt())).toContain(
+      "mutually exclusive",
+    );
+    expect(expectRejected({}, ["--no-vad", "--vad"], okFmt())).toContain(
       "mutually exclusive",
     );
   });
 
-  test("vadMode derives correctly from rawArgs", () => {
+  test("vadMode derives from the production parse and normalization boundary", () => {
     expect(expectAccepted({}, [], okFmt()).vadMode).toBe("auto");
-    expect(expectAccepted({ vad: true }, ["--vad"], okFmt()).vadMode).toBe("on");
+    expect(expectAccepted({}, ["--vad"], okFmt()).vadMode).toBe("on");
     expect(expectAccepted({}, ["--no-vad"], okFmt()).vadMode).toBe("off");
+    expect(expectAccepted({}, ["--noVad"], okFmt()).vadMode).toBe("off");
   });
 
   test("--speakers with --no-vad is rejected (#768)", () => {

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { renderUsage } from "citty";
+import { parseArgs, renderUsage } from "citty";
 import { decode as decodeToon } from "@toon-format/toon";
 import { createMainCommand, completionsCommand, doctorCommand, initCommand, installCommand, logsCommand, manpageCommand, recordCommand, statusCommand, statsCommand, supportBundleCommand, sayCommand, formatJsonOutput, formatToonOutput, detectLanguage, checkLanguageMismatch, estimateTranscriptDurationSeconds, isDirectoryPath, noRecordingBackendMessage, resolveOutputFormat, resolveRecordArgs, shouldReportTranscribeProgress, shouldRunAudioLanguageDetection, validateTranscribeArgs } from "../../src/cli";
 import type { ResolvedOutputFormat } from "../../src/cli";
@@ -34,6 +34,17 @@ function defaultMainArgs(overrides: Record<string, unknown> = {}): Record<string
     ...overrides,
   };
 }
+
+describe("citty negated flags", () => {
+  test("--no-vad is represented as vad: false, not a no-vad key", () => {
+    const args: Record<string, unknown> = parseArgs(["--no-vad"], {
+      vad: { type: "boolean", default: false },
+    });
+
+    expect(args.vad).toBe(false);
+    expect(args["no-vad"]).toBeUndefined();
+  });
+});
 
 describe("CLI help", () => {
   test("init help contains onboarding and feature options", async () => {
@@ -508,62 +519,42 @@ describe("resolveOutputFormat (#300 regression)", () => {
   // #300: `--format toon` silently fell through to plain text; these lock in the contract.
 
   describe("boolean flags route to their format", () => {
-    test("--json sets wantsJson", () => {
+    test("--json resolves to json", () => {
       const r = resolveOutputFormat({ json: true });
       expect(r.ok).toBe(true);
-      if (r.ok) {
-        expect(r.wantsJson).toBe(true);
-        expect(r.wantsToon).toBe(false);
-        expect(r.wantsTranscript).toBe(false);
-      }
+      if (r.ok) expect(r.format).toBe("json");
     });
 
-    test("--toon sets wantsToon", () => {
+    test("--toon resolves to toon", () => {
       const r = resolveOutputFormat({ toon: true });
       expect(r.ok).toBe(true);
-      if (r.ok) {
-        expect(r.wantsToon).toBe(true);
-        expect(r.wantsJson).toBe(false);
-        expect(r.wantsTranscript).toBe(false);
-      }
+      if (r.ok) expect(r.format).toBe("toon");
     });
 
-    test("no flags → all false (default plain-text)", () => {
+    test("no flags resolve to plain text", () => {
       const r = resolveOutputFormat({});
       expect(r.ok).toBe(true);
-      if (r.ok) {
-        expect(r.wantsJson).toBe(false);
-        expect(r.wantsToon).toBe(false);
-        expect(r.wantsTranscript).toBe(false);
-      }
+      if (r.ok) expect(r.format).toBe("text");
     });
   });
 
   describe("--format string is an alias for the boolean", () => {
-    test("--format json", () => {
+    test("--format json resolves to json", () => {
       const r = resolveOutputFormat({ format: "json" });
       expect(r.ok).toBe(true);
-      if (r.ok) expect(r.wantsJson).toBe(true);
+      if (r.ok) expect(r.format).toBe("json");
     });
 
     test("--format toon (the bug fixed in #300)", () => {
       const r = resolveOutputFormat({ format: "toon" });
       expect(r.ok).toBe(true);
-      if (r.ok) {
-        expect(r.wantsToon).toBe(true);
-        expect(r.wantsJson).toBe(false);
-        expect(r.wantsTranscript).toBe(false);
-      }
+      if (r.ok) expect(r.format).toBe("toon");
     });
 
     test("--format transcript", () => {
       const r = resolveOutputFormat({ format: "transcript" });
       expect(r.ok).toBe(true);
-      if (r.ok) {
-        expect(r.wantsTranscript).toBe(true);
-        expect(r.wantsJson).toBe(false);
-        expect(r.wantsToon).toBe(false);
-      }
+      if (r.ok) expect(r.format).toBe("transcript");
     });
   });
 
@@ -627,22 +618,22 @@ describe("resolveOutputFormat (#300 regression)", () => {
   });
 
   describe("boolean + --format same value is harmless (idempotent)", () => {
-    test("--json --format json → wantsJson true, no mutex", () => {
+    test("--json --format json resolves to json without a mutex", () => {
       const r = resolveOutputFormat({ json: true, format: "json" });
       expect(r.ok).toBe(true);
-      if (r.ok) expect(r.wantsJson).toBe(true);
+      if (r.ok) expect(r.format).toBe("json");
     });
 
-    test("--toon --format toon → wantsToon true, no mutex", () => {
+    test("--toon --format toon resolves to toon without a mutex", () => {
       const r = resolveOutputFormat({ toon: true, format: "toon" });
       expect(r.ok).toBe(true);
-      if (r.ok) expect(r.wantsToon).toBe(true);
+      if (r.ok) expect(r.format).toBe("toon");
     });
   });
 });
 
-function okFmt(json = false, toon = false, transcript = false): ResolvedOutputFormat & { ok: true } {
-  return { ok: true, wantsJson: json, wantsToon: toon, wantsTranscript: transcript };
+function okFmt(format: "json" | "toon" | "transcript" | "text" = "text"): ResolvedOutputFormat & { ok: true } {
+  return { ok: true, format };
 }
 
 describe("validateTranscribeArgs guards", () => {
@@ -651,7 +642,10 @@ describe("validateTranscribeArgs guards", () => {
     rawArgs: string[],
     fmt: ResolvedOutputFormat & { ok: true },
   ) {
-    return validateTranscribeArgs(defaultMainArgs(argsOverrides) as never, rawArgs, fmt);
+    return validateTranscribeArgs(
+      { ...defaultMainArgs(argsOverrides), noVad: rawArgs.includes("--no-vad") } as never,
+      fmt,
+    );
   }
 
   function expectRejected(
@@ -684,7 +678,7 @@ describe("validateTranscribeArgs guards", () => {
 
   test("--timestamps with --json is accepted", () => {
     expect(
-      expectAccepted({ timestamps: true, json: true }, ["--timestamps", "--json"], okFmt(true))
+      expectAccepted({ timestamps: true, json: true }, ["--timestamps", "--json"], okFmt("json"))
         .outputFormat,
     ).toBe("json");
   });
@@ -697,7 +691,7 @@ describe("validateTranscribeArgs guards", () => {
 
   test("--speakers with --toon is accepted", () => {
     expect(
-      expectAccepted({ speakers: true, toon: true }, ["--speakers", "--toon"], okFmt(false, true))
+      expectAccepted({ speakers: true, toon: true }, ["--speakers", "--toon"], okFmt("toon"))
         .outputFormat,
     ).toBe("toon");
   });
@@ -710,7 +704,7 @@ describe("validateTranscribeArgs guards", () => {
 
   test("--include-errors with --json is accepted", () => {
     expect(
-      expectAccepted({ "include-errors": true, json: true }, ["--include-errors", "--json"], okFmt(true))
+      expectAccepted({ "include-errors": true, json: true }, ["--include-errors", "--json"], okFmt("json"))
         .outputFormat,
     ).toBe("json");
   });
@@ -720,7 +714,7 @@ describe("validateTranscribeArgs guards", () => {
       expectAccepted(
         { "include-errors": true, toon: true },
         ["--include-errors", "--toon"],
-        okFmt(false, true),
+        okFmt("toon"),
       ).outputFormat,
     ).toBe("toon");
   });
@@ -739,13 +733,13 @@ describe("validateTranscribeArgs guards", () => {
 
   test("--speakers with --no-vad is rejected (#768)", () => {
     expect(
-      expectRejected({ speakers: true, json: true }, ["--speakers", "--no-vad"], okFmt(true)),
+      expectRejected({ speakers: true, json: true }, ["--speakers", "--no-vad"], okFmt("json")),
     ).toContain("--speakers cannot be combined with --no-vad");
   });
 
   test("--speakers alone still routes through auto VAD", () => {
     expect(
-      expectAccepted({ speakers: true, json: true }, ["--speakers", "--json"], okFmt(true)).vadMode,
+      expectAccepted({ speakers: true, json: true }, ["--speakers", "--json"], okFmt("json")).vadMode,
     ).toBe("auto");
   });
 });


### PR DESCRIPTION
## Summary

- return one resolved output format instead of three mutually dependent booleans
- narrow `--format` with an explicit predicate and use the resolved format for validation gates
- characterize citty's `--no-vad` parsing and normalize raw VAD intent once at the command boundary

## Validation

- `bun test tests/unit/cli.test.ts` (75 pass)
- `bun test tests/integration/cli-contracts.test.ts` (unchanged suite, pass)
- `bunx tsc --noEmit`
- `bun run coverage:ts && bun run coverage:check:ts` (81.05% total; `src/cli/main.ts` 39.57% >= 35%)
- `just preflight`

Closes #931
