### PR TITLE
test(models): pin the receive deadline by the timeout ureq blames, not a stopwatch

### DIFF
--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -4592,6 +4592,52 @@ mod retry_tests {
         base
     }
 
+    /// Drips `chunk * chunks` bytes `gap_ms` apart while promising twice that
+    /// many, then holds the socket open and quiet for `hold_ms` before hanging
+    /// up. The body is still arriving when a deadline shorter than the drip
+    /// fires, and no scheduling delay can hand the client the promised length —
+    /// those bytes are never sent, so the read cannot come back `Ok` (#1013).
+    fn never_completing_server(chunk: usize, chunks: usize, gap_ms: u64, hold_ms: u64) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind never-completing server");
+        let base = format!("http://{}", listener.local_addr().expect("stub addr"));
+        std::thread::spawn(move || {
+            let Ok((mut stream, _)) = listener.accept() else {
+                return;
+            };
+            if !read_request(&mut stream) {
+                return;
+            }
+            let head = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                chunk * chunks * 2
+            );
+            if stream.write_all(head.as_bytes()).is_err() {
+                return;
+            }
+            for _ in 0..chunks {
+                if stream.write_all(&vec![b'k'; chunk]).is_err() {
+                    return;
+                }
+                let _ = stream.flush();
+                std::thread::sleep(Duration::from_millis(gap_ms));
+            }
+            std::thread::sleep(Duration::from_millis(hold_ms));
+        });
+        base
+    }
+
+    /// The `Timeout` ureq blames for a cut body read, `None` if the reader
+    /// failed for any other reason. `io::copy` hands back the wrapped
+    /// `ureq::Error`, and the variant is what tells a rolling stall budget from
+    /// the whole-body deadline — a wall-clock band cannot, and goes flaky under
+    /// suite load besides (#1013).
+    fn timeout_reason(err: &io::Error) -> Option<ureq::Timeout> {
+        match err.get_ref()?.downcast_ref::<ureq::Error>()? {
+            ureq::Error::Timeout(reason) => Some(*reason),
+            _ => None,
+        }
+    }
+
     /// Promises `promised` bytes, sends `sent` of them, then holds the socket
     /// open and quiet for `silence_ms` without ever closing it.
     fn stalling_server(sent: usize, promised: usize, silence_ms: u64) -> String {
@@ -4680,10 +4726,14 @@ mod retry_tests {
 
         assert_eq!(sink.len(), SENT, "the prefix must survive for resume");
         assert!(
-            (BUDGET..BUDGET * 4).contains(&elapsed),
-            "aborted after {elapsed:?}, budget {BUDGET:?}"
+            elapsed >= BUDGET,
+            "cut after {elapsed:?}, budget {BUDGET:?}"
         );
-        assert!(err.to_string().to_lowercase().contains("timeout"), "{err}");
+        assert_eq!(
+            timeout_reason(&err),
+            Some(ureq::Timeout::RecvBody),
+            "the stall budget must be what cut it: {err:?}"
+        );
     }
 
     /// The coupling the swap rests on. With the body budget generous, the only
@@ -4706,8 +4756,8 @@ mod retry_tests {
         let elapsed = started.elapsed();
 
         assert!(
-            (BUDGET..BUDGET * 4).contains(&elapsed),
-            "aborted after {elapsed:?}, budget {BUDGET:?}"
+            elapsed >= BUDGET,
+            "cut after {elapsed:?}, budget {BUDGET:?}"
         );
         assert!(
             matches!(err, ureq::Error::Timeout(ureq::Timeout::SendRequest)),
@@ -4733,6 +4783,12 @@ mod retry_tests {
     /// why #776 reproduced on ubuntu while windows fetched the same file in
     /// 86s. Asserting the windows behaviour would pin a platform bug, so this
     /// pins the semantics the cap actually has where it is enforced (#893).
+    ///
+    /// The server promises more than it will ever send because ureq enforces
+    /// the deadline through the socket read timeout: a client descheduled long
+    /// enough for the whole body to land in the kernel buffer drains it without
+    /// a single blocking read and never sees the cut. Against a body that
+    /// cannot complete that race has no winning side (#1013).
     #[cfg(unix)]
     #[test]
     fn the_receive_deadline_caps_the_whole_body_not_just_a_stall() {
@@ -4741,7 +4797,7 @@ mod retry_tests {
         const CHUNKS: usize = 100;
 
         for recv_body in [None, Some(Duration::from_secs(30))] {
-            let base = streaming_server(CHUNK, CHUNKS, 20);
+            let base = never_completing_server(CHUNK, CHUNKS, 20, 10_000);
             let started = std::time::Instant::now();
             let response = ureq::get(format!("{base}/payload.bin"))
                 .config()
@@ -4758,16 +4814,13 @@ mod retry_tests {
             let elapsed = started.elapsed();
 
             assert!(
-                sink.len() < CHUNK * CHUNKS,
-                "{recv_body:?}: the body finished, so nothing was capped"
+                elapsed >= DEADLINE,
+                "{recv_body:?}: cut after {elapsed:?}, deadline {DEADLINE:?}"
             );
-            assert!(
-                (DEADLINE..DEADLINE * 3).contains(&elapsed),
-                "{recv_body:?}: aborted after {elapsed:?}, deadline {DEADLINE:?}"
-            );
-            assert!(
-                err.to_string().to_lowercase().contains("timeout"),
-                "{recv_body:?}: {err}"
+            assert_eq!(
+                timeout_reason(&err),
+                Some(ureq::Timeout::RecvResponse),
+                "{recv_body:?}: the whole-body deadline must be what cut it: {err:?}"
             );
         }
     }

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -4597,6 +4597,7 @@ mod retry_tests {
     /// up. The body is still arriving when a deadline shorter than the drip
     /// fires, and no scheduling delay can hand the client the promised length —
     /// those bytes are never sent, so the read cannot come back `Ok` (#1013).
+    #[cfg(unix)]
     fn never_completing_server(chunk: usize, chunks: usize, gap_ms: u64, hold_ms: u64) -> String {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind never-completing server");
         let base = format!("http://{}", listener.local_addr().expect("stub addr"));


### PR DESCRIPTION
Closes #1013

## Why it flaked, mechanically

ureq does not check elapsed time against the receive deadline — it enforces it by
setting the **socket read timeout** to whatever is left (`tcp.rs::await_input`, and
`maybe_await_input` returns early when the input buffer already has bytes). A timeout
can therefore only fire on a read that actually blocks.

`streaming_server(64, 100, 20)` wrote 6.4 KB into a kernel buffer far larger than that,
so the server's writes never blocked. Under full-suite load the client thread was
descheduled long enough for the whole body to land in that buffer; when it resumed it
drained every byte without one blocking read, and `io::copy` returned `Ok(6400)`. That is
the exact `6400` in the panic. The band `DEADLINE..DEADLINE * 3` was the second half of
the problem: every one of these tests measured a wall clock that load stretches.

## The fix

**Make the body genuinely unable to finish.** New `never_completing_server` promises
twice the bytes it will ever send, drips the rest at the same rate, then holds the socket
open. However long the client is starved, the promised length is not in the buffer,
because those bytes were never written — so the read must block and the deadline must
fire. The cut still lands mid-flow (2 s of drip against a 500 ms deadline), so the test
asserts the same semantics as before.

**Assert the property, not the stopwatch.** The contract is *which* budget did the
cutting, and ureq names it: `Error::Timeout(Timeout::RecvResponse)` vs
`Timeout::RecvBody`, reachable through the `io::Error` via a small `timeout_reason`
helper. The wall-clock upper bounds are gone; the lower bound (`elapsed >= BUDGET`)
stays because a deadline cannot fire early no matter the load.

Bands were **not** widened — that would have kept the flake and lowered the signal.

## Siblings share the shape — fixed once

Three tests carried the same `BUDGET..BUDGET * 4` band, all fragile the same way (client
starvation shifts elapsed past the ceiling):

| test | before | after |
| --- | --- | --- |
| `the_receive_deadline_caps_the_whole_body_not_just_a_stall` | band + `contains("timeout")` | `Timeout::RecvResponse` |
| `a_body_that_goes_silent_is_cut_at_the_stall_budget` | band + `contains("timeout")` | `Timeout::RecvBody` |
| `a_host_that_never_answers_is_cut_by_the_header_budget` | band + `matches!(SendRequest)` | band ceiling dropped; variant assertion already there |

`a_steady_body_outlasting_the_stall_budget_completes` is a different shape (it asserts a
steady body is *not* cut) and is left alone; its residual sensitivity is a >500 ms hiccup
of the stub's own drip thread, 25x its 20 ms gap, and it has never been observed to trip.

This is a net **strengthening**: `contains("timeout")` could not distinguish a rolling
stall budget from the whole-body cap, which is precisely the distinction #893 turns on.

## Sabotage checks (all RED, then reverted)

1. **Drop `timeout_recv_response` from the test's own config** — the config under
   characterization: `FAILED` after 12.8 s, `left: None, right: Some(RecvResponse)`,
   error `UnexpectedEof "Peer disconnected"`. The reader survived to the server hangup.
2. **Drop `timeout_recv_body(Some(stall_budget))` from `download_request`** — the shipped
   knob: `a_body_that_goes_silent_is_cut_at_the_stall_budget` `FAILED`,
   `left: None, right: Some(RecvBody)`.
3. **Re-add `timeout_recv_response` to `download_request`** (the #893 regression):
   `a_body_that_goes_silent_is_cut_at_the_stall_budget` `FAILED`,
   `left: Some(RecvResponse), right: Some(RecvBody)`. The old string assertion would have
   passed straight through this one — the new tripwire is strictly better.

## Runs

- `just rust-test` full suite, **3 consecutive runs**: 602/602 passed each (71.9 s / 61.5 s / 110.4 s).
- `just preflight` (TS + lint + fmt + clippy + full nextest): green, 602/602.
- Adversarial: 16 busy-loop threads pinning all 8 cores, `retry_tests` **8 consecutive
  runs** — 27/27 passed every time. (One `LEAK` on `a_failing_file_does_not_cancel_its_siblings`,
  pre-existing and unrelated; it still passed.)
- `cargo fmt --check` clean, `cargo clippy --all-targets -- -D warnings` clean.
