### PR TITLE
fix(tests): reap the engine stubs a failed suite left running

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,8 @@ Model-dependent suites self-skip, and not uniformly: `e2e-engine` and `mcp-e2e` 
 
 On the Rust side the guard **is** enforced: `KESHA_REQUIRE_MODEL_TESTS` names which weights a lane promised (`mini` or real), every gate in `rust/tests/common/mod.rs` refuses the wrong tier, and `rust/tests/model_gate.rs` is the meta-test — including the exemptions it lists deliberately. `KESHA_REQUIRE_G2P_TESTS` and `KESHA_REQUIRE_VOSK_TESTS` do the same for the two bundles that have no stand-in. The TS side now mirrors it: `tests/integration/README.md` states the convention and `tests/unit/model-suite-guards.test.ts` enforces it, detecting a real-engine suite by its imports only and listing ungated-by-design suites explicitly (#921).
 
+A test that spawns a stub owns its death. `bunfig.toml` preloads `tests/helpers/leak-guard.ts` into every suite, which reaps what a failed, timed-out or interrupted test left behind and fails the run naming it — before that, three stubs sat at `PPID=1` for two and a half days (#1003). Call sites need nothing: `waitForPidFile` tracks the pid it returns, and the per-file pass sweeps the runner's descendants. Convention and reach: `tests/integration/README.md`.
+
 ### PR ETIQUETTE
 
 - `main` is protected; every change goes through a PR and CI must pass.

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./tests/helpers/leak-guard.ts"]

--- a/tests/helpers/leak-guard.ts
+++ b/tests/helpers/leak-guard.ts
@@ -1,0 +1,20 @@
+/**
+ * Preloaded into every suite (`bunfig.toml`): a spawned stub has to be reaped even when the test
+ * that spawned it failed, timed out or was interrupted, and a leak has to be loud rather than
+ * found days later in `ps` (#1003).
+ */
+import { afterAll, afterEach } from "bun:test";
+import { installInterruptReaper, reapLeakedProcesses } from "./process";
+
+installInterruptReaper();
+
+function report(scope: string, leaked: string[]): void {
+  if (leaked.length === 0) return;
+  throw new Error(
+    `${scope} left ${leaked.length} process(es) running; the leak guard reaped them:\n  ${leaked.join("\n  ")}`,
+  );
+}
+
+afterEach(async () => report("this test", await reapLeakedProcesses()));
+
+afterAll(async () => report("this suite", await reapLeakedProcesses({ sweepDescendants: true })));

--- a/tests/helpers/process.ts
+++ b/tests/helpers/process.ts
@@ -4,13 +4,14 @@ const PID_FILE_POLL_INTERVAL_MS = 25;
 // 10s: the fake engine traps SIGTERM, so every abort waits out FORCE_KILL_GRACE_MS before SIGKILL.
 const PID_FILE_POLL_ATTEMPTS = 400;
 const PID_EXIT_POLL_ATTEMPTS = 400;
+const REAP_GRACE_MS = 500;
 
 export async function waitForPidFile(
   path: string,
   attempts: number = PID_FILE_POLL_ATTEMPTS,
 ): Promise<number> {
   for (let i = 0; i < attempts; i++) {
-    if (existsSync(path)) return Number(readFileSync(path, "utf8"));
+    if (existsSync(path)) return trackPid(Number(readFileSync(path, "utf8")));
     await Bun.sleep(PID_FILE_POLL_INTERVAL_MS);
   }
   throw new Error(`timed out waiting for pid file: ${path}`);
@@ -31,4 +32,134 @@ export async function waitForPidExit(pid: number): Promise<boolean> {
     await Bun.sleep(PID_FILE_POLL_INTERVAL_MS);
   }
   return false;
+}
+
+/**
+ * A stub that announces itself by pid file is a grandchild the harness never holds a handle to,
+ * so when the test fails before killing it nothing else can. Tracking it here is what lets the
+ * leak guard reap it (#1003).
+ */
+const trackedPids = new Set<number>();
+
+/** A pid the OS recycled belongs to a stranger, so only a command still shaped like one of this
+ *  suite's fixtures may be signalled. */
+const FIXTURE_COMMAND = /kesha|cli-entry\.ts/;
+
+export function trackPid(pid: number): number {
+  if (Number.isInteger(pid) && pid > 0) trackedPids.add(pid);
+  return pid;
+}
+
+interface ProcessRow {
+  pid: number;
+  ppid: number;
+  command: string;
+}
+
+function processTable(): ProcessRow[] {
+  if (process.platform === "win32") return [];
+  const format = "pid=,ppid=,command=";
+  const res = Bun.spawnSync(["ps", "-eo", format], { stdout: "pipe", stderr: "ignore" });
+  if (!res.success) return [];
+  return res.stdout
+    .toString()
+    .split("\n")
+    .flatMap((line) => {
+      const match = /^\s*(\d+)\s+(\d+)\s+(\S.*)$/.exec(line);
+      if (!match || match[3]!.includes(format)) return [];
+      return [{ pid: Number(match[1]), ppid: Number(match[2]), command: match[3]! }];
+    });
+}
+
+function descendantsOf(table: ProcessRow[], root: number): ProcessRow[] {
+  const children = new Map<number, ProcessRow[]>();
+  for (const row of table) {
+    const siblings = children.get(row.ppid);
+    if (siblings) siblings.push(row);
+    else children.set(row.ppid, [row]);
+  }
+  const found: ProcessRow[] = [];
+  const queue = [root];
+  while (queue.length > 0) {
+    for (const child of children.get(queue.pop()!) ?? []) {
+      found.push(child);
+      queue.push(child.pid);
+    }
+  }
+  return found;
+}
+
+function survivors(sweepDescendants: boolean): ProcessRow[] {
+  const live = new Set([...trackedPids].filter(pidIsAlive));
+  for (const pid of [...trackedPids]) if (!live.has(pid)) trackedPids.delete(pid);
+  if (!sweepDescendants && live.size === 0) return [];
+
+  const table = processTable();
+  const found = new Map<number, ProcessRow>();
+  // Descendants only: another lane's strays are never ours to kill.
+  if (sweepDescendants) for (const row of descendantsOf(table, process.pid)) found.set(row.pid, row);
+  for (const row of table) {
+    if (live.has(row.pid) && FIXTURE_COMMAND.test(row.command)) found.set(row.pid, row);
+  }
+  return [...found.values()];
+}
+
+function safeKill(pid: number, signal: "SIGTERM" | "SIGKILL"): void {
+  try {
+    process.kill(pid, signal);
+  } catch {
+    // Already gone between the sweep listing it and the signal reaching the kernel.
+  }
+}
+
+async function waitForAllExit(rows: ProcessRow[]): Promise<void> {
+  const deadline = Date.now() + REAP_GRACE_MS;
+  while (Date.now() < deadline && rows.some((row) => pidIsAlive(row.pid))) {
+    await Bun.sleep(PID_FILE_POLL_INTERVAL_MS);
+  }
+}
+
+/**
+ * Kills everything the suite left running and names it. `sweepDescendants` also collects children
+ * no test ever saw a pid for — an engine spawned in-process announces nothing — and costs one `ps`,
+ * so the per-test pass leaves it off and the per-file pass turns it on.
+ */
+export async function reapLeakedProcesses(
+  opts: { sweepDescendants?: boolean } = {},
+): Promise<string[]> {
+  const leaked = survivors(opts.sweepDescendants === true);
+  if (leaked.length === 0) return [];
+
+  for (const row of leaked) safeKill(row.pid, "SIGTERM");
+  await waitForAllExit(leaked);
+  // Some fixtures trap SIGTERM on purpose, which is exactly the shape that outlives a suite.
+  for (const row of leaked) if (pidIsAlive(row.pid)) safeKill(row.pid, "SIGKILL");
+  await waitForAllExit(leaked);
+
+  for (const row of leaked) trackedPids.delete(row.pid);
+  return leaked.map(
+    (row) => `pid ${row.pid}${pidIsAlive(row.pid) ? " (survived SIGKILL)" : ""}: ${row.command}`,
+  );
+}
+
+let interruptReaperInstalled = false;
+
+/** An interrupted run reaches no hook at all, which is how the #1003 strays outlived the suite by
+ *  days; a synchronous SIGKILL on the way out is the only reaping left. */
+export function installInterruptReaper(): void {
+  if (interruptReaperInstalled) return;
+  interruptReaperInstalled = true;
+  const reap = () => {
+    for (const row of survivors(true)) safeKill(row.pid, "SIGKILL");
+  };
+  process.on("exit", reap);
+  for (const [signal, exitCode] of [
+    ["SIGINT", 130],
+    ["SIGTERM", 143],
+  ] as const) {
+    process.on(signal, () => {
+      reap();
+      process.exit(exitCode);
+    });
+  }
 }

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -49,3 +49,16 @@ the `requiredFailure` shape above.
 
 Running ungated is still available; it just has to be deliberate now. Add the suite to
 `UNGATED_BY_DESIGN` in that file with a one-line reason, and the loud CI signal is yours.
+
+## No suite may leave a process running
+
+`bunfig.toml` preloads `tests/helpers/leak-guard.ts` into every suite, so a stub that outlives the
+test that spawned it fails the run and is reaped rather than sitting in `ps` for days (#1003). It
+reaps twice: after each test, the pids `waitForPidFile` handed out — that is every fake engine
+announcing itself — and after each file, every descendant the runner still has, which is how an
+engine spawned in-process gets caught. Signal escalates SIGTERM → SIGKILL, because the fixtures
+worth catching are the ones that trap SIGTERM.
+
+Nothing to do at a call site: `waitForPidFile` tracks what it returns. Only descendants and pids a
+test actually saw are ever signalled, so a parallel lane's processes are out of reach by
+construction.

--- a/tests/unit/process-leak-guard.test.ts
+++ b/tests/unit/process-leak-guard.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import { pidIsAlive, reapLeakedProcesses, trackPid, waitForPidExit } from "../helpers/process";
+
+const posix = process.platform === "win32" ? test.skip : test;
+
+/** `label` lands in argv as `$0`, which is what makes the fixture recognisable in `ps`. */
+function spawnStubborn(label: string): number {
+  const proc = Bun.spawn(["sh", "-c", "trap '' TERM INT; while :; do sleep 1; done", label], {
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  proc.unref();
+  return proc.pid;
+}
+
+function spawnStranger(): number {
+  const proc = Bun.spawn(["sleep", "300"], { stdout: "ignore", stderr: "ignore" });
+  proc.unref();
+  return proc.pid;
+}
+
+describe("process leak guard", () => {
+  posix("reaps a tracked stub the test never killed, and names it", async () => {
+    const pid = trackPid(spawnStubborn("kesha-engine-leak-guard-fixture"));
+
+    const leaked = await reapLeakedProcesses();
+
+    expect(leaked).toHaveLength(1);
+    expect(leaked[0]).toContain(String(pid));
+    expect(await waitForPidExit(pid)).toBe(true);
+  });
+
+  /** The fixture traps SIGTERM on purpose, so only the SIGKILL escalation can end it. */
+  posix("escalates to SIGKILL rather than reporting a stub it failed to kill", async () => {
+    const pid = trackPid(spawnStubborn("kesha-engine-leak-guard-fixture"));
+
+    const leaked = await reapLeakedProcesses();
+
+    expect(leaked[0]).not.toContain("survived SIGKILL");
+    expect(pidIsAlive(pid)).toBe(false);
+  });
+
+  /** A pid the OS recycled onto a stranger must not be signalled just because a test held it. */
+  posix("leaves a tracked pid alone once its command is no longer a fixture", async () => {
+    const pid = trackPid(spawnStranger());
+
+    const leaked = await reapLeakedProcesses();
+
+    expect(leaked).toEqual([]);
+    expect(pidIsAlive(pid)).toBe(true);
+    process.kill(pid, "SIGKILL");
+    expect(await waitForPidExit(pid)).toBe(true);
+  });
+
+  /** An in-process spawn publishes no pid file, so only the descendant sweep can find it. */
+  posix("sweeps an untracked descendant the suite left running", async () => {
+    const pid = spawnStubborn("kesha-engine-leak-guard-fixture");
+
+    const leaked = await reapLeakedProcesses({ sweepDescendants: true });
+
+    expect(leaked.some((entry) => entry.includes(String(pid)))).toBe(true);
+    expect(await waitForPidExit(pid)).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #1003

`bun test` left engine stubs running after the suite exited — three at `PPID=1` on the reporter's machine, the oldest 2 days 13 hours old.

## Per-stub root cause

All three leaks share one shape: **the kill only ever ran on the happy path.** Each of these tests spawns a deliberately hanging fake engine, then asserts that production reaps it. When the assertion holds, the stub dies because *production* killed it — the test itself never had a teardown. So any run that failed, timed out or was interrupted before reaching that point orphaned the stub, and nothing was left to collect it.

| Stray | Spawned by | Why it outlived the suite |
| --- | --- | --- |
| `kesha-engine-long-running transcribe audio.wav` | `tests/unit/engine.test.ts:483` "abort terminates the spawned engine process tree" | The stub is spawned in-process by `transcribeEngine`; the test holds no handle to it and only `controller.abort()` ends it. A throw anywhere before the abort (including `waitForPidFile` timing out) leaves the stub *and* its `trap '' TERM INT` helper running. |
| `kesha-mcp-lifecycle-*/kesha-engine say --list-voices` | `tests/integration/mcp-lifecycle.test.ts:63` | The stub dies only when the test SIGINTs the MCP server. Fail before that and both the server and the stub survive — and the server does not exit on stdin EOF, so it stays alive after the runner is gone (see the production note below). |
| `kesha-cli-contract-listvoices-sigint-*/kesha-engine-listvoices-hang` | `tests/integration/cli-contracts.test.ts:1226` | Same shape: `proc.kill("SIGINT")` on the CLI is the only thing that ends the stub, and it sits after two awaits that can throw. |

Worth noting what is *not* broken: the sibling helper at `cli-contracts.test.ts:300` already SIGKILLs a stub that would not stop and reports it — that one never leaked. The bug is the absence of that discipline everywhere else.

### Reproduction

Forcing one assertion to fail in `mcp-lifecycle` (before the fix):

```console
$ bun test --timeout 15000 tests/integration/mcp-lifecycle.test.ts   # one forced failure
 0 pass
 1 fail
$ ps -eo pid,ppid,etime,command | grep -E "kesha-engine|kesha-mcp|cli-entry"
30267  1  00:45  bun run src/cli-entry.ts mcp
30269  30267  00:44  bun …/T/kesha-mcp-lifecycle-KZitIs/kesha-engine say --list-voices
```

Both survive indefinitely; `PPID=1` on the server means the runner is already gone.

## Helper, not call sites

Fixed in the shared helper, so current and future tests inherit it and no call site changed:

- `tests/helpers/process.ts` — `waitForPidFile` now tracks the pid it returns. That is the seam every announcing stub already goes through, so every fixture is covered by construction. `reapLeakedProcesses()` does the killing: SIGTERM, then **SIGKILL after a 500 ms bound**, because the fixtures worth catching are precisely the ones that trap SIGTERM (the process-tree helper literally is `trap '' TERM INT`).
- `tests/helpers/leak-guard.ts` + `bunfig.toml` — preloaded into **every** suite. `afterEach` reaps tracked pids; `afterAll` also sweeps the runner's live descendants, which is how an engine spawned in-process — no pid file, no handle — gets caught. An interrupt handler SIGKILLs on the way out, since an interrupted run reaches no hook at all.

Patching the three call sites would have fixed three tests; this fixes the class.

### The guard

It fails the run and names what it killed:

```
error: this test left 1 process(es) running; the leak guard reaped them:
  pid 62845: bun …/T/kesha-mcp-lifecycle-9K2QJ7/kesha-engine say --list-voices
error: this suite left 1 process(es) running; the leak guard reaped them:
  pid 62794: bun run src/cli-entry.ts mcp
```

Cost and safety:

- **Cheap** — per test it is `kill(pid, 0)` on the handful of tracked pids and nothing else; it only shells out to `ps` when something is actually still alive. Per file it is one `ps`. Full suite went 1471 tests / 105 files with no measurable change and no false positive.
- **Cannot touch another lane** — only the runner's own descendants and pids a test itself observed are ever signalled. A parallel worktree's processes are out of reach by construction.
- **PID-reuse safe** — a tracked pid whose command no longer looks like one of this suite's fixtures is dropped rather than signalled. `tests/unit/process-leak-guard.test.ts` covers that case, the SIGKILL escalation, and the descendant sweep.

## Is this a production gap? (#970 / #971)

**No, at the registration level.** Every engine spawn on these paths does go through `registerProcessTree` (`src/engine.ts:199,550`, `src/mcp/voices.ts:124`), and the happy-path runs prove the reaping works — the stubs die when the signal lands. Nothing here bypasses registration the way #971 describes. This is a test-harness bug, fixed test-side.

**One real gap surfaced next door, and it is not what #1003 is about.** The `kesha mcp` stdio server does not exit when its stdin reaches EOF: in the repro above it stayed alive 45 s after the test runner died, holding its engine spawn with it. `registerProcessTree`'s handlers cover SIGINT/SIGTERM only, so an MCP client that dies without signalling leaves a `kesha mcp` server and its engine child running for good. Worth its own issue; deliberately not fixed here.

## Evidence

Pre-existing strays on this machine were cleaned before measuring: `31071` (2d 22h, `kesha-engine-long-running`), `68520` (3h, `kesha-mcp-lifecycle`), `79049` (1d 19h, `kesha-mcp-lifecycle`), `80632` (1d 19h, `kesha-engine-listvoices-hang`).

**Failing run, after the fix** — same forced failure as the repro above:

```console
$ bun test --timeout 15000 tests/integration/mcp-lifecycle.test.ts   # one forced failure
 0 pass
 2 fail        # the forced failure + the guard reporting the leak
$ ps -eo pid,ppid,etime,command | grep -E "kesha-engine|kesha-mcp|cli-entry"
(nothing)
```

**Interrupted run** — a hanging suite with a SIGTERM-trapping stub, SIGINT to the runner after 3 s:

| | runner after SIGINT | stub |
| --- | --- | --- |
| without the guard | still running | still running (survived 19 s, would survive forever) |
| with the guard | exited 130 | reaped |

**Full suite:** `ps` clean afterwards.

## Gates

| Gate | Result |
| --- | --- |
| `bun run test` | 1465 pass, 6 skip, 0 fail (105 files, 283 s) — `ps` clean after |
| `bunx tsc --noEmit` | clean |
| `bun run check` | 1305 pass, 0 fail |
| `bun run coverage:check:ts` | 81.32% total; `src/engine.ts` 92.65%, `src/cli/say.ts` 78.70%, `src/cli/main.ts` 41.26%, `src/engine-install.ts` 87.05% — all floors met |
