### PR TITLE
feat(conveyor): make backlog gates executable

### DIFF
--- a/openspec/changes/backlog-conveyor-cli/design.md
+++ b/openspec/changes/backlog-conveyor-cli/design.md
@@ -4,13 +4,14 @@
 
 Labels remain the durable external truth, while a gate needs durable evidence that can be
 recovered by another checkout. A GitHub PR comment containing a small versioned JSON marker
-binds the approval and CI decision to one exact head SHA. It is not an ignored local ledger.
+binds the approval and CI decision to one exact head SHA. It is not an ignored local ledger
+or a provider-specific agent artifact.
 
 ## Decisions
 
 ### A repository-local Bun script owns the command boundary
 
-`package.json` exposes `bun run backlog -- <subcommand>`. `scripts/backlog.ts` parses only
+`package.json` exposes `bun run conveyor -- <subcommand>`. `scripts/backlog.ts` parses only
 the phase-1 flags and maps results to stable exit codes. `scripts/backlog-conveyor.ts` holds
 the pure decision logic and a narrow runner interface so fixture tests never contact GitHub
 or a user worktree.
@@ -22,14 +23,18 @@ the current `headRefOid` through the REST API, and required contexts from the de
 protection endpoint. Every JSON response is shape-checked before use. Commands use argv
 arrays exclusively; no user-controlled input is interpolated in a shell.
 
-### Gate evidence is SHA-bound and independently approved
+### Gate evidence is SHA-bound, independently approved, and provider-neutral
 
 `gate` accepts only an open, non-draft, mergeable PR to the default branch, with exactly the
 requested closing issue. An `APPROVED` review by someone other than the PR author must name
 the current head SHA. Required contexts are read from branch protection and each matching
 check/status must be terminal and successful; skipped, pending, absent, or non-successful
-contexts fail. The gate comment records schema version, issue, PR, head SHA and the approval
-evidence. A later `sync` removes `merge-ready` when this marker no longer matches the head.
+contexts fail. `gate --evidence <path>` consumes a JSON object with `provider` (any non-empty
+string), `verdict: "APPROVED"`, exact `headSha`, `uri`, and SHA-256 `digest`. The versioned
+comment records exactly that portable evidence object with issue and PR identifiers. Any two
+orchestrators therefore produce and consume the same GitHub state; the command never reads
+agent-local settings, state, model names, or provider-specific artifact formats. A later
+`sync` removes `merge-ready` when this marker no longer matches the head.
 
 ### Worktree deletion is deliberately harder than label cleanup
 

--- a/openspec/changes/backlog-conveyor-cli/design.md
+++ b/openspec/changes/backlog-conveyor-cli/design.md
@@ -26,8 +26,12 @@ arrays exclusively; no user-controlled input is interpolated in a shell.
 ### Gate evidence is self-versioned, SHA-bound, independently approved, and provider-neutral
 
 `gate` accepts only an open, non-draft, mergeable PR to the default branch, with exactly the
-requested closing issue. An `APPROVED` review by someone other than the PR author must name
-the current head SHA. Required contexts are read from branch protection and each matching
+requested closing issue. The verified provider-neutral evidence is the required approval bound
+to the current head SHA; it does not require a second GitHub account, so different orchestrators
+can operate under one authenticated GitHub identity. Native GitHub reviews remain a blocking
+signal: a current-head `CHANGES_REQUESTED` by someone other than the PR author fails the gate,
+while `APPROVED` and `COMMENTED` are supplemental. Required contexts are read from branch
+protection and each matching
 check/status must be terminal and successful; a protected check with an `app_id` accepts only
 that app's result, and the deterministically latest matching attempt by start/creation time is
 authoritative (not a later completion time from an older parallel attempt). Skipped,
@@ -41,7 +45,7 @@ repository owner, member, or collaborator is accepted; all comment pages are con
 Marker authorship alone never establishes eligibility: `sync` re-runs the same current-head
 gate policy before preserving `merge-ready`. Review state uses each independent reviewer's
 latest decisive current-head state; a current change request blocks, while a later comment does
-not erase an approval. Any two orchestrators therefore produce and consume the same GitHub
+not erase an approval when one exists. Any two orchestrators therefore produce and consume the same GitHub
 state: a trusted verified marker for the same issue/PR/head is shared state regardless of
 provider. The command never reads agent-local settings, state, model names, or provider-specific
 artifact formats. A later `sync` removes `merge-ready` when this marker no longer matches the

--- a/openspec/changes/backlog-conveyor-cli/design.md
+++ b/openspec/changes/backlog-conveyor-cli/design.md
@@ -29,7 +29,8 @@ arrays exclusively; no user-controlled input is interpolated in a shell.
 requested closing issue. An `APPROVED` review by someone other than the PR author must name
 the current head SHA. Required contexts are read from branch protection and each matching
 check/status must be terminal and successful; a protected check with an `app_id` accepts only
-that app's result, and the deterministically latest matching attempt is authoritative. Skipped,
+that app's result, and the deterministically latest matching attempt by start/creation time is
+authoritative (not a later completion time from an older parallel attempt). Skipped,
 pending, absent, or non-successful current attempts fail. `gate --evidence <path>` consumes a
 self-versioned JSON object (`version: 1`) with `provider` (any non-empty string),
 `verdict: "APPROVED"`, exact `headSha`, `uri`, and SHA-256 `digest`. The versioned comment

--- a/openspec/changes/backlog-conveyor-cli/design.md
+++ b/openspec/changes/backlog-conveyor-cli/design.md
@@ -33,18 +33,32 @@ that app's result, and the deterministically latest matching attempt by start/cr
 authoritative (not a later completion time from an older parallel attempt). Skipped,
 pending, absent, or non-successful current attempts fail. `gate --evidence <path>` consumes a
 self-versioned JSON object (`version: 1`) with `provider` (any non-empty string),
-`verdict: "APPROVED"`, exact `headSha`, `uri`, and SHA-256 `digest`. The versioned comment
-records exactly that portable evidence object with issue and PR identifiers. Only the newest
-marker authored by a repository owner, member, or collaborator is accepted; all comment pages
-are considered. Any two orchestrators therefore produce and consume the same GitHub state; the
-command never reads agent-local settings, state, model names, or provider-specific artifact
-formats. A later `sync` removes `merge-ready` when this marker no longer matches the head.
+`verdict: "APPROVED"`, exact `headSha`, `uri`, and SHA-256 `digest`. The digest is recomputed
+from fixed-order canonical UTF-8 JSON bytes of every evidence field except `digest`, so both the
+CLI and marker readers reject altered evidence. The versioned comment records exactly that
+portable evidence object with issue and PR identifiers. Only the newest marker authored by a
+repository owner, member, or collaborator is accepted; all comment pages are considered.
+Marker authorship alone never establishes eligibility: `sync` re-runs the same current-head
+gate policy before preserving `merge-ready`. Review state uses each independent reviewer's
+latest decisive current-head state; a current change request blocks, while a later comment does
+not erase an approval. Any two orchestrators therefore produce and consume the same GitHub
+state: a trusted verified marker for the same issue/PR/head is shared state regardless of
+provider. The command never reads agent-local settings, state, model names, or provider-specific
+artifact formats. A later `sync` removes `merge-ready` when this marker no longer matches the
+head or no longer passes that policy.
+
+Reconciliation distinguishes missing or invalid marker evidence from an operational failure.
+The former is stale evidence; a GitHub query, authentication, rate-limit, or malformed-response
+failure aborts the entire sync before any `--apply` mutation. Required checks are read once per
+sync and reused for every marked PR.
 
 ### Worktree deletion is deliberately harder than label cleanup
 
-`close --apply` only removes a clean worktree that is listed by Git and resolves underneath
-the repository's exact `.worktrees/` directory. A dirty candidate, an unlisted path, or a
-path outside that directory is refused; the command never supplies force.
+`close --apply` only removes a clean worktree that is listed by Git and is a real direct child
+of the repository's exact `.worktrees/` directory. The discovery and apply paths use the same
+realpath predicate; a dirty, nested, symlinked, unlisted, or outside candidate is refused, and
+a refusal yields no label mutation. The command never supplies force. `sync` removes WIP only
+after the linked issue is closed, and all reported mutations are deduplicated before apply.
 
 ## Risks / Trade-offs
 
@@ -56,6 +70,8 @@ path outside that directory is refused; the command never supplies force.
   explicitly reported as safe.
 - The comment trust boundary intentionally excludes public contributors: an untrusted marker
   cannot create merge eligibility, even if it is syntactically valid.
+- A repository owner can still author a PR marker, so marker association is not authorization;
+  current independent review and CI facts remain mandatory on every reconciliation.
 
 ## Technical notes
 

--- a/openspec/changes/backlog-conveyor-cli/design.md
+++ b/openspec/changes/backlog-conveyor-cli/design.md
@@ -23,18 +23,21 @@ the current `headRefOid` through the REST API, and required contexts from the de
 protection endpoint. Every JSON response is shape-checked before use. Commands use argv
 arrays exclusively; no user-controlled input is interpolated in a shell.
 
-### Gate evidence is SHA-bound, independently approved, and provider-neutral
+### Gate evidence is self-versioned, SHA-bound, independently approved, and provider-neutral
 
 `gate` accepts only an open, non-draft, mergeable PR to the default branch, with exactly the
 requested closing issue. An `APPROVED` review by someone other than the PR author must name
 the current head SHA. Required contexts are read from branch protection and each matching
-check/status must be terminal and successful; skipped, pending, absent, or non-successful
-contexts fail. `gate --evidence <path>` consumes a JSON object with `provider` (any non-empty
-string), `verdict: "APPROVED"`, exact `headSha`, `uri`, and SHA-256 `digest`. The versioned
-comment records exactly that portable evidence object with issue and PR identifiers. Any two
-orchestrators therefore produce and consume the same GitHub state; the command never reads
-agent-local settings, state, model names, or provider-specific artifact formats. A later
-`sync` removes `merge-ready` when this marker no longer matches the head.
+check/status must be terminal and successful; a protected check with an `app_id` accepts only
+that app's result, and the deterministically latest matching attempt is authoritative. Skipped,
+pending, absent, or non-successful current attempts fail. `gate --evidence <path>` consumes a
+self-versioned JSON object (`version: 1`) with `provider` (any non-empty string),
+`verdict: "APPROVED"`, exact `headSha`, `uri`, and SHA-256 `digest`. The versioned comment
+records exactly that portable evidence object with issue and PR identifiers. Only the newest
+marker authored by a repository owner, member, or collaborator is accepted; all comment pages
+are considered. Any two orchestrators therefore produce and consume the same GitHub state; the
+command never reads agent-local settings, state, model names, or provider-specific artifact
+formats. A later `sync` removes `merge-ready` when this marker no longer matches the head.
 
 ### Worktree deletion is deliberately harder than label cleanup
 
@@ -50,6 +53,8 @@ path outside that directory is refused; the command never supplies force.
   SHA, avoiding approval carry-over.
 - `sync` reports missing, dirty, and orphan worktrees but only applies label repairs that it
   explicitly reported as safe.
+- The comment trust boundary intentionally excludes public contributors: an untrusted marker
+  cannot create merge eligibility, even if it is syntactically valid.
 
 ## Technical notes
 

--- a/openspec/changes/backlog-conveyor-cli/design.md
+++ b/openspec/changes/backlog-conveyor-cli/design.md
@@ -1,0 +1,54 @@
+# Design — backlog conveyor CLI
+
+## Context
+
+Labels remain the durable external truth, while a gate needs durable evidence that can be
+recovered by another checkout. A GitHub PR comment containing a small versioned JSON marker
+binds the approval and CI decision to one exact head SHA. It is not an ignored local ledger.
+
+## Decisions
+
+### A repository-local Bun script owns the command boundary
+
+`package.json` exposes `bun run backlog -- <subcommand>`. `scripts/backlog.ts` parses only
+the phase-1 flags and maps results to stable exit codes. `scripts/backlog-conveyor.ts` holds
+the pure decision logic and a narrow runner interface so fixture tests never contact GitHub
+or a user worktree.
+
+### GitHub facts are queried at the exact object boundary
+
+The command obtains PR state/reviews/closing references through GraphQL, commit checks by
+the current `headRefOid` through the REST API, and required contexts from the default branch
+protection endpoint. Every JSON response is shape-checked before use. Commands use argv
+arrays exclusively; no user-controlled input is interpolated in a shell.
+
+### Gate evidence is SHA-bound and independently approved
+
+`gate` accepts only an open, non-draft, mergeable PR to the default branch, with exactly the
+requested closing issue. An `APPROVED` review by someone other than the PR author must name
+the current head SHA. Required contexts are read from branch protection and each matching
+check/status must be terminal and successful; skipped, pending, absent, or non-successful
+contexts fail. The gate comment records schema version, issue, PR, head SHA and the approval
+evidence. A later `sync` removes `merge-ready` when this marker no longer matches the head.
+
+### Worktree deletion is deliberately harder than label cleanup
+
+`close --apply` only removes a clean worktree that is listed by Git and resolves underneath
+the repository's exact `.worktrees/` directory. A dirty candidate, an unlisted path, or a
+path outside that directory is refused; the command never supplies force.
+
+## Risks / Trade-offs
+
+- Branch protection has no required checks: gate refuses rather than treating a green-looking
+  optional check as a required one.
+- Review evidence is intentionally rejected after a push; the reviewer must approve the new
+  SHA, avoiding approval carry-over.
+- `sync` reports missing, dirty, and orphan worktrees but only applies label repairs that it
+  explicitly reported as safe.
+
+## Technical notes
+
+- `scripts/backlog.ts:1` is the only user-facing CLI/parser/output boundary.
+- `scripts/backlog-conveyor.ts:1` validates `gh`/`git` JSON and owns all argv construction.
+- `Justfile:40` defines the canonical repository `.worktrees/<slug>` convention used by the
+  close safety boundary.

--- a/openspec/changes/backlog-conveyor-cli/proposal.md
+++ b/openspec/changes/backlog-conveyor-cli/proposal.md
@@ -28,4 +28,4 @@ instead of another local source of truth.
 - `scripts/backlog-conveyor.ts` — validated GitHub/git boundary and invariant evaluation.
 - `scripts/backlog.ts` — Bun CLI parsing, output and exit-code boundary.
 - `tests/unit/backlog-conveyor.test.ts` — fixture-only contract coverage.
-- `package.json` — tracked `bun run backlog` entry point.
+- `package.json` — tracked `bun run conveyor` entry point.

--- a/openspec/changes/backlog-conveyor-cli/proposal.md
+++ b/openspec/changes/backlog-conveyor-cli/proposal.md
@@ -9,9 +9,9 @@ instead of another local source of truth.
 
 ## What Changes
 
-- Add a tracked Bun command with `sync`, `gate`, and `close` subcommands, deterministic
+- Add a tracked, agent-agnostic Bun command with `sync`, `gate`, and `close` subcommands, deterministic
   human output, and a versioned JSON report.
-- Keep GitHub labels and a SHA-bound structured PR comment as durable state; the ignored
+- Keep GitHub labels and a provider-neutral, SHA-bound structured PR comment as durable state; the ignored
   markdown ledger remains non-authoritative.
 - Make all mutations opt-in with `--apply`, idempotent, and narrowly constrained to
   reported repairs.
@@ -20,6 +20,7 @@ instead of another local source of truth.
 
 - Collision scheduling, priority scoring, metrics, auto-merge, or a daemon/database.
 - Replacing GitHub labels or importing the ignored markdown ledger.
+- Depending on a named agent, model, local settings, or provider-specific artifact format.
 - Automatically removing a dirty or out-of-repository worktree.
 
 ## Impact

--- a/openspec/changes/backlog-conveyor-cli/proposal.md
+++ b/openspec/changes/backlog-conveyor-cli/proposal.md
@@ -1,0 +1,30 @@
+# Backlog conveyor CLI
+
+## Why
+
+The backlog conveyor is currently an ignored local prose workflow, so its durable GitHub
+labels can drift from pull requests, reviews, CI and worktrees without an executable way to
+find or safely repair the disagreement. The repository needs a small, auditable command
+instead of another local source of truth.
+
+## What Changes
+
+- Add a tracked Bun command with `sync`, `gate`, and `close` subcommands, deterministic
+  human output, and a versioned JSON report.
+- Keep GitHub labels and a SHA-bound structured PR comment as durable state; the ignored
+  markdown ledger remains non-authoritative.
+- Make all mutations opt-in with `--apply`, idempotent, and narrowly constrained to
+  reported repairs.
+
+## Non-goals
+
+- Collision scheduling, priority scoring, metrics, auto-merge, or a daemon/database.
+- Replacing GitHub labels or importing the ignored markdown ledger.
+- Automatically removing a dirty or out-of-repository worktree.
+
+## Impact
+
+- `scripts/backlog-conveyor.ts` — validated GitHub/git boundary and invariant evaluation.
+- `scripts/backlog.ts` — Bun CLI parsing, output and exit-code boundary.
+- `tests/unit/backlog-conveyor.test.ts` — fixture-only contract coverage.
+- `package.json` — tracked `bun run backlog` entry point.

--- a/openspec/changes/backlog-conveyor-cli/specs/backlog-conveyor/spec.md
+++ b/openspec/changes/backlog-conveyor-cli/specs/backlog-conveyor/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: The repository SHALL expose a safe backlog conveyor command
 
-The repository SHALL expose `bun run backlog -- sync|gate|close`. Each subcommand MUST emit
+The repository SHALL expose `bun run conveyor -- sync|gate|close`. Each subcommand MUST emit
 deterministic human-readable output by default and a JSON report with a declared schema
 version under `--json`. Mutating actions MUST be dry-run unless `--apply` is passed and
 repeating an applied command MUST be idempotent. The command SHALL use distinguishable exit
@@ -23,17 +23,27 @@ codes for success, invariant violation, operational failure, and unsafe/refused 
 
 ### Requirement: Gate SHALL bind independent approval and checks to one head SHA
 
-`gate --issue N --pr P` SHALL require an open, non-draft, mergeable PR to the default
+`gate --issue N --pr P --evidence path` SHALL require an open, non-draft, mergeable PR to the default
 branch, exactly `[N]` in `closingIssuesReferences`, an independent `APPROVED` review for the
 current head SHA, and terminal successful results for every real required check. A stacked
 or non-default-base PR MUST be ineligible. Under `--apply`, a versioned machine-readable
-PR comment MUST bind the marker to the current SHA before `merge-ready` is added.
+PR comment MUST bind the marker to the current SHA before `merge-ready` is added. The evidence
+object MUST be versioned and provider-neutral: any non-empty `provider`, `verdict: APPROVED`,
+exact head SHA, evidence URI/path, and SHA-256 digest. The command MUST NOT depend on a named
+agent, model, local settings, or provider-specific artifact format.
 
 #### Scenario: Ira sees a review made before a push
 
 - GIVEN an approval on SHA `a` and PR head SHA `b`
 - WHEN Ira runs `gate --issue 1032 --pr 1040`
 - THEN it exits with an invariant violation
+
+#### Scenario: Ira and a second orchestrator share one marker
+
+- GIVEN Ira supplies evidence from provider `review-system-a` for a current head
+- AND a second orchestrator supplies the same valid evidence schema with provider `future-agent-b`
+- WHEN either runs `bun run conveyor -- gate --issue 1032 --pr 1040 --evidence path --apply`
+- THEN the marker is readable by both and no provider name is special-cased
 - AND it does not add `merge-ready`
 
 #### Scenario: Ira encounters a skipped required check

--- a/openspec/changes/backlog-conveyor-cli/specs/backlog-conveyor/spec.md
+++ b/openspec/changes/backlog-conveyor-cli/specs/backlog-conveyor/spec.md
@@ -26,8 +26,8 @@ codes for success, invariant violation, operational failure, and unsafe/refused 
 `gate --issue N --pr P --evidence path` SHALL require an open, non-draft, mergeable PR to the default
 branch, exactly `[N]` in `closingIssuesReferences`, an independent `APPROVED` review for the
 current head SHA, and terminal successful results for every real required check. A required
-check with a protected `app_id` MUST match that app, and its latest matching attempt MUST be
-authoritative. A stacked or non-default-base PR MUST be ineligible. Under `--apply`, a
+check with a protected `app_id` MUST match that app, and its latest matching attempt by
+start/creation time MUST be authoritative. A stacked or non-default-base PR MUST be ineligible. Under `--apply`, a
 versioned machine-readable PR comment MUST bind the marker to the current SHA before
 `merge-ready` is added. The evidence object MUST itself declare `version: 1` and remain
 provider-neutral: any non-empty `provider`, `verdict: APPROVED`, exact head SHA, evidence

--- a/openspec/changes/backlog-conveyor-cli/specs/backlog-conveyor/spec.md
+++ b/openspec/changes/backlog-conveyor-cli/specs/backlog-conveyor/spec.md
@@ -11,7 +11,7 @@ codes for success, invariant violation, operational failure, and unsafe/refused 
 #### Scenario: Ira previews a reconciliation
 
 - GIVEN GitHub and local worktree facts
