### PR TITLE
chore(rust): pin CI toolchain to 1.94.1

### DIFF
--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -17,6 +17,63 @@ import { parse, YAMLParseError } from "yaml";
 import { engineTargetEntries, targetKey } from "../../src/engine-targets";
 
 const dirs = [".github/workflows", ".github/actions"];
+const RUST_TOOLCHAIN_FILE = "rust-toolchain.toml";
+
+export type RustToolchainPin = {
+  channel: string;
+  components: string[];
+};
+
+/** Read the source-controlled Rust toolchain contract shared by contributors and CI. */
+export function readRustToolchainPin(): { pin?: RustToolchainPin; errors: string[] } {
+  try {
+    const contents = readFileSync(RUST_TOOLCHAIN_FILE, "utf8");
+    const toolchain = /^\[toolchain\]\s*$([\s\S]*)/m.exec(contents)?.[1];
+    if (!toolchain) return { errors: [`${RUST_TOOLCHAIN_FILE}: expected a [toolchain] table`] };
+
+    const channel = /^channel\s*=\s*"([^"]+)"\s*$/m.exec(toolchain)?.[1];
+    const componentList = /^components\s*=\s*\[([^\]]*)\]\s*$/m.exec(toolchain)?.[1] ?? "";
+    const components = [...componentList.matchAll(/"([^"]+)"/g)].map((match) => match[1] ?? "");
+
+    if (!channel) return { errors: [`${RUST_TOOLCHAIN_FILE}: expected [toolchain].channel`] };
+    if (components.length === 0) return { errors: [`${RUST_TOOLCHAIN_FILE}: expected [toolchain].components`] };
+
+    return { pin: { channel, components }, errors: [] };
+  } catch (err) {
+    return { errors: [`${RUST_TOOLCHAIN_FILE}: ${err instanceof Error ? err.message : String(err)}`] };
+  }
+}
+
+/**
+ * The action installs the toolchain passed through `with.toolchain`, rather than reading the
+ * repository toolchain file. Keep every explicit action invocation aligned with that file.
+ */
+export function requirePinnedRustToolchain(path: string, document: unknown, pin: RustToolchainPin): string[] {
+  const jobs = (document as { jobs?: Record<string, { steps?: unknown[] }> })?.jobs;
+  if (!jobs || typeof jobs !== "object") return [];
+
+  const errors: string[] = [];
+  for (const [job, definition] of Object.entries(jobs)) {
+    if (!Array.isArray(definition?.steps)) continue;
+    for (const step of definition.steps as Step[]) {
+      if (typeof step?.uses !== "string" || !step.uses.startsWith("dtolnay/rust-toolchain@")) continue;
+
+      if (step.with?.toolchain !== pin.channel) {
+        errors.push(`${path}: \`${job}\` must install Rust ${pin.channel}, not \`${String(step.with?.toolchain ?? "") }\``);
+      }
+
+      const components = String(step.with?.components ?? "")
+        .split(",")
+        .map((component) => component.trim())
+        .filter(Boolean);
+      const missing = pin.components.filter((component) => !components.includes(component));
+      if (missing.length > 0) {
+        errors.push(`${path}: \`${job}\` must install ${missing.join(", ")} from ${RUST_TOOLCHAIN_FILE}`);
+      }
+    }
+  }
+  return errors;
+}
 
 function collectYamlFiles(dir: string): string[] {
   return readdirSync(dir, { recursive: true })
@@ -449,7 +506,12 @@ function describeUnreadable(path: string, err: unknown): string {
   return `${path}: ${err instanceof Error ? err.message : String(err)}`;
 }
 
-function checkFile(path: string, testedScripts: string[], cacheWriters: CacheEntry[]): string[] {
+function checkFile(
+  path: string,
+  testedScripts: string[],
+  cacheWriters: CacheEntry[],
+  rustToolchain: RustToolchainPin | undefined,
+): string[] {
   try {
     const contents = readFileSync(path, "utf8");
     const document = parse(contents);
@@ -464,6 +526,7 @@ function checkFile(path: string, testedScripts: string[], cacheWriters: CacheEnt
       ...requireDepsBeforeBunTest(path, document),
       ...requireRestoreOnlyCachesHaveAWriter(path, document, cacheWriters),
       ...requireTestedScriptsInCodeFilter(path, document, testedScripts),
+      ...(rustToolchain ? requirePinnedRustToolchain(path, document, rustToolchain) : []),
     ];
   } catch (err) {
     return [describeUnreadable(path, err)];
@@ -484,7 +547,11 @@ function main(): void {
   const cacheWriters = existsSync(SEED_WORKFLOW)
     ? collectCacheWriters(parse(readFileSync(SEED_WORKFLOW, "utf8")))
     : [];
-  const errors = files.flatMap((path) => checkFile(path, testedScripts, cacheWriters));
+  const { pin: rustToolchain, errors: rustToolchainErrors } = readRustToolchainPin();
+  const errors = [
+    ...rustToolchainErrors,
+    ...files.flatMap((path) => checkFile(path, testedScripts, cacheWriters, rustToolchain)),
+  ];
   for (const error of errors) console.error(error);
 
   if (errors.length > 0) {

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -124,8 +124,9 @@ jobs:
           xcode-version: "16.2"
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
-          toolchain: stable
+          toolchain: "1.94.1"
           targets: ${{ matrix.target }}
+          components: rustfmt,clippy
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: rust

--- a/.github/workflows/cache-seed.yml
+++ b/.github/workflows/cache-seed.yml
@@ -125,7 +125,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         if: steps.probe.outputs.cache-hit != 'true'
         with:
-          toolchain: stable
+          toolchain: "1.94.1"
+          components: rustfmt,clippy
 
       # Deliberately no rust-cache: this job builds only on a miss, and its artifacts
       # cost 716 MB of a budget whose pressure already evicts the bundle it seeds.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
           #   a legitimately skipped `unit-tests` on rust-only PRs (#274).
           filters: |
             code:
+              - 'rust-toolchain.toml'
               - 'src/**'
               - 'tests/**'
               - 'tests/fixtures/**'
@@ -670,7 +671,8 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
-          toolchain: stable
+          toolchain: "1.94.1"
+          components: rustfmt,clippy
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
@@ -781,7 +783,8 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
-          toolchain: stable
+          toolchain: "1.94.1"
+          components: rustfmt,clippy
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:

--- a/.github/workflows/mini-model-pact.yml
+++ b/.github/workflows/mini-model-pact.yml
@@ -58,7 +58,8 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
-          toolchain: stable
+          toolchain: "1.94.1"
+          components: rustfmt,clippy
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:

--- a/.github/workflows/real-model-canary.yml
+++ b/.github/workflows/real-model-canary.yml
@@ -56,7 +56,8 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
-          toolchain: stable
+          toolchain: "1.94.1"
+          components: rustfmt,clippy
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -11,6 +11,7 @@ on:
     branches: [main]
     paths:
       - "rust/**"
+      - "rust-toolchain.toml"
       - ".github/workflows/rust-test.yml"
 
 permissions:
@@ -32,6 +33,7 @@ jobs:
           filters: |
             rust:
               - 'rust/**'
+              - 'rust-toolchain.toml'
               - '.github/workflows/rust-test.yml'
               - '.github/scripts/check-coverage.ts'
               - 'package.json'
@@ -74,7 +76,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
-          toolchain: stable
+          toolchain: "1.94.1"
+          components: rustfmt,clippy
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: rust
@@ -125,7 +128,8 @@ jobs:
           xcode-version: "16.2"
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
-          toolchain: stable
+          toolchain: "1.94.1"
+          components: rustfmt,clippy
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: rust
@@ -270,8 +274,8 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
-          toolchain: stable
-          components: llvm-tools-preview
+          toolchain: "1.94.1"
+          components: rustfmt,clippy,llvm-tools-preview
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
@@ -366,7 +370,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
-          toolchain: stable
+          toolchain: "1.94.1"
+          components: rustfmt,clippy
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: rust
@@ -446,7 +451,8 @@ jobs:
           xcode-version: "16.2"
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
-          toolchain: stable
+          toolchain: "1.94.1"
+          components: rustfmt,clippy
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: rust

--- a/docs/runbooks/rust-gotchas.md
+++ b/docs/runbooks/rust-gotchas.md
@@ -71,6 +71,6 @@ Moved out of CLAUDE.md (2026-07-26) with the rest of the Rust detail.
 
 - Always `cargo nextest run`, never plain `cargo test`. CI uses nextest (`ci` profile, JUnit → Flakiness.io); it isolates tests in fresh processes, runs integration binaries in parallel, and streams `SLOW [>60.000s]` markers for Vosk/Kokoro. Install once: `cargo install cargo-nextest --locked`. The only sanctioned plain `cargo test` calls are `--doc` and the pin-bump's `cargo test models::manifest_tests`.
 - Keep `--all-targets` on clippy. Without it, local clippy misses `#[cfg(test)]` dead code that ubuntu CI catches (#125 M1).
-- CI rustc may be newer than local (no `rust-toolchain.toml`). If CI-only clippy fails, read `gh run view <id> --log-failed`; common fixes are `#[derive(Default)]` + `#[default]`, removing redundant `.map_err(Into::into)` / `u64::from(u64_value)`, and `x.is_multiple_of(n)` (#224).
+- The root `rust-toolchain.toml` pins CI and local Rust. Confirm the active compiler with `rustup show`; if CI-only clippy fails, read `gh run view <id> --log-failed` before changing code.
 - CI `rustfmt --check` wins over local formatting. If it rejects line wrapping, re-run `cargo fmt` and push the whitespace-only diff (#309).
 - Fresh cargo builds need `protoc` for `vosk-tts-rs`/`prost-build`; macOS: `brew install protobuf`, then expose the protobuf bin dir or set `PROTOC`.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.94.1"
+components = ["rustfmt", "clippy"]

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -9,7 +9,9 @@ import {
   requireDepsBeforeBunTest,
   requireNpmPublishAfterPackaging,
   requirePactVerificationCoversEveryTarget,
+  requirePinnedRustToolchain,
   requirePreUploadSynthesisSmoke,
+  readRustToolchainPin,
   requireTestedScriptsInCodeFilter,
 } from "../../.github/scripts/check-workflows";
 import { parseRepoYaml, readRepoFile, repoPath } from "../helpers/repo";
@@ -459,5 +461,22 @@ describe("requireDepsBeforeBunTest", () => {
 
   test("ignores a mention that is not a run", () => {
     expect(requireDepsBeforeBunTest(PATH, job("decide", [{ name: "x", run: 'echo "bun test"' }]))).toEqual([]);
+  });
+});
+
+describe("Rust toolchain pin", () => {
+  const PIN = { channel: "1.94.1", components: ["rustfmt", "clippy"] };
+
+  test("the root toolchain file declares the exact compiler and developer components", () => {
+    const { pin, errors } = readRustToolchainPin();
+    expect(errors).toEqual([]);
+    expect(pin).toEqual(PIN);
+  });
+
+  test("every explicit Rust CI setup installs the root compiler and components", () => {
+    for (const file of readdirSync(repoPath(".github/workflows"))) {
+      const path = `.github/workflows/${file}`;
+      expect([path, requirePinnedRustToolchain(path, parseRepoYaml(path), PIN)]).toEqual([path, []]);
+    }
   });
 });


### PR DESCRIPTION
Closes #955

## Slice 1 of 2

Pins the Rust toolchain; the Edition 2024 migration is intentionally pending collision clearance for #1013 active rust/src/models.rs work.

## What changed

- Add root rust-toolchain.toml for Rust 1.94.1 with rustfmt and clippy.
- Align all 12 explicit dtolnay/rust-toolchain CI steps across six workflows to 1.94.1 and install those components, while preserving build-engine target input and coverage llvm-tools-preview input.
- Add an executable workflow guard that derives the pin from the root file and rejects any CI drift; root changes now trigger the relevant CI and Rust filters.

## Why the root file alone was insufficient

rustup honors the root file for normal repository commands, but every CI lane passes an explicit toolchain input to dtolnay/rust-toolchain. That action installs the supplied value with a minimal profile, so stable would keep overriding the repository pin and omit the requested components unless the action inputs were updated too.

## Verification

- RED: the new contract failed on the prior state: rust-toolchain.toml was absent and the first audited lane used stable without rustfmt or clippy.
- GREEN: bun test --timeout 30000 tests/unit/check-workflows.test.ts (80 pass); bun run check:workflows; bun run lint; git diff --check; final just preflight.
- Sabotage: changing mini-model-pact.yml back to stable made the guard fail with: must install Rust 1.94.1, not stable. Restoring it returned the targeted test to green.
- actionlint reports the pre-existing origin/main failure in npm-publish.yml: unsupported concurrency.queue. No actionlint findings are introduced by this change.