### PR TITLE
refactor(test): type env guard locking

### DIFF
--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -2431,7 +2431,7 @@ mod mirror_tests {
         let _lock = crate::util::test_env::lock();
 
         {
-            let _g = EnvGuard::unset("KESHA_MODEL_MIRROR");
+            let _g = EnvGuard::unset(&_lock, "KESHA_MODEL_MIRROR");
             assert_eq!(model_mirror(), None);
             assert_eq!(
                 apply_mirror("https://huggingface.co/foo/bar/resolve/main/file.onnx"),
@@ -2439,7 +2439,7 @@ mod mirror_tests {
             );
         }
         {
-            let _g = EnvGuard::set("KESHA_MODEL_MIRROR", "");
+            let _g = EnvGuard::set(&_lock, "KESHA_MODEL_MIRROR", "");
             assert_eq!(model_mirror(), None);
             assert_eq!(
                 apply_mirror("https://huggingface.co/foo/bar/resolve/main/file.onnx"),
@@ -2447,7 +2447,7 @@ mod mirror_tests {
             );
         }
         {
-            let _g = EnvGuard::set("KESHA_MODEL_MIRROR", "   ");
+            let _g = EnvGuard::set(&_lock, "KESHA_MODEL_MIRROR", "   ");
             assert_eq!(model_mirror(), None);
         }
     }
@@ -2455,7 +2455,11 @@ mod mirror_tests {
     #[test]
     fn rewrites_hf_url_onto_mirror_base_preserving_path() {
         let _lock = crate::util::test_env::lock();
-        let _g = EnvGuard::set("KESHA_MODEL_MIRROR", "https://mirror.example.com/kesha");
+        let _g = EnvGuard::set(
+            &_lock,
+            "KESHA_MODEL_MIRROR",
+            "https://mirror.example.com/kesha",
+        );
         assert_eq!(
             apply_mirror("https://huggingface.co/foo/bar/resolve/main/file.onnx"),
             "https://mirror.example.com/kesha/foo/bar/resolve/main/file.onnx"
@@ -2465,7 +2469,11 @@ mod mirror_tests {
     #[test]
     fn strips_trailing_slash_from_mirror_base() {
         let _lock = crate::util::test_env::lock();
-        let _g = EnvGuard::set("KESHA_MODEL_MIRROR", "https://mirror.example.com/kesha/");
+        let _g = EnvGuard::set(
+            &_lock,
+            "KESHA_MODEL_MIRROR",
+            "https://mirror.example.com/kesha/",
+        );
         assert_eq!(
             apply_mirror("https://huggingface.co/x/y/resolve/main/z.bin"),
             "https://mirror.example.com/kesha/x/y/resolve/main/z.bin"
@@ -2477,7 +2485,7 @@ mod mirror_tests {
         // github.com release assets (engine binary + avspeech sidecar) must
         // NOT be redirected — KESHA_MODEL_MIRROR only covers model files.
         let _lock = crate::util::test_env::lock();
-        let _g = EnvGuard::set("KESHA_MODEL_MIRROR", "https://mirror.example.com");
+        let _g = EnvGuard::set(&_lock, "KESHA_MODEL_MIRROR", "https://mirror.example.com");
         let url = "https://github.com/drakulavich/kesha-voice-kit/releases/download/v1.3.0/kesha-engine-darwin-arm64";
         assert_eq!(apply_mirror(url), url);
     }
@@ -2816,7 +2824,7 @@ mod tts_tests {
     #[test]
     fn cache_dir_honors_env_var() {
         let _lock = crate::util::test_env::lock();
-        let guard = EnvGuard::set("KESHA_CACHE_DIR", "/tmp/kesha-test-xyz");
+        let guard = EnvGuard::set(&_lock, "KESHA_CACHE_DIR", "/tmp/kesha-test-xyz");
         assert_eq!(cache_dir().unwrap(), PathBuf::from("/tmp/kesha-test-xyz"));
         drop(guard);
     }
@@ -3706,6 +3714,7 @@ mod characterization_tests {
         let _lock = crate::util::test_env::lock();
         let tmp = tempfile::tempdir().unwrap();
         let _guard = crate::util::test_env::EnvGuard::set(
+            &_lock,
             "KESHA_CACHE_DIR",
             tmp.path().to_str().expect("utf-8 temp path"),
         );
@@ -3743,6 +3752,7 @@ mod characterization_tests {
         let _lock = crate::util::test_env::lock();
         let tmp = tempfile::tempdir().unwrap();
         let _guard = crate::util::test_env::EnvGuard::set(
+            &_lock,
             "KESHA_CACHE_DIR",
             tmp.path().to_str().expect("utf-8 temp path"),
         );
@@ -3769,6 +3779,7 @@ mod characterization_tests {
         let _lock = crate::util::test_env::lock();
         let tmp = tempfile::tempdir().unwrap();
         let _guard = crate::util::test_env::EnvGuard::set(
+            &_lock,
             "KESHA_CACHE_DIR",
             tmp.path().to_str().expect("utf-8 temp path"),
         );
@@ -3790,6 +3801,7 @@ mod characterization_tests {
         let _lock = crate::util::test_env::lock();
         let tmp = tempfile::tempdir().unwrap();
         let _guard = crate::util::test_env::EnvGuard::set(
+            &_lock,
             "KESHA_CACHE_DIR",
             tmp.path().to_str().expect("utf-8 temp path"),
         );
@@ -4872,7 +4884,7 @@ mod retry_tests {
             partial_response(&body, cut),
         ]);
         let _lock = crate::util::test_env::lock();
-        let _guard = crate::util::test_env::EnvGuard::set("KESHA_MODEL_MIRROR", &base);
+        let _guard = crate::util::test_env::EnvGuard::set(&_lock, "KESHA_MODEL_MIRROR", &base);
         let cache = TempCache::new("mirror-resume");
         let file = model_file(
             "models/retry/payload.bin",

--- a/rust/src/record.rs
+++ b/rust/src/record.rs
@@ -900,7 +900,7 @@ mod tests {
     fn recovery_audio_lives_under_the_kesha_cache() {
         let _lock = crate::util::test_env::lock();
         let _guard =
-            crate::util::test_env::EnvGuard::set("KESHA_CACHE_DIR", "/tmp/kesha-962-cache");
+            crate::util::test_env::EnvGuard::set(&_lock, "KESHA_CACHE_DIR", "/tmp/kesha-962-cache");
         assert_eq!(
             spill::recovery_dir().unwrap(),
             std::path::PathBuf::from("/tmp/kesha-962-cache/recordings")
@@ -1086,7 +1086,7 @@ mod tests {
         let _lock = crate::util::test_env::lock();
         let cache = tempfile::tempdir().unwrap();
         let cache_path = cache.path().to_string_lossy().into_owned();
-        let _guard = crate::util::test_env::EnvGuard::set("KESHA_CACHE_DIR", &cache_path);
+        let _guard = crate::util::test_env::EnvGuard::set(&_lock, "KESHA_CACHE_DIR", &cache_path);
 
         let err = match load_live_endpoint(crate::vad::EndpointConfig::default()) {
             Ok(_) => panic!("a missing VAD model must not start endpointing"),

--- a/rust/src/transcribe/diarize.rs
+++ b/rust/src/transcribe/diarize.rs
@@ -1259,16 +1259,16 @@ mod tests {
     fn compute_units_default_to_all_and_reject_junk() {
         let _guard = crate::util::test_env::lock();
 
-        let _unset = crate::util::test_env::EnvGuard::unset(COMPUTE_UNITS_ENV);
+        let _unset = crate::util::test_env::EnvGuard::unset(&_guard, COMPUTE_UNITS_ENV);
         assert_eq!(compute_units_from_env().unwrap(), DiarizeComputeUnits::All);
 
-        let _env = crate::util::test_env::EnvGuard::set(COMPUTE_UNITS_ENV, "CPU-Only");
+        let _env = crate::util::test_env::EnvGuard::set(&_guard, COMPUTE_UNITS_ENV, "CPU-Only");
         assert_eq!(
             compute_units_from_env().unwrap(),
             DiarizeComputeUnits::CpuOnly
         );
 
-        let _env = crate::util::test_env::EnvGuard::set(COMPUTE_UNITS_ENV, "tpu");
+        let _env = crate::util::test_env::EnvGuard::set(&_guard, COMPUTE_UNITS_ENV, "tpu");
         let err = compute_units_from_env().unwrap_err().to_string();
         assert!(err.contains("is not a known CoreML compute-units preset"));
         assert!(err.contains("cpu-and-gpu"));
@@ -1278,10 +1278,10 @@ mod tests {
     fn total_timeout_is_opt_in() {
         let _guard = crate::util::test_env::lock();
 
-        let _unset = crate::util::test_env::EnvGuard::unset(TOTAL_TIMEOUT_ENV);
+        let _unset = crate::util::test_env::EnvGuard::unset(&_guard, TOTAL_TIMEOUT_ENV);
         assert_eq!(total_timeout_from_env().unwrap(), None);
 
-        let _env = crate::util::test_env::EnvGuard::set(TOTAL_TIMEOUT_ENV, "3600");
+        let _env = crate::util::test_env::EnvGuard::set(&_guard, TOTAL_TIMEOUT_ENV, "3600");
         assert_eq!(
             total_timeout_from_env().unwrap(),
             Some(Duration::from_secs(3_600))
@@ -1289,7 +1289,7 @@ mod tests {
 
         // Empty reads as "not configured"; a wrapper exporting an unset variable is not
         // making a claim about the cap.
-        let _env = crate::util::test_env::EnvGuard::set(TOTAL_TIMEOUT_ENV, "  ");
+        let _env = crate::util::test_env::EnvGuard::set(&_guard, TOTAL_TIMEOUT_ENV, "  ");
         assert_eq!(total_timeout_from_env().unwrap(), None);
     }
 
@@ -1300,7 +1300,7 @@ mod tests {
         // Silently reading as "no cap" is how a typo removes the only bound the user
         // asked for; `0` gets the same treatment because unsetting already means no cap.
         for bad in ["0", "-1", "1.5", "300s", "nope"] {
-            let _env = crate::util::test_env::EnvGuard::set(TOTAL_TIMEOUT_ENV, bad);
+            let _env = crate::util::test_env::EnvGuard::set(&_guard, TOTAL_TIMEOUT_ENV, bad);
             let err = total_timeout_from_env().unwrap_err().to_string();
             assert!(err.contains(TOTAL_TIMEOUT_ENV), "{bad}: {err}");
             assert!(
@@ -1314,17 +1314,17 @@ mod tests {
     fn load_budget_is_overridable_but_never_zero() {
         let _guard = crate::util::test_env::lock();
 
-        let _unset = crate::util::test_env::EnvGuard::unset(LOAD_TIMEOUT_ENV);
+        let _unset = crate::util::test_env::EnvGuard::unset(&_guard, LOAD_TIMEOUT_ENV);
         assert_eq!(
             load_budget_from_env().unwrap(),
             Duration::from_secs(MODEL_LOAD_BUDGET_SECS)
         );
 
-        let _env = crate::util::test_env::EnvGuard::set(LOAD_TIMEOUT_ENV, "900");
+        let _env = crate::util::test_env::EnvGuard::set(&_guard, LOAD_TIMEOUT_ENV, "900");
         assert_eq!(load_budget_from_env().unwrap(), Duration::from_secs(900));
 
         // A typo here used to hand back the default budget without a word.
-        let _env = crate::util::test_env::EnvGuard::set(LOAD_TIMEOUT_ENV, "nope");
+        let _env = crate::util::test_env::EnvGuard::set(&_guard, LOAD_TIMEOUT_ENV, "nope");
         let err = load_budget_from_env().unwrap_err().to_string();
         assert!(err.contains(LOAD_TIMEOUT_ENV), "{err}");
     }

--- a/rust/src/transcribe/mod.rs
+++ b/rust/src/transcribe/mod.rs
@@ -1783,9 +1783,13 @@ mod tests {
         let _env_lock = crate::util::test_env::lock();
         let cache = tempfile::tempdir().unwrap();
         let missing_diarize_model = cache.path().join("missing-diarize.mlpackage");
-        let _cache_guard =
-            crate::util::test_env::EnvGuard::set("KESHA_CACHE_DIR", cache.path().to_str().unwrap());
+        let _cache_guard = crate::util::test_env::EnvGuard::set(
+            &_env_lock,
+            "KESHA_CACHE_DIR",
+            cache.path().to_str().unwrap(),
+        );
         let _diarize_guard = crate::util::test_env::EnvGuard::set(
+            &_env_lock,
             "KESHA_DIARIZE_MODEL_PATH",
             missing_diarize_model.to_str().unwrap(),
         );

--- a/rust/src/tts/fluid_kokoro.rs
+++ b/rust/src/tts/fluid_kokoro.rs
@@ -487,7 +487,7 @@ mod tests {
         let _lock = lock();
 
         {
-            let _g = EnvGuard::unset(COMPUTE_UNITS_ENV);
+            let _g = EnvGuard::unset(&_lock, COMPUTE_UNITS_ENV);
             assert_eq!(
                 compute_units_from_env().expect("unset is valid"),
                 KokoroComputeUnits::Default
@@ -496,7 +496,7 @@ mod tests {
 
         // GHA exports a conditional `env:` as the empty string rather than omitting it.
         for blank in ["", "   "] {
-            let _g = EnvGuard::set(COMPUTE_UNITS_ENV, blank);
+            let _g = EnvGuard::set(&_lock, COMPUTE_UNITS_ENV, blank);
             assert_eq!(
                 compute_units_from_env().expect("blank is valid"),
                 KokoroComputeUnits::Default
@@ -509,14 +509,14 @@ mod tests {
             ("ALL-ANE", KokoroComputeUnits::AllAne),
             ("default", KokoroComputeUnits::Default),
         ] {
-            let _g = EnvGuard::set(COMPUTE_UNITS_ENV, value);
+            let _g = EnvGuard::set(&_lock, COMPUTE_UNITS_ENV, value);
             let parsed = compute_units_from_env().unwrap_or_else(|e| panic!("{value:?}: {e}"));
             assert_eq!(parsed, expected);
             assert_eq!(preset_name(parsed), value.trim().to_ascii_lowercase());
         }
 
         // Must fail loudly instead of silently using the ANE the caller was avoiding.
-        let _g = EnvGuard::set(COMPUTE_UNITS_ENV, "ane-please");
+        let _g = EnvGuard::set(&_lock, COMPUTE_UNITS_ENV, "ane-please");
         let err = compute_units_from_env().expect_err("unknown preset must error");
         assert_eq!(crate::errors::code_of(&err), ErrorCode::InvalidArg);
         let msg = err.to_string();

--- a/rust/src/util.rs
+++ b/rust/src/util.rs
@@ -28,44 +28,58 @@ pub fn argmax(xs: &[f32]) -> usize {
 pub mod test_env {
     use std::sync::{Mutex, MutexGuard, OnceLock};
 
-    /// Crate-wide lock for every env-mutating test. Poisoning is ignored:
-    /// a panicked env test must not cascade into unrelated ones.
-    pub fn lock() -> MutexGuard<'static, ()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
+    /// Crate-wide lock for every env-mutating test.
+    pub struct EnvLock {
+        _guard: MutexGuard<'static, ()>,
     }
 
-    /// Restores the env var to its original value on drop. Hold the guard
-    /// from [`lock`] for the whole test — `EnvGuard` deliberately does not
-    /// take it itself so a test can set several vars.
-    pub struct EnvGuard {
+    /// Acquires the crate-wide env lock. Poisoning is ignored so a panicked
+    /// env test does not cascade into unrelated ones.
+    pub fn lock() -> EnvLock {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        EnvLock {
+            _guard: LOCK
+                .get_or_init(|| Mutex::new(()))
+                .lock()
+                .unwrap_or_else(|e| e.into_inner()),
+        }
+    }
+
+    /// Restores the env var to its original value on drop while its borrowed
+    /// [`EnvLock`] keeps env mutation serialized.
+    pub struct EnvGuard<'lock> {
         key: &'static str,
         original: Option<String>,
+        _lock: std::marker::PhantomData<&'lock EnvLock>,
     }
 
-    impl EnvGuard {
-        pub fn set(key: &'static str, val: &str) -> Self {
+    impl<'lock> EnvGuard<'lock> {
+        pub fn set(_lock: &'lock EnvLock, key: &'static str, val: &str) -> Self {
             let original = std::env::var(key).ok();
-            // SAFETY: callers must hold [`lock`], which serializes every env-mutating
-            // test in the crate. #954 tracks making that a type-level requirement.
+            // SAFETY: the borrowed `EnvLock` serializes every env-mutating test in the crate.
             unsafe { std::env::set_var(key, val) };
-            Self { key, original }
+            Self {
+                key,
+                original,
+                _lock: std::marker::PhantomData,
+            }
         }
 
-        pub fn unset(key: &'static str) -> Self {
+        pub fn unset(_lock: &'lock EnvLock, key: &'static str) -> Self {
             let original = std::env::var(key).ok();
-            // SAFETY: callers must hold [`lock`], which serializes every env-mutating
-            // test in the crate. #954 tracks making that a type-level requirement.
+            // SAFETY: the borrowed `EnvLock` serializes every env-mutating test in the crate.
             unsafe { std::env::remove_var(key) };
-            Self { key, original }
+            Self {
+                key,
+                original,
+                _lock: std::marker::PhantomData,
+            }
         }
     }
 
-    impl Drop for EnvGuard {
+    impl Drop for EnvGuard<'_> {
         fn drop(&mut self) {
-            // Locals drop in reverse order, so a test that took [`lock`] first still holds it here.
+            // `EnvGuard` cannot outlive its borrowed `EnvLock`.
             match &self.original {
                 // SAFETY: restoration runs under that still-held lock, like the set did.
                 Some(v) => unsafe { std::env::set_var(self.key, v) },
@@ -73,5 +87,20 @@ pub mod test_env {
                 None => unsafe { std::env::remove_var(self.key) },
             }
         }
+    }
+
+    #[test]
+    fn env_guard_mutators_require_a_borrowed_env_lock() {
+        fn set<'lock>(lock: &'lock EnvLock) -> EnvGuard<'lock> {
+            EnvGuard::set(lock, "KESHA_TEST_ENV_GUARD", "value")
+        }
+
+        fn unset<'lock>(lock: &'lock EnvLock) -> EnvGuard<'lock> {
+            EnvGuard::unset(lock, "KESHA_TEST_ENV_GUARD")
+        }
+
+        let lock = lock();
+        drop(set(&lock));
+        drop(unset(&lock));
     }
 }


### PR DESCRIPTION
## Summary

Make test-only `EnvGuard::set` and `EnvGuard::unset` borrow an `EnvLock`. The guard now carries that borrow for its full lifetime, so Rust prevents an environment mutation without the crate-wide serialization lock and prevents a guard from outliving it.

Updated every current call site: `models.rs`, `record.rs`, `tts/fluid_kokoro.rs`, `transcribe/mod.rs`, and `transcribe/diarize.rs`.

Closes #954

## RED / GREEN / sabotage evidence

- RED: the new compile-time contract test failed before the type change because `EnvLock` and the lifetime-bound `EnvGuard` API did not exist (`E0425`, `E0107`).
- GREEN: the targeted nextest contract check passed after implementing `EnvLock` and `EnvGuard<'lock>`.
- Sabotage: temporarily removing the lock parameter made compilation fail (`E0061`) at both the contract proof and every migrated call site; restored immediately.

## Validation

- `cargo nextest run --all-targets --features tts env_guard_mutators_require_a_borrowed_env_lock`
- `just rust-test` — 603 passed
- `just preflight` — passed (TS tests, lint, Rust fmt/clippy, and 603 nextest tests)

## Public API impact

Test-only internal API change; no shipped CLI or programmatic API impact.