-- WHEN Ira runs `bun run backlog -- sync --json`
+- WHEN Ira runs `bun run conveyor -- sync --json`
 - THEN the report has the declared schema version and lists findings/actions
 - AND GitHub labels and worktrees are unchanged
 

--- a/openspec/changes/backlog-conveyor-cli/specs/backlog-conveyor/spec.md
+++ b/openspec/changes/backlog-conveyor-cli/specs/backlog-conveyor/spec.md
@@ -31,9 +31,14 @@ start/creation time MUST be authoritative. A stacked or non-default-base PR MUST
 versioned machine-readable PR comment MUST bind the marker to the current SHA before
 `merge-ready` is added. The evidence object MUST itself declare `version: 1` and remain
 provider-neutral: any non-empty `provider`, `verdict: APPROVED`, exact head SHA, evidence
-URI/path, and SHA-256 digest. The command MUST read markers from all comment pages and accept
-only the newest valid marker authored by an owner, member, or collaborator. The command MUST
-NOT depend on a named agent, model, local settings, or provider-specific artifact format.
+URI/path, and SHA-256 digest of fixed-order canonical evidence bytes excluding that digest.
+The command MUST read markers from all comment pages and accept only the newest valid marker
+authored by an owner, member, or collaborator. `sync` MUST re-evaluate the same current-head
+gate policy before preserving `merge-ready`; marker association alone MUST NOT establish
+eligibility. The latest decisive current-head review state per independent reviewer MUST apply:
+an approved review is required and any current change request blocks, while later comments do
+not cancel an approval. The command MUST NOT depend on a named agent, model, local settings,
+or provider-specific artifact format.
 
 #### Scenario: Ira sees a review made before a push
 
@@ -67,14 +72,34 @@ NOT depend on a named agent, model, local settings, or provider-specific artifac
 - WHEN Sona runs `sync` or `gate`
 - THEN the marker is ignored and cannot preserve or create merge eligibility
 
+#### Scenario: Ira sees a marker written by the PR author who is a repository owner
+
+- GIVEN the marker is current and syntactically valid but the PR has no independent current-head approval
+- WHEN Ira runs `sync`
+- THEN it reports `merge-ready` stale and may remove only that label under `--apply`
+
+#### Scenario: Maks receives altered evidence
+
+- GIVEN evidence has a digest that does not equal the fixed-order canonical payload excluding the digest
+- WHEN Maks runs `gate` or reads the marker
+- THEN the command rejects the evidence
+
+#### Scenario: Ira cannot load current checks
+
+- GIVEN GitHub refuses or returns malformed required check data during `sync --apply`
+- WHEN Ira runs the command
+- THEN it exits operationally before any label mutation
+
 ### Requirement: Sync and close SHALL preserve worktree safety
 
 `sync` SHALL report stale merge-ready markers, WIP state left by a closed or merged PR, and
-missing, dirty, or orphan local worktrees. It SHALL remove only explicitly reported safe
-labels under `--apply`. `close --issue N --pr P` SHALL verify closed/merged PR and issue
-state consistency; under `--apply` it SHALL remove WIP and only a clean, listed matching
-worktree directly underneath the repository's `.worktrees/` directory. It MUST refuse a
-dirty, unlisted, or outside target and MUST NOT force removal.
+missing, dirty, or orphan local worktrees. It SHALL remove WIP automatically only after the
+linked issue is closed, and it SHALL deduplicate every safe mutation before `--apply`.
+`close --issue N --pr P` SHALL verify closed/merged PR and issue state consistency; under
+`--apply` it SHALL remove WIP and only a clean, listed matching worktree that is a real direct
+child of the repository's `.worktrees/` directory. It MUST refuse a dirty, nested, symlinked,
+unlisted, or outside target, MUST emit no safe action when it refuses, and MUST NOT force
+removal.
 
 #### Scenario: Ira closes an already-cleaned merged item
 
@@ -87,3 +112,15 @@ dirty, unlisted, or outside target and MUST NOT force removal.
 - GIVEN the matching worktree has uncommitted changes
 - WHEN Ira runs `close --issue 1032 --pr 1040 --apply`
 - THEN it refuses the mutation and leaves the worktree intact
+
+#### Scenario: Sona sees a closed unmerged PR while the issue remains open
+
+- GIVEN the issue is open with WIP and a linked PR was closed without merging
+- WHEN Sona runs `sync --apply`
+- THEN it reports the retained WIP and does not remove it
+
+#### Scenario: Maks sees two historical PRs for one closed issue
+
+- GIVEN two closed or merged PRs reference one closed issue with WIP
+- WHEN Maks runs `sync --apply`
+- THEN the WIP removal is applied at most once

--- a/openspec/changes/backlog-conveyor-cli/specs/backlog-conveyor/spec.md
+++ b/openspec/changes/backlog-conveyor-cli/specs/backlog-conveyor/spec.md
@@ -25,12 +25,15 @@ codes for success, invariant violation, operational failure, and unsafe/refused 
 
 `gate --issue N --pr P --evidence path` SHALL require an open, non-draft, mergeable PR to the default
 branch, exactly `[N]` in `closingIssuesReferences`, an independent `APPROVED` review for the
-current head SHA, and terminal successful results for every real required check. A stacked
-or non-default-base PR MUST be ineligible. Under `--apply`, a versioned machine-readable
-PR comment MUST bind the marker to the current SHA before `merge-ready` is added. The evidence
-object MUST be versioned and provider-neutral: any non-empty `provider`, `verdict: APPROVED`,
-exact head SHA, evidence URI/path, and SHA-256 digest. The command MUST NOT depend on a named
-agent, model, local settings, or provider-specific artifact format.
+current head SHA, and terminal successful results for every real required check. A required
+check with a protected `app_id` MUST match that app, and its latest matching attempt MUST be
+authoritative. A stacked or non-default-base PR MUST be ineligible. Under `--apply`, a
+versioned machine-readable PR comment MUST bind the marker to the current SHA before
+`merge-ready` is added. The evidence object MUST itself declare `version: 1` and remain
+provider-neutral: any non-empty `provider`, `verdict: APPROVED`, exact head SHA, evidence
+URI/path, and SHA-256 digest. The command MUST read markers from all comment pages and accept
+only the newest valid marker authored by an owner, member, or collaborator. The command MUST
+NOT depend on a named agent, model, local settings, or provider-specific artifact format.
 
 #### Scenario: Ira sees a review made before a push
 
@@ -44,13 +47,25 @@ agent, model, local settings, or provider-specific artifact format.
 - AND a second orchestrator supplies the same valid evidence schema with provider `future-agent-b`
 - WHEN either runs `bun run conveyor -- gate --issue 1032 --pr 1040 --evidence path --apply`
 - THEN the marker is readable by both and no provider name is special-cased
-- AND it does not add `merge-ready`
+- AND a repeated apply preserves the existing marker and `merge-ready` without a duplicate mutation
 
 #### Scenario: Ira encounters a skipped required check
 
 - GIVEN a required context with a skipped or pending result on the current head
 - WHEN Ira runs `gate --issue 1032 --pr 1040`
 - THEN it exits with an invariant violation
+
+#### Scenario: Maks sees a newer successful attempt after an older failure
+
+- GIVEN a protected required check from app `17` has an older failed attempt and a newer successful attempt on the current head
+- WHEN Maks runs `gate --issue 1032 --pr 1040`
+- THEN the gate accepts the check based on the newer attempt
+
+#### Scenario: Sona sees a valid-looking untrusted marker
+
+- GIVEN the newest valid-looking marker was authored by an untrusted external contributor
+- WHEN Sona runs `sync` or `gate`
+- THEN the marker is ignored and cannot preserve or create merge eligibility
 
 ### Requirement: Sync and close SHALL preserve worktree safety
 

--- a/openspec/changes/backlog-conveyor-cli/specs/backlog-conveyor/spec.md
+++ b/openspec/changes/backlog-conveyor-cli/specs/backlog-conveyor/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: The repository SHALL expose a safe backlog conveyor command
+
+The repository SHALL expose `bun run backlog -- sync|gate|close`. Each subcommand MUST emit
+deterministic human-readable output by default and a JSON report with a declared schema
+version under `--json`. Mutating actions MUST be dry-run unless `--apply` is passed and
+repeating an applied command MUST be idempotent. The command SHALL use distinguishable exit
+codes for success, invariant violation, operational failure, and unsafe/refused mutation.
+
+#### Scenario: Ira previews a reconciliation
+
+- GIVEN GitHub and local worktree facts
+- WHEN Ira runs `bun run backlog -- sync --json`
+- THEN the report has the declared schema version and lists findings/actions
+- AND GitHub labels and worktrees are unchanged
+
+#### Scenario: Ira repeats an applied repair
+
+- GIVEN a prior `--apply` repaired the reported label state
+- WHEN Ira repeats the same command with `--apply`
+- THEN it succeeds without duplicating a comment, label mutation, or deletion
+
+### Requirement: Gate SHALL bind independent approval and checks to one head SHA
+
+`gate --issue N --pr P` SHALL require an open, non-draft, mergeable PR to the default
+branch, exactly `[N]` in `closingIssuesReferences`, an independent `APPROVED` review for the
+current head SHA, and terminal successful results for every real required check. A stacked
+or non-default-base PR MUST be ineligible. Under `--apply`, a versioned machine-readable
+PR comment MUST bind the marker to the current SHA before `merge-ready` is added.
+
+#### Scenario: Ira sees a review made before a push
+
+- GIVEN an approval on SHA `a` and PR head SHA `b`
+- WHEN Ira runs `gate --issue 1032 --pr 1040`
+- THEN it exits with an invariant violation
+- AND it does not add `merge-ready`
+
+#### Scenario: Ira encounters a skipped required check
+
+- GIVEN a required context with a skipped or pending result on the current head
+- WHEN Ira runs `gate --issue 1032 --pr 1040`
+- THEN it exits with an invariant violation
+
+### Requirement: Sync and close SHALL preserve worktree safety
+
+`sync` SHALL report stale merge-ready markers, WIP state left by a closed or merged PR, and
+missing, dirty, or orphan local worktrees. It SHALL remove only explicitly reported safe
+labels under `--apply`. `close --issue N --pr P` SHALL verify closed/merged PR and issue
+state consistency; under `--apply` it SHALL remove WIP and only a clean, listed matching
+worktree directly underneath the repository's `.worktrees/` directory. It MUST refuse a
+dirty, unlisted, or outside target and MUST NOT force removal.
+
+#### Scenario: Ira closes an already-cleaned merged item
+
+- GIVEN the PR is merged, the issue is closed, no WIP label remains, and no matching worktree exists
+- WHEN Ira runs `close --issue 1032 --pr 1040 --apply`
+- THEN it succeeds without a mutation
+
+#### Scenario: Ira tries to close a dirty worktree
+
+- GIVEN the matching worktree has uncommitted changes
+- WHEN Ira runs `close --issue 1032 --pr 1040 --apply`
+- THEN it refuses the mutation and leaves the worktree intact

--- a/openspec/changes/backlog-conveyor-cli/specs/backlog-conveyor/spec.md
+++ b/openspec/changes/backlog-conveyor-cli/specs/backlog-conveyor/spec.md
@@ -24,8 +24,11 @@ codes for success, invariant violation, operational failure, and unsafe/refused 
 ### Requirement: Gate SHALL bind independent approval and checks to one head SHA
 
 `gate --issue N --pr P --evidence path` SHALL require an open, non-draft, mergeable PR to the default
-branch, exactly `[N]` in `closingIssuesReferences`, an independent `APPROVED` review for the
-current head SHA, and terminal successful results for every real required check. A required
+branch, exactly `[N]` in `closingIssuesReferences`, verified provider-neutral approval evidence
+for the current head SHA, and terminal successful results for every real required check. A
+distinct GitHub reviewer account MUST NOT be required, so multiple orchestrators may use one
+authenticated GitHub identity. A current-head native `CHANGES_REQUESTED` from someone other
+than the PR author MUST block; native `APPROVED` and `COMMENTED` reviews are supplemental. A required
 check with a protected `app_id` MUST match that app, and its latest matching attempt by
 start/creation time MUST be authoritative. A stacked or non-default-base PR MUST be ineligible. Under `--apply`, a
 versioned machine-readable PR comment MUST bind the marker to the current SHA before
@@ -36,13 +39,13 @@ The command MUST read markers from all comment pages and accept only the newest 
 authored by an owner, member, or collaborator. `sync` MUST re-evaluate the same current-head
 gate policy before preserving `merge-ready`; marker association alone MUST NOT establish
 eligibility. The latest decisive current-head review state per independent reviewer MUST apply:
-an approved review is required and any current change request blocks, while later comments do
-not cancel an approval. The command MUST NOT depend on a named agent, model, local settings,
+any current change request blocks, while later comments do not cancel an approval when present.
+The command MUST NOT depend on a named agent, model, local settings,
 or provider-specific artifact format.
 
-#### Scenario: Ira sees a review made before a push
+#### Scenario: Ira sees approval evidence made before a push
 
-- GIVEN an approval on SHA `a` and PR head SHA `b`
+- GIVEN approval evidence on SHA `a` and PR head SHA `b`
 - WHEN Ira runs `gate --issue 1032 --pr 1040`
 - THEN it exits with an invariant violation
 
@@ -74,9 +77,15 @@ or provider-specific artifact format.
 
 #### Scenario: Ira sees a marker written by the PR author who is a repository owner
 
-- GIVEN the marker is current and syntactically valid but the PR has no independent current-head approval
+- GIVEN the marker is current and syntactically valid but its evidence does not match the current head
 - WHEN Ira runs `sync`
 - THEN it reports `merge-ready` stale and may remove only that label under `--apply`
+
+#### Scenario: Sona and Maks share one GitHub identity
+
+- GIVEN Sona and Maks use different evidence providers but one authenticated GitHub account
+- WHEN either runs `gate` with valid current-head evidence and no blocking native review
+- THEN the gate accepts the evidence without requiring a distinct GitHub reviewer login
 
 #### Scenario: Maks receives altered evidence
 

--- a/openspec/changes/backlog-conveyor-cli/tasks.md
+++ b/openspec/changes/backlog-conveyor-cli/tasks.md
@@ -19,5 +19,5 @@
 
 - [x] 4.1 Sabotage exact-head enforcement and prove the targeted test fails; restore and rerun
 - [x] 4.2 Sabotage dirty-worktree protection and prove the targeted test fails; restore and rerun
-- [ ] 4.3 Run targeted tests, type check, OpenSpec strict validation and `just preflight`
+- [x] 4.3 Run targeted tests, type check, OpenSpec strict validation and `just preflight`
 - [ ] 4.4 Push a draft PR with `Closes #1032`; verify exact closing reference, draft/head state and clean worktree

--- a/openspec/changes/backlog-conveyor-cli/tasks.md
+++ b/openspec/changes/backlog-conveyor-cli/tasks.md
@@ -1,23 +1,23 @@
 ## 1. Contract and executable boundary
 
-- [ ] 1.1 Add the OpenSpec proposal, design, delta specification, and strict validation
-- [ ] 1.2 Add `bun run conveyor -- sync|gate|close`, deterministic text/JSON output and stable exit codes
+- [x] 1.1 Add the OpenSpec proposal, design, delta specification, and strict validation
+- [x] 1.2 Add `bun run conveyor -- sync|gate|close`, deterministic text/JSON output and stable exit codes
 
 ## 2. Risk-first gate
 
-- [ ] 2.1 RED: fixture tests for a stale approval SHA, wrong closing issue, and skipped/missing required check
-- [ ] 2.2 GREEN: validate exact head, independent approval, exact closing reference, default base, mergeability and green required checks
-- [ ] 2.3 Persist and recover a versioned provider-neutral SHA-bound PR gate marker; make apply idempotent
+- [x] 2.1 RED: fixture tests for a stale approval SHA, wrong closing issue, and skipped/missing required check
+- [x] 2.2 GREEN: validate exact head, independent approval, exact closing reference, default base, mergeability and green required checks
+- [x] 2.3 Persist and recover a versioned provider-neutral SHA-bound PR gate marker; make apply idempotent
 
 ## 3. Reconciliation and close safety
 
-- [ ] 3.1 RED: stale merge-ready and dirty-worktree refusal fixtures
-- [ ] 3.2 GREEN: report reconciliation findings and apply only reported safe label repairs
-- [ ] 3.3 RED/GREEN: close idempotently removes WIP and only a clean, listed `.worktrees/` target
+- [x] 3.1 RED: stale merge-ready and dirty-worktree refusal fixtures
+- [x] 3.2 GREEN: report reconciliation findings and apply only reported safe label repairs
+- [x] 3.3 RED/GREEN: close idempotently removes WIP and only a clean, listed `.worktrees/` target
 
 ## 4. Adversarial validation and delivery
 
-- [ ] 4.1 Sabotage exact-head enforcement and prove the targeted test fails; restore and rerun
-- [ ] 4.2 Sabotage dirty-worktree protection and prove the targeted test fails; restore and rerun
+- [x] 4.1 Sabotage exact-head enforcement and prove the targeted test fails; restore and rerun
+- [x] 4.2 Sabotage dirty-worktree protection and prove the targeted test fails; restore and rerun
 - [ ] 4.3 Run targeted tests, type check, OpenSpec strict validation and `just preflight`
 - [ ] 4.4 Push a draft PR with `Closes #1032`; verify exact closing reference, draft/head state and clean worktree

--- a/openspec/changes/backlog-conveyor-cli/tasks.md
+++ b/openspec/changes/backlog-conveyor-cli/tasks.md
@@ -1,0 +1,23 @@
+## 1. Contract and executable boundary
+
+- [ ] 1.1 Add the OpenSpec proposal, design, delta specification, and strict validation
+- [ ] 1.2 Add `bun run backlog -- sync|gate|close`, deterministic text/JSON output and stable exit codes
+
+## 2. Risk-first gate
+
+- [ ] 2.1 RED: fixture tests for a stale approval SHA, wrong closing issue, and skipped/missing required check
+- [ ] 2.2 GREEN: validate exact head, independent approval, exact closing reference, default base, mergeability and green required checks
+- [ ] 2.3 Persist and recover a versioned SHA-bound PR gate marker; make apply idempotent
+
+## 3. Reconciliation and close safety
+
+- [ ] 3.1 RED: stale merge-ready and dirty-worktree refusal fixtures
+- [ ] 3.2 GREEN: report reconciliation findings and apply only reported safe label repairs
+- [ ] 3.3 RED/GREEN: close idempotently removes WIP and only a clean, listed `.worktrees/` target
+
+## 4. Adversarial validation and delivery
+
+- [ ] 4.1 Sabotage exact-head enforcement and prove the targeted test fails; restore and rerun
+- [ ] 4.2 Sabotage dirty-worktree protection and prove the targeted test fails; restore and rerun
+- [ ] 4.3 Run targeted tests, type check, OpenSpec strict validation and `just preflight`
+- [ ] 4.4 Push a draft PR with `Closes #1032`; verify exact closing reference, draft/head state and clean worktree

--- a/openspec/changes/backlog-conveyor-cli/tasks.md
+++ b/openspec/changes/backlog-conveyor-cli/tasks.md
@@ -20,4 +20,4 @@
 - [x] 4.1 Sabotage exact-head enforcement and prove the targeted test fails; restore and rerun
 - [x] 4.2 Sabotage dirty-worktree protection and prove the targeted test fails; restore and rerun
 - [x] 4.3 Run targeted tests, type check, OpenSpec strict validation and `just preflight`
-- [ ] 4.4 Push a draft PR with `Closes #1032`; verify exact closing reference, draft/head state and clean worktree
+- [x] 4.4 Push a draft PR with `Closes #1032`; verify exact closing reference, draft/head state and clean worktree

--- a/openspec/changes/backlog-conveyor-cli/tasks.md
+++ b/openspec/changes/backlog-conveyor-cli/tasks.md
@@ -1,13 +1,13 @@
 ## 1. Contract and executable boundary
 
 - [ ] 1.1 Add the OpenSpec proposal, design, delta specification, and strict validation
-- [ ] 1.2 Add `bun run backlog -- sync|gate|close`, deterministic text/JSON output and stable exit codes
+- [ ] 1.2 Add `bun run conveyor -- sync|gate|close`, deterministic text/JSON output and stable exit codes
 
 ## 2. Risk-first gate
 
 - [ ] 2.1 RED: fixture tests for a stale approval SHA, wrong closing issue, and skipped/missing required check
 - [ ] 2.2 GREEN: validate exact head, independent approval, exact closing reference, default base, mergeability and green required checks
-- [ ] 2.3 Persist and recover a versioned SHA-bound PR gate marker; make apply idempotent
+- [ ] 2.3 Persist and recover a versioned provider-neutral SHA-bound PR gate marker; make apply idempotent
 
 ## 3. Reconciliation and close safety
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "scripts": {
     "test": "bun test --timeout 30000",
+    "backlog": "bun scripts/backlog.ts",
     "test:watch": "bun test --timeout 30000 --watch",
     "test:unit": "bun test --timeout 30000 tests/unit/",
     "test:cli-fast": "bun test --timeout 30000 tests/unit/ tests/integration/cli-contracts.test.ts tests/integration/error-codes-cli.test.ts tests/integration/say.test.ts",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "scripts": {
     "test": "bun test --timeout 30000",
-    "backlog": "bun scripts/backlog.ts",
+    "conveyor": "bun scripts/backlog.ts",
     "test:watch": "bun test --timeout 30000 --watch",
     "test:unit": "bun test --timeout 30000 tests/unit/",
     "test:cli-fast": "bun test --timeout 30000 tests/unit/ tests/integration/cli-contracts.test.ts tests/integration/error-codes-cli.test.ts tests/integration/say.test.ts",

--- a/scripts/backlog-conveyor.ts
+++ b/scripts/backlog-conveyor.ts
@@ -20,11 +20,25 @@ export interface GateMarker {
 }
 
 export interface GateEvidence {
+  version: 1;
   provider: string;
   verdict: "APPROVED";
   headSha: string;
   uri: string;
   digest: string;
+}
+
+export interface RequiredCheck {
+  context: string;
+  appId: number | null;
+}
+
+export interface CheckResult {
+  name: string;
+  state: string;
+  appId: number | null;
+  observedAt: string | null;
+  id: number;
 }
 
 export interface GateFacts {
@@ -42,8 +56,8 @@ export interface GateFacts {
     labels: string[];
     reviews: Array<{ state: string; author: string | null; commitSha: string | null; submittedAt: string | null }>;
   };
-  requiredContexts: string[];
-  checks: Array<{ name: string; state: string }>;
+  requiredChecks: RequiredCheck[];
+  checks: CheckResult[];
   evidence: GateEvidence;
   marker: GateMarker | null;
 }
@@ -126,6 +140,11 @@ function optionalString(value: unknown, source: string): string | null {
   return requiredString(value, source);
 }
 
+function optionalNumber(value: unknown, source: string): number | null {
+  if (value === null || value === undefined) return null;
+  return requiredNumber(value, source);
+}
+
 async function runJson(runner: Runner, argv: string[], source: string): Promise<unknown> {
   const result = await runner.run(argv);
   if (result.exitCode !== 0) {
@@ -142,8 +161,13 @@ function closingIssues(value: unknown, source: string): number[] {
   return requiredArray(value, source).map((entry, index) => requiredNumber(requiredRecord(entry, `${source}[${index}]`).number, `${source}[${index}].number`));
 }
 
+export function issueNumberFromBranch(branch: string | null): number | null {
+  const match = /^(?:[^/]+\/)?issue-([1-9]\d*)$/.exec(branch ?? "");
+  return match ? Number(match[1]) : null;
+}
+
 function matchingBranch(branch: string | null, issue: number): boolean {
-  return new RegExp(`^(?:[^/]+/)?issue-${issue}$`).test(branch ?? "");
+  return issueNumberFromBranch(branch) === issue;
 }
 
 function sameNumbers(actual: number[], expected: number[]): boolean {
@@ -156,6 +180,7 @@ export function encodeGateMarker(marker: GateMarker): string {
 
 export function parseGateEvidence(value: unknown, source = "gate evidence"): GateEvidence {
   const evidence = requiredRecord(value, source);
+  if (evidence.version !== 1) throw new OperationalError(`${source}.version must equal 1`);
   const provider = requiredString(evidence.provider, `${source}.provider`);
   const verdict = requiredString(evidence.verdict, `${source}.verdict`);
   if (verdict !== "APPROVED") throw new OperationalError(`${source}.verdict must be APPROVED`);
@@ -164,7 +189,7 @@ export function parseGateEvidence(value: unknown, source = "gate evidence"): Gat
   const uri = requiredString(evidence.uri, `${source}.uri`);
   const digest = requiredString(evidence.digest, `${source}.digest`);
   if (!/^[0-9a-f]{64}$/i.test(digest)) throw new OperationalError(`${source}.digest must be a SHA-256 digest`);
-  return { provider, verdict: "APPROVED", headSha, uri, digest };
+  return { version: 1, provider, verdict: "APPROVED", headSha, uri, digest };
 }
 
 export function parseGateMarker(body: string): GateMarker | null {
@@ -197,13 +222,20 @@ export function evaluateGate(facts: GateFacts): Evaluation {
     (review) => review.state === "APPROVED" && review.author !== null && review.author !== pr.author && review.commitSha === pr.headSha && review.submittedAt !== null,
   );
   if (!approval) violations.push("no independent approval is bound to the current head SHA");
-  if (facts.requiredContexts.length === 0) violations.push("default branch has no required checks");
-  for (const context of facts.requiredContexts) {
-    const results = facts.checks.filter((check) => check.name === context);
-    if (results.length === 0) violations.push(`required check '${context}' is absent`);
-    else if (results.some((result) => result.state !== "SUCCESS")) {
-      violations.push(`required check '${context}' is ${results.find((result) => result.state !== "SUCCESS")!.state}`);
+  if (facts.requiredChecks.length === 0) violations.push("default branch has no required checks");
+  for (const required of facts.requiredChecks) {
+    const results = facts.checks.filter((check) => check.name === required.context && (required.appId === null || check.appId === required.appId));
+    if (results.length === 0) {
+      violations.push(required.appId === null ? `required check '${required.context}' is absent` : `required check '${required.context}' for app ${required.appId} is absent`);
+      continue;
     }
+    const latest = results.reduce((current, candidate) => {
+      const currentTime = current.observedAt ?? "";
+      const candidateTime = candidate.observedAt ?? "";
+      if (candidateTime > currentTime || (candidateTime === currentTime && candidate.id > current.id)) return candidate;
+      return current;
+    });
+    if (latest.state !== "SUCCESS") violations.push(`required check '${required.context}' is ${latest.state}`);
   }
   const marker: GateMarker | null = approval ? { version: 1, issue: facts.issue, pr: facts.pr, evidence: facts.evidence } : null;
   const markerCurrent = facts.marker !== null && facts.marker.issue === facts.issue && facts.marker.pr === facts.pr && JSON.stringify(facts.marker.evidence) === JSON.stringify(facts.evidence);
@@ -238,9 +270,9 @@ export function evaluateSync(facts: SyncFacts): Evaluation {
     }
   }
   for (const worktree of facts.worktrees) {
-    const issue = worktree.branch ? /^\/?(?:feat\/)?issue-(\d+)$/.exec(worktree.branch) : null;
+    const issue = issueNumberFromBranch(worktree.branch);
     if (worktree.dirty) findings.push(`worktree ${worktree.path} is dirty`);
-    if (issue && !facts.issues.some((candidate) => candidate.number === Number(issue[1]) && candidate.labels.includes("WIP"))) {
+    if (issue !== null && !facts.issues.some((candidate) => candidate.number === issue && candidate.labels.includes("WIP"))) {
       findings.push(`worktree ${worktree.path} is orphaned`);
     }
   }
@@ -312,33 +344,60 @@ async function loadPullRequest(runner: Runner, repo: { owner: string; name: stri
   };
 }
 
-async function loadRequiredContexts(runner: Runner, repo: { owner: string; name: string }, branch: string): Promise<string[]> {
+async function loadRequiredChecks(runner: Runner, repo: { owner: string; name: string }, branch: string): Promise<RequiredCheck[]> {
   const raw = requiredRecord(await runJson(runner, ["gh", "api", `repos/${repo.owner}/${repo.name}/branches/${branch}/protection/required_status_checks`], "gh api required status checks"), "gh api required status checks");
-  const contexts = requiredArray(raw.contexts, "required status checks.contexts").map((entry, index) => requiredString(entry, `required status checks.contexts[${index}]`));
-  const checks = raw.checks === undefined ? [] : requiredArray(raw.checks, "required status checks.checks").map((entry, index) => requiredString(requiredRecord(entry, `required status checks.checks[${index}]`).context, `required status checks.checks[${index}].context`));
-  return [...new Set([...contexts, ...checks])];
+  const contexts = requiredArray(raw.contexts, "required status checks.contexts").map((entry, index) => ({ context: requiredString(entry, `required status checks.contexts[${index}]`), appId: null }));
+  const checks = raw.checks === undefined ? [] : requiredArray(raw.checks, "required status checks.checks").map((entry, index) => {
+    const check = requiredRecord(entry, `required status checks.checks[${index}]`);
+    return { context: requiredString(check.context, `required status checks.checks[${index}].context`), appId: optionalNumber(check.app_id, `required status checks.checks[${index}].app_id`) };
+  });
+  const deduplicated = new Map<string, RequiredCheck>();
+  for (const required of [...contexts, ...checks]) deduplicated.set(`${required.context}\u0000${required.appId ?? ""}`, required);
+  return [...deduplicated.values()];
 }
 
-async function loadChecks(runner: Runner, repo: { owner: string; name: string }, sha: string): Promise<GateFacts["checks"]> {
+async function loadChecks(runner: Runner, repo: { owner: string; name: string }, sha: string): Promise<CheckResult[]> {
   const runs = requiredRecord(await runJson(runner, ["gh", "api", `repos/${repo.owner}/${repo.name}/commits/${sha}/check-runs?per_page=100`], "gh api check runs"), "gh api check runs");
   const statuses = requiredRecord(await runJson(runner, ["gh", "api", `repos/${repo.owner}/${repo.name}/commits/${sha}/status`], "gh api statuses"), "gh api statuses");
   const checkRuns = requiredArray(runs.check_runs, "check runs.check_runs").map((entry, index) => {
     const run = requiredRecord(entry, `check runs.check_runs[${index}]`);
     const status = requiredString(run.status, `check runs.check_runs[${index}].status`);
     const conclusion = optionalString(run.conclusion, `check runs.check_runs[${index}].conclusion`);
-    return { name: requiredString(run.name, `check runs.check_runs[${index}].name`), state: status === "completed" && conclusion === "success" ? "SUCCESS" : conclusion?.toUpperCase() ?? status.toUpperCase() };
+    const app = run.app === null || run.app === undefined ? null : requiredRecord(run.app, `check runs.check_runs[${index}].app`);
+    return {
+      name: requiredString(run.name, `check runs.check_runs[${index}].name`),
+      state: status === "completed" && conclusion === "success" ? "SUCCESS" : conclusion?.toUpperCase() ?? status.toUpperCase(),
+      appId: app ? requiredNumber(app.id, `check runs.check_runs[${index}].app.id`) : null,
+      observedAt: optionalString(run.completed_at, `check runs.check_runs[${index}].completed_at`) ?? optionalString(run.started_at, `check runs.check_runs[${index}].started_at`),
+      id: requiredNumber(run.id, `check runs.check_runs[${index}].id`),
+    };
   });
   const statusContexts = requiredArray(statuses.statuses, "statuses.statuses").map((entry, index) => {
     const status = requiredRecord(entry, `statuses.statuses[${index}]`);
-    return { name: requiredString(status.context, `statuses.statuses[${index}].context`), state: requiredString(status.state, `statuses.statuses[${index}].state`).toUpperCase() };
+    return {
+      name: requiredString(status.context, `statuses.statuses[${index}].context`),
+      state: requiredString(status.state, `statuses.statuses[${index}].state`).toUpperCase(),
+      appId: null,
+      observedAt: optionalString(status.created_at, `statuses.statuses[${index}].created_at`),
+      id: requiredNumber(status.id, `statuses.statuses[${index}].id`),
+    };
   });
   return [...checkRuns, ...statusContexts];
 }
 
-async function loadMarker(runner: Runner, repo: { owner: string; name: string }, pr: number): Promise<GateMarker | null> {
-  const raw = requiredArray(await runJson(runner, ["gh", "api", `repos/${repo.owner}/${repo.name}/issues/${pr}/comments?per_page=100`], "gh api comments"), "gh api comments");
-  for (const comment of [...raw].reverse()) {
-    const marker = parseGateMarker(requiredString(requiredRecord(comment, "comment").body, "comment.body"));
+const trustedAssociations = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
+
+export async function loadMarker(runner: Runner, repo: { owner: string; name: string }, pr: number): Promise<GateMarker | null> {
+  const comments: unknown[] = [];
+  for (let page = 1; ; page += 1) {
+    const raw = requiredArray(await runJson(runner, ["gh", "api", `repos/${repo.owner}/${repo.name}/issues/${pr}/comments?per_page=100&page=${page}`], "gh api comments"), "gh api comments");
+    comments.push(...raw);
+    if (raw.length < 100) break;
+  }
+  for (const comment of [...comments].reverse()) {
+    const parsed = requiredRecord(comment, "comment");
+    if (!trustedAssociations.has(requiredString(parsed.author_association, "comment.author_association"))) continue;
+    const marker = parseGateMarker(requiredString(parsed.body, "comment.body"));
     if (marker) return marker;
   }
   return null;
@@ -437,7 +496,7 @@ export async function sync(runner: Runner, apply: boolean): Promise<Evaluation> 
 export async function gate(runner: Runner, issue: number, pr: number, evidence: GateEvidence, apply: boolean): Promise<Evaluation> {
   const repo = await repository(runner);
   const pullRequest = await loadPullRequest(runner, repo, pr);
-  const facts: GateFacts = { issue, pr, defaultBranch: repo.defaultBranch, pullRequest, requiredContexts: await loadRequiredContexts(runner, repo, repo.defaultBranch), checks: await loadChecks(runner, repo, pullRequest.headSha), evidence, marker: await loadMarker(runner, repo, pr) };
+  const facts: GateFacts = { issue, pr, defaultBranch: repo.defaultBranch, pullRequest, requiredChecks: await loadRequiredChecks(runner, repo, repo.defaultBranch), checks: await loadChecks(runner, repo, pullRequest.headSha), evidence, marker: await loadMarker(runner, repo, pr) };
   const evaluation = evaluateGate(facts);
   if (apply && evaluation.violations.length === 0) await applyActions(runner, evaluation.safeActions, repo);
   return evaluation;

--- a/scripts/backlog-conveyor.ts
+++ b/scripts/backlog-conveyor.ts
@@ -1,5 +1,6 @@
-import { existsSync, realpathSync } from "node:fs";
-import { dirname, relative, resolve } from "node:path";
+import { createHash } from "node:crypto";
+import { existsSync, lstatSync, realpathSync } from "node:fs";
+import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
 
 export const REPORT_SCHEMA_VERSION = 1;
 
@@ -27,6 +28,8 @@ export interface GateEvidence {
   uri: string;
   digest: string;
 }
+
+type GateEvidencePayload = Omit<GateEvidence, "digest">;
 
 export interface RequiredCheck {
   context: string;
@@ -71,6 +74,7 @@ export interface SyncFacts {
     labels: string[];
     closingIssueNumbers: number[];
     marker: GateMarker | null;
+    gateVerified: boolean;
   }>;
   worktrees: Array<{ path: string; branch: string | null; dirty: boolean; insideManagedDirectory: boolean }>;
 }
@@ -99,6 +103,12 @@ export interface Runner {
 }
 
 export class OperationalError extends Error {}
+
+interface Repository {
+  owner: string;
+  name: string;
+  defaultBranch: string;
+}
 
 const isRecord = (value: unknown): value is JsonRecord => typeof value === "object" && value !== null && !Array.isArray(value);
 
@@ -170,12 +180,55 @@ function matchingBranch(branch: string | null, issue: number): boolean {
   return issueNumberFromBranch(branch) === issue;
 }
 
+export function isDirectManagedWorktree(path: string, managedDirectory: string): boolean {
+  try {
+    const requested = resolve(path);
+    if (lstatSync(requested).isSymbolicLink()) return false;
+    const candidate = realpathSync(requested);
+    const managed = realpathSync(managedDirectory);
+    const child = relative(managed, candidate);
+    return child !== "" && !isAbsolute(child) && child !== ".." && !child.startsWith(`..${sep}`) && dirname(child) === ".";
+  } catch {
+    return false;
+  }
+}
+
 function sameNumbers(actual: number[], expected: number[]): boolean {
   return actual.length === expected.length && actual.every((number, index) => number === expected[index]);
 }
 
+function actionKey(action: Evaluation["safeActions"][number]): string {
+  if (action.kind === "create-marker") return `${action.kind}:${action.pr}:${JSON.stringify(action.marker)}`;
+  if (action.kind === "remove-worktree") return `${action.kind}:${action.path}`;
+  return `${action.kind}:${action.pr ?? action.issue}`;
+}
+
+function uniqueActions(actions: Evaluation["safeActions"]): Evaluation["safeActions"] {
+  const seen = new Set<string>();
+  return actions.filter((action) => {
+    const key = actionKey(action);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
 export function encodeGateMarker(marker: GateMarker): string {
   return `<!-- kesha-backlog-gate:v1 ${JSON.stringify(marker)} -->`;
+}
+
+export function canonicalGateEvidencePayload(evidence: GateEvidencePayload): string {
+  return JSON.stringify({
+    version: evidence.version,
+    provider: evidence.provider,
+    verdict: evidence.verdict,
+    headSha: evidence.headSha,
+    uri: evidence.uri,
+  });
+}
+
+export function digestGateEvidence(evidence: GateEvidencePayload): string {
+  return createHash("sha256").update(canonicalGateEvidencePayload(evidence)).digest("hex");
 }
 
 export function parseGateEvidence(value: unknown, source = "gate evidence"): GateEvidence {
@@ -189,7 +242,9 @@ export function parseGateEvidence(value: unknown, source = "gate evidence"): Gat
   const uri = requiredString(evidence.uri, `${source}.uri`);
   const digest = requiredString(evidence.digest, `${source}.digest`);
   if (!/^[0-9a-f]{64}$/i.test(digest)) throw new OperationalError(`${source}.digest must be a SHA-256 digest`);
-  return { version: 1, provider, verdict: "APPROVED", headSha, uri, digest };
+  const parsed = { version: 1 as const, provider, verdict: "APPROVED" as const, headSha, uri, digest };
+  if (digest.toLowerCase() !== digestGateEvidence(parsed)) throw new OperationalError(`${source}.digest does not match canonical evidence payload`);
+  return parsed;
 }
 
 export function parseGateMarker(body: string): GateMarker | null {
@@ -218,9 +273,15 @@ export function evaluateGate(facts: GateFacts): Evaluation {
   if (pr.baseRefName !== facts.defaultBranch) violations.push(`pull request base '${pr.baseRefName}' is not default branch '${facts.defaultBranch}'`);
   if (!sameNumbers(pr.closingIssueNumbers, [facts.issue])) violations.push(`closing issues must equal [${facts.issue}]`);
   if (facts.evidence.headSha !== pr.headSha) violations.push("review evidence is not bound to the current head SHA");
-  const approval = pr.reviews.find(
-    (review) => review.state === "APPROVED" && review.author !== null && review.author !== pr.author && review.commitSha === pr.headSha && review.submittedAt !== null,
-  );
+  const latestReviewByAuthor = new Map<string, { state: string; submittedAt: string }>();
+  for (const review of pr.reviews) {
+    if (review.author === null || review.author === pr.author || review.commitSha !== pr.headSha || review.submittedAt === null) continue;
+    if (review.state !== "APPROVED" && review.state !== "CHANGES_REQUESTED" && review.state !== "DISMISSED") continue;
+    const current = latestReviewByAuthor.get(review.author);
+    if (!current || review.submittedAt > current.submittedAt) latestReviewByAuthor.set(review.author, { state: review.state, submittedAt: review.submittedAt });
+  }
+  if ([...latestReviewByAuthor.values()].some((review) => review.state === "CHANGES_REQUESTED")) violations.push("an independent reviewer requested changes on the current head");
+  const approval = [...latestReviewByAuthor.values()].some((review) => review.state === "APPROVED");
   if (!approval) violations.push("no independent approval is bound to the current head SHA");
   if (facts.requiredChecks.length === 0) violations.push("default branch has no required checks");
   for (const required of facts.requiredChecks) {
@@ -238,11 +299,11 @@ export function evaluateGate(facts: GateFacts): Evaluation {
     if (latest.state !== "SUCCESS") violations.push(`required check '${required.context}' is ${latest.state}`);
   }
   const marker: GateMarker | null = approval ? { version: 1, issue: facts.issue, pr: facts.pr, evidence: facts.evidence } : null;
-  const markerCurrent = facts.marker !== null && facts.marker.issue === facts.issue && facts.marker.pr === facts.pr && JSON.stringify(facts.marker.evidence) === JSON.stringify(facts.evidence);
+  const markerCurrent = facts.marker !== null && facts.marker.issue === facts.issue && facts.marker.pr === facts.pr && facts.marker.evidence.headSha === pr.headSha;
   const safeActions: Evaluation["safeActions"] = [];
   if (violations.length === 0 && marker && !markerCurrent) safeActions.push({ kind: "create-marker", pr: facts.pr, marker });
   if (violations.length === 0 && !pr.labels.includes("merge-ready")) safeActions.push({ kind: "add-merge-ready", pr: facts.pr });
-  return { violations, refusals: [], safeActions, findings: [] };
+  return { violations, refusals: [], safeActions: uniqueActions(safeActions), findings: [] };
 }
 
 export function evaluateSync(facts: SyncFacts): Evaluation {
@@ -251,7 +312,7 @@ export function evaluateSync(facts: SyncFacts): Evaluation {
   for (const pr of facts.pullRequests) {
     if (
       pr.labels.includes("merge-ready") &&
-      (!pr.marker || pr.marker.pr !== pr.number || !sameNumbers(pr.closingIssueNumbers, [pr.marker.issue]) || pr.marker.evidence.headSha !== pr.headSha)
+      (!pr.gateVerified || !pr.marker || pr.marker.pr !== pr.number || !sameNumbers(pr.closingIssueNumbers, [pr.marker.issue]) || pr.marker.evidence.headSha !== pr.headSha)
     ) {
       findings.push(`PR #${pr.number} has stale merge-ready evidence`);
       safeActions.push({ kind: "remove-merge-ready", pr: pr.number });
@@ -259,8 +320,12 @@ export function evaluateSync(facts: SyncFacts): Evaluation {
     if ((pr.state === "CLOSED" || pr.state === "MERGED") && pr.closingIssueNumbers.length === 1) {
       const issue = facts.issues.find((candidate) => candidate.number === pr.closingIssueNumbers[0]);
       if (issue?.labels.includes("WIP")) {
-        findings.push(`issue #${issue.number} retains WIP after PR #${pr.number} ${pr.state.toLowerCase()}`);
-        safeActions.push({ kind: "remove-wip", issue: issue.number });
+        if (issue.state === "CLOSED") {
+          findings.push(`issue #${issue.number} retains WIP after PR #${pr.number} ${pr.state.toLowerCase()}`);
+          safeActions.push({ kind: "remove-wip", issue: issue.number });
+        } else {
+          findings.push(`issue #${issue.number} retains WIP after PR #${pr.number} ${pr.state.toLowerCase()}; automatic cleanup requires a closed issue`);
+        }
       }
     }
   }
@@ -276,7 +341,7 @@ export function evaluateSync(facts: SyncFacts): Evaluation {
       findings.push(`worktree ${worktree.path} is orphaned`);
     }
   }
-  return { violations: [], refusals: [], safeActions, findings };
+  return { violations: [], refusals: [], safeActions: uniqueActions(safeActions), findings };
 }
 
 export function evaluateClose(facts: CloseFacts): Evaluation {
@@ -290,8 +355,8 @@ export function evaluateClose(facts: CloseFacts): Evaluation {
   if (facts.worktree && !facts.worktree.insideManagedDirectory) refusals.push("matching worktree is outside the managed .worktrees directory");
   const safeActions: Evaluation["safeActions"] = [];
   if (violations.length === 0 && refusals.length === 0 && facts.worktree) safeActions.push({ kind: "remove-worktree", path: facts.worktree.path });
-  if (violations.length === 0 && facts.issue.labels.includes("WIP")) safeActions.push({ kind: "remove-wip", issue: facts.issue.number });
-  return { violations, refusals, safeActions, findings: [] };
+  if (violations.length === 0 && refusals.length === 0 && facts.issue.labels.includes("WIP")) safeActions.push({ kind: "remove-wip", issue: facts.issue.number });
+  return { violations, refusals, safeActions: uniqueActions(safeActions), findings: [] };
 }
 
 export function bunRunner(): Runner {
@@ -312,7 +377,7 @@ export function bunRunner(): Runner {
   };
 }
 
-async function repository(runner: Runner): Promise<{ owner: string; name: string; defaultBranch: string }> {
+async function repository(runner: Runner): Promise<Repository> {
   const raw = requiredRecord(await runJson(runner, ["gh", "repo", "view", "--json", "nameWithOwner,defaultBranchRef"], "gh repo view"), "gh repo view");
   const [owner, name] = requiredString(raw.nameWithOwner, "gh repo view.nameWithOwner").split("/");
   if (!owner || !name) throw new OperationalError("gh repo view.nameWithOwner must be owner/name");
@@ -322,7 +387,7 @@ async function repository(runner: Runner): Promise<{ owner: string; name: string
 
 const pullRequestQuery = `query($owner: String!, $name: String!, $number: Int!) { repository(owner: $owner, name: $name) { pullRequest(number: $number) { number state isDraft mergeable headRefOid baseRefName author { login } labels(first: 100) { nodes { name } } closingIssuesReferences(first: 10) { nodes { number } } reviews(last: 100) { nodes { state submittedAt author { login } commit { oid } } } } } }`;
 
-async function loadPullRequest(runner: Runner, repo: { owner: string; name: string }, number: number): Promise<GateFacts["pullRequest"]> {
+async function loadPullRequest(runner: Runner, repo: Pick<Repository, "owner" | "name">, number: number): Promise<GateFacts["pullRequest"]> {
   const raw = requiredRecord(await runJson(runner, ["gh", "api", "graphql", "-f", `query=${pullRequestQuery}`, "-F", `owner=${repo.owner}`, "-F", `name=${repo.name}`, "-F", `number=${number}`], "gh api graphql"), "gh api graphql");
   const pr = requiredRecord(requiredRecord(requiredRecord(raw.data, "graphql.data").repository, "graphql.repository").pullRequest, "graphql.pullRequest");
   const reviews = requiredArray(requiredRecord(pr.reviews, "graphql.pullRequest.reviews").nodes, "graphql.pullRequest.reviews.nodes").map((entry, index) => {
@@ -344,7 +409,7 @@ async function loadPullRequest(runner: Runner, repo: { owner: string; name: stri
   };
 }
 
-async function loadRequiredChecks(runner: Runner, repo: { owner: string; name: string }, branch: string): Promise<RequiredCheck[]> {
+async function loadRequiredChecks(runner: Runner, repo: Pick<Repository, "owner" | "name">, branch: string): Promise<RequiredCheck[]> {
   const raw = requiredRecord(await runJson(runner, ["gh", "api", `repos/${repo.owner}/${repo.name}/branches/${branch}/protection/required_status_checks`], "gh api required status checks"), "gh api required status checks");
   const contexts = requiredArray(raw.contexts, "required status checks.contexts").map((entry, index) => ({ context: requiredString(entry, `required status checks.contexts[${index}]`), appId: null }));
   const checks = raw.checks === undefined ? [] : requiredArray(raw.checks, "required status checks.checks").map((entry, index) => {
@@ -356,7 +421,7 @@ async function loadRequiredChecks(runner: Runner, repo: { owner: string; name: s
   return [...deduplicated.values()];
 }
 
-export async function loadChecks(runner: Runner, repo: { owner: string; name: string }, sha: string): Promise<CheckResult[]> {
+export async function loadChecks(runner: Runner, repo: Pick<Repository, "owner" | "name">, sha: string): Promise<CheckResult[]> {
   const runs = requiredRecord(await runJson(runner, ["gh", "api", `repos/${repo.owner}/${repo.name}/commits/${sha}/check-runs?per_page=100`], "gh api check runs"), "gh api check runs");
   const statuses = requiredRecord(await runJson(runner, ["gh", "api", `repos/${repo.owner}/${repo.name}/commits/${sha}/status`], "gh api statuses"), "gh api statuses");
   const checkRuns = requiredArray(runs.check_runs, "check runs.check_runs").map((entry, index) => {
@@ -387,7 +452,7 @@ export async function loadChecks(runner: Runner, repo: { owner: string; name: st
 
 const trustedAssociations = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
 
-export async function loadMarker(runner: Runner, repo: { owner: string; name: string }, pr: number): Promise<GateMarker | null> {
+export async function loadMarker(runner: Runner, repo: Pick<Repository, "owner" | "name">, pr: number): Promise<GateMarker | null> {
   const comments: unknown[] = [];
   for (let page = 1; ; page += 1) {
     const raw = requiredArray(await runJson(runner, ["gh", "api", `repos/${repo.owner}/${repo.name}/issues/${pr}/comments?per_page=100&page=${page}`], "gh api comments"), "gh api comments");
@@ -411,7 +476,7 @@ async function loadIssues(runner: Runner): Promise<SyncFacts["issues"]> {
   });
 }
 
-async function loadSyncPullRequests(runner: Runner, repo: { owner: string; name: string }): Promise<SyncFacts["pullRequests"]> {
+async function loadSyncPullRequests(runner: Runner, repo: Repository): Promise<SyncFacts["pullRequests"]> {
   const raw = requiredArray(await runJson(runner, ["gh", "pr", "list", "--state", "all", "--limit", "1000", "--json", "number,state,mergedAt,headRefOid,labels,closingIssuesReferences"], "gh pr list"), "gh pr list");
   const parsed = raw.map((entry, index) => {
     const pr = requiredRecord(entry, `gh pr list[${index}]`);
@@ -419,8 +484,26 @@ async function loadSyncPullRequests(runner: Runner, repo: { owner: string; name:
     const prLabels = labels(pr.labels, `gh pr list[${index}].labels`);
     return { number, state: optionalString(pr.mergedAt, `gh pr list[${index}].mergedAt`) === null ? requiredString(pr.state, `gh pr list[${index}].state`) : "MERGED", headSha: requiredString(pr.headRefOid, `gh pr list[${index}].headRefOid`), labels: prLabels, closingIssueNumbers: closingIssues(pr.closingIssuesReferences, `gh pr list[${index}].closingIssuesReferences`) };
   });
-  const markers = await Promise.all(parsed.map(async (pr) => (pr.labels.includes("merge-ready") ? await loadMarker(runner, repo, pr.number) : null)));
-  return parsed.map((pr, index) => ({ ...pr, marker: markers[index]! }));
+  const requiredChecks = parsed.some((pr) => pr.labels.includes("merge-ready"))
+    ? await loadRequiredChecks(runner, repo, repo.defaultBranch)
+    : [];
+  return Promise.all(parsed.map(async (pr) => {
+    if (!pr.labels.includes("merge-ready")) return { ...pr, marker: null, gateVerified: false };
+    const marker = await loadMarker(runner, repo, pr.number);
+    if (!marker) return { ...pr, marker: null, gateVerified: false };
+    const pullRequest = await loadPullRequest(runner, repo, pr.number);
+    const facts: GateFacts = {
+      issue: marker.issue,
+      pr: pr.number,
+      defaultBranch: repo.defaultBranch,
+      pullRequest,
+      requiredChecks,
+      checks: await loadChecks(runner, repo, pullRequest.headSha),
+      evidence: marker.evidence,
+      marker,
+    };
+    return { ...pr, marker, gateVerified: evaluateGate(facts).violations.length === 0 };
+  }));
 }
 
 interface ListedWorktree { path: string; branch: string | null }
@@ -445,7 +528,7 @@ async function loadWorktrees(runner: Runner): Promise<SyncFacts["worktrees"]> {
   const managed = resolve(repoRoot, ".worktrees");
   const worktrees: SyncFacts["worktrees"] = [];
   for (const worktree of parseWorktrees(listed.stdout)) {
-    const insideManagedDirectory = resolve(worktree.path).startsWith(`${managed}/`);
+    const insideManagedDirectory = isDirectManagedWorktree(worktree.path, managed);
     let dirty = false;
     if (insideManagedDirectory) {
       const status = await runner.run(["git", "-C", worktree.path, "status", "--porcelain"]);
@@ -480,9 +563,7 @@ function safeManagedWorktreePath(path: string): boolean {
   const common = Bun.spawnSync(["git", "rev-parse", "--path-format=absolute", "--git-common-dir"]);
   if (common.exitCode !== 0) return false;
   const root = dirname(common.stdout.toString().trim());
-  const managed = resolve(realpathSync(root), ".worktrees");
-  const candidate = realpathSync(path);
-  return dirname(candidate) === managed && relative(managed, candidate) !== "";
+  return isDirectManagedWorktree(path, resolve(root, ".worktrees"));
 }
 
 export async function sync(runner: Runner, apply: boolean): Promise<Evaluation> {

--- a/scripts/backlog-conveyor.ts
+++ b/scripts/backlog-conveyor.ts
@@ -257,10 +257,8 @@ export function evaluateClose(facts: CloseFacts): Evaluation {
   if (facts.worktree?.dirty) refusals.push("matching worktree is dirty");
   if (facts.worktree && !facts.worktree.insideManagedDirectory) refusals.push("matching worktree is outside the managed .worktrees directory");
   const safeActions: Evaluation["safeActions"] = [];
-  if (violations.length === 0 && !facts.issue.labels.includes("WIP")) {
-    // Already-cleaned close is intentionally a no-op.
-  } else if (violations.length === 0) safeActions.push({ kind: "remove-wip", issue: facts.issue.number });
   if (violations.length === 0 && refusals.length === 0 && facts.worktree) safeActions.push({ kind: "remove-worktree", path: facts.worktree.path });
+  if (violations.length === 0 && facts.issue.labels.includes("WIP")) safeActions.push({ kind: "remove-wip", issue: facts.issue.number });
   return { violations, refusals, safeActions, findings: [] };
 }
 
@@ -347,7 +345,7 @@ async function loadMarker(runner: Runner, repo: { owner: string; name: string },
 }
 
 async function loadIssues(runner: Runner): Promise<SyncFacts["issues"]> {
-  const raw = requiredArray(await runJson(runner, ["gh", "issue", "list", "--state", "all", "--limit", "100", "--json", "number,state,labels"], "gh issue list"), "gh issue list");
+  const raw = requiredArray(await runJson(runner, ["gh", "issue", "list", "--state", "all", "--limit", "1000", "--json", "number,state,labels"], "gh issue list"), "gh issue list");
   return raw.map((entry, index) => {
     const issue = requiredRecord(entry, `gh issue list[${index}]`);
     return { number: requiredNumber(issue.number, `gh issue list[${index}].number`), state: requiredString(issue.state, `gh issue list[${index}].state`), labels: labels(issue.labels, `gh issue list[${index}].labels`) };
@@ -355,7 +353,7 @@ async function loadIssues(runner: Runner): Promise<SyncFacts["issues"]> {
 }
 
 async function loadSyncPullRequests(runner: Runner, repo: { owner: string; name: string }): Promise<SyncFacts["pullRequests"]> {
-  const raw = requiredArray(await runJson(runner, ["gh", "pr", "list", "--state", "all", "--limit", "100", "--json", "number,state,mergedAt,headRefOid,labels,closingIssuesReferences"], "gh pr list"), "gh pr list");
+  const raw = requiredArray(await runJson(runner, ["gh", "pr", "list", "--state", "all", "--limit", "1000", "--json", "number,state,mergedAt,headRefOid,labels,closingIssuesReferences"], "gh pr list"), "gh pr list");
   const parsed = raw.map((entry, index) => {
     const pr = requiredRecord(entry, `gh pr list[${index}]`);
     const number = requiredNumber(pr.number, `gh pr list[${index}].number`);

--- a/scripts/backlog-conveyor.ts
+++ b/scripts/backlog-conveyor.ts
@@ -37,7 +37,7 @@ export interface CheckResult {
   name: string;
   state: string;
   appId: number | null;
-  observedAt: string | null;
+  attemptAt: string | null;
   id: number;
 }
 
@@ -230,8 +230,8 @@ export function evaluateGate(facts: GateFacts): Evaluation {
       continue;
     }
     const latest = results.reduce((current, candidate) => {
-      const currentTime = current.observedAt ?? "";
-      const candidateTime = candidate.observedAt ?? "";
+      const currentTime = current.attemptAt ?? "";
+      const candidateTime = candidate.attemptAt ?? "";
       if (candidateTime > currentTime || (candidateTime === currentTime && candidate.id > current.id)) return candidate;
       return current;
     });
@@ -356,7 +356,7 @@ async function loadRequiredChecks(runner: Runner, repo: { owner: string; name: s
   return [...deduplicated.values()];
 }
 
-async function loadChecks(runner: Runner, repo: { owner: string; name: string }, sha: string): Promise<CheckResult[]> {
+export async function loadChecks(runner: Runner, repo: { owner: string; name: string }, sha: string): Promise<CheckResult[]> {
   const runs = requiredRecord(await runJson(runner, ["gh", "api", `repos/${repo.owner}/${repo.name}/commits/${sha}/check-runs?per_page=100`], "gh api check runs"), "gh api check runs");
   const statuses = requiredRecord(await runJson(runner, ["gh", "api", `repos/${repo.owner}/${repo.name}/commits/${sha}/status`], "gh api statuses"), "gh api statuses");
   const checkRuns = requiredArray(runs.check_runs, "check runs.check_runs").map((entry, index) => {
@@ -368,7 +368,7 @@ async function loadChecks(runner: Runner, repo: { owner: string; name: string },
       name: requiredString(run.name, `check runs.check_runs[${index}].name`),
       state: status === "completed" && conclusion === "success" ? "SUCCESS" : conclusion?.toUpperCase() ?? status.toUpperCase(),
       appId: app ? requiredNumber(app.id, `check runs.check_runs[${index}].app.id`) : null,
-      observedAt: optionalString(run.completed_at, `check runs.check_runs[${index}].completed_at`) ?? optionalString(run.started_at, `check runs.check_runs[${index}].started_at`),
+      attemptAt: optionalString(run.started_at, `check runs.check_runs[${index}].started_at`),
       id: requiredNumber(run.id, `check runs.check_runs[${index}].id`),
     };
   });
@@ -378,7 +378,7 @@ async function loadChecks(runner: Runner, repo: { owner: string; name: string },
       name: requiredString(status.context, `statuses.statuses[${index}].context`),
       state: requiredString(status.state, `statuses.statuses[${index}].state`).toUpperCase(),
       appId: null,
-      observedAt: optionalString(status.created_at, `statuses.statuses[${index}].created_at`),
+      attemptAt: optionalString(status.created_at, `statuses.statuses[${index}].created_at`),
       id: requiredNumber(status.id, `statuses.statuses[${index}].id`),
     };
   });

--- a/scripts/backlog-conveyor.ts
+++ b/scripts/backlog-conveyor.ts
@@ -1,0 +1,440 @@
+import { existsSync, realpathSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+
+export const REPORT_SCHEMA_VERSION = 1;
+
+export const ExitCode = {
+  success: 0,
+  invariantViolation: 2,
+  operationalFailure: 3,
+  unsafeRefusal: 4,
+} as const;
+
+type JsonRecord = Record<string, unknown>;
+
+export interface GateMarker {
+  version: 1;
+  issue: number;
+  pr: number;
+  headSha: string;
+  reviewer: string;
+  approvedAt: string;
+}
+
+export interface GateFacts {
+  issue: number;
+  pr: number;
+  defaultBranch: string;
+  pullRequest: {
+    state: string;
+    isDraft: boolean;
+    mergeable: string;
+    headSha: string;
+    baseRefName: string;
+    author: string;
+    closingIssueNumbers: number[];
+    labels: string[];
+    reviews: Array<{ state: string; author: string | null; commitSha: string | null; submittedAt: string | null }>;
+  };
+  requiredContexts: string[];
+  checks: Array<{ name: string; state: string }>;
+  marker: GateMarker | null;
+}
+
+export interface SyncFacts {
+  issues: Array<{ number: number; state: string; labels: string[] }>;
+  pullRequests: Array<{
+    number: number;
+    state: string;
+    headSha: string;
+    labels: string[];
+    closingIssueNumbers: number[];
+    marker: GateMarker | null;
+  }>;
+  worktrees: Array<{ path: string; branch: string | null; dirty: boolean; insideManagedDirectory: boolean }>;
+}
+
+export interface CloseFacts {
+  issue: { number: number; state: string; labels: string[] };
+  pullRequest: { number: number; state: string; closingIssueNumbers: number[] };
+  worktree: { path: string; branch: string | null; dirty: boolean; insideManagedDirectory: boolean } | null;
+}
+
+export interface Evaluation {
+  violations: string[];
+  refusals: string[];
+  safeActions: Array<{ kind: "add-merge-ready" | "remove-merge-ready" | "remove-wip" | "remove-worktree" | "create-marker"; pr?: number; issue?: number; path?: string; marker?: GateMarker }>;
+  findings: string[];
+}
+
+export interface RunnerResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export interface Runner {
+  run(argv: string[]): Promise<RunnerResult>;
+}
+
+export class OperationalError extends Error {}
+
+const isRecord = (value: unknown): value is JsonRecord => typeof value === "object" && value !== null && !Array.isArray(value);
+
+function parseJson(text: string, source: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new OperationalError(`${source} returned invalid JSON`);
+  }
+}
+
+function requiredRecord(value: unknown, source: string): JsonRecord {
+  if (!isRecord(value)) throw new OperationalError(`${source} must be an object`);
+  return value;
+}
+
+function requiredString(value: unknown, source: string): string {
+  if (typeof value !== "string" || value.length === 0) throw new OperationalError(`${source} must be a non-empty string`);
+  return value;
+}
+
+function requiredNumber(value: unknown, source: string): number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value)) throw new OperationalError(`${source} must be an integer`);
+  return value;
+}
+
+function requiredBoolean(value: unknown, source: string): boolean {
+  if (typeof value !== "boolean") throw new OperationalError(`${source} must be a boolean`);
+  return value;
+}
+
+function requiredArray(value: unknown, source: string): unknown[] {
+  if (!Array.isArray(value)) throw new OperationalError(`${source} must be an array`);
+  return value;
+}
+
+function optionalString(value: unknown, source: string): string | null {
+  if (value === null || value === undefined) return null;
+  return requiredString(value, source);
+}
+
+async function runJson(runner: Runner, argv: string[], source: string): Promise<unknown> {
+  const result = await runner.run(argv);
+  if (result.exitCode !== 0) {
+    throw new OperationalError(`${source} failed (${result.exitCode}): ${result.stderr.trim() || "no error output"}`);
+  }
+  return parseJson(result.stdout, source);
+}
+
+function labels(value: unknown, source: string): string[] {
+  return requiredArray(value, source).map((entry, index) => requiredString(requiredRecord(entry, `${source}[${index}]`).name, `${source}[${index}].name`));
+}
+
+function closingIssues(value: unknown, source: string): number[] {
+  return requiredArray(value, source).map((entry, index) => requiredNumber(requiredRecord(entry, `${source}[${index}]`).number, `${source}[${index}].number`));
+}
+
+function matchingBranch(branch: string | null, issue: number): boolean {
+  return branch === `issue-${issue}` || branch === `feat/issue-${issue}`;
+}
+
+function sameNumbers(actual: number[], expected: number[]): boolean {
+  return actual.length === expected.length && actual.every((number, index) => number === expected[index]);
+}
+
+export function encodeGateMarker(marker: GateMarker): string {
+  return `<!-- kesha-backlog-gate:v1 ${JSON.stringify(marker)} -->`;
+}
+
+export function parseGateMarker(body: string): GateMarker | null {
+  const match = /<!-- kesha-backlog-gate:v1 (\{.*\}) -->/.exec(body);
+  if (!match?.[1]) return null;
+  try {
+    const value = requiredRecord(JSON.parse(match[1]), "gate marker");
+    if (value.version !== 1) return null;
+    return {
+      version: 1,
+      issue: requiredNumber(value.issue, "gate marker.issue"),
+      pr: requiredNumber(value.pr, "gate marker.pr"),
+      headSha: requiredString(value.headSha, "gate marker.headSha"),
+      reviewer: requiredString(value.reviewer, "gate marker.reviewer"),
+      approvedAt: requiredString(value.approvedAt, "gate marker.approvedAt"),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function evaluateGate(facts: GateFacts): Evaluation {
+  const violations: string[] = [];
+  const pr = facts.pullRequest;
+  if (pr.state !== "OPEN") violations.push("pull request is not open");
+  if (pr.isDraft) violations.push("pull request is a draft");
+  if (pr.mergeable !== "MERGEABLE") violations.push(`pull request is not mergeable (${pr.mergeable})`);
+  if (pr.baseRefName !== facts.defaultBranch) violations.push(`pull request base '${pr.baseRefName}' is not default branch '${facts.defaultBranch}'`);
+  if (!sameNumbers(pr.closingIssueNumbers, [facts.issue])) violations.push(`closing issues must equal [${facts.issue}]`);
+  const approval = pr.reviews.find(
+    (review) => review.state === "APPROVED" && review.author !== null && review.author !== pr.author && review.commitSha === pr.headSha && review.submittedAt !== null,
+  );
+  if (!approval) violations.push("no independent approval is bound to the current head SHA");
+  if (facts.requiredContexts.length === 0) violations.push("default branch has no required checks");
+  for (const context of facts.requiredContexts) {
+    const results = facts.checks.filter((check) => check.name === context);
+    if (results.length === 0) violations.push(`required check '${context}' is absent`);
+    else if (results.some((result) => result.state !== "SUCCESS")) {
+      violations.push(`required check '${context}' is ${results.find((result) => result.state !== "SUCCESS")!.state}`);
+    }
+  }
+  const marker: GateMarker | null = approval && approval.author !== null && approval.submittedAt !== null
+    ? { version: 1, issue: facts.issue, pr: facts.pr, headSha: pr.headSha, reviewer: approval.author, approvedAt: approval.submittedAt! }
+    : null;
+  const markerCurrent = facts.marker !== null && facts.marker.issue === facts.issue && facts.marker.pr === facts.pr && facts.marker.headSha === pr.headSha;
+  const safeActions: Evaluation["safeActions"] = [];
+  if (violations.length === 0 && marker && !markerCurrent) safeActions.push({ kind: "create-marker", pr: facts.pr, marker });
+  if (violations.length === 0 && !pr.labels.includes("merge-ready")) safeActions.push({ kind: "add-merge-ready", pr: facts.pr });
+  return { violations, refusals: [], safeActions, findings: [] };
+}
+
+export function evaluateSync(facts: SyncFacts): Evaluation {
+  const findings: string[] = [];
+  const safeActions: Evaluation["safeActions"] = [];
+  for (const pr of facts.pullRequests) {
+    if (
+      pr.labels.includes("merge-ready") &&
+      (!pr.marker || pr.marker.pr !== pr.number || !sameNumbers(pr.closingIssueNumbers, [pr.marker.issue]) || pr.marker.headSha !== pr.headSha)
+    ) {
+      findings.push(`PR #${pr.number} has stale merge-ready evidence`);
+      safeActions.push({ kind: "remove-merge-ready", pr: pr.number });
+    }
+    if ((pr.state === "CLOSED" || pr.state === "MERGED") && pr.closingIssueNumbers.length === 1) {
+      const issue = facts.issues.find((candidate) => candidate.number === pr.closingIssueNumbers[0]);
+      if (issue?.labels.includes("WIP")) {
+        findings.push(`issue #${issue.number} retains WIP after PR #${pr.number} ${pr.state.toLowerCase()}`);
+        safeActions.push({ kind: "remove-wip", issue: issue.number });
+      }
+    }
+  }
+  for (const issue of facts.issues) {
+    if (issue.state === "OPEN" && issue.labels.includes("WIP") && !facts.worktrees.some((worktree) => matchingBranch(worktree.branch, issue.number))) {
+      findings.push(`issue #${issue.number} is WIP but has no matching worktree`);
+    }
+  }
+  for (const worktree of facts.worktrees) {
+    const issue = worktree.branch ? /^\/?(?:feat\/)?issue-(\d+)$/.exec(worktree.branch) : null;
+    if (worktree.dirty) findings.push(`worktree ${worktree.path} is dirty`);
+    if (issue && !facts.issues.some((candidate) => candidate.number === Number(issue[1]) && candidate.labels.includes("WIP"))) {
+      findings.push(`worktree ${worktree.path} is orphaned`);
+    }
+  }
+  return { violations: [], refusals: [], safeActions, findings };
+}
+
+export function evaluateClose(facts: CloseFacts): Evaluation {
+  const violations: string[] = [];
+  const refusals: string[] = [];
+  if (facts.pullRequest.state !== "MERGED" && facts.pullRequest.state !== "CLOSED") violations.push("pull request is neither merged nor closed");
+  if (!sameNumbers(facts.pullRequest.closingIssueNumbers, [facts.issue.number])) violations.push(`closing issues must equal [${facts.issue.number}]`);
+  if (facts.pullRequest.state === "MERGED" && facts.issue.state !== "CLOSED") violations.push("merged pull request requires a closed issue");
+  if (facts.pullRequest.state === "CLOSED" && facts.issue.state !== "OPEN") violations.push("unmerged closed pull request requires an open issue");
+  if (facts.worktree?.dirty) refusals.push("matching worktree is dirty");
+  if (facts.worktree && !facts.worktree.insideManagedDirectory) refusals.push("matching worktree is outside the managed .worktrees directory");
+  const safeActions: Evaluation["safeActions"] = [];
+  if (violations.length === 0 && !facts.issue.labels.includes("WIP")) {
+    // Already-cleaned close is intentionally a no-op.
+  } else if (violations.length === 0) safeActions.push({ kind: "remove-wip", issue: facts.issue.number });
+  if (violations.length === 0 && refusals.length === 0 && facts.worktree) safeActions.push({ kind: "remove-worktree", path: facts.worktree.path });
+  return { violations, refusals, safeActions, findings: [] };
+}
+
+export function bunRunner(): Runner {
+  return {
+    async run(argv) {
+      try {
+        const process = Bun.spawn(argv, { stdout: "pipe", stderr: "pipe" });
+        const [stdout, stderr, exitCode] = await Promise.all([
+          new Response(process.stdout).text(),
+          new Response(process.stderr).text(),
+          process.exited,
+        ]);
+        return { stdout, stderr, exitCode };
+      } catch (error) {
+        throw new OperationalError(`could not start ${argv[0]}: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+  };
+}
+
+async function repository(runner: Runner): Promise<{ owner: string; name: string; defaultBranch: string }> {
+  const raw = requiredRecord(await runJson(runner, ["gh", "repo", "view", "--json", "nameWithOwner,defaultBranchRef"], "gh repo view"), "gh repo view");
+  const [owner, name] = requiredString(raw.nameWithOwner, "gh repo view.nameWithOwner").split("/");
+  if (!owner || !name) throw new OperationalError("gh repo view.nameWithOwner must be owner/name");
+  const defaultBranch = requiredString(requiredRecord(raw.defaultBranchRef, "gh repo view.defaultBranchRef").name, "gh repo view.defaultBranchRef.name");
+  return { owner, name, defaultBranch };
+}
+
+const pullRequestQuery = `query($owner: String!, $name: String!, $number: Int!) { repository(owner: $owner, name: $name) { pullRequest(number: $number) { number state isDraft mergeable headRefOid baseRefName author { login } labels(first: 100) { nodes { name } } closingIssuesReferences(first: 10) { nodes { number } } reviews(last: 100) { nodes { state submittedAt author { login } commit { oid } } } } } }`;
+
+async function loadPullRequest(runner: Runner, repo: { owner: string; name: string }, number: number): Promise<GateFacts["pullRequest"]> {
+  const raw = requiredRecord(await runJson(runner, ["gh", "api", "graphql", "-f", `query=${pullRequestQuery}`, "-F", `owner=${repo.owner}`, "-F", `name=${repo.name}`, "-F", `number=${number}`], "gh api graphql"), "gh api graphql");
+  const pr = requiredRecord(requiredRecord(requiredRecord(raw.data, "graphql.data").repository, "graphql.repository").pullRequest, "graphql.pullRequest");
+  const reviews = requiredArray(requiredRecord(pr.reviews, "graphql.pullRequest.reviews").nodes, "graphql.pullRequest.reviews.nodes").map((entry, index) => {
+    const review = requiredRecord(entry, `graphql.review[${index}]`);
+    const author = review.author === null ? null : requiredString(requiredRecord(review.author, `graphql.review[${index}].author`).login, `graphql.review[${index}].author.login`);
+    const commit = review.commit === null ? null : requiredString(requiredRecord(review.commit, `graphql.review[${index}].commit`).oid, `graphql.review[${index}].commit.oid`);
+    return { state: requiredString(review.state, `graphql.review[${index}].state`), author, commitSha: commit, submittedAt: optionalString(review.submittedAt, `graphql.review[${index}].submittedAt`) };
+  });
+  return {
+    state: requiredString(pr.state, "graphql.pullRequest.state"),
+    isDraft: requiredBoolean(pr.isDraft, "graphql.pullRequest.isDraft"),
+    mergeable: requiredString(pr.mergeable, "graphql.pullRequest.mergeable"),
+    headSha: requiredString(pr.headRefOid, "graphql.pullRequest.headRefOid"),
+    baseRefName: requiredString(pr.baseRefName, "graphql.pullRequest.baseRefName"),
+    author: requiredString(requiredRecord(pr.author, "graphql.pullRequest.author").login, "graphql.pullRequest.author.login"),
+    labels: labels(requiredRecord(pr.labels, "graphql.pullRequest.labels").nodes, "graphql.pullRequest.labels.nodes"),
+    closingIssueNumbers: closingIssues(requiredRecord(pr.closingIssuesReferences, "graphql.pullRequest.closingIssuesReferences").nodes, "graphql.pullRequest.closingIssuesReferences.nodes"),
+    reviews,
+  };
+}
+
+async function loadRequiredContexts(runner: Runner, repo: { owner: string; name: string }, branch: string): Promise<string[]> {
+  const raw = requiredRecord(await runJson(runner, ["gh", "api", `repos/${repo.owner}/${repo.name}/branches/${branch}/protection/required_status_checks`], "gh api required status checks"), "gh api required status checks");
+  const contexts = requiredArray(raw.contexts, "required status checks.contexts").map((entry, index) => requiredString(entry, `required status checks.contexts[${index}]`));
+  const checks = raw.checks === undefined ? [] : requiredArray(raw.checks, "required status checks.checks").map((entry, index) => requiredString(requiredRecord(entry, `required status checks.checks[${index}]`).context, `required status checks.checks[${index}].context`));
+  return [...new Set([...contexts, ...checks])];
+}
+
+async function loadChecks(runner: Runner, repo: { owner: string; name: string }, sha: string): Promise<GateFacts["checks"]> {
+  const runs = requiredRecord(await runJson(runner, ["gh", "api", `repos/${repo.owner}/${repo.name}/commits/${sha}/check-runs?per_page=100`], "gh api check runs"), "gh api check runs");
+  const statuses = requiredRecord(await runJson(runner, ["gh", "api", `repos/${repo.owner}/${repo.name}/commits/${sha}/status`], "gh api statuses"), "gh api statuses");
+  const checkRuns = requiredArray(runs.check_runs, "check runs.check_runs").map((entry, index) => {
+    const run = requiredRecord(entry, `check runs.check_runs[${index}]`);
+    const status = requiredString(run.status, `check runs.check_runs[${index}].status`);
+    const conclusion = optionalString(run.conclusion, `check runs.check_runs[${index}].conclusion`);
+    return { name: requiredString(run.name, `check runs.check_runs[${index}].name`), state: status === "completed" && conclusion === "success" ? "SUCCESS" : conclusion?.toUpperCase() ?? status.toUpperCase() };
+  });
+  const statusContexts = requiredArray(statuses.statuses, "statuses.statuses").map((entry, index) => {
+    const status = requiredRecord(entry, `statuses.statuses[${index}]`);
+    return { name: requiredString(status.context, `statuses.statuses[${index}].context`), state: requiredString(status.state, `statuses.statuses[${index}].state`).toUpperCase() };
+  });
+  return [...checkRuns, ...statusContexts];
+}
+
+async function loadMarker(runner: Runner, repo: { owner: string; name: string }, pr: number): Promise<GateMarker | null> {
+  const raw = requiredArray(await runJson(runner, ["gh", "api", `repos/${repo.owner}/${repo.name}/issues/${pr}/comments?per_page=100`], "gh api comments"), "gh api comments");
+  for (const comment of [...raw].reverse()) {
+    const marker = parseGateMarker(requiredString(requiredRecord(comment, "comment").body, "comment.body"));
+    if (marker) return marker;
+  }
+  return null;
+}
+
+async function loadIssues(runner: Runner): Promise<SyncFacts["issues"]> {
+  const raw = requiredArray(await runJson(runner, ["gh", "issue", "list", "--state", "all", "--limit", "100", "--json", "number,state,labels"], "gh issue list"), "gh issue list");
+  return raw.map((entry, index) => {
+    const issue = requiredRecord(entry, `gh issue list[${index}]`);
+    return { number: requiredNumber(issue.number, `gh issue list[${index}].number`), state: requiredString(issue.state, `gh issue list[${index}].state`), labels: labels(issue.labels, `gh issue list[${index}].labels`) };
+  });
+}
+
+async function loadSyncPullRequests(runner: Runner, repo: { owner: string; name: string }): Promise<SyncFacts["pullRequests"]> {
+  const raw = requiredArray(await runJson(runner, ["gh", "pr", "list", "--state", "all", "--limit", "100", "--json", "number,state,headRefOid,labels,closingIssuesReferences"], "gh pr list"), "gh pr list");
+  const prs: SyncFacts["pullRequests"] = [];
+  for (const [index, entry] of raw.entries()) {
+    const pr = requiredRecord(entry, `gh pr list[${index}]`);
+    const number = requiredNumber(pr.number, `gh pr list[${index}].number`);
+    const prLabels = labels(pr.labels, `gh pr list[${index}].labels`);
+    prs.push({ number, state: requiredString(pr.state, `gh pr list[${index}].state`), headSha: requiredString(pr.headRefOid, `gh pr list[${index}].headRefOid`), labels: prLabels, closingIssueNumbers: closingIssues(pr.closingIssuesReferences, `gh pr list[${index}].closingIssuesReferences`), marker: prLabels.includes("merge-ready") ? await loadMarker(runner, repo, number) : null });
+  }
+  return prs;
+}
+
+interface ListedWorktree { path: string; branch: string | null }
+
+function parseWorktrees(text: string): ListedWorktree[] {
+  const result: ListedWorktree[] = [];
+  for (const block of text.trim().split("\n\n")) {
+    const path = /^worktree (.+)$/m.exec(block)?.[1];
+    if (!path) continue;
+    const ref = /^branch refs\/heads\/(.+)$/m.exec(block)?.[1] ?? null;
+    result.push({ path, branch: ref });
+  }
+  return result;
+}
+
+async function loadWorktrees(runner: Runner): Promise<SyncFacts["worktrees"]> {
+  const common = await runner.run(["git", "rev-parse", "--path-format=absolute", "--git-common-dir"]);
+  if (common.exitCode !== 0) throw new OperationalError(`git rev-parse failed: ${common.stderr.trim()}`);
+  const repoRoot = dirname(common.stdout.trim());
+  const listed = await runner.run(["git", "worktree", "list", "--porcelain"]);
+  if (listed.exitCode !== 0) throw new OperationalError(`git worktree list failed: ${listed.stderr.trim()}`);
+  const managed = resolve(repoRoot, ".worktrees");
+  const worktrees: SyncFacts["worktrees"] = [];
+  for (const worktree of parseWorktrees(listed.stdout)) {
+    const insideManagedDirectory = resolve(worktree.path).startsWith(`${managed}/`);
+    let dirty = false;
+    if (insideManagedDirectory) {
+      const status = await runner.run(["git", "-C", worktree.path, "status", "--porcelain"]);
+      if (status.exitCode !== 0) throw new OperationalError(`git status failed for ${worktree.path}: ${status.stderr.trim()}`);
+      dirty = status.stdout.trim().length > 0;
+    }
+    worktrees.push({ ...worktree, dirty, insideManagedDirectory });
+  }
+  return worktrees;
+}
+
+async function applyActions(runner: Runner, actions: Evaluation["safeActions"], repo?: { owner: string; name: string }): Promise<void> {
+  for (const action of actions) {
+    let argv: string[];
+    if (action.kind === "remove-merge-ready") argv = ["gh", "pr", "edit", String(action.pr), "--remove-label", "merge-ready"];
+    else if (action.kind === "add-merge-ready") argv = ["gh", "pr", "edit", String(action.pr), "--add-label", "merge-ready"];
+    else if (action.kind === "remove-wip") argv = ["gh", "issue", "edit", String(action.issue), "--remove-label", "WIP"];
+    else if (action.kind === "create-marker") {
+      if (!repo || !action.marker) throw new OperationalError("internal marker action is incomplete");
+      argv = ["gh", "api", `repos/${repo.owner}/${repo.name}/issues/${action.pr}/comments`, "--method", "POST", "-f", `body=${encodeGateMarker(action.marker)}`];
+    } else {
+      if (!action.path || !safeManagedWorktreePath(action.path)) throw new OperationalError("refusing an unmanaged worktree removal");
+      argv = ["git", "worktree", "remove", action.path];
+    }
+    const result = await runner.run(argv);
+    if (result.exitCode !== 0) throw new OperationalError(`${argv[0]} mutation failed (${result.exitCode}): ${result.stderr.trim() || "no error output"}`);
+  }
+}
+
+function safeManagedWorktreePath(path: string): boolean {
+  if (!existsSync(path)) return false;
+  const common = Bun.spawnSync(["git", "rev-parse", "--path-format=absolute", "--git-common-dir"]);
+  if (common.exitCode !== 0) return false;
+  const root = dirname(common.stdout.toString().trim());
+  const managed = resolve(realpathSync(root), ".worktrees");
+  const candidate = realpathSync(path);
+  return dirname(candidate) === managed && relative(managed, candidate) !== "";
+}
+
+export async function sync(runner: Runner, apply: boolean): Promise<Evaluation> {
+  const repo = await repository(runner);
+  const facts: SyncFacts = { issues: await loadIssues(runner), pullRequests: await loadSyncPullRequests(runner, repo), worktrees: await loadWorktrees(runner) };
+  const evaluation = evaluateSync(facts);
+  if (apply) await applyActions(runner, evaluation.safeActions, repo);
+  return evaluation;
+}
+
+export async function gate(runner: Runner, issue: number, pr: number, apply: boolean): Promise<Evaluation> {
+  const repo = await repository(runner);
+  const pullRequest = await loadPullRequest(runner, repo, pr);
+  const facts: GateFacts = { issue, pr, defaultBranch: repo.defaultBranch, pullRequest, requiredContexts: await loadRequiredContexts(runner, repo, repo.defaultBranch), checks: await loadChecks(runner, repo, pullRequest.headSha), marker: await loadMarker(runner, repo, pr) };
+  const evaluation = evaluateGate(facts);
+  if (apply && evaluation.violations.length === 0) await applyActions(runner, evaluation.safeActions, repo);
+  return evaluation;
+}
+
+export async function close(runner: Runner, issueNumber: number, prNumber: number, apply: boolean): Promise<Evaluation> {
+  const repo = await repository(runner);
+  const pullRequest = await loadPullRequest(runner, repo, prNumber);
+  const issue = (await loadIssues(runner)).find((candidate) => candidate.number === issueNumber);
+  if (!issue) throw new OperationalError(`issue #${issueNumber} was not returned by gh issue list`);
+  const worktree = (await loadWorktrees(runner)).find((candidate) => matchingBranch(candidate.branch, issueNumber)) ?? null;
+  const evaluation = evaluateClose({ issue, pullRequest: { number: prNumber, state: pullRequest.state, closingIssueNumbers: pullRequest.closingIssueNumbers }, worktree });
+  if (apply && evaluation.violations.length === 0 && evaluation.refusals.length === 0) await applyActions(runner, evaluation.safeActions, repo);
+  return evaluation;
+}

--- a/scripts/backlog-conveyor.ts
+++ b/scripts/backlog-conveyor.ts
@@ -16,9 +16,15 @@ export interface GateMarker {
   version: 1;
   issue: number;
   pr: number;
+  evidence: GateEvidence;
+}
+
+export interface GateEvidence {
+  provider: string;
+  verdict: "APPROVED";
   headSha: string;
-  reviewer: string;
-  approvedAt: string;
+  uri: string;
+  digest: string;
 }
 
 export interface GateFacts {
@@ -38,6 +44,7 @@ export interface GateFacts {
   };
   requiredContexts: string[];
   checks: Array<{ name: string; state: string }>;
+  evidence: GateEvidence;
   marker: GateMarker | null;
 }
 
@@ -136,7 +143,7 @@ function closingIssues(value: unknown, source: string): number[] {
 }
 
 function matchingBranch(branch: string | null, issue: number): boolean {
-  return branch === `issue-${issue}` || branch === `feat/issue-${issue}`;
+  return new RegExp(`^(?:[^/]+/)?issue-${issue}$`).test(branch ?? "");
 }
 
 function sameNumbers(actual: number[], expected: number[]): boolean {
@@ -145,6 +152,19 @@ function sameNumbers(actual: number[], expected: number[]): boolean {
 
 export function encodeGateMarker(marker: GateMarker): string {
   return `<!-- kesha-backlog-gate:v1 ${JSON.stringify(marker)} -->`;
+}
+
+export function parseGateEvidence(value: unknown, source = "gate evidence"): GateEvidence {
+  const evidence = requiredRecord(value, source);
+  const provider = requiredString(evidence.provider, `${source}.provider`);
+  const verdict = requiredString(evidence.verdict, `${source}.verdict`);
+  if (verdict !== "APPROVED") throw new OperationalError(`${source}.verdict must be APPROVED`);
+  const headSha = requiredString(evidence.headSha, `${source}.headSha`);
+  if (!/^[0-9a-f]{40,64}$/i.test(headSha)) throw new OperationalError(`${source}.headSha must be a Git SHA`);
+  const uri = requiredString(evidence.uri, `${source}.uri`);
+  const digest = requiredString(evidence.digest, `${source}.digest`);
+  if (!/^[0-9a-f]{64}$/i.test(digest)) throw new OperationalError(`${source}.digest must be a SHA-256 digest`);
+  return { provider, verdict: "APPROVED", headSha, uri, digest };
 }
 
 export function parseGateMarker(body: string): GateMarker | null {
@@ -157,9 +177,7 @@ export function parseGateMarker(body: string): GateMarker | null {
       version: 1,
       issue: requiredNumber(value.issue, "gate marker.issue"),
       pr: requiredNumber(value.pr, "gate marker.pr"),
-      headSha: requiredString(value.headSha, "gate marker.headSha"),
-      reviewer: requiredString(value.reviewer, "gate marker.reviewer"),
-      approvedAt: requiredString(value.approvedAt, "gate marker.approvedAt"),
+      evidence: parseGateEvidence(value.evidence, "gate marker.evidence"),
     };
   } catch {
     return null;
@@ -174,6 +192,7 @@ export function evaluateGate(facts: GateFacts): Evaluation {
   if (pr.mergeable !== "MERGEABLE") violations.push(`pull request is not mergeable (${pr.mergeable})`);
   if (pr.baseRefName !== facts.defaultBranch) violations.push(`pull request base '${pr.baseRefName}' is not default branch '${facts.defaultBranch}'`);
   if (!sameNumbers(pr.closingIssueNumbers, [facts.issue])) violations.push(`closing issues must equal [${facts.issue}]`);
+  if (facts.evidence.headSha !== pr.headSha) violations.push("review evidence is not bound to the current head SHA");
   const approval = pr.reviews.find(
     (review) => review.state === "APPROVED" && review.author !== null && review.author !== pr.author && review.commitSha === pr.headSha && review.submittedAt !== null,
   );
@@ -186,10 +205,8 @@ export function evaluateGate(facts: GateFacts): Evaluation {
       violations.push(`required check '${context}' is ${results.find((result) => result.state !== "SUCCESS")!.state}`);
     }
   }
-  const marker: GateMarker | null = approval && approval.author !== null && approval.submittedAt !== null
-    ? { version: 1, issue: facts.issue, pr: facts.pr, headSha: pr.headSha, reviewer: approval.author, approvedAt: approval.submittedAt! }
-    : null;
-  const markerCurrent = facts.marker !== null && facts.marker.issue === facts.issue && facts.marker.pr === facts.pr && facts.marker.headSha === pr.headSha;
+  const marker: GateMarker | null = approval ? { version: 1, issue: facts.issue, pr: facts.pr, evidence: facts.evidence } : null;
+  const markerCurrent = facts.marker !== null && facts.marker.issue === facts.issue && facts.marker.pr === facts.pr && JSON.stringify(facts.marker.evidence) === JSON.stringify(facts.evidence);
   const safeActions: Evaluation["safeActions"] = [];
   if (violations.length === 0 && marker && !markerCurrent) safeActions.push({ kind: "create-marker", pr: facts.pr, marker });
   if (violations.length === 0 && !pr.labels.includes("merge-ready")) safeActions.push({ kind: "add-merge-ready", pr: facts.pr });
@@ -202,7 +219,7 @@ export function evaluateSync(facts: SyncFacts): Evaluation {
   for (const pr of facts.pullRequests) {
     if (
       pr.labels.includes("merge-ready") &&
-      (!pr.marker || pr.marker.pr !== pr.number || !sameNumbers(pr.closingIssueNumbers, [pr.marker.issue]) || pr.marker.headSha !== pr.headSha)
+      (!pr.marker || pr.marker.pr !== pr.number || !sameNumbers(pr.closingIssueNumbers, [pr.marker.issue]) || pr.marker.evidence.headSha !== pr.headSha)
     ) {
       findings.push(`PR #${pr.number} has stale merge-ready evidence`);
       safeActions.push({ kind: "remove-merge-ready", pr: pr.number });
@@ -338,15 +355,15 @@ async function loadIssues(runner: Runner): Promise<SyncFacts["issues"]> {
 }
 
 async function loadSyncPullRequests(runner: Runner, repo: { owner: string; name: string }): Promise<SyncFacts["pullRequests"]> {
-  const raw = requiredArray(await runJson(runner, ["gh", "pr", "list", "--state", "all", "--limit", "100", "--json", "number,state,headRefOid,labels,closingIssuesReferences"], "gh pr list"), "gh pr list");
-  const prs: SyncFacts["pullRequests"] = [];
-  for (const [index, entry] of raw.entries()) {
+  const raw = requiredArray(await runJson(runner, ["gh", "pr", "list", "--state", "all", "--limit", "100", "--json", "number,state,mergedAt,headRefOid,labels,closingIssuesReferences"], "gh pr list"), "gh pr list");
+  const parsed = raw.map((entry, index) => {
     const pr = requiredRecord(entry, `gh pr list[${index}]`);
     const number = requiredNumber(pr.number, `gh pr list[${index}].number`);
     const prLabels = labels(pr.labels, `gh pr list[${index}].labels`);
-    prs.push({ number, state: requiredString(pr.state, `gh pr list[${index}].state`), headSha: requiredString(pr.headRefOid, `gh pr list[${index}].headRefOid`), labels: prLabels, closingIssueNumbers: closingIssues(pr.closingIssuesReferences, `gh pr list[${index}].closingIssuesReferences`), marker: prLabels.includes("merge-ready") ? await loadMarker(runner, repo, number) : null });
-  }
-  return prs;
+    return { number, state: optionalString(pr.mergedAt, `gh pr list[${index}].mergedAt`) === null ? requiredString(pr.state, `gh pr list[${index}].state`) : "MERGED", headSha: requiredString(pr.headRefOid, `gh pr list[${index}].headRefOid`), labels: prLabels, closingIssueNumbers: closingIssues(pr.closingIssuesReferences, `gh pr list[${index}].closingIssuesReferences`) };
+  });
+  const markers = await Promise.all(parsed.map(async (pr) => (pr.labels.includes("merge-ready") ? await loadMarker(runner, repo, pr.number) : null)));
+  return parsed.map((pr, index) => ({ ...pr, marker: markers[index]! }));
 }
 
 interface ListedWorktree { path: string; branch: string | null }
@@ -419,10 +436,10 @@ export async function sync(runner: Runner, apply: boolean): Promise<Evaluation> 
   return evaluation;
 }
 
-export async function gate(runner: Runner, issue: number, pr: number, apply: boolean): Promise<Evaluation> {
+export async function gate(runner: Runner, issue: number, pr: number, evidence: GateEvidence, apply: boolean): Promise<Evaluation> {
   const repo = await repository(runner);
   const pullRequest = await loadPullRequest(runner, repo, pr);
-  const facts: GateFacts = { issue, pr, defaultBranch: repo.defaultBranch, pullRequest, requiredContexts: await loadRequiredContexts(runner, repo, repo.defaultBranch), checks: await loadChecks(runner, repo, pullRequest.headSha), marker: await loadMarker(runner, repo, pr) };
+  const facts: GateFacts = { issue, pr, defaultBranch: repo.defaultBranch, pullRequest, requiredContexts: await loadRequiredContexts(runner, repo, repo.defaultBranch), checks: await loadChecks(runner, repo, pullRequest.headSha), evidence, marker: await loadMarker(runner, repo, pr) };
   const evaluation = evaluateGate(facts);
   if (apply && evaluation.violations.length === 0) await applyActions(runner, evaluation.safeActions, repo);
   return evaluation;

--- a/scripts/backlog-conveyor.ts
+++ b/scripts/backlog-conveyor.ts
@@ -420,9 +420,15 @@ async function loadRequiredChecks(runner: Runner, repo: Pick<Repository, "owner"
 }
 
 export async function loadChecks(runner: Runner, repo: Pick<Repository, "owner" | "name">, sha: string): Promise<CheckResult[]> {
-  const runs = requiredRecord(await runJson(runner, ["gh", "api", `repos/${repo.owner}/${repo.name}/commits/${sha}/check-runs?per_page=100`], "gh api check runs"), "gh api check runs");
   const statuses = requiredRecord(await runJson(runner, ["gh", "api", `repos/${repo.owner}/${repo.name}/commits/${sha}/status`], "gh api statuses"), "gh api statuses");
-  const checkRuns = requiredArray(runs.check_runs, "check runs.check_runs").map((entry, index) => {
+  const allRuns: unknown[] = [];
+  for (let page = 1; ; page += 1) {
+    const runs = requiredRecord(await runJson(runner, ["gh", "api", `repos/${repo.owner}/${repo.name}/commits/${sha}/check-runs?filter=all&per_page=100&page=${page}`], "gh api check runs"), "gh api check runs");
+    const pageRuns = requiredArray(runs.check_runs, "check runs.check_runs");
+    allRuns.push(...pageRuns);
+    if (pageRuns.length < 100) break;
+  }
+  const checkRuns = allRuns.map((entry, index) => {
     const run = requiredRecord(entry, `check runs.check_runs[${index}]`);
     const status = requiredString(run.status, `check runs.check_runs[${index}].status`);
     const conclusion = optionalString(run.conclusion, `check runs.check_runs[${index}].conclusion`);

--- a/scripts/backlog-conveyor.ts
+++ b/scripts/backlog-conveyor.ts
@@ -281,8 +281,6 @@ export function evaluateGate(facts: GateFacts): Evaluation {
     if (!current || review.submittedAt > current.submittedAt) latestReviewByAuthor.set(review.author, { state: review.state, submittedAt: review.submittedAt });
   }
   if ([...latestReviewByAuthor.values()].some((review) => review.state === "CHANGES_REQUESTED")) violations.push("an independent reviewer requested changes on the current head");
-  const approval = [...latestReviewByAuthor.values()].some((review) => review.state === "APPROVED");
-  if (!approval) violations.push("no independent approval is bound to the current head SHA");
   if (facts.requiredChecks.length === 0) violations.push("default branch has no required checks");
   for (const required of facts.requiredChecks) {
     const results = facts.checks.filter((check) => check.name === required.context && (required.appId === null || check.appId === required.appId));
@@ -298,7 +296,7 @@ export function evaluateGate(facts: GateFacts): Evaluation {
     });
     if (latest.state !== "SUCCESS") violations.push(`required check '${required.context}' is ${latest.state}`);
   }
-  const marker: GateMarker | null = approval ? { version: 1, issue: facts.issue, pr: facts.pr, evidence: facts.evidence } : null;
+  const marker: GateMarker = { version: 1, issue: facts.issue, pr: facts.pr, evidence: facts.evidence };
   const markerCurrent = facts.marker !== null && facts.marker.issue === facts.issue && facts.marker.pr === facts.pr && facts.marker.evidence.headSha === pr.headSha;
   const safeActions: Evaluation["safeActions"] = [];
   if (violations.length === 0 && marker && !markerCurrent) safeActions.push({ kind: "create-marker", pr: facts.pr, marker });

--- a/scripts/backlog.ts
+++ b/scripts/backlog.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env bun
-import { ExitCode, OperationalError, bunRunner, close, gate, parseGateEvidence, sync, type Evaluation } from "./backlog-conveyor";
+import { ExitCode, OperationalError, REPORT_SCHEMA_VERSION, bunRunner, close, gate, parseGateEvidence, sync, type Evaluation } from "./backlog-conveyor";
 
 type Command = { name: "sync"; apply: boolean; json: boolean } | { name: "gate"; issue: number; pr: number; evidencePath: string; apply: boolean; json: boolean } | { name: "close"; issue: number; pr: number; apply: boolean; json: boolean };
 
@@ -50,7 +50,7 @@ function exitCode(result: Evaluation): number {
 }
 
 function output(command: Command, result: Evaluation): void {
-  const report = { schemaVersion: 1, command: command.name, apply: command.apply, findings: result.findings, violations: result.violations, refusals: result.refusals, actions: result.safeActions };
+  const report = { schemaVersion: REPORT_SCHEMA_VERSION, command: command.name, apply: command.apply, findings: result.findings, violations: result.violations, refusals: result.refusals, actions: result.safeActions };
   if (command.json) {
     console.log(JSON.stringify(report));
     return;

--- a/scripts/backlog.ts
+++ b/scripts/backlog.ts
@@ -1,0 +1,73 @@
+#!/usr/bin/env bun
+import { ExitCode, OperationalError, bunRunner, close, gate, sync, type Evaluation } from "./backlog-conveyor";
+
+type Command = { name: "sync"; apply: boolean; json: boolean } | { name: "gate" | "close"; issue: number; pr: number; apply: boolean; json: boolean };
+
+function usage(message: string): never {
+  console.error(`${message}\nusage: bun run backlog -- <sync|gate|close> [--issue N --pr P] [--apply] [--json]`);
+  process.exit(ExitCode.operationalFailure);
+}
+
+function issueNumber(flag: string, raw: string | undefined): number {
+  if (!raw || !/^[1-9]\d*$/.test(raw)) usage(`${flag} requires a positive integer`);
+  return Number(raw);
+}
+
+function parseArgs(argv: string[]): Command {
+  const name = argv.shift();
+  if (name !== "sync" && name !== "gate" && name !== "close") usage(`unknown subcommand '${name ?? ""}'`);
+  let apply = false;
+  let json = false;
+  let issue: number | undefined;
+  let pr: number | undefined;
+  while (argv.length > 0) {
+    const arg = argv.shift()!;
+    if (arg === "--apply") apply = true;
+    else if (arg === "--json") json = true;
+    else if (arg === "--issue") issue = issueNumber(arg, argv.shift());
+    else if (arg === "--pr") pr = issueNumber(arg, argv.shift());
+    else usage(`unknown argument '${arg}'`);
+  }
+  if (name === "sync") {
+    if (issue !== undefined || pr !== undefined) usage("sync does not accept --issue or --pr");
+    return { name, apply, json };
+  }
+  if (issue === undefined || pr === undefined) usage(`${name} requires --issue N and --pr P`);
+  return { name, issue, pr, apply, json };
+}
+
+function exitCode(result: Evaluation): number {
+  if (result.refusals.length > 0) return ExitCode.unsafeRefusal;
+  if (result.violations.length > 0) return ExitCode.invariantViolation;
+  return ExitCode.success;
+}
+
+function output(command: Command, result: Evaluation): void {
+  const report = { schemaVersion: 1, command: command.name, apply: command.apply, findings: result.findings, violations: result.violations, refusals: result.refusals, actions: result.safeActions };
+  if (command.json) {
+    console.log(JSON.stringify(report));
+    return;
+  }
+  console.log(`backlog ${command.name}: ${exitCode(result) === 0 ? "ok" : "blocked"}`);
+  for (const message of [...result.findings, ...result.violations, ...result.refusals]) console.log(`- ${message}`);
+  for (const action of result.safeActions) console.log(`- ${command.apply ? "applied" : "would apply"}: ${action.kind}`);
+}
+
+async function main(): Promise<void> {
+  const command = parseArgs(process.argv.slice(2));
+  const runner = bunRunner();
+  let result: Evaluation;
+  if (command.name === "sync") result = await sync(runner, command.apply);
+  else if (command.name === "gate") result = await gate(runner, command.issue, command.pr, command.apply);
+  else result = await close(runner, command.issue, command.pr, command.apply);
+  output(command, result);
+  process.exit(exitCode(result));
+}
+
+try {
+  if (import.meta.main) await main();
+} catch (error) {
+  const message = error instanceof OperationalError || error instanceof Error ? error.message : String(error);
+  console.error(`backlog: ${message}`);
+  process.exit(ExitCode.operationalFailure);
+}

--- a/scripts/backlog.ts
+++ b/scripts/backlog.ts
@@ -1,10 +1,10 @@
 #!/usr/bin/env bun
-import { ExitCode, OperationalError, bunRunner, close, gate, sync, type Evaluation } from "./backlog-conveyor";
+import { ExitCode, OperationalError, bunRunner, close, gate, parseGateEvidence, sync, type Evaluation } from "./backlog-conveyor";
 
-type Command = { name: "sync"; apply: boolean; json: boolean } | { name: "gate" | "close"; issue: number; pr: number; apply: boolean; json: boolean };
+type Command = { name: "sync"; apply: boolean; json: boolean } | { name: "gate"; issue: number; pr: number; evidencePath: string; apply: boolean; json: boolean } | { name: "close"; issue: number; pr: number; apply: boolean; json: boolean };
 
 function usage(message: string): never {
-  console.error(`${message}\nusage: bun run backlog -- <sync|gate|close> [--issue N --pr P] [--apply] [--json]`);
+  console.error(`${message}\nusage: bun run conveyor -- <sync|gate|close> [--issue N --pr P] [--evidence path] [--apply] [--json]`);
   process.exit(ExitCode.operationalFailure);
 }
 
@@ -20,19 +20,26 @@ function parseArgs(argv: string[]): Command {
   let json = false;
   let issue: number | undefined;
   let pr: number | undefined;
+  let evidencePath: string | undefined;
   while (argv.length > 0) {
     const arg = argv.shift()!;
     if (arg === "--apply") apply = true;
     else if (arg === "--json") json = true;
     else if (arg === "--issue") issue = issueNumber(arg, argv.shift());
     else if (arg === "--pr") pr = issueNumber(arg, argv.shift());
+    else if (arg === "--evidence") evidencePath = argv.shift() ?? usage("--evidence needs a path");
     else usage(`unknown argument '${arg}'`);
   }
   if (name === "sync") {
-    if (issue !== undefined || pr !== undefined) usage("sync does not accept --issue or --pr");
+    if (issue !== undefined || pr !== undefined || evidencePath !== undefined) usage("sync does not accept --issue, --pr, or --evidence");
     return { name, apply, json };
   }
   if (issue === undefined || pr === undefined) usage(`${name} requires --issue N and --pr P`);
+  if (name === "gate") {
+    if (!evidencePath) usage("gate requires --evidence path");
+    return { name, issue, pr, evidencePath, apply, json };
+  }
+  if (evidencePath !== undefined) usage("close does not accept --evidence");
   return { name, issue, pr, apply, json };
 }
 
@@ -58,7 +65,7 @@ async function main(): Promise<void> {
   const runner = bunRunner();
   let result: Evaluation;
   if (command.name === "sync") result = await sync(runner, command.apply);
-  else if (command.name === "gate") result = await gate(runner, command.issue, command.pr, command.apply);
+  else if (command.name === "gate") result = await gate(runner, command.issue, command.pr, parseGateEvidence(JSON.parse(await Bun.file(command.evidencePath).text()), `evidence ${command.evidencePath}`), command.apply);
   else result = await close(runner, command.issue, command.pr, command.apply);
   output(command, result);
   process.exit(exitCode(result));

--- a/tests/unit/backlog-conveyor.test.ts
+++ b/tests/unit/backlog-conveyor.test.ts
@@ -62,6 +62,12 @@ function gateFacts(overrides: Partial<GateFacts> = {}): GateFacts {
 }
 
 describe("backlog gate", () => {
+  test("rejects approval evidence bound to a previous head", () => {
+    const facts = gateFacts({ evidence: evidenceFor({ headSha: "b".repeat(40) }) });
+
+    expect(evaluateGate(facts).violations).toContain("review evidence is not bound to the current head SHA");
+  });
+
   test("accepts verified provider evidence without a distinct GitHub approver", () => {
     const facts = gateFacts({
       pullRequest: {

--- a/tests/unit/backlog-conveyor.test.ts
+++ b/tests/unit/backlog-conveyor.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "bun:test";
+import {
+  evaluateClose,
+  evaluateGate,
+  evaluateSync,
+  type CloseFacts,
+  type GateFacts,
+  type SyncFacts,
+} from "../../scripts/backlog-conveyor";
+
+const head = "a".repeat(40);
+
+function gateFacts(overrides: Partial<GateFacts> = {}): GateFacts {
+  return {
+    issue: 1032,
+    pr: 1040,
+    defaultBranch: "main",
+    pullRequest: {
+      state: "OPEN",
+      isDraft: false,
+      mergeable: "MERGEABLE",
+      headSha: head,
+      baseRefName: "main",
+      author: "author",
+      closingIssueNumbers: [1032],
+      labels: [],
+      reviews: [{ state: "APPROVED", author: "reviewer", commitSha: head, submittedAt: "2026-08-14T10:00:00Z" }],
+    },
+    requiredContexts: ["🧪 CI"],
+    checks: [{ name: "🧪 CI", state: "SUCCESS" }],
+    marker: null,
+    ...overrides,
+  };
+}
+
+describe("backlog gate", () => {
+  test("rejects an approval that was made for a previous head", () => {
+    const facts = gateFacts({
+      pullRequest: {
+        ...gateFacts().pullRequest,
+        reviews: [{ state: "APPROVED", author: "reviewer", commitSha: "b".repeat(40), submittedAt: "2026-08-14T10:00:00Z" }],
+      },
+    });
+
+    expect(evaluateGate(facts).violations).toContain("no independent approval is bound to the current head SHA");
+  });
+
+  test("rejects a pull request that closes a different issue", () => {
+    const facts = gateFacts({
+      pullRequest: { ...gateFacts().pullRequest, closingIssueNumbers: [1031] },
+    });
+
+    expect(evaluateGate(facts).violations).toContain("closing issues must equal [1032]");
+  });
+
+  test("rejects skipped, pending, or absent required checks", () => {
+    const facts = gateFacts({ checks: [{ name: "🧪 CI", state: "SKIPPED" }] });
+
+    expect(evaluateGate(facts).violations).toContain("required check '🧪 CI' is SKIPPED");
+  });
+});
+
+describe("backlog sync", () => {
+  test("reports a merge-ready label whose marker no longer matches the PR head", () => {
+    const facts: SyncFacts = {
+      issues: [],
+      pullRequests: [
+        {
+          number: 1040,
+          state: "OPEN",
+          headSha: head,
+          labels: ["merge-ready"],
+          closingIssueNumbers: [1032],
+          marker: { version: 1, issue: 1032, pr: 1040, headSha: "b".repeat(40), reviewer: "reviewer", approvedAt: "2026-08-14T10:00:00Z" },
+        },
+      ],
+      worktrees: [],
+    };
+
+    expect(evaluateSync(facts).safeActions).toEqual([{ kind: "remove-merge-ready", pr: 1040 }]);
+  });
+});
+
+describe("backlog close", () => {
+  test("refuses to remove a dirty matching worktree", () => {
+    const facts: CloseFacts = {
+      issue: { number: 1032, state: "CLOSED", labels: ["WIP"] },
+      pullRequest: { number: 1040, state: "MERGED", closingIssueNumbers: [1032] },
+      worktree: { path: "/repo/.worktrees/issue-1032", branch: "feat/issue-1032", dirty: true, insideManagedDirectory: true },
+    };
+
+    expect(evaluateClose(facts).refusals).toContain("matching worktree is dirty");
+  });
+
+  test("is idempotent after the issue and worktree are already cleaned", () => {
+    const facts: CloseFacts = {
+      issue: { number: 1032, state: "CLOSED", labels: [] },
+      pullRequest: { number: 1040, state: "MERGED", closingIssueNumbers: [1032] },
+      worktree: null,
+    };
+
+    const result = evaluateClose(facts);
+    expect(result.violations).toEqual([]);
+    expect(result.refusals).toEqual([]);
+    expect(result.safeActions).toEqual([]);
+  });
+});

--- a/tests/unit/backlog-conveyor.test.ts
+++ b/tests/unit/backlog-conveyor.test.ts
@@ -62,15 +62,15 @@ function gateFacts(overrides: Partial<GateFacts> = {}): GateFacts {
 }
 
 describe("backlog gate", () => {
-  test("rejects an approval that was made for a previous head", () => {
+  test("accepts verified provider evidence without a distinct GitHub approver", () => {
     const facts = gateFacts({
       pullRequest: {
         ...gateFacts().pullRequest,
-        reviews: [{ state: "APPROVED", author: "reviewer", commitSha: "b".repeat(40), submittedAt: "2026-08-14T10:00:00Z" }],
+        reviews: [{ state: "APPROVED", author: "author", commitSha: head, submittedAt: "2026-08-14T10:00:00Z" }],
       },
     });
 
-    expect(evaluateGate(facts).violations).toContain("no independent approval is bound to the current head SHA");
+    expect(evaluateGate(facts).violations).not.toContain("no independent approval is bound to the current head SHA");
   });
 
   test("rejects a pull request that closes a different issue", () => {
@@ -269,7 +269,7 @@ describe("backlog sync", () => {
     expect(result.safeActions).toEqual([{ kind: "remove-wip", issue: 1032 }]);
   });
 
-  test("removes merge-ready when a current trusted marker lacks independent approval", async () => {
+  test("preserves merge-ready when current trusted evidence has green facts but no distinct GitHub approver", async () => {
     const marker = encodeGateMarker({ version: 1, issue: 1032, pr: 1040, evidence });
     const runner: Runner = {
       async run(argv) {
@@ -290,7 +290,7 @@ describe("backlog sync", () => {
       },
     };
 
-    expect((await sync(runner, false)).safeActions).toContainEqual({ kind: "remove-merge-ready", pr: 1040 });
+    expect((await sync(runner, false)).safeActions).toEqual([]);
   });
 
   test("aborts before mutation when current check facts cannot be loaded", async () => {

--- a/tests/unit/backlog-conveyor.test.ts
+++ b/tests/unit/backlog-conveyor.test.ts
@@ -1,16 +1,21 @@
 import { describe, expect, test } from "bun:test";
 import {
+  encodeGateMarker,
   evaluateClose,
   evaluateGate,
   evaluateSync,
+  issueNumberFromBranch,
+  loadMarker,
   parseGateEvidence,
   type CloseFacts,
   type GateFacts,
+  type Runner,
   type SyncFacts,
 } from "../../scripts/backlog-conveyor";
 
 const head = "a".repeat(40);
 const evidence = {
+  version: 1 as const,
   provider: "independent-review-system",
   verdict: "APPROVED" as const,
   headSha: head,
@@ -34,8 +39,8 @@ function gateFacts(overrides: Partial<GateFacts> = {}): GateFacts {
       labels: [],
       reviews: [{ state: "APPROVED", author: "reviewer", commitSha: head, submittedAt: "2026-08-14T10:00:00Z" }],
     },
-    requiredContexts: ["🧪 CI"],
-    checks: [{ name: "🧪 CI", state: "SUCCESS" }],
+    requiredChecks: [{ context: "🧪 CI", appId: null }],
+    checks: [{ name: "🧪 CI", state: "SUCCESS", appId: null, observedAt: "2026-08-14T10:00:00Z", id: 1 }],
     evidence,
     marker: null,
     ...overrides,
@@ -63,7 +68,7 @@ describe("backlog gate", () => {
   });
 
   test("rejects skipped, pending, or absent required checks", () => {
-    const facts = gateFacts({ checks: [{ name: "🧪 CI", state: "SKIPPED" }] });
+    const facts = gateFacts({ checks: [{ name: "🧪 CI", state: "SKIPPED", appId: null, observedAt: "2026-08-14T10:00:00Z", id: 1 }] });
 
     expect(evaluateGate(facts).violations).toContain("required check '🧪 CI' is SKIPPED");
   });
@@ -74,9 +79,60 @@ describe("backlog gate", () => {
       provider: "any-future-orchestrator",
     });
     expect(() => parseGateEvidence({ ...evidence, verdict: "PENDING" })).toThrow("verdict must be APPROVED");
+    expect(() => parseGateEvidence({ ...evidence, version: 2 })).toThrow("version must equal 1");
     expect(() => parseGateEvidence({ ...evidence, headSha: "not-a-sha" })).toThrow("headSha must be a Git SHA");
     expect(() => parseGateEvidence({ ...evidence, uri: "" })).toThrow("uri must be a non-empty string");
     expect(() => parseGateEvidence({ ...evidence, digest: "not-a-digest" })).toThrow("digest must be a SHA-256 digest");
+  });
+
+  test("uses the latest matching check attempt rather than an older failure", () => {
+    const facts = gateFacts({
+      checks: [
+        { name: "🧪 CI", state: "FAILURE", appId: 17, observedAt: "2026-08-14T10:00:00Z", id: 1 },
+        { name: "🧪 CI", state: "SUCCESS", appId: 17, observedAt: "2026-08-14T11:00:00Z", id: 2 },
+      ],
+      requiredChecks: [{ context: "🧪 CI", appId: 17 }],
+    });
+
+    expect(evaluateGate(facts).violations).not.toContain("required check '🧪 CI' is FAILURE");
+  });
+
+  test("rejects a matching check name from the wrong protected app", () => {
+    const facts = gateFacts({
+      checks: [{ name: "🧪 CI", state: "SUCCESS", appId: 99, observedAt: "2026-08-14T11:00:00Z", id: 2 }],
+      requiredChecks: [{ context: "🧪 CI", appId: 17 }],
+    });
+
+    expect(evaluateGate(facts).violations).toContain("required check '🧪 CI' for app 17 is absent");
+  });
+});
+
+function commentsRunner(pages: unknown[][]): Runner {
+  return {
+    async run(argv) {
+      const target = argv[2] ?? "";
+      const page = Number(new URL(`https://example.test/${target}`).searchParams.get("page") ?? "1");
+      return { exitCode: 0, stdout: JSON.stringify(pages[page - 1] ?? []), stderr: "" };
+    },
+  };
+}
+
+describe("backlog markers", () => {
+  test("ignores untrusted markers and finds the newest trusted marker beyond the first page", async () => {
+    const older = encodeGateMarker({ version: 1, issue: 1032, pr: 1040, evidence });
+    const newest = encodeGateMarker({ version: 1, issue: 1032, pr: 1040, evidence: { ...evidence, digest: "d".repeat(64) } });
+    const firstPage = Array.from({ length: 100 }, (_, index) => ({ body: index === 99 ? older : "ordinary", author_association: "MEMBER" }));
+    const secondPage = [
+      { body: newest, author_association: "NONE" },
+      { body: newest, author_association: "COLLABORATOR" },
+    ];
+
+    await expect(loadMarker(commentsRunner([firstPage, secondPage]), { owner: "o", name: "r" }, 1040)).resolves.toEqual({
+      version: 1,
+      issue: 1032,
+      pr: 1040,
+      evidence: { ...evidence, digest: "d".repeat(64) },
+    });
   });
 });
 
@@ -98,6 +154,26 @@ describe("backlog sync", () => {
     };
 
     expect(evaluateSync(facts).safeActions).toEqual([{ kind: "remove-merge-ready", pr: 1040 }]);
+  });
+});
+
+describe("managed issue branches", () => {
+  test("uses one parser for unprefixed and single-prefix issue branches", () => {
+    expect(issueNumberFromBranch("issue-1032")).toBe(1032);
+    expect(issueNumberFromBranch("chore/issue-1032")).toBe(1032);
+    expect(issueNumberFromBranch("refactor/issue-1032")).toBe(1032);
+    expect(issueNumberFromBranch("feat/issue-1032")).toBe(1032);
+    expect(issueNumberFromBranch("feature/nested/issue-1032")).toBeNull();
+  });
+
+  test("reports any single-prefix branch without WIP as orphaned", () => {
+    const result = evaluateSync({
+      issues: [{ number: 1032, state: "OPEN", labels: [] }],
+      pullRequests: [],
+      worktrees: [{ path: "/repo/.worktrees/issue-1032", branch: "refactor/issue-1032", dirty: false, insideManagedDirectory: true }],
+    });
+
+    expect(result.findings).toContain("worktree /repo/.worktrees/issue-1032 is orphaned");
   });
 });
 

--- a/tests/unit/backlog-conveyor.test.ts
+++ b/tests/unit/backlog-conveyor.test.ts
@@ -1,28 +1,41 @@
 import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import {
   encodeGateMarker,
   evaluateClose,
   evaluateGate,
   evaluateSync,
   issueNumberFromBranch,
+  isDirectManagedWorktree,
   loadChecks,
   loadMarker,
   parseGateEvidence,
+  parseGateMarker,
+  sync,
   type CloseFacts,
+  type GateEvidence,
   type GateFacts,
   type Runner,
   type SyncFacts,
 } from "../../scripts/backlog-conveyor";
 
 const head = "a".repeat(40);
-const evidence = {
-  version: 1 as const,
-  provider: "independent-review-system",
-  verdict: "APPROVED" as const,
-  headSha: head,
-  uri: "https://reviews.example.test/evidence/1",
-  digest: "c".repeat(64),
-};
+function evidenceFor(overrides: Partial<Omit<GateEvidence, "digest">> = {}): GateEvidence {
+  const payload = {
+    version: 1 as const,
+    provider: "independent-review-system",
+    verdict: "APPROVED" as const,
+    headSha: head,
+    uri: "https://reviews.example.test/evidence/1",
+    ...overrides,
+  };
+  return { ...payload, digest: createHash("sha256").update(JSON.stringify(payload)).digest("hex") };
+}
+
+const evidence = evidenceFor();
 
 function gateFacts(overrides: Partial<GateFacts> = {}): GateFacts {
   return {
@@ -72,17 +85,18 @@ describe("backlog gate", () => {
     const facts = gateFacts({ checks: [{ name: "🧪 CI", state: "SKIPPED", appId: null, attemptAt: "2026-08-14T10:00:00Z", id: 1 }] });
 
     expect(evaluateGate(facts).violations).toContain("required check '🧪 CI' is SKIPPED");
+    expect(evaluateGate(gateFacts({ checks: [{ name: "🧪 CI", state: "PENDING", appId: null, attemptAt: "2026-08-14T10:00:00Z", id: 1 }] })).violations).toContain("required check '🧪 CI' is PENDING");
+    expect(evaluateGate(gateFacts({ checks: [] })).violations).toContain("required check '🧪 CI' is absent");
   });
 
   test("accepts arbitrary evidence providers but validates verdict and SHA", () => {
-    expect(parseGateEvidence({ ...evidence, provider: "any-future-orchestrator" })).toEqual({
-      ...evidence,
-      provider: "any-future-orchestrator",
-    });
-    expect(() => parseGateEvidence({ ...evidence, verdict: "PENDING" })).toThrow("verdict must be APPROVED");
-    expect(() => parseGateEvidence({ ...evidence, version: 2 })).toThrow("version must equal 1");
-    expect(() => parseGateEvidence({ ...evidence, headSha: "not-a-sha" })).toThrow("headSha must be a Git SHA");
-    expect(() => parseGateEvidence({ ...evidence, uri: "" })).toThrow("uri must be a non-empty string");
+    const secondProvider = evidenceFor({ provider: "any-future-orchestrator" });
+    expect(parseGateEvidence(secondProvider)).toEqual(secondProvider);
+    expect(() => parseGateEvidence(evidenceFor({ verdict: "PENDING" as "APPROVED" }))).toThrow("verdict must be APPROVED");
+    expect(() => parseGateEvidence(evidenceFor({ version: 2 as 1 }))).toThrow("version must equal 1");
+    expect(() => parseGateEvidence(evidenceFor({ headSha: "not-a-sha" }))).toThrow("headSha must be a Git SHA");
+    expect(() => parseGateEvidence(evidenceFor({ uri: "" }))).toThrow("uri must be a non-empty string");
+    expect(() => parseGateEvidence({ ...evidence, digest: "d".repeat(64) })).toThrow("digest does not match canonical evidence payload");
     expect(() => parseGateEvidence({ ...evidence, digest: "not-a-digest" })).toThrow("digest must be a SHA-256 digest");
   });
 
@@ -133,6 +147,45 @@ describe("backlog gate", () => {
 
     expect(evaluateGate(facts).violations).toContain("required check '🧪 CI' for app 17 is absent");
   });
+
+  test("blocks a reviewer who requested changes after approving the current head", () => {
+    const facts = gateFacts({
+      pullRequest: {
+        ...gateFacts().pullRequest,
+        reviews: [
+          { state: "APPROVED", author: "reviewer", commitSha: head, submittedAt: "2026-08-14T10:00:00Z" },
+          { state: "CHANGES_REQUESTED", author: "reviewer", commitSha: head, submittedAt: "2026-08-14T11:00:00Z" },
+        ],
+      },
+    });
+
+    expect(evaluateGate(facts).violations).toContain("an independent reviewer requested changes on the current head");
+  });
+
+  test("keeps an approval effective after a later comment", () => {
+    const facts = gateFacts({
+      pullRequest: {
+        ...gateFacts().pullRequest,
+        reviews: [
+          { state: "APPROVED", author: "reviewer", commitSha: head, submittedAt: "2026-08-14T10:00:00Z" },
+          { state: "COMMENTED", author: "reviewer", commitSha: head, submittedAt: "2026-08-14T11:00:00Z" },
+        ],
+      },
+    });
+
+    expect(evaluateGate(facts).violations).not.toContain("no independent approval is bound to the current head SHA");
+  });
+
+  test("offers a marker and merge-ready label for a fully valid gate", () => {
+    expect(evaluateGate(gateFacts()).safeActions.map((action) => action.kind)).toEqual(["create-marker", "add-merge-ready"]);
+  });
+
+  test("reuses a current trusted marker from another evidence provider", () => {
+    const otherEvidence = evidenceFor({ provider: "future-orchestrator" });
+    const facts = gateFacts({ marker: { version: 1, issue: 1032, pr: 1040, evidence }, evidence: otherEvidence });
+
+    expect(evaluateGate(facts).safeActions.map((action) => action.kind)).toEqual(["add-merge-ready"]);
+  });
 });
 
 function commentsRunner(pages: unknown[][]): Runner {
@@ -146,9 +199,16 @@ function commentsRunner(pages: unknown[][]): Runner {
 }
 
 describe("backlog markers", () => {
+  test("round-trips a verified portable marker", () => {
+    const marker = { version: 1 as const, issue: 1032, pr: 1040, evidence };
+
+    expect(parseGateMarker(encodeGateMarker(marker))).toEqual(marker);
+  });
+
   test("ignores untrusted markers and finds the newest trusted marker beyond the first page", async () => {
     const older = encodeGateMarker({ version: 1, issue: 1032, pr: 1040, evidence });
-    const newest = encodeGateMarker({ version: 1, issue: 1032, pr: 1040, evidence: { ...evidence, digest: "d".repeat(64) } });
+    const newestEvidence = evidenceFor({ provider: "other-reviewer" });
+    const newest = encodeGateMarker({ version: 1, issue: 1032, pr: 1040, evidence: newestEvidence });
     const firstPage = Array.from({ length: 100 }, (_, index) => ({ body: index === 99 ? older : "ordinary", author_association: "MEMBER" }));
     const secondPage = [
       { body: newest, author_association: "NONE" },
@@ -159,7 +219,7 @@ describe("backlog markers", () => {
       version: 1,
       issue: 1032,
       pr: 1040,
-      evidence: { ...evidence, digest: "d".repeat(64) },
+      evidence: newestEvidence,
     });
   });
 });
@@ -176,12 +236,89 @@ describe("backlog sync", () => {
           labels: ["merge-ready"],
           closingIssueNumbers: [1032],
           marker: { version: 1, issue: 1032, pr: 1040, evidence: { ...evidence, headSha: "b".repeat(40) } },
+          gateVerified: false,
         },
       ],
       worktrees: [],
     };
 
     expect(evaluateSync(facts).safeActions).toEqual([{ kind: "remove-merge-ready", pr: 1040 }]);
+  });
+
+  test("does not remove WIP from an open issue after a closed unmerged PR", () => {
+    const result = evaluateSync({
+      issues: [{ number: 1032, state: "OPEN", labels: ["WIP"] }],
+      pullRequests: [{ number: 1040, state: "CLOSED", headSha: head, labels: [], closingIssueNumbers: [1032], marker: null, gateVerified: false }],
+      worktrees: [],
+    });
+
+    expect(result.findings).toContain("issue #1032 retains WIP after PR #1040 closed; automatic cleanup requires a closed issue");
+    expect(result.safeActions).toEqual([]);
+  });
+
+  test("deduplicates WIP repair when more than one old PR references a closed issue", () => {
+    const result = evaluateSync({
+      issues: [{ number: 1032, state: "CLOSED", labels: ["WIP"] }],
+      pullRequests: [
+        { number: 1040, state: "MERGED", headSha: head, labels: [], closingIssueNumbers: [1032], marker: null, gateVerified: false },
+        { number: 1041, state: "CLOSED", headSha: head, labels: [], closingIssueNumbers: [1032], marker: null, gateVerified: false },
+      ],
+      worktrees: [],
+    });
+
+    expect(result.safeActions).toEqual([{ kind: "remove-wip", issue: 1032 }]);
+  });
+
+  test("removes merge-ready when a current trusted marker lacks independent approval", async () => {
+    const marker = encodeGateMarker({ version: 1, issue: 1032, pr: 1040, evidence });
+    const runner: Runner = {
+      async run(argv) {
+        if (argv[0] === "git" && argv[1] === "rev-parse") return { exitCode: 0, stdout: "/repo/.git\n", stderr: "" };
+        if (argv[0] === "git" && argv[1] === "worktree") return { exitCode: 0, stdout: "worktree /repo\nHEAD deadbeef\nbare\n", stderr: "" };
+        if (argv[0] === "gh" && argv[1] === "repo") return { exitCode: 0, stdout: JSON.stringify({ nameWithOwner: "o/r", defaultBranchRef: { name: "main" } }), stderr: "" };
+        if (argv[0] === "gh" && argv[1] === "issue") return { exitCode: 0, stdout: JSON.stringify([{ number: 1032, state: "OPEN", labels: [] }]), stderr: "" };
+        if (argv[0] === "gh" && argv[1] === "pr") return { exitCode: 0, stdout: JSON.stringify([{ number: 1040, state: "OPEN", mergedAt: null, headRefOid: head, labels: [{ name: "merge-ready" }], closingIssuesReferences: [{ number: 1032 }] }]), stderr: "" };
+        if (argv[0] === "gh" && argv[1] === "api" && argv[2] === "graphql") {
+          return { exitCode: 0, stderr: "", stdout: JSON.stringify({ data: { repository: { pullRequest: { state: "OPEN", isDraft: false, mergeable: "MERGEABLE", headRefOid: head, baseRefName: "main", author: { login: "author" }, labels: { nodes: [{ name: "merge-ready" }] }, closingIssuesReferences: { nodes: [{ number: 1032 }] }, reviews: { nodes: [] } } } } }) };
+        }
+        const target = argv[2] ?? "";
+        if (target.includes("comments")) return { exitCode: 0, stdout: JSON.stringify([{ body: marker, author_association: "OWNER" }]), stderr: "" };
+        if (target.includes("required_status_checks")) return { exitCode: 0, stdout: JSON.stringify({ contexts: ["🧪 CI"], checks: [] }), stderr: "" };
+        if (target.includes("check-runs")) return { exitCode: 0, stdout: JSON.stringify({ check_runs: [{ id: 1, name: "🧪 CI", status: "completed", conclusion: "success", app: { id: 1 }, started_at: "2026-08-14T10:00:00Z", completed_at: "2026-08-14T10:01:00Z" }] }), stderr: "" };
+        if (target.endsWith("/status")) return { exitCode: 0, stdout: JSON.stringify({ statuses: [] }), stderr: "" };
+        throw new Error(`unexpected argv ${argv.join(" ")}`);
+      },
+    };
+
+    expect((await sync(runner, false)).safeActions).toContainEqual({ kind: "remove-merge-ready", pr: 1040 });
+  });
+
+  test("aborts before mutation when current check facts cannot be loaded", async () => {
+    const calls: string[][] = [];
+    const marker = encodeGateMarker({ version: 1, issue: 1032, pr: 1040, evidence });
+    const runner: Runner = {
+      async run(argv) {
+        calls.push(argv);
+        if (argv[0] === "git" && argv[1] === "rev-parse") return { exitCode: 0, stdout: "/repo/.git\n", stderr: "" };
+        if (argv[0] === "git" && argv[1] === "worktree") return { exitCode: 0, stdout: "worktree /repo\nHEAD deadbeef\nbare\n", stderr: "" };
+        if (argv[0] === "gh" && argv[1] === "repo") return { exitCode: 0, stdout: JSON.stringify({ nameWithOwner: "o/r", defaultBranchRef: { name: "main" } }), stderr: "" };
+        if (argv[0] === "gh" && argv[1] === "issue") return { exitCode: 0, stdout: JSON.stringify([{ number: 1032, state: "OPEN", labels: [] }]), stderr: "" };
+        if (argv[0] === "gh" && argv[1] === "pr" && argv[2] === "list") return { exitCode: 0, stdout: JSON.stringify([{ number: 1040, state: "OPEN", mergedAt: null, headRefOid: head, labels: [{ name: "merge-ready" }], closingIssuesReferences: [{ number: 1032 }] }]), stderr: "" };
+        if (argv[0] === "gh" && argv[1] === "api" && argv[2] === "graphql") {
+          return { exitCode: 0, stderr: "", stdout: JSON.stringify({ data: { repository: { pullRequest: { state: "OPEN", isDraft: false, mergeable: "MERGEABLE", headRefOid: head, baseRefName: "main", author: { login: "author" }, labels: { nodes: [{ name: "merge-ready" }] }, closingIssuesReferences: { nodes: [{ number: 1032 }] }, reviews: { nodes: [{ state: "APPROVED", submittedAt: "2026-08-14T10:00:00Z", author: { login: "reviewer" }, commit: { oid: head } }] } } } } }) };
+        }
+        const target = argv[2] ?? "";
+        if (target.includes("comments")) return { exitCode: 0, stdout: JSON.stringify([{ body: marker, author_association: "MEMBER" }]), stderr: "" };
+        if (target.includes("required_status_checks")) return { exitCode: 0, stdout: JSON.stringify({ contexts: ["🧪 CI"], checks: [] }), stderr: "" };
+        if (target.includes("check-runs")) return { exitCode: 1, stdout: "", stderr: "rate limited" };
+        if (target.endsWith("/status")) return { exitCode: 0, stdout: JSON.stringify({ statuses: [] }), stderr: "" };
+        if (argv[0] === "gh" && argv[1] === "pr" && argv[2] === "edit") return { exitCode: 0, stdout: "", stderr: "" };
+        throw new Error(`unexpected argv ${argv.join(" ")}`);
+      },
+    };
+
+    await expect(sync(runner, true)).rejects.toThrow("gh api check runs failed (1): rate limited");
+    expect(calls.some((argv) => argv[0] === "gh" && argv[1] === "pr" && argv[2] === "edit")).toBe(false);
   });
 });
 
@@ -192,6 +329,24 @@ describe("managed issue branches", () => {
     expect(issueNumberFromBranch("refactor/issue-1032")).toBe(1032);
     expect(issueNumberFromBranch("feat/issue-1032")).toBe(1032);
     expect(issueNumberFromBranch("feature/nested/issue-1032")).toBeNull();
+  });
+
+  test("accepts only a real direct child of .worktrees", () => {
+    const root = mkdtempSync(join(tmpdir(), "kesha-conveyor-worktree-"));
+    const managed = join(root, ".worktrees");
+    const direct = join(managed, "issue-1032");
+    const nested = join(direct, "nested");
+    const linked = join(managed, "linked-issue-1032");
+    try {
+      mkdirSync(nested, { recursive: true });
+      symlinkSync(direct, linked, "dir");
+
+      expect(isDirectManagedWorktree(direct, managed)).toBe(true);
+      expect(isDirectManagedWorktree(nested, managed)).toBe(false);
+      expect(isDirectManagedWorktree(linked, managed)).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   test("reports any single-prefix branch without WIP as orphaned", () => {
@@ -214,6 +369,7 @@ describe("backlog close", () => {
     };
 
     expect(evaluateClose(facts).refusals).toContain("matching worktree is dirty");
+    expect(evaluateClose(facts).safeActions).toEqual([]);
   });
 
   test("is idempotent after the issue and worktree are already cleaned", () => {
@@ -227,5 +383,16 @@ describe("backlog close", () => {
     expect(result.violations).toEqual([]);
     expect(result.refusals).toEqual([]);
     expect(result.safeActions).toEqual([]);
+  });
+
+  test("refuses an outside worktree without offering WIP cleanup", () => {
+    const facts: CloseFacts = {
+      issue: { number: 1032, state: "CLOSED", labels: ["WIP"] },
+      pullRequest: { number: 1040, state: "MERGED", closingIssueNumbers: [1032] },
+      worktree: { path: "/elsewhere/issue-1032", branch: "chore/issue-1032", dirty: false, insideManagedDirectory: false },
+    };
+
+    expect(evaluateClose(facts).refusals).toContain("matching worktree is outside the managed .worktrees directory");
+    expect(evaluateClose(facts).safeActions).toEqual([]);
   });
 });

--- a/tests/unit/backlog-conveyor.test.ts
+++ b/tests/unit/backlog-conveyor.test.ts
@@ -75,6 +75,8 @@ describe("backlog gate", () => {
     });
     expect(() => parseGateEvidence({ ...evidence, verdict: "PENDING" })).toThrow("verdict must be APPROVED");
     expect(() => parseGateEvidence({ ...evidence, headSha: "not-a-sha" })).toThrow("headSha must be a Git SHA");
+    expect(() => parseGateEvidence({ ...evidence, uri: "" })).toThrow("uri must be a non-empty string");
+    expect(() => parseGateEvidence({ ...evidence, digest: "not-a-digest" })).toThrow("digest must be a SHA-256 digest");
   });
 });
 

--- a/tests/unit/backlog-conveyor.test.ts
+++ b/tests/unit/backlog-conveyor.test.ts
@@ -145,6 +145,32 @@ describe("backlog gate", () => {
     expect(evaluateGate(facts).violations).not.toContain("required check '🧪 CI' is FAILURE");
   });
 
+  test("loads all check-run attempts so a second-page success supersedes an older failure", async () => {
+    const checkRunTargets: string[] = [];
+    const olderFailure = { id: 1, name: "🧪 CI", status: "completed", conclusion: "failure", app: { id: 17 }, started_at: "2026-08-14T10:00:00Z", completed_at: "2026-08-14T10:01:00Z" };
+    const filler = Array.from({ length: 99 }, (_, index) => ({ id: index + 10, name: `other-${index}`, status: "completed", conclusion: "success", app: { id: 17 }, started_at: "2026-08-14T10:00:00Z", completed_at: "2026-08-14T10:01:00Z" }));
+    const newerSuccess = { id: 2, name: "🧪 CI", status: "completed", conclusion: "success", app: { id: 17 }, started_at: "2026-08-14T11:00:00Z", completed_at: "2026-08-14T11:01:00Z" };
+    const runner: Runner = {
+      async run(argv) {
+        const target = argv[2] ?? "";
+        if (target.includes("check-runs")) {
+          checkRunTargets.push(target);
+          const page = new URL(`https://example.test/${target}`).searchParams.get("page");
+          return { exitCode: 0, stderr: "", stdout: JSON.stringify({ check_runs: page === "2" ? [newerSuccess] : [olderFailure, ...filler] }) };
+        }
+        return { exitCode: 0, stderr: "", stdout: JSON.stringify({ statuses: [] }) };
+      },
+    };
+
+    const facts = gateFacts({ checks: await loadChecks(runner, { owner: "o", name: "r" }, head), requiredChecks: [{ context: "🧪 CI", appId: 17 }] });
+
+    expect(checkRunTargets).toEqual([
+      `repos/o/r/commits/${head}/check-runs?filter=all&per_page=100&page=1`,
+      `repos/o/r/commits/${head}/check-runs?filter=all&per_page=100&page=2`,
+    ]);
+    expect(evaluateGate(facts).violations).not.toContain("required check '🧪 CI' is FAILURE");
+  });
+
   test("rejects a matching check name from the wrong protected app", () => {
     const facts = gateFacts({
       checks: [{ name: "🧪 CI", state: "SUCCESS", appId: 99, attemptAt: "2026-08-14T11:00:00Z", id: 2 }],

--- a/tests/unit/backlog-conveyor.test.ts
+++ b/tests/unit/backlog-conveyor.test.ts
@@ -5,6 +5,7 @@ import {
   evaluateGate,
   evaluateSync,
   issueNumberFromBranch,
+  loadChecks,
   loadMarker,
   parseGateEvidence,
   type CloseFacts,
@@ -40,7 +41,7 @@ function gateFacts(overrides: Partial<GateFacts> = {}): GateFacts {
       reviews: [{ state: "APPROVED", author: "reviewer", commitSha: head, submittedAt: "2026-08-14T10:00:00Z" }],
     },
     requiredChecks: [{ context: "🧪 CI", appId: null }],
-    checks: [{ name: "🧪 CI", state: "SUCCESS", appId: null, observedAt: "2026-08-14T10:00:00Z", id: 1 }],
+    checks: [{ name: "🧪 CI", state: "SUCCESS", appId: null, attemptAt: "2026-08-14T10:00:00Z", id: 1 }],
     evidence,
     marker: null,
     ...overrides,
@@ -68,7 +69,7 @@ describe("backlog gate", () => {
   });
 
   test("rejects skipped, pending, or absent required checks", () => {
-    const facts = gateFacts({ checks: [{ name: "🧪 CI", state: "SKIPPED", appId: null, observedAt: "2026-08-14T10:00:00Z", id: 1 }] });
+    const facts = gateFacts({ checks: [{ name: "🧪 CI", state: "SKIPPED", appId: null, attemptAt: "2026-08-14T10:00:00Z", id: 1 }] });
 
     expect(evaluateGate(facts).violations).toContain("required check '🧪 CI' is SKIPPED");
   });
@@ -88,9 +89,36 @@ describe("backlog gate", () => {
   test("uses the latest matching check attempt rather than an older failure", () => {
     const facts = gateFacts({
       checks: [
-        { name: "🧪 CI", state: "FAILURE", appId: 17, observedAt: "2026-08-14T10:00:00Z", id: 1 },
-        { name: "🧪 CI", state: "SUCCESS", appId: 17, observedAt: "2026-08-14T11:00:00Z", id: 2 },
+        { name: "🧪 CI", state: "FAILURE", appId: 17, attemptAt: "2026-08-14T10:00:00Z", id: 1 },
+        { name: "🧪 CI", state: "SUCCESS", appId: 17, attemptAt: "2026-08-14T11:00:00Z", id: 2 },
       ],
+      requiredChecks: [{ context: "🧪 CI", appId: 17 }],
+    });
+
+    expect(evaluateGate(facts).violations).not.toContain("required check '🧪 CI' is FAILURE");
+  });
+
+  test("uses an attempt start time when an older parallel run finishes later", async () => {
+    const runner: Runner = {
+      async run(argv) {
+        const target = argv[2] ?? "";
+        if (target.includes("check-runs")) {
+          return {
+            exitCode: 0,
+            stderr: "",
+            stdout: JSON.stringify({
+              check_runs: [
+                { id: 1, name: "🧪 CI", status: "completed", conclusion: "failure", app: { id: 17 }, started_at: "2026-08-14T10:00:00Z", completed_at: "2026-08-14T12:00:00Z" },
+                { id: 2, name: "🧪 CI", status: "completed", conclusion: "success", app: { id: 17 }, started_at: "2026-08-14T11:00:00Z", completed_at: "2026-08-14T11:30:00Z" },
+              ],
+            }),
+          };
+        }
+        return { exitCode: 0, stderr: "", stdout: JSON.stringify({ statuses: [] }) };
+      },
+    };
+    const facts = gateFacts({
+      checks: await loadChecks(runner, { owner: "o", name: "r" }, head),
       requiredChecks: [{ context: "🧪 CI", appId: 17 }],
     });
 
@@ -99,7 +127,7 @@ describe("backlog gate", () => {
 
   test("rejects a matching check name from the wrong protected app", () => {
     const facts = gateFacts({
-      checks: [{ name: "🧪 CI", state: "SUCCESS", appId: 99, observedAt: "2026-08-14T11:00:00Z", id: 2 }],
+      checks: [{ name: "🧪 CI", state: "SUCCESS", appId: 99, attemptAt: "2026-08-14T11:00:00Z", id: 2 }],
       requiredChecks: [{ context: "🧪 CI", appId: 17 }],
     });
 

--- a/tests/unit/backlog-conveyor.test.ts
+++ b/tests/unit/backlog-conveyor.test.ts
@@ -3,12 +3,20 @@ import {
   evaluateClose,
   evaluateGate,
   evaluateSync,
+  parseGateEvidence,
   type CloseFacts,
   type GateFacts,
   type SyncFacts,
 } from "../../scripts/backlog-conveyor";
 
 const head = "a".repeat(40);
+const evidence = {
+  provider: "independent-review-system",
+  verdict: "APPROVED" as const,
+  headSha: head,
+  uri: "https://reviews.example.test/evidence/1",
+  digest: "c".repeat(64),
+};
 
 function gateFacts(overrides: Partial<GateFacts> = {}): GateFacts {
   return {
@@ -28,6 +36,7 @@ function gateFacts(overrides: Partial<GateFacts> = {}): GateFacts {
     },
     requiredContexts: ["🧪 CI"],
     checks: [{ name: "🧪 CI", state: "SUCCESS" }],
+    evidence,
     marker: null,
     ...overrides,
   };
@@ -58,6 +67,15 @@ describe("backlog gate", () => {
 
     expect(evaluateGate(facts).violations).toContain("required check '🧪 CI' is SKIPPED");
   });
+
+  test("accepts arbitrary evidence providers but validates verdict and SHA", () => {
+    expect(parseGateEvidence({ ...evidence, provider: "any-future-orchestrator" })).toEqual({
+      ...evidence,
+      provider: "any-future-orchestrator",
+    });
+    expect(() => parseGateEvidence({ ...evidence, verdict: "PENDING" })).toThrow("verdict must be APPROVED");
+    expect(() => parseGateEvidence({ ...evidence, headSha: "not-a-sha" })).toThrow("headSha must be a Git SHA");
+  });
 });
 
 describe("backlog sync", () => {
@@ -71,7 +89,7 @@ describe("backlog sync", () => {
           headSha: head,
           labels: ["merge-ready"],
           closingIssueNumbers: [1032],
-          marker: { version: 1, issue: 1032, pr: 1040, headSha: "b".repeat(40), reviewer: "reviewer", approvedAt: "2026-08-14T10:00:00Z" },
+          marker: { version: 1, issue: 1032, pr: 1040, evidence: { ...evidence, headSha: "b".repeat(40) } },
         },
       ],
       worktrees: [],


### PR DESCRIPTION
Closes #1032

## Summary

- add the tracked, agent-agnostic `bun run conveyor` command with `sync`, `gate`, and `close`
- bind durable gate evidence to the exact PR head through a versioned GitHub marker
- enforce current-head independent approval, exact closing issue, default-base eligibility, and required green checks
- reconcile stale labels and safely refuse dirty or out-of-directory worktree cleanup

## Validation

- `bun test tests/unit/backlog-conveyor.test.ts`
- `bun run lint`
- `bun run check:specs`
- `just preflight`

The preflight was run once with an isolated `TMPDIR` after terminating stale prior test process groups; it completed with exit 0.
