### PR TITLE
feat: add conveyor priority metrics

### DIFF
--- a/openspec/changes/backlog-conveyor-priority-metrics/design.md
+++ b/openspec/changes/backlog-conveyor-priority-metrics/design.md
@@ -50,7 +50,8 @@ counts scan all open issues and merge-ready counts scan all open pull requests r
 `since`. A historical gate is the newest valid marker by `(createdAt, databaseId)`, independent
 of open-PR gate eligibility: it is trusted, strict/digest-valid, has marker PR equal to its
 comment container, marker issue equal to the PR's sole closing issue, and evidence SHA equal to
-the PR head. For valid chronology
+the PR head. A PR without exactly one closing issue is simply ungated, not a report error; the
+closing-issue read occurs only after a trusted container/head-matching candidate marker exists. For valid chronology
 it calculates durations in seconds for `open→gate`, `gate→merge`, and `open→merge`; each reports sample size,
 median (average of middle pair for even samples), and nearest-rank p90 on sorted values. A missing
 sample is null, never zero. Negative, non-finite, or otherwise invalid durations are rejected

--- a/openspec/changes/backlog-conveyor-priority-metrics/design.md
+++ b/openspec/changes/backlog-conveyor-priority-metrics/design.md
@@ -11,8 +11,8 @@ measurements without making the authenticated account or opaque provider field a
 ### Priority is manifest input, not prose inference
 
 `prioritize` reads a JSON manifest with `version: 1`, a positive existing open issue number, an opaque
-non-empty provider, dimensions `impact`, `urgency`, `unblock`, and `riskReduction` in 0..5,
-`confidence` and `effort` in 1..5, plus a concise non-empty rationale. It never accepts a
+non-empty opaque provider of at most 256 trimmed characters, dimensions `impact`, `urgency`, `unblock`, and `riskReduction` in 0..5,
+`confidence` and `effort` in 1..5, plus a concise trimmed non-empty rationale of at most 280 characters. It never accepts a
 caller score. The canonical score is rounded to two decimals from
 `((4*impact + 3*urgency + 2*unblock + 2*riskReduction) * confidence / effort)`.
 

--- a/openspec/changes/backlog-conveyor-priority-metrics/design.md
+++ b/openspec/changes/backlog-conveyor-priority-metrics/design.md
@@ -1,0 +1,62 @@
+# Design — backlog conveyor priority and lifecycle metrics
+
+## Context
+
+The existing conveyor treats GitHub facts and trusted versioned markers as its durable
+boundaries. Phase 3 adds a deliberately mechanical priority policy and aggregate lifecycle
+measurements without making the authenticated account or opaque provider field authoritative.
+
+## Decisions
+
+### Priority is manifest input, not prose inference
+
+`prioritize` reads a JSON manifest with `version: 1`, a positive existing open issue number, an opaque
+non-empty provider, dimensions `impact`, `urgency`, `unblock`, and `riskReduction` in 0..5,
+`confidence` and `effort` in 1..5, plus a concise non-empty rationale. It never accepts a
+caller score. The canonical score is rounded to two decimals from
+`((4*impact + 3*urgency + 2*unblock + 2*riskReduction) * confidence / effort)`.
+
+The applied comment is a versioned structured marker containing the normalized assessment and
+computed score. Only `OWNER`, `MEMBER`, and `COLLABORATOR` comments are trusted. Valid
+lookalikes from another association are ignored. A trusted marker carrying the real prefix but
+malformed payload is an operational failure, so partial or compromised trusted state cannot
+silently affect ordering. Markers order by `(createdAt, databaseId)`, and the latest trusted
+assessment wins. Under `--apply`, the marker is posted, every comment page is read again, and
+the command reports acceptance only if that exact posted marker is still current; identical
+current input is idempotent with no new comment.
+
+### Queue is a complete, deterministic GitHub view
+
+`queue` reads all open issues and all relevant issue-comment pages. It excludes WIP,
+needs-decision, and wontfix labelled issues, and it never includes pull requests. Optional
+label filtering is exact. The result sorts assessed issues by descending score, then oldest
+`createdAt`, then issue number; visible unassessed issues have score zero and come after every
+assessed issue. It emits component dimensions and rationale, not an inferred explanation. Any
+page cap, malformed response, or malformed trusted marker fails closed.
+
+### Metrics use only GitHub lifecycle facts and trusted gate markers
+
+`metrics --since` rejects a lower bound after an injected `now` and evaluates facts at that fixed
+upper bound, making tests deterministic. It reports the bounds, merged PR count, gated PR count,
+current WIP count, and current merge-ready count. Merged counts and merge-ended samples include
+only `mergedAt` in `[since, now]`; gated counts and open→gate samples include only trusted marker
+creation times in `[since, now]`; and merge-ended samples allow an earlier valid gate. Current WIP
+and merge-ready counts scan all currently open issues regardless of `since`. For valid chronology
+it calculates durations `open→gate`, `gate→merge`, and `open→merge`; each reports sample size,
+median (average of middle pair for even samples), and nearest-rank p90 on sorted values. A missing
+sample is null, never zero. Negative, non-finite, or otherwise invalid durations are rejected
+rather than clamped. Gate times come only from trusted valid gate markers; the ignored local ledger
+is never read. Complete pagination and parsing are prerequisites to a report.
+
+## Risks / Trade-offs
+
+- Issue comments have concurrent writers. Rereading after an applied marker favours truthful
+  current-state reporting over claiming a now-superseded write was accepted.
+- GitHub list endpoints expose a finite per-page API. Reaching a configured cap is a failure,
+  rather than silently reporting a partial queue or metric.
+- Scores describe an explicit policy, not objective truth; the rationale and components remain
+  visible for review.
+
+## Open Questions
+
+- None. The owner-approved issue body fixes the scoring weights and command surface.

--- a/openspec/changes/backlog-conveyor-priority-metrics/design.md
+++ b/openspec/changes/backlog-conveyor-priority-metrics/design.md
@@ -21,28 +21,37 @@ computed score. Only `OWNER`, `MEMBER`, and `COLLABORATOR` comments are trusted.
 lookalikes from another association are ignored. A trusted marker carrying the real prefix but
 malformed payload is an operational failure, so partial or compromised trusted state cannot
 silently affect ordering. Markers order by `(createdAt, databaseId)`, and the latest trusted
-assessment wins. Under `--apply`, the marker is posted, every comment page is read again, and
-the command reports acceptance only if that exact posted marker is still current; identical
-current input is idempotent with no new comment.
+assessment wins. Under `--apply`, the marker is posted, its REST response comment id is parsed,
+and every comment page is read again; the command reports acceptance only if that exact posted id
+is still current. Identity compares every normalized assessment field, including opaque provider
+and rationale, but excludes derived score and comment transport; identical current input is
+idempotent with no new comment.
 
 ### Queue is a complete, deterministic GitHub view
 
-`queue` reads all open issues and all relevant issue-comment pages. It excludes WIP,
-needs-decision, and wontfix labelled issues, and it never includes pull requests. Optional
-label filtering is exact. The result sorts assessed issues by descending score, then oldest
+`queue` reads all open issues and all relevant issue-comment pages through REST `per_page=100`
+pages from 1 through a finite cap, stopping only on a short page and failing at a cap without one.
+It excludes WIP, needs-decision, and wontfix labelled issues, and it never includes pull requests.
+Optional label filtering is exact. `--limit` is a bounded positive integer applied after sorting.
+The result sorts assessed issues by descending score, then oldest
 `createdAt`, then issue number; visible unassessed issues have score zero and come after every
 assessed issue. It emits component dimensions and rationale, not an inferred explanation. Any
 page cap, malformed response, or malformed trusted marker fails closed.
 
 ### Metrics use only GitHub lifecycle facts and trusted gate markers
 
-`metrics --since` rejects a lower bound after an injected `now` and evaluates facts at that fixed
-upper bound, making tests deterministic. It reports the bounds, merged PR count, gated PR count,
+`metrics --since` rejects a lower bound after an injected `now`, captured before reads, and
+evaluates facts at that fixed upper bound, making tests deterministic; bounds are an event filter,
+not a transactional snapshot. It reports stable JSON keys and nullability for the bounds, merged PR count, gated PR count,
 current WIP count, and current merge-ready count. Merged counts and merge-ended samples include
 only `mergedAt` in `[since, now]`; gated counts and open→gate samples include only trusted marker
 creation times in `[since, now]`; and merge-ended samples allow an earlier valid gate. Current WIP
-and merge-ready counts scan all currently open issues regardless of `since`. For valid chronology
-it calculates durations `open→gate`, `gate→merge`, and `open→merge`; each reports sample size,
+counts scan all open issues and merge-ready counts scan all open pull requests regardless of
+`since`. A historical gate is the newest valid marker by `(createdAt, databaseId)`, independent
+of open-PR gate eligibility: it is trusted, strict/digest-valid, has marker PR equal to its
+comment container, marker issue equal to the PR's sole closing issue, and evidence SHA equal to
+the PR head. For valid chronology
+it calculates durations in seconds for `open→gate`, `gate→merge`, and `open→merge`; each reports sample size,
 median (average of middle pair for even samples), and nearest-rank p90 on sorted values. A missing
 sample is null, never zero. Negative, non-finite, or otherwise invalid durations are rejected
 rather than clamped. Gate times come only from trusted valid gate markers; the ignored local ledger

--- a/openspec/changes/backlog-conveyor-priority-metrics/design.md
+++ b/openspec/changes/backlog-conveyor-priority-metrics/design.md
@@ -32,7 +32,7 @@ idempotent with no new comment.
 `queue` reads all open issues and all relevant issue-comment pages through REST `per_page=100`
 pages from 1 through a finite cap, stopping only on a short page and failing at a cap without one.
 It excludes WIP, needs-decision, and wontfix labelled issues, and it never includes pull requests.
-Optional label filtering is exact. `--limit` is a bounded positive integer applied after sorting.
+Optional label filtering is exact. `--limit` is an integer in 1..1000 applied after sorting.
 The result sorts assessed issues by descending score, then oldest
 `createdAt`, then issue number; visible unassessed issues have score zero and come after every
 assessed issue. It emits component dimensions and rationale, not an inferred explanation. Any

--- a/openspec/changes/backlog-conveyor-priority-metrics/proposal.md
+++ b/openspec/changes/backlog-conveyor-priority-metrics/proposal.md
@@ -1,0 +1,29 @@
+# Backlog conveyor priority and lifecycle metrics
+
+## Why
+
+Phase 3 makes an issue queue explainable without turning prose, a provider identity, or a
+model into scheduling authority. It also supplies aggregate lifecycle timing facts so the
+conveyor can be improved from observed GitHub state.
+
+## What Changes
+
+- Add versioned manifest-backed `prioritize` assessments and read-only `queue` ordering.
+- Add read-only `metrics --since <ISO timestamp>` aggregate PR lifecycle measurements.
+- Preserve schema version 1, existing exit codes, dry-run defaults, trusted-marker rules,
+  and argv-only GitHub calls.
+
+## Non-goals
+
+- Semantic scoring from prose or an LLM, provider ranking, auto-starting work, label changes,
+  auto-merge, a UI, daemon, cron job, or external database.
+- Reading the ignored coordination ledger for metrics.
+
+## Impact
+
+- `scripts/backlog-priority.ts` owns pure validation, scoring, ordering, marker parsing, and
+  lifecycle aggregation.
+- `scripts/backlog-conveyor.ts` owns complete, validated GitHub reads and the applied marker
+  boundary.
+- `scripts/backlog.ts` owns the CLI grammar and report formatting.
+- `tests/unit/backlog-priority.test.ts` provides fake-runner behavioural coverage.

--- a/openspec/changes/backlog-conveyor-priority-metrics/specs/backlog-conveyor/spec.md
+++ b/openspec/changes/backlog-conveyor-priority-metrics/specs/backlog-conveyor/spec.md
@@ -9,8 +9,10 @@ rationale. It SHALL derive, rather than accept, the two-decimal score
 `round(((4*impact + 3*urgency + 2*unblock + 2*riskReduction) * confidence / effort) * 100) / 100`.
 The command SHALL remain dry-run unless applied, publish a versioned structured marker when
 needed, trust only OWNER, MEMBER, or COLLABORATOR markers, and reread all pages after a write.
-A repeated identical current assessment SHALL be idempotent, and the latest trusted marker by
-`(createdAt, databaseId)` SHALL supersede earlier assessments.
+A repeated identical normalized assessment SHALL be idempotent, and the latest trusted marker by
+`(createdAt, databaseId)` SHALL supersede earlier assessments. Under apply, the conveyor SHALL
+parse the REST-created comment id and report accepted only when that exact id remains current
+after complete comment pagination.
 
 #### Scenario: Ira applies an assessment
 
@@ -31,8 +33,10 @@ The conveyor SHALL expose `queue [--label <name>] [--limit <N>] [--json]` as a r
 of open issues and trusted priority markers. It SHALL exclude WIP, needs-decision, and wontfix
 labels and pull requests; sort assessed entries by descending score, then oldest creation time,
 then issue number; and place visible unassessed entries at score zero after assessed entries.
-It SHALL emit score components and rationale, honour an exact optional label, and fail closed on
-incomplete pagination or malformed trusted markers.
+It SHALL emit score components and rationale, honour an exact optional label, apply a bounded
+positive integer limit only after ordering, and fail closed on incomplete pagination or malformed
+trusted markers. Every paginated collection SHALL use REST `per_page=100`, start at page 1, stop
+only after a short page, and fail when its finite cap is reached without a short page.
 
 #### Scenario: Sona views a mixed queue
 
@@ -49,13 +53,20 @@ incomplete pagination or malformed trusted markers.
 ### Requirement: The conveyor SHALL aggregate lifecycle metrics from GitHub facts and trusted gates
 
 The conveyor SHALL expose read-only `metrics --since <ISO timestamp> [--json]` using GitHub
-issue and PR facts and trusted gate markers only. It SHALL reject `since` after its report upper
+issue and PR facts and trusted gate markers only. It SHALL capture its report upper bound before
+reads, reject `since` after that bound, and use bounds as an event filter rather than a
+transactional snapshot. It SHALL reject `since` after its report upper
 bound; include merged counts and merge-ended samples only for `mergedAt` within inclusive bounds;
 include gated counts and open→gate samples only for trusted gate-marker creation within bounds;
-allow an earlier valid gate for merge-ended samples; and count all currently open WIP and
-merge-ready issues regardless of bounds. It SHALL report sample size, median, and nearest-rank
-p90 for valid PR-open→gate, gate→merge, and PR-open→merge durations. It SHALL use null for an
-empty sample, reject negative or non-finite chronology, and never read the ignored ledger.
+allow an earlier valid gate for merge-ended samples; and count all currently open WIP issues and
+open merge-ready pull requests regardless of bounds. A historical gate SHALL be the latest valid
+trusted marker by `(createdAt, databaseId)` whose marker PR equals its comment container, whose
+marker issue equals that PR's sole closing issue, and whose evidence SHA equals that PR head SHA;
+this validation is independent of open-PR gate eligibility. It SHALL report seconds, sample size,
+median, and nearest-rank p90 for valid PR-open→gate, gate→merge, and PR-open→merge durations with
+stable JSON keys and null for an empty sample; reject negative or non-finite chronology; and never
+read the ignored ledger. Every paginated collection SHALL use REST `per_page=100`, start at page 1,
+stop only after a short page, and fail when its finite cap is reached without a short page.
 
 #### Scenario: Maks measures a completed lifecycle
 

--- a/openspec/changes/backlog-conveyor-priority-metrics/specs/backlog-conveyor/spec.md
+++ b/openspec/changes/backlog-conveyor-priority-metrics/specs/backlog-conveyor/spec.md
@@ -33,8 +33,8 @@ The conveyor SHALL expose `queue [--label <name>] [--limit <N>] [--json]` as a r
 of open issues and trusted priority markers. It SHALL exclude WIP, needs-decision, and wontfix
 labels and pull requests; sort assessed entries by descending score, then oldest creation time,
 then issue number; and place visible unassessed entries at score zero after assessed entries.
-It SHALL emit score components and rationale, honour an exact optional label, apply a bounded
-positive integer limit only after ordering, and fail closed on incomplete pagination or malformed
+It SHALL emit score components and rationale, honour an exact optional label, apply an integer
+limit in 1..1000 only after ordering, and fail closed on incomplete pagination or malformed
 trusted markers. Every paginated collection SHALL use REST `per_page=100`, start at page 1, stop
 only after a short page, and fail when its finite cap is reached without a short page.
 

--- a/openspec/changes/backlog-conveyor-priority-metrics/specs/backlog-conveyor/spec.md
+++ b/openspec/changes/backlog-conveyor-priority-metrics/specs/backlog-conveyor/spec.md
@@ -62,7 +62,8 @@ allow an earlier valid gate for merge-ended samples; and count all currently ope
 open merge-ready pull requests regardless of bounds. A historical gate SHALL be the latest valid
 trusted marker by `(createdAt, databaseId)` whose marker PR equals its comment container, whose
 marker issue equals that PR's sole closing issue, and whose evidence SHA equals that PR head SHA;
-this validation is independent of open-PR gate eligibility. It SHALL report seconds, sample size,
+a PR without exactly one closing issue SHALL be ungated rather than fail the aggregate. This
+validation is independent of open-PR gate eligibility. It SHALL report seconds, sample size,
 median, and nearest-rank p90 for valid PR-open→gate, gate→merge, and PR-open→merge durations with
 stable JSON keys and null for an empty sample; reject negative or non-finite chronology; and never
 read the ignored ledger. Every paginated collection SHALL use REST `per_page=100`, start at page 1,

--- a/openspec/changes/backlog-conveyor-priority-metrics/specs/backlog-conveyor/spec.md
+++ b/openspec/changes/backlog-conveyor-priority-metrics/specs/backlog-conveyor/spec.md
@@ -1,0 +1,80 @@
+## ADDED Requirements
+
+### Requirement: The conveyor SHALL record explainable priority assessments without provider identity authority
+
+The conveyor SHALL accept `prioritize --manifest <path> [--apply] [--json]` with a version 1
+manifest containing a positive existing open issue, opaque non-empty provider, integer impact, urgency,
+unblock, and riskReduction values in 0..5, confidence and effort values in 1..5, and a concise
+rationale. It SHALL derive, rather than accept, the two-decimal score
+`round(((4*impact + 3*urgency + 2*unblock + 2*riskReduction) * confidence / effort) * 100) / 100`.
+The command SHALL remain dry-run unless applied, publish a versioned structured marker when
+needed, trust only OWNER, MEMBER, or COLLABORATOR markers, and reread all pages after a write.
+A repeated identical current assessment SHALL be idempotent, and the latest trusted marker by
+`(createdAt, databaseId)` SHALL supersede earlier assessments.
+
+#### Scenario: Ira applies an assessment
+
+- GIVEN Ira has a valid version 1 manifest for open issue 1036
+- WHEN Ira runs `prioritize --manifest assessment.json --apply --json`
+- THEN the report accepts the exact current structured marker and its computed score
+- AND no provider value is treated as an account identity
+
+#### Scenario: Maks supplies an unsafe marker
+
+- GIVEN a trusted comment carries the priority marker prefix with malformed JSON
+- WHEN Maks runs `prioritize` or `queue`
+- THEN the conveyor fails closed without publishing an assessment
+
+### Requirement: The conveyor SHALL present a deterministic assessed issue queue
+
+The conveyor SHALL expose `queue [--label <name>] [--limit <N>] [--json]` as a read-only view
+of open issues and trusted priority markers. It SHALL exclude WIP, needs-decision, and wontfix
+labels and pull requests; sort assessed entries by descending score, then oldest creation time,
+then issue number; and place visible unassessed entries at score zero after assessed entries.
+It SHALL emit score components and rationale, honour an exact optional label, and fail closed on
+incomplete pagination or malformed trusted markers.
+
+#### Scenario: Sona views a mixed queue
+
+- GIVEN two assessed visible issues and one unassessed visible issue
+- WHEN Sona runs `queue --json`
+- THEN the assessed issues appear in deterministic score order followed by the unassessed issue
+
+#### Scenario: Ira reaches an incomplete page cap
+
+- GIVEN the open issue listing reaches its configured cap
+- WHEN Ira runs `queue`
+- THEN the conveyor returns an operational failure instead of a partial queue
+
+### Requirement: The conveyor SHALL aggregate lifecycle metrics from GitHub facts and trusted gates
+
+The conveyor SHALL expose read-only `metrics --since <ISO timestamp> [--json]` using GitHub
+issue and PR facts and trusted gate markers only. It SHALL reject `since` after its report upper
+bound; include merged counts and merge-ended samples only for `mergedAt` within inclusive bounds;
+include gated counts and open→gate samples only for trusted gate-marker creation within bounds;
+allow an earlier valid gate for merge-ended samples; and count all currently open WIP and
+merge-ready issues regardless of bounds. It SHALL report sample size, median, and nearest-rank
+p90 for valid PR-open→gate, gate→merge, and PR-open→merge durations. It SHALL use null for an
+empty sample, reject negative or non-finite chronology, and never read the ignored ledger.
+
+#### Scenario: Maks measures a completed lifecycle
+
+- GIVEN a trusted gate marker and merged PR after the lower bound
+- WHEN Maks runs `metrics --since 2026-08-01T00:00:00Z --json`
+- THEN the report includes its valid lifecycle samples and aggregate percentiles
+
+#### Scenario: Sona has no gate-to-merge samples
+
+- GIVEN no PR has both a valid gate time and merge time in the window
+- WHEN Sona runs `metrics --since 2026-08-01T00:00:00Z`
+- THEN gate-to-merge metrics are null rather than zero
+
+#### Scenario: Ira supplies an invalid metric window
+
+- GIVEN Ira supplies a `since` timestamp after the report upper bound
+- WHEN Ira runs `metrics`
+- THEN the conveyor rejects the invalid window instead of producing a partial aggregate
+
+> _Technical Note — sources: `scripts/backlog.ts` owns CLI parsing and report output;
+> `scripts/backlog-conveyor.ts` owns validated GitHub pagination; `scripts/backlog-priority.ts`
+> owns pure assessment and aggregate lifecycle policy._

--- a/openspec/changes/backlog-conveyor-priority-metrics/specs/backlog-conveyor/spec.md
+++ b/openspec/changes/backlog-conveyor-priority-metrics/specs/backlog-conveyor/spec.md
@@ -3,9 +3,9 @@
 ### Requirement: The conveyor SHALL record explainable priority assessments without provider identity authority
 
 The conveyor SHALL accept `prioritize --manifest <path> [--apply] [--json]` with a version 1
-manifest containing a positive existing open issue, opaque non-empty provider, integer impact, urgency,
+manifest containing a positive existing open issue, opaque trimmed provider of at most 256 characters, integer impact, urgency,
 unblock, and riskReduction values in 0..5, confidence and effort values in 1..5, and a concise
-rationale. It SHALL derive, rather than accept, the two-decimal score
+trimmed rationale of at most 280 characters. It SHALL derive, rather than accept, the two-decimal score
 `round(((4*impact + 3*urgency + 2*unblock + 2*riskReduction) * confidence / effort) * 100) / 100`.
 The command SHALL remain dry-run unless applied, publish a versioned structured marker when
 needed, trust only OWNER, MEMBER, or COLLABORATOR markers, and reread all pages after a write.

--- a/openspec/changes/backlog-conveyor-priority-metrics/tasks.md
+++ b/openspec/changes/backlog-conveyor-priority-metrics/tasks.md
@@ -1,8 +1,8 @@
 # Tasks
 
-- [ ] Add the Phase 3 proposal, design, and delta specification.
-- [ ] Write failing unit tests for manifest validation, score ordering, marker trust, and metrics percentiles.
-- [ ] Implement the extracted pure priority/metrics module and focused GitHub boundary.
-- [ ] Add CLI parsing and reporting for `prioritize`, `queue`, and `metrics`.
-- [ ] Record RED and sabotage evidence; run focused tests after each slice.
+- [x] Add the Phase 3 proposal, design, and delta specification.
+- [x] Write failing unit tests for manifest validation, score ordering, marker trust, and metrics percentiles.
+- [x] Implement the extracted pure priority/metrics module and focused GitHub boundary.
+- [x] Add CLI parsing and reporting for `prioritize`, `queue`, and `metrics`.
+- [x] Record RED and sabotage evidence; run focused tests after each slice.
 - [ ] Validate OpenSpec, lint, and preflight under a released conveyor lease; push and open a draft PR.

--- a/openspec/changes/backlog-conveyor-priority-metrics/tasks.md
+++ b/openspec/changes/backlog-conveyor-priority-metrics/tasks.md
@@ -1,0 +1,8 @@
+# Tasks
+
+- [ ] Add the Phase 3 proposal, design, and delta specification.
+- [ ] Write failing unit tests for manifest validation, score ordering, marker trust, and metrics percentiles.
+- [ ] Implement the extracted pure priority/metrics module and focused GitHub boundary.
+- [ ] Add CLI parsing and reporting for `prioritize`, `queue`, and `metrics`.
+- [ ] Record RED and sabotage evidence; run focused tests after each slice.
+- [ ] Validate OpenSpec, lint, and preflight under a released conveyor lease; push and open a draft PR.

--- a/scripts/backlog-conveyor.ts
+++ b/scripts/backlog-conveyor.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { existsSync, lstatSync, realpathSync } from "node:fs";
 import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
 import { acquireLease, claimOrder, encodeClaimMarker, evaluateCollisionPlan, isLiveClaim, issueNumberFromBranch, leaseDirectory, normalizedPath, parseClaimManifest, parseClaimMarker, releaseLease, sameManifest, statusLease, timestamp, type ClaimManifest, type ClaimMarker, type ClaimRecord, type CollisionPlan, type LeaseResult, type LeaseState } from "./backlog-coordination";
+import { encodePriorityMarker, evaluateMetrics, parsePriorityMarker, selectCurrentAssessment, sortQueue, type LifecycleIssue, type LifecyclePullRequest, type PriorityAssessment, type PriorityComment, type QueueEntry } from "./backlog-priority";
 
 export { acquireLease, encodeClaimMarker, evaluateCollisionPlan, issueNumberFromBranch, leaseDirectory, parseClaimManifest, releaseLease, statusLease } from "./backlog-coordination";
 export type { ClaimManifest, ClaimMarker, ClaimRecord, CollisionPlan, LeaseResult, LeaseState } from "./backlog-coordination";
@@ -455,6 +456,108 @@ export async function loadChecks(runner: Runner, repo: Pick<Repository, "owner" 
 }
 
 const trustedAssociations = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
+const pageCap = 100;
+
+async function pagedArray(runner: Runner, endpoint: (page: number) => string, source: string): Promise<unknown[]> {
+  const values: unknown[] = [];
+  for (let page = 1; page <= pageCap; page += 1) {
+    const current = requiredArray(await runJson(runner, ["gh", "api", endpoint(page)], source), source);
+    values.push(...current);
+    if (current.length < 100) return values;
+  }
+  throw new OperationalError(`${source} reached pagination cap; refusing incomplete result`);
+}
+
+function priorityComments(values: unknown[], source: string): PriorityComment[] {
+  return values.map((entry, index) => {
+    const comment = requiredRecord(entry, `${source}[${index}]`);
+    return {
+      marker: requiredString(comment.body, `${source}[${index}].body`),
+      authorAssociation: requiredString(comment.author_association, `${source}[${index}].author_association`),
+      createdAt: requiredString(comment.created_at, `${source}[${index}].created_at`),
+      databaseId: requiredNumber(comment.id, `${source}[${index}].id`),
+    };
+  });
+}
+
+async function loadPriorityAssessment(runner: Runner, repo: Pick<Repository, "owner" | "name">, issue: number) {
+  return selectCurrentAssessment(priorityComments(await pagedArray(runner, (page) => `repos/${repo.owner}/${repo.name}/issues/${issue}/comments?per_page=100&page=${page}`, "gh api priority comments"), "priority comment"));
+}
+
+function sameAssessment(left: PriorityAssessment, right: PriorityAssessment): boolean {
+  return left.version === right.version && left.issue === right.issue && left.provider === right.provider && left.impact === right.impact && left.urgency === right.urgency && left.unblock === right.unblock && left.riskReduction === right.riskReduction && left.confidence === right.confidence && left.effort === right.effort && left.rationale === right.rationale;
+}
+
+export async function prioritize(runner: Runner, assessment: PriorityAssessment, apply: boolean): Promise<Evaluation & { accepted: boolean; assessment: PriorityAssessment; score: number }> {
+  const repo = await repository(runner);
+  const issue = requiredRecord(await runJson(runner, ["gh", "api", `repos/${repo.owner}/${repo.name}/issues/${assessment.issue}`], "gh api priority issue"), "gh api priority issue");
+  if (requiredNumber(issue.number, "priority issue.number") !== assessment.issue) throw new OperationalError("priority issue number does not match request");
+  if (requiredString(issue.state, "priority issue.state") !== "open") return { findings: [], refusals: [], safeActions: [], violations: [`issue #${assessment.issue} must be open`], accepted: false, assessment, score: 0 };
+  if (issue.pull_request !== undefined) return { findings: [], refusals: [], safeActions: [], violations: [`issue #${assessment.issue} must not be a pull request`], accepted: false, assessment, score: 0 };
+  const current = await loadPriorityAssessment(runner, repo, assessment.issue);
+  const score = Math.round(((4 * assessment.impact + 3 * assessment.urgency + 2 * assessment.unblock + 2 * assessment.riskReduction) * assessment.confidence / assessment.effort) * 100) / 100;
+  if (current && sameAssessment(current.assessment, assessment)) return { findings: ["matching priority assessment already current"], refusals: [], safeActions: [], violations: [], accepted: true, assessment, score };
+  if (!apply) return { findings: [], refusals: [], safeActions: [{ kind: "create-marker", issue: assessment.issue }], violations: [], accepted: false, assessment, score };
+  const posted = requiredRecord(await runJson(runner, ["gh", "api", `repos/${repo.owner}/${repo.name}/issues/${assessment.issue}/comments`, "--method", "POST", "-f", `body=${encodePriorityMarker(assessment)}`], "gh api priority mutation"), "gh api priority mutation");
+  const postedId = requiredNumber(posted.id, "priority mutation.id");
+  const after = await loadPriorityAssessment(runner, repo, assessment.issue);
+  if (!after || after.databaseId !== postedId) return { findings: [], refusals: [], safeActions: [], violations: ["priority assessment was superseded before confirmation"], accepted: false, assessment, score };
+  return { findings: ["priority assessment accepted"], refusals: [], safeActions: [], violations: [], accepted: true, assessment: after.assessment, score: after.score };
+}
+
+interface QueueIssue { number: number; state: string; labels: string[]; createdAt: string }
+
+async function loadPriorityIssues(runner: Runner, repo: Pick<Repository, "owner" | "name">, state: "open" | "all" = "open"): Promise<QueueIssue[]> {
+  return pagedArray(runner, (page) => `repos/${repo.owner}/${repo.name}/issues?state=${state}&per_page=100&page=${page}`, "gh api priority issues").then((values) => values.map((entry, index) => {
+    const issue = requiredRecord(entry, `priority issue[${index}]`);
+    return { number: requiredNumber(issue.number, `priority issue[${index}].number`), state: requiredString(issue.state, `priority issue[${index}].state`).toUpperCase(), labels: labels(issue.labels, `priority issue[${index}].labels`), createdAt: requiredString(issue.createdAt ?? issue.created_at, `priority issue[${index}].createdAt`) };
+  }));
+}
+
+export async function queue(runner: Runner, label?: string, limit?: number): Promise<{ entries: QueueEntry[] }> {
+  const repo = await repository(runner);
+  const issues = (await loadPriorityIssues(runner, repo)).filter((issue) => !issue.labels.some((candidate) => candidate === "WIP" || candidate === "needs-decision" || candidate === "wontfix") && (label === undefined || issue.labels.includes(label)));
+  const entries = sortQueue(await Promise.all(issues.map(async (issue) => ({ ...issue, assessment: (await loadPriorityAssessment(runner, repo, issue.number))?.assessment ?? null }))));
+  return { entries: limit === undefined ? entries : entries.slice(0, limit) };
+}
+
+async function loadHistoricalGate(runner: Runner, repo: Pick<Repository, "owner" | "name">, pullRequest: { number: number; headSha: string; closingIssueNumbers: number[] }): Promise<string | null> {
+  const comments = await pagedArray(runner, (page) => `repos/${repo.owner}/${repo.name}/issues/${pullRequest.number}/comments?per_page=100&page=${page}`, "gh api gate comments");
+  const valid: Array<{ createdAt: string; databaseId: number }> = [];
+  for (const [index, entry] of comments.entries()) {
+    const comment = requiredRecord(entry, `gate comment[${index}]`);
+    if (!trustedAssociations.has(requiredString(comment.author_association, `gate comment[${index}].author_association`))) continue;
+    const body = requiredString(comment.body, `gate comment[${index}].body`);
+    const marker = parseGateMarker(body);
+    if (body.includes("<!-- kesha-backlog-gate:v1 ") && marker === null) throw new OperationalError("trusted gate marker is malformed");
+    if (!marker || marker.pr !== pullRequest.number || pullRequest.closingIssueNumbers.length !== 1 || marker.issue !== pullRequest.closingIssueNumbers[0] || marker.evidence.headSha !== pullRequest.headSha) continue;
+    valid.push({ createdAt: requiredString(comment.created_at, `gate comment[${index}].created_at`), databaseId: requiredNumber(comment.id, `gate comment[${index}].id`) });
+  }
+  valid.sort((left, right) => left.createdAt.localeCompare(right.createdAt) || left.databaseId - right.databaseId);
+  return valid.at(-1)?.createdAt ?? null;
+}
+
+export async function metrics(runner: Runner, since: string, now = new Date()) {
+  const repo = await repository(runner);
+  const issues = await loadPriorityIssues(runner, repo, "all");
+  const raw = requiredArray(await runJson(runner, ["gh", "pr", "list", "--state", "all", "--limit", "1000", "--json", "number,state,createdAt,mergedAt,headRefOid,labels,closingIssuesReferences"], "gh pr metrics list"), "gh pr metrics list");
+  if (raw.length === 1000) throw new OperationalError("metrics pull request list reached limit; refusing incomplete result");
+  const pullRequests: LifecyclePullRequest[] = await Promise.all(raw.map(async (entry, index) => {
+    const pullRequest = requiredRecord(entry, `metrics pull request[${index}]`);
+    const number = requiredNumber(pullRequest.number, `metrics pull request[${index}].number`);
+    const closingIssueNumbers = closingIssues(pullRequest.closingIssuesReferences, `metrics pull request[${index}].closingIssuesReferences`);
+    return {
+      number,
+      createdAt: requiredString(pullRequest.createdAt, `metrics pull request[${index}].createdAt`),
+      mergedAt: optionalString(pullRequest.mergedAt, `metrics pull request[${index}].mergedAt`),
+      gateAt: await loadHistoricalGate(runner, repo, { number, headSha: requiredString(pullRequest.headRefOid, `metrics pull request[${index}].headRefOid`), closingIssueNumbers }),
+      state: requiredString(pullRequest.state, `metrics pull request[${index}].state`),
+      labels: labels(pullRequest.labels, `metrics pull request[${index}].labels`),
+    };
+  }));
+  const metricIssues: LifecycleIssue[] = issues.map((issue) => ({ number: issue.number, state: issue.state, labels: issue.labels, createdAt: issue.createdAt }));
+  return evaluateMetrics({ since, now: now.toISOString(), issues: metricIssues, pullRequests });
+}
 
 export async function loadMarker(runner: Runner, repo: Pick<Repository, "owner" | "name">, pr: number): Promise<GateMarker | null> {
   const comments: unknown[] = [];

--- a/scripts/backlog-conveyor.ts
+++ b/scripts/backlog-conveyor.ts
@@ -457,6 +457,21 @@ export async function loadChecks(runner: Runner, repo: Pick<Repository, "owner" 
 
 const trustedAssociations = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
 const pageCap = 100;
+const phase3Concurrency = 4;
+
+export async function mapBounded<T, U>(values: T[], limit: number, map: (value: T, index: number) => Promise<U>): Promise<U[]> {
+  const results = new Array<U>(values.length);
+  let next = 0;
+  await Promise.all(Array.from({ length: Math.min(limit, values.length) }, async () => {
+    for (;;) {
+      const index = next;
+      next += 1;
+      if (index >= values.length) return;
+      results[index] = await map(values[index]!, index);
+    }
+  }));
+  return results;
+}
 
 async function pagedArray(runner: Runner, endpoint: (page: number) => string, source: string): Promise<unknown[]> {
   const values: unknown[] = [];
@@ -474,7 +489,7 @@ function priorityComments(values: unknown[], source: string): PriorityComment[] 
     return {
       marker: requiredString(comment.body, `${source}[${index}].body`),
       authorAssociation: requiredString(comment.author_association, `${source}[${index}].author_association`),
-      createdAt: requiredString(comment.created_at, `${source}[${index}].created_at`),
+      createdAt: timestamp(comment.created_at, `${source}[${index}].created_at`),
       databaseId: requiredNumber(comment.id, `${source}[${index}].id`),
     };
   });
@@ -510,14 +525,14 @@ interface QueueIssue { number: number; state: string; labels: string[]; createdA
 async function loadPriorityIssues(runner: Runner, repo: Pick<Repository, "owner" | "name">, state: "open" | "all" = "open"): Promise<QueueIssue[]> {
   return pagedArray(runner, (page) => `repos/${repo.owner}/${repo.name}/issues?state=${state}&per_page=100&page=${page}`, "gh api priority issues").then((values) => values.map((entry, index) => {
     const issue = requiredRecord(entry, `priority issue[${index}]`);
-    return { number: requiredNumber(issue.number, `priority issue[${index}].number`), state: requiredString(issue.state, `priority issue[${index}].state`).toUpperCase(), labels: labels(issue.labels, `priority issue[${index}].labels`), createdAt: requiredString(issue.createdAt ?? issue.created_at, `priority issue[${index}].createdAt`), isPullRequest: issue.pull_request !== undefined && issue.pull_request !== null };
+    return { number: requiredNumber(issue.number, `priority issue[${index}].number`), state: requiredString(issue.state, `priority issue[${index}].state`).toUpperCase(), labels: labels(issue.labels, `priority issue[${index}].labels`), createdAt: timestamp(issue.createdAt ?? issue.created_at, `priority issue[${index}].createdAt`), isPullRequest: issue.pull_request !== undefined && issue.pull_request !== null };
   }));
 }
 
 export async function queue(runner: Runner, label?: string, limit?: number): Promise<{ entries: QueueEntry[] }> {
   const repo = await repository(runner);
   const issues = (await loadPriorityIssues(runner, repo)).filter((issue) => !issue.isPullRequest && !issue.labels.some((candidate) => candidate === "WIP" || candidate === "needs-decision" || candidate === "wontfix") && (label === undefined || issue.labels.includes(label)));
-  const entries = sortQueue(await Promise.all(issues.map(async (issue) => ({ ...issue, assessment: (await loadPriorityAssessment(runner, repo, issue.number))?.assessment ?? null }))));
+  const entries = sortQueue(await mapBounded(issues, phase3Concurrency, async (issue) => ({ ...issue, assessment: (await loadPriorityAssessment(runner, repo, issue.number))?.assessment ?? null })));
   return { entries: limit === undefined ? entries : entries.slice(0, limit) };
 }
 
@@ -531,7 +546,7 @@ async function loadHistoricalGate(runner: Runner, repo: Pick<Repository, "owner"
     const marker = parseGateMarker(body);
     if (body.includes("<!-- kesha-backlog-gate:v1 ") && marker === null) throw new OperationalError("trusted gate marker is malformed");
     if (!marker || marker.pr !== pullRequest.number || pullRequest.closingIssueNumbers.length !== 1 || marker.issue !== pullRequest.closingIssueNumbers[0] || marker.evidence.headSha !== pullRequest.headSha) continue;
-    valid.push({ createdAt: requiredString(comment.created_at, `gate comment[${index}].created_at`), databaseId: requiredNumber(comment.id, `gate comment[${index}].id`) });
+    valid.push({ createdAt: timestamp(comment.created_at, `gate comment[${index}].created_at`), databaseId: requiredNumber(comment.id, `gate comment[${index}].id`) });
   }
   valid.sort((left, right) => left.createdAt.localeCompare(right.createdAt) || left.databaseId - right.databaseId);
   return valid.at(-1)?.createdAt ?? null;
@@ -541,20 +556,20 @@ export async function metrics(runner: Runner, since: string, now = new Date()) {
   const repo = await repository(runner);
   const issues = await loadPriorityIssues(runner, repo, "all");
   const raw = await pagedArray(runner, (page) => `repos/${repo.owner}/${repo.name}/pulls?state=all&per_page=100&page=${page}`, "gh api metrics pull requests");
-  const pullRequests: LifecyclePullRequest[] = await Promise.all(raw.map(async (entry, index) => {
+  const pullRequests: LifecyclePullRequest[] = await mapBounded(raw, phase3Concurrency, async (entry, index) => {
     const pullRequest = requiredRecord(entry, `metrics pull request[${index}]`);
     const number = requiredNumber(pullRequest.number, `metrics pull request[${index}].number`);
     const closingIssueNumbers = await loadMetricClosingIssues(runner, repo, number);
     const head = requiredRecord(pullRequest.head, `metrics pull request[${index}].head`);
     return {
       number,
-      createdAt: requiredString(pullRequest.created_at, `metrics pull request[${index}].created_at`),
-      mergedAt: optionalString(pullRequest.merged_at, `metrics pull request[${index}].merged_at`),
+      createdAt: timestamp(pullRequest.created_at, `metrics pull request[${index}].created_at`),
+      mergedAt: pullRequest.merged_at === null ? null : timestamp(pullRequest.merged_at, `metrics pull request[${index}].merged_at`),
       gateAt: await loadHistoricalGate(runner, repo, { number, headSha: requiredString(head.sha, `metrics pull request[${index}].head.sha`), closingIssueNumbers }),
       state: requiredString(pullRequest.state, `metrics pull request[${index}].state`),
       labels: labels(pullRequest.labels, `metrics pull request[${index}].labels`),
     };
-  }));
+  });
   const metricIssues: LifecycleIssue[] = issues.filter((issue) => !issue.isPullRequest).map((issue) => ({ number: issue.number, state: issue.state, labels: issue.labels, createdAt: issue.createdAt }));
   return evaluateMetrics({ since, now: now.toISOString(), issues: metricIssues, pullRequests });
 }

--- a/scripts/backlog-conveyor.ts
+++ b/scripts/backlog-conveyor.ts
@@ -536,20 +536,21 @@ export async function queue(runner: Runner, label?: string, limit?: number): Pro
   return { entries: limit === undefined ? entries : entries.slice(0, limit) };
 }
 
-async function loadHistoricalGate(runner: Runner, repo: Pick<Repository, "owner" | "name">, pullRequest: { number: number; headSha: string; closingIssueNumbers: number[] }): Promise<string | null> {
+interface GateCandidate { issue: number; createdAt: string; databaseId: number }
+
+async function loadHistoricalGateCandidates(runner: Runner, repo: Pick<Repository, "owner" | "name">, pullRequest: { number: number; headSha: string }): Promise<GateCandidate[]> {
   const comments = await pagedArray(runner, (page) => `repos/${repo.owner}/${repo.name}/issues/${pullRequest.number}/comments?per_page=100&page=${page}`, "gh api gate comments");
-  const valid: Array<{ createdAt: string; databaseId: number }> = [];
+  const valid: GateCandidate[] = [];
   for (const [index, entry] of comments.entries()) {
     const comment = requiredRecord(entry, `gate comment[${index}]`);
     if (!trustedAssociations.has(requiredString(comment.author_association, `gate comment[${index}].author_association`))) continue;
     const body = requiredString(comment.body, `gate comment[${index}].body`);
     const marker = parseGateMarker(body);
     if (body.includes("<!-- kesha-backlog-gate:v1 ") && marker === null) throw new OperationalError("trusted gate marker is malformed");
-    if (!marker || marker.pr !== pullRequest.number || pullRequest.closingIssueNumbers.length !== 1 || marker.issue !== pullRequest.closingIssueNumbers[0] || marker.evidence.headSha !== pullRequest.headSha) continue;
-    valid.push({ createdAt: timestamp(comment.created_at, `gate comment[${index}].created_at`), databaseId: requiredNumber(comment.id, `gate comment[${index}].id`) });
+    if (!marker || marker.pr !== pullRequest.number || marker.evidence.headSha !== pullRequest.headSha) continue;
+    valid.push({ issue: marker.issue, createdAt: timestamp(comment.created_at, `gate comment[${index}].created_at`), databaseId: requiredNumber(comment.id, `gate comment[${index}].id`) });
   }
-  valid.sort((left, right) => Date.parse(left.createdAt) - Date.parse(right.createdAt) || left.databaseId - right.databaseId);
-  return valid.at(-1)?.createdAt ?? null;
+  return valid;
 }
 
 export async function metrics(runner: Runner, since: string, now = new Date()) {
@@ -559,13 +560,19 @@ export async function metrics(runner: Runner, since: string, now = new Date()) {
   const pullRequests: LifecyclePullRequest[] = await mapBounded(raw, phase3Concurrency, async (entry, index) => {
     const pullRequest = requiredRecord(entry, `metrics pull request[${index}]`);
     const number = requiredNumber(pullRequest.number, `metrics pull request[${index}].number`);
-    const closingIssueNumbers = await loadMetricClosingIssues(runner, repo, number);
     const head = requiredRecord(pullRequest.head, `metrics pull request[${index}].head`);
+    const headSha = requiredString(head.sha, `metrics pull request[${index}].head.sha`);
+    const candidates = await loadHistoricalGateCandidates(runner, repo, { number, headSha });
+    const soleIssue = candidates.length === 0 ? null : await loadMetricClosingIssue(runner, repo, number);
+    const gate = soleIssue === null ? null : candidates
+      .filter((candidate) => candidate.issue === soleIssue)
+      .sort((left, right) => Date.parse(left.createdAt) - Date.parse(right.createdAt) || left.databaseId - right.databaseId)
+      .at(-1) ?? null;
     return {
       number,
       createdAt: timestamp(pullRequest.created_at, `metrics pull request[${index}].created_at`),
       mergedAt: pullRequest.merged_at === null ? null : timestamp(pullRequest.merged_at, `metrics pull request[${index}].merged_at`),
-      gateAt: await loadHistoricalGate(runner, repo, { number, headSha: requiredString(head.sha, `metrics pull request[${index}].head.sha`), closingIssueNumbers }),
+      gateAt: gate?.createdAt ?? null,
       state: requiredString(pullRequest.state, `metrics pull request[${index}].state`).toUpperCase(),
       labels: labels(pullRequest.labels, `metrics pull request[${index}].labels`),
     };
@@ -576,11 +583,12 @@ export async function metrics(runner: Runner, since: string, now = new Date()) {
 
 const metricClosingIssueQuery = `query($owner: String!, $name: String!, $number: Int!) { repository(owner: $owner, name: $name) { pullRequest(number: $number) { closingIssuesReferences(first: 2) { nodes { number } pageInfo { hasNextPage } } } } }`;
 
-async function loadMetricClosingIssues(runner: Runner, repo: Pick<Repository, "owner" | "name">, number: number): Promise<number[]> {
+async function loadMetricClosingIssue(runner: Runner, repo: Pick<Repository, "owner" | "name">, number: number): Promise<number | null> {
   const raw = requiredRecord(await runJson(runner, ["gh", "api", "graphql", "-f", `query=${metricClosingIssueQuery}`, "-F", `owner=${repo.owner}`, "-F", `name=${repo.name}`, "-F", `number=${number}`], "gh api metric closing issues"), "gh api metric closing issues");
   const references = requiredRecord(requiredRecord(requiredRecord(requiredRecord(raw.data, "metric closing issues.data").repository, "metric closing issues.repository").pullRequest, "metric closing issues.pullRequest").closingIssuesReferences, "metric closing issues.references");
-  if (requiredBoolean(requiredRecord(references.pageInfo, "metric closing issues.pageInfo").hasNextPage, "metric closing issues.pageInfo.hasNextPage")) throw new OperationalError("metric closing issue references are incomplete");
-  return closingIssues(references.nodes, "metric closing issues.nodes");
+  if (requiredBoolean(requiredRecord(references.pageInfo, "metric closing issues.pageInfo").hasNextPage, "metric closing issues.pageInfo.hasNextPage")) return null;
+  const issues = closingIssues(references.nodes, "metric closing issues.nodes");
+  return issues.length === 1 ? issues[0]! : null;
 }
 
 export async function loadMarker(runner: Runner, repo: Pick<Repository, "owner" | "name">, pr: number): Promise<GateMarker | null> {

--- a/scripts/backlog-conveyor.ts
+++ b/scripts/backlog-conveyor.ts
@@ -505,18 +505,18 @@ export async function prioritize(runner: Runner, assessment: PriorityAssessment,
   return { findings: ["priority assessment accepted"], refusals: [], safeActions: [], violations: [], accepted: true, assessment: after.assessment, score: after.score };
 }
 
-interface QueueIssue { number: number; state: string; labels: string[]; createdAt: string }
+interface QueueIssue { number: number; state: string; labels: string[]; createdAt: string; isPullRequest: boolean }
 
 async function loadPriorityIssues(runner: Runner, repo: Pick<Repository, "owner" | "name">, state: "open" | "all" = "open"): Promise<QueueIssue[]> {
   return pagedArray(runner, (page) => `repos/${repo.owner}/${repo.name}/issues?state=${state}&per_page=100&page=${page}`, "gh api priority issues").then((values) => values.map((entry, index) => {
     const issue = requiredRecord(entry, `priority issue[${index}]`);
-    return { number: requiredNumber(issue.number, `priority issue[${index}].number`), state: requiredString(issue.state, `priority issue[${index}].state`).toUpperCase(), labels: labels(issue.labels, `priority issue[${index}].labels`), createdAt: requiredString(issue.createdAt ?? issue.created_at, `priority issue[${index}].createdAt`) };
+    return { number: requiredNumber(issue.number, `priority issue[${index}].number`), state: requiredString(issue.state, `priority issue[${index}].state`).toUpperCase(), labels: labels(issue.labels, `priority issue[${index}].labels`), createdAt: requiredString(issue.createdAt ?? issue.created_at, `priority issue[${index}].createdAt`), isPullRequest: issue.pull_request !== undefined && issue.pull_request !== null };
   }));
 }
 
 export async function queue(runner: Runner, label?: string, limit?: number): Promise<{ entries: QueueEntry[] }> {
   const repo = await repository(runner);
-  const issues = (await loadPriorityIssues(runner, repo)).filter((issue) => !issue.labels.some((candidate) => candidate === "WIP" || candidate === "needs-decision" || candidate === "wontfix") && (label === undefined || issue.labels.includes(label)));
+  const issues = (await loadPriorityIssues(runner, repo)).filter((issue) => !issue.isPullRequest && !issue.labels.some((candidate) => candidate === "WIP" || candidate === "needs-decision" || candidate === "wontfix") && (label === undefined || issue.labels.includes(label)));
   const entries = sortQueue(await Promise.all(issues.map(async (issue) => ({ ...issue, assessment: (await loadPriorityAssessment(runner, repo, issue.number))?.assessment ?? null }))));
   return { entries: limit === undefined ? entries : entries.slice(0, limit) };
 }
@@ -540,23 +540,32 @@ async function loadHistoricalGate(runner: Runner, repo: Pick<Repository, "owner"
 export async function metrics(runner: Runner, since: string, now = new Date()) {
   const repo = await repository(runner);
   const issues = await loadPriorityIssues(runner, repo, "all");
-  const raw = requiredArray(await runJson(runner, ["gh", "pr", "list", "--state", "all", "--limit", "1000", "--json", "number,state,createdAt,mergedAt,headRefOid,labels,closingIssuesReferences"], "gh pr metrics list"), "gh pr metrics list");
-  if (raw.length === 1000) throw new OperationalError("metrics pull request list reached limit; refusing incomplete result");
+  const raw = await pagedArray(runner, (page) => `repos/${repo.owner}/${repo.name}/pulls?state=all&per_page=100&page=${page}`, "gh api metrics pull requests");
   const pullRequests: LifecyclePullRequest[] = await Promise.all(raw.map(async (entry, index) => {
     const pullRequest = requiredRecord(entry, `metrics pull request[${index}]`);
     const number = requiredNumber(pullRequest.number, `metrics pull request[${index}].number`);
-    const closingIssueNumbers = closingIssues(pullRequest.closingIssuesReferences, `metrics pull request[${index}].closingIssuesReferences`);
+    const closingIssueNumbers = await loadMetricClosingIssues(runner, repo, number);
+    const head = requiredRecord(pullRequest.head, `metrics pull request[${index}].head`);
     return {
       number,
-      createdAt: requiredString(pullRequest.createdAt, `metrics pull request[${index}].createdAt`),
-      mergedAt: optionalString(pullRequest.mergedAt, `metrics pull request[${index}].mergedAt`),
-      gateAt: await loadHistoricalGate(runner, repo, { number, headSha: requiredString(pullRequest.headRefOid, `metrics pull request[${index}].headRefOid`), closingIssueNumbers }),
+      createdAt: requiredString(pullRequest.created_at, `metrics pull request[${index}].created_at`),
+      mergedAt: optionalString(pullRequest.merged_at, `metrics pull request[${index}].merged_at`),
+      gateAt: await loadHistoricalGate(runner, repo, { number, headSha: requiredString(head.sha, `metrics pull request[${index}].head.sha`), closingIssueNumbers }),
       state: requiredString(pullRequest.state, `metrics pull request[${index}].state`),
       labels: labels(pullRequest.labels, `metrics pull request[${index}].labels`),
     };
   }));
-  const metricIssues: LifecycleIssue[] = issues.map((issue) => ({ number: issue.number, state: issue.state, labels: issue.labels, createdAt: issue.createdAt }));
+  const metricIssues: LifecycleIssue[] = issues.filter((issue) => !issue.isPullRequest).map((issue) => ({ number: issue.number, state: issue.state, labels: issue.labels, createdAt: issue.createdAt }));
   return evaluateMetrics({ since, now: now.toISOString(), issues: metricIssues, pullRequests });
+}
+
+const metricClosingIssueQuery = `query($owner: String!, $name: String!, $number: Int!) { repository(owner: $owner, name: $name) { pullRequest(number: $number) { closingIssuesReferences(first: 2) { nodes { number } pageInfo { hasNextPage } } } } }`;
+
+async function loadMetricClosingIssues(runner: Runner, repo: Pick<Repository, "owner" | "name">, number: number): Promise<number[]> {
+  const raw = requiredRecord(await runJson(runner, ["gh", "api", "graphql", "-f", `query=${metricClosingIssueQuery}`, "-F", `owner=${repo.owner}`, "-F", `name=${repo.name}`, "-F", `number=${number}`], "gh api metric closing issues"), "gh api metric closing issues");
+  const references = requiredRecord(requiredRecord(requiredRecord(requiredRecord(raw.data, "metric closing issues.data").repository, "metric closing issues.repository").pullRequest, "metric closing issues.pullRequest").closingIssuesReferences, "metric closing issues.references");
+  if (requiredBoolean(requiredRecord(references.pageInfo, "metric closing issues.pageInfo").hasNextPage, "metric closing issues.pageInfo.hasNextPage")) throw new OperationalError("metric closing issue references are incomplete");
+  return closingIssues(references.nodes, "metric closing issues.nodes");
 }
 
 export async function loadMarker(runner: Runner, repo: Pick<Repository, "owner" | "name">, pr: number): Promise<GateMarker | null> {

--- a/scripts/backlog-conveyor.ts
+++ b/scripts/backlog-conveyor.ts
@@ -496,7 +496,7 @@ function priorityComments(values: unknown[], source: string): PriorityComment[] 
 }
 
 async function loadPriorityAssessment(runner: Runner, repo: Pick<Repository, "owner" | "name">, issue: number) {
-  return selectCurrentAssessment(priorityComments(await pagedArray(runner, (page) => `repos/${repo.owner}/${repo.name}/issues/${issue}/comments?per_page=100&page=${page}`, "gh api priority comments"), "priority comment"));
+  return selectCurrentAssessment(priorityComments(await pagedArray(runner, (page) => `repos/${repo.owner}/${repo.name}/issues/${issue}/comments?per_page=100&page=${page}`, "gh api priority comments"), "priority comment"), issue);
 }
 
 function sameAssessment(left: PriorityAssessment, right: PriorityAssessment): boolean {
@@ -548,7 +548,7 @@ async function loadHistoricalGate(runner: Runner, repo: Pick<Repository, "owner"
     if (!marker || marker.pr !== pullRequest.number || pullRequest.closingIssueNumbers.length !== 1 || marker.issue !== pullRequest.closingIssueNumbers[0] || marker.evidence.headSha !== pullRequest.headSha) continue;
     valid.push({ createdAt: timestamp(comment.created_at, `gate comment[${index}].created_at`), databaseId: requiredNumber(comment.id, `gate comment[${index}].id`) });
   }
-  valid.sort((left, right) => left.createdAt.localeCompare(right.createdAt) || left.databaseId - right.databaseId);
+  valid.sort((left, right) => Date.parse(left.createdAt) - Date.parse(right.createdAt) || left.databaseId - right.databaseId);
   return valid.at(-1)?.createdAt ?? null;
 }
 
@@ -566,7 +566,7 @@ export async function metrics(runner: Runner, since: string, now = new Date()) {
       createdAt: timestamp(pullRequest.created_at, `metrics pull request[${index}].created_at`),
       mergedAt: pullRequest.merged_at === null ? null : timestamp(pullRequest.merged_at, `metrics pull request[${index}].merged_at`),
       gateAt: await loadHistoricalGate(runner, repo, { number, headSha: requiredString(head.sha, `metrics pull request[${index}].head.sha`), closingIssueNumbers }),
-      state: requiredString(pullRequest.state, `metrics pull request[${index}].state`),
+      state: requiredString(pullRequest.state, `metrics pull request[${index}].state`).toUpperCase(),
       labels: labels(pullRequest.labels, `metrics pull request[${index}].labels`),
     };
   });

--- a/scripts/backlog-priority.ts
+++ b/scripts/backlog-priority.ts
@@ -88,6 +88,7 @@ function isRecord(value: unknown): value is JsonRecord {
 
 function requiredString(value: unknown, name: string): string {
   if (typeof value !== "string" || value.length === 0) throw new Error(`${name} must be a non-empty string`);
+  if (value.trim() !== value) throw new Error(`${name} must not have surrounding whitespace`);
   return value;
 }
 
@@ -108,10 +109,12 @@ export function parsePriorityManifest(value: unknown, source = "priority manifes
   if (value.version !== 1) throw new Error(`${source}.version must equal 1`);
   const rationale = requiredString(value.rationale, `${source}.rationale`);
   if (rationale.length > 280) throw new Error(`${source}.rationale must be at most 280 characters`);
+  const provider = requiredString(value.provider, `${source}.provider`);
+  if (provider.length > 256) throw new Error(`${source}.provider must be at most 256 characters`);
   return {
     version: 1,
     issue: requiredInteger(value.issue, `${source}.issue`, 1, Number.MAX_SAFE_INTEGER),
-    provider: requiredString(value.provider, `${source}.provider`),
+    provider,
     impact: requiredInteger(value.impact, `${source}.impact`, 0, 5),
     urgency: requiredInteger(value.urgency, `${source}.urgency`, 0, 5),
     unblock: requiredInteger(value.unblock, `${source}.unblock`, 0, 5),
@@ -142,6 +145,7 @@ export function parsePriorityMarker(body: string): PriorityMarker | null {
     throw new Error("priority marker is malformed");
   }
   if (!isRecord(raw) || raw.version !== 1) throw new Error("priority marker is malformed");
+  exactKeys(raw, ["version", "assessment", "score"], "priority marker");
   const assessment = parsePriorityManifest(raw.assessment, "priority marker.assessment");
   if (typeof raw.score !== "number" || !Number.isFinite(raw.score) || raw.score !== computePriorityScore(assessment)) {
     throw new Error("priority marker.score does not match assessment");

--- a/scripts/backlog-priority.ts
+++ b/scripts/backlog-priority.ts
@@ -153,12 +153,17 @@ export function parsePriorityMarker(body: string): PriorityMarker | null {
   return { version: 1, assessment, score: raw.score };
 }
 
-export function selectCurrentAssessment(comments: PriorityComment[]): { assessment: PriorityAssessment; score: number; createdAt: string; databaseId: number } | null {
+export function selectCurrentAssessment(comments: PriorityComment[], expectedIssue?: number): { assessment: PriorityAssessment; score: number; createdAt: string; databaseId: number } | null {
   const trusted = comments
     .filter((comment) => trustedAssociations.has(comment.authorAssociation))
-    .map((comment) => ({ ...comment, parsed: parsePriorityMarker(comment.marker) }))
+    .map((comment) => {
+      const parsed = parsePriorityMarker(comment.marker);
+      if (parsed !== null && expectedIssue !== undefined && parsed.assessment.issue !== expectedIssue) throw new Error("priority marker issue does not match comment container");
+      if (!Number.isFinite(Date.parse(comment.createdAt))) throw new Error("priority comment.createdAt must be an ISO timestamp");
+      return { ...comment, parsed };
+    })
     .filter((comment): comment is PriorityComment & { parsed: PriorityMarker } => comment.parsed !== null)
-    .sort((left, right) => left.createdAt.localeCompare(right.createdAt) || left.databaseId - right.databaseId);
+    .sort((left, right) => Date.parse(left.createdAt) - Date.parse(right.createdAt) || left.databaseId - right.databaseId);
   const current = trusted.at(-1);
   return current ? { assessment: current.parsed.assessment, score: current.parsed.score, createdAt: current.createdAt, databaseId: current.databaseId } : null;
 }
@@ -184,7 +189,7 @@ export function sortQueue(entries: QueueInput[]): QueueEntry[] {
         rationale: assessment?.rationale ?? null,
       };
     })
-    .sort((left, right) => Number(right.assessed) - Number(left.assessed) || right.score - left.score || left.createdAt.localeCompare(right.createdAt) || left.number - right.number);
+    .sort((left, right) => Number(right.assessed) - Number(left.assessed) || right.score - left.score || Date.parse(left.createdAt) - Date.parse(right.createdAt) || left.number - right.number);
 }
 
 function parsedTime(value: string, source: string): number {

--- a/scripts/backlog-priority.ts
+++ b/scripts/backlog-priority.ts
@@ -1,0 +1,242 @@
+export interface PriorityAssessment {
+  version: 1;
+  issue: number;
+  provider: string;
+  impact: number;
+  urgency: number;
+  unblock: number;
+  riskReduction: number;
+  confidence: number;
+  effort: number;
+  rationale: string;
+}
+
+export interface PriorityMarker {
+  version: 1;
+  assessment: PriorityAssessment;
+  score: number;
+}
+
+export interface PriorityComment {
+  marker: string;
+  authorAssociation: string;
+  createdAt: string;
+  databaseId: number;
+}
+
+export interface QueueInput {
+  number: number;
+  createdAt: string;
+  labels: string[];
+  assessment: PriorityAssessment | null;
+}
+
+export interface QueueEntry {
+  number: number;
+  createdAt: string;
+  labels: string[];
+  assessed: boolean;
+  score: number;
+  components: Pick<PriorityAssessment, "impact" | "urgency" | "unblock" | "riskReduction" | "confidence" | "effort"> | null;
+  rationale: string | null;
+}
+
+export interface LifecycleIssue {
+  number: number;
+  state: string;
+  labels: string[];
+  createdAt: string;
+}
+
+export interface LifecyclePullRequest {
+  number: number;
+  createdAt: string;
+  gateAt: string | null;
+  mergedAt: string | null;
+}
+
+export interface DurationSummary {
+  sampleSize: number;
+  median: number;
+  p90: number;
+}
+
+export interface LifecycleMetrics {
+  bounds: { since: string; until: string };
+  mergedPullRequests: number;
+  gatedPullRequests: number;
+  currentWip: number;
+  currentMergeReady: number;
+  durations: {
+    openToGate: DurationSummary | null;
+    gateToMerge: DurationSummary | null;
+    openToMerge: DurationSummary | null;
+  };
+}
+
+type JsonRecord = Record<string, unknown>;
+
+const trustedAssociations = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
+const markerPrefix = "<!-- kesha-backlog-priority:v1 ";
+const markerSuffix = " -->";
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function requiredString(value: unknown, name: string): string {
+  if (typeof value !== "string" || value.length === 0) throw new Error(`${name} must be a non-empty string`);
+  return value;
+}
+
+function requiredInteger(value: unknown, name: string, min: number, max: number): number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < min || value > max) {
+    throw new Error(`${name} must be an integer between ${min} and ${max}`);
+  }
+  return value;
+}
+
+function exactKeys(record: JsonRecord, keys: string[], source: string): void {
+  for (const key of Object.keys(record)) if (!keys.includes(key)) throw new Error(`${source} must not include ${key}`);
+}
+
+export function parsePriorityManifest(value: unknown, source = "priority manifest"): PriorityAssessment {
+  if (!isRecord(value)) throw new Error(`${source} must be an object`);
+  exactKeys(value, ["version", "issue", "provider", "impact", "urgency", "unblock", "riskReduction", "confidence", "effort", "rationale"], source);
+  if (value.version !== 1) throw new Error(`${source}.version must equal 1`);
+  const rationale = requiredString(value.rationale, `${source}.rationale`);
+  if (rationale.length > 280) throw new Error(`${source}.rationale must be at most 280 characters`);
+  return {
+    version: 1,
+    issue: requiredInteger(value.issue, `${source}.issue`, 1, Number.MAX_SAFE_INTEGER),
+    provider: requiredString(value.provider, `${source}.provider`),
+    impact: requiredInteger(value.impact, `${source}.impact`, 0, 5),
+    urgency: requiredInteger(value.urgency, `${source}.urgency`, 0, 5),
+    unblock: requiredInteger(value.unblock, `${source}.unblock`, 0, 5),
+    riskReduction: requiredInteger(value.riskReduction, `${source}.riskReduction`, 0, 5),
+    confidence: requiredInteger(value.confidence, `${source}.confidence`, 1, 5),
+    effort: requiredInteger(value.effort, `${source}.effort`, 1, 5),
+    rationale,
+  };
+}
+
+export function computePriorityScore(assessment: PriorityAssessment): number {
+  return Math.round(((4 * assessment.impact + 3 * assessment.urgency + 2 * assessment.unblock + 2 * assessment.riskReduction) * assessment.confidence / assessment.effort) * 100) / 100;
+}
+
+export function encodePriorityMarker(assessment: PriorityAssessment): string {
+  return `${markerPrefix}${JSON.stringify({ version: 1, assessment, score: computePriorityScore(assessment) })}${markerSuffix}`;
+}
+
+export function parsePriorityMarker(body: string): PriorityMarker | null {
+  const start = body.indexOf(markerPrefix);
+  if (start === -1) return null;
+  const end = body.indexOf(markerSuffix, start + markerPrefix.length);
+  if (end === -1) throw new Error("priority marker is malformed");
+  let raw: unknown;
+  try {
+    raw = JSON.parse(body.slice(start + markerPrefix.length, end));
+  } catch {
+    throw new Error("priority marker is malformed");
+  }
+  if (!isRecord(raw) || raw.version !== 1) throw new Error("priority marker is malformed");
+  const assessment = parsePriorityManifest(raw.assessment, "priority marker.assessment");
+  if (typeof raw.score !== "number" || !Number.isFinite(raw.score) || raw.score !== computePriorityScore(assessment)) {
+    throw new Error("priority marker.score does not match assessment");
+  }
+  return { version: 1, assessment, score: raw.score };
+}
+
+export function selectCurrentAssessment(comments: PriorityComment[]): { assessment: PriorityAssessment; score: number; createdAt: string; databaseId: number } | null {
+  const trusted = comments
+    .filter((comment) => trustedAssociations.has(comment.authorAssociation))
+    .map((comment) => ({ ...comment, parsed: parsePriorityMarker(comment.marker) }))
+    .filter((comment): comment is PriorityComment & { parsed: PriorityMarker } => comment.parsed !== null)
+    .sort((left, right) => left.createdAt.localeCompare(right.createdAt) || left.databaseId - right.databaseId);
+  const current = trusted.at(-1);
+  return current ? { assessment: current.parsed.assessment, score: current.parsed.score, createdAt: current.createdAt, databaseId: current.databaseId } : null;
+}
+
+export function sortQueue(entries: QueueInput[]): QueueEntry[] {
+  return entries
+    .map((entry) => {
+      const assessment = entry.assessment;
+      return {
+        number: entry.number,
+        createdAt: entry.createdAt,
+        labels: entry.labels,
+        assessed: assessment !== null,
+        score: assessment === null ? 0 : computePriorityScore(assessment),
+        components: assessment === null ? null : {
+          impact: assessment.impact,
+          urgency: assessment.urgency,
+          unblock: assessment.unblock,
+          riskReduction: assessment.riskReduction,
+          confidence: assessment.confidence,
+          effort: assessment.effort,
+        },
+        rationale: assessment?.rationale ?? null,
+      };
+    })
+    .sort((left, right) => Number(right.assessed) - Number(left.assessed) || right.score - left.score || left.createdAt.localeCompare(right.createdAt) || left.number - right.number);
+}
+
+function parsedTime(value: string, source: string): number {
+  const result = Date.parse(value);
+  if (!Number.isFinite(result)) throw new Error(`${source} must be an ISO timestamp`);
+  return result;
+}
+
+function isInWindow(value: number, since: number, now: number): boolean {
+  return value >= since && value <= now;
+}
+
+function duration(from: number, until: number, source: string): number {
+  const value = (until - from) / 1000;
+  if (!Number.isFinite(value) || value < 0) throw new Error(`${source} has negative ${source.includes("gate") ? "open-to-gate" : "lifecycle"} duration`);
+  return value;
+}
+
+function summary(values: number[]): DurationSummary | null {
+  if (values.length === 0) return null;
+  const ordered = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(ordered.length / 2);
+  const median = ordered.length % 2 === 1 ? ordered[middle]! : (ordered[middle - 1]! + ordered[middle]!) / 2;
+  return { sampleSize: ordered.length, median, p90: ordered[Math.ceil(ordered.length * 0.9) - 1]! };
+}
+
+export function evaluateMetrics(input: { since: string; now: string; issues: LifecycleIssue[]; pullRequests: LifecyclePullRequest[] }): LifecycleMetrics {
+  const since = parsedTime(input.since, "since");
+  const now = parsedTime(input.now, "now");
+  if (since > now) throw new Error("since must not be after now");
+  const openToGate: number[] = [];
+  const gateToMerge: number[] = [];
+  const openToMerge: number[] = [];
+  let mergedPullRequests = 0;
+  let gatedPullRequests = 0;
+  for (const pullRequest of input.pullRequests) {
+    const opened = parsedTime(pullRequest.createdAt, `PR #${pullRequest.number}.createdAt`);
+    const gate = pullRequest.gateAt === null ? null : parsedTime(pullRequest.gateAt, `PR #${pullRequest.number}.gateAt`);
+    const merged = pullRequest.mergedAt === null ? null : parsedTime(pullRequest.mergedAt, `PR #${pullRequest.number}.mergedAt`);
+    if (gate !== null && gate < opened) throw new Error(`PR #${pullRequest.number} has negative open-to-gate duration`);
+    if (merged !== null && merged < opened) throw new Error(`PR #${pullRequest.number} has negative open-to-merge duration`);
+    if (gate !== null && merged !== null && merged < gate) throw new Error(`PR #${pullRequest.number} has negative gate-to-merge duration`);
+    if (gate !== null && isInWindow(gate, since, now)) {
+      gatedPullRequests += 1;
+      openToGate.push((gate - opened) / 1000);
+    }
+    if (merged !== null && isInWindow(merged, since, now)) {
+      mergedPullRequests += 1;
+      openToMerge.push((merged - opened) / 1000);
+      if (gate !== null) gateToMerge.push((merged - gate) / 1000);
+    }
+  }
+  return {
+    bounds: { since: new Date(since).toISOString(), until: new Date(now).toISOString() },
+    mergedPullRequests,
+    gatedPullRequests,
+    currentWip: input.issues.filter((issue) => issue.state === "OPEN" && issue.labels.includes("WIP")).length,
+    currentMergeReady: input.issues.filter((issue) => issue.state === "OPEN" && issue.labels.includes("merge-ready")).length,
+    durations: { openToGate: summary(openToGate), gateToMerge: summary(gateToMerge), openToMerge: summary(openToMerge) },
+  };
+}

--- a/scripts/backlog-priority.ts
+++ b/scripts/backlog-priority.ts
@@ -53,6 +53,8 @@ export interface LifecyclePullRequest {
   createdAt: string;
   gateAt: string | null;
   mergedAt: string | null;
+  state?: string;
+  labels?: string[];
 }
 
 export interface DurationSummary {
@@ -191,12 +193,6 @@ function isInWindow(value: number, since: number, now: number): boolean {
   return value >= since && value <= now;
 }
 
-function duration(from: number, until: number, source: string): number {
-  const value = (until - from) / 1000;
-  if (!Number.isFinite(value) || value < 0) throw new Error(`${source} has negative ${source.includes("gate") ? "open-to-gate" : "lifecycle"} duration`);
-  return value;
-}
-
 function summary(values: number[]): DurationSummary | null {
   if (values.length === 0) return null;
   const ordered = [...values].sort((left, right) => left - right);
@@ -236,7 +232,7 @@ export function evaluateMetrics(input: { since: string; now: string; issues: Lif
     mergedPullRequests,
     gatedPullRequests,
     currentWip: input.issues.filter((issue) => issue.state === "OPEN" && issue.labels.includes("WIP")).length,
-    currentMergeReady: input.issues.filter((issue) => issue.state === "OPEN" && issue.labels.includes("merge-ready")).length,
+    currentMergeReady: input.pullRequests.filter((pullRequest) => pullRequest.state === "OPEN" && pullRequest.labels?.includes("merge-ready")).length,
     durations: { openToGate: summary(openToGate), gateToMerge: summary(gateToMerge), openToMerge: summary(openToMerge) },
   };
 }

--- a/scripts/backlog.ts
+++ b/scripts/backlog.ts
@@ -24,6 +24,13 @@ function ttlSeconds(raw: string | undefined): number {
   return parsed;
 }
 
+function queueLimit(raw: string | undefined): number {
+  if (!raw || !/^\d+$/.test(raw)) usage("--limit requires a positive integer");
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed < 1 || parsed > 1000) usage("--limit must be between 1 and 1000");
+  return parsed;
+}
+
 function issueNumber(flag: string, raw: string | undefined): number {
   if (!raw || !/^[1-9]\d*$/.test(raw)) usage(`${flag} requires a positive integer`);
   return Number(raw);
@@ -58,7 +65,7 @@ function parseArgs(argv: string[]): Command {
     else if (arg === "--holder") holder = argv.shift() ?? usage("--holder needs an opaque value");
     else if (arg === "--ttl-seconds") leaseTtl = ttlSeconds(argv.shift());
     else if (arg === "--label") label = argv.shift() ?? usage("--label needs a name");
-    else if (arg === "--limit") limit = ttlSeconds(argv.shift());
+    else if (arg === "--limit") limit = queueLimit(argv.shift());
     else if (arg === "--since") since = argv.shift() ?? usage("--since needs an ISO timestamp");
     else usage(`unknown argument '${arg}'`);
   }

--- a/scripts/backlog.ts
+++ b/scripts/backlog.ts
@@ -70,7 +70,7 @@ function parseArgs(argv: string[]): Command {
     else usage(`unknown argument '${arg}'`);
   }
   if (name === "sync") {
-    if (issue !== undefined || pr !== undefined || evidencePath !== undefined || manifestPath !== undefined || resource !== undefined || holder !== undefined || leaseTtl !== undefined) usage("sync does not accept command-specific flags");
+    if (issue !== undefined || pr !== undefined || evidencePath !== undefined || manifestPath !== undefined || resource !== undefined || holder !== undefined || leaseTtl !== undefined || label !== undefined || limit !== undefined || since !== undefined) usage("sync does not accept command-specific flags");
     return { name, apply, json };
   }
   if (name === "prioritize") {
@@ -89,13 +89,13 @@ function parseArgs(argv: string[]): Command {
   }
   if (name === "plan" || name === "claim" || name === "release") {
     if (!manifestPath) usage(`${name} requires --manifest path`);
-    if (issue !== undefined || pr !== undefined || evidencePath !== undefined || resource !== undefined || holder !== undefined || leaseTtl !== undefined) usage(`${name} only accepts --manifest, --apply, and --json`);
+    if (issue !== undefined || pr !== undefined || evidencePath !== undefined || resource !== undefined || holder !== undefined || leaseTtl !== undefined || label !== undefined || limit !== undefined || since !== undefined) usage(`${name} only accepts --manifest, --apply, and --json`);
     if (name === "plan" && apply) usage("plan is read-only and does not accept --apply");
     return { name, manifestPath, apply, json };
   }
   if (name === "lease") {
     if (!resource) usage("lease requires --resource name");
-    if (issue !== undefined || pr !== undefined || evidencePath !== undefined || manifestPath !== undefined) usage("lease does not accept issue, pull request, evidence, or manifest flags");
+    if (issue !== undefined || pr !== undefined || evidencePath !== undefined || manifestPath !== undefined || label !== undefined || limit !== undefined || since !== undefined) usage("lease does not accept issue, pull request, evidence, manifest, queue, or metrics flags");
     if (operation === "status") {
       if (holder !== undefined || leaseTtl !== undefined || apply) usage("lease status accepts only --resource and --json");
       return { name, operation, resource, apply, json };
@@ -107,9 +107,10 @@ function parseArgs(argv: string[]): Command {
   if (issue === undefined || pr === undefined) usage(`${name} requires --issue N and --pr P`);
   if (name === "gate") {
     if (!evidencePath) usage("gate requires --evidence path");
+    if (manifestPath !== undefined || label !== undefined || limit !== undefined || since !== undefined) usage("gate does not accept manifest, queue, or metrics flags");
     return { name, issue, pr, evidencePath, apply, json };
   }
-  if (evidencePath !== undefined) usage("close does not accept --evidence");
+  if (evidencePath !== undefined || manifestPath !== undefined || label !== undefined || limit !== undefined || since !== undefined) usage("close does not accept evidence, manifest, queue, or metrics flags");
   return { name, issue, pr, apply, json };
 }
 

--- a/scripts/backlog.ts
+++ b/scripts/backlog.ts
@@ -1,15 +1,19 @@
 #!/usr/bin/env bun
-import { ExitCode, OperationalError, REPORT_SCHEMA_VERSION, acquireLease, bunRunner, claim, close, evaluateLeaseOperation, gate, leaseRoot, parseClaimManifest, parseGateEvidence, plan, releaseClaim, releaseLease, statusLease, sync, type Evaluation } from "./backlog-conveyor";
+import { ExitCode, OperationalError, REPORT_SCHEMA_VERSION, acquireLease, bunRunner, claim, close, evaluateLeaseOperation, gate, leaseRoot, metrics, parseClaimManifest, parseGateEvidence, plan, prioritize, queue, releaseClaim, releaseLease, statusLease, sync, type Evaluation } from "./backlog-conveyor";
+import { parsePriorityManifest } from "./backlog-priority";
 
 type Command =
   | { name: "sync"; apply: boolean; json: boolean }
   | { name: "gate"; issue: number; pr: number; evidencePath: string; apply: boolean; json: boolean }
   | { name: "close"; issue: number; pr: number; apply: boolean; json: boolean }
+  | { name: "prioritize"; manifestPath: string; apply: boolean; json: boolean }
+  | { name: "queue"; label?: string; limit?: number; json: boolean }
+  | { name: "metrics"; since: string; json: boolean }
   | { name: "plan" | "claim" | "release"; manifestPath: string; apply: boolean; json: boolean }
   | { name: "lease"; operation: "acquire" | "release" | "status"; resource: string; holder?: string; ttlSeconds?: number; apply: boolean; json: boolean };
 
 function usage(message: string): never {
-  console.error(`${message}\nusage: bun run conveyor -- <sync|gate|close|plan|claim|release|lease> [--issue N --pr P] [--evidence path] [--manifest path] [--resource name --holder opaque --ttl-seconds N] [--apply] [--json]`);
+  console.error(`${message}\nusage: bun run conveyor -- <sync|gate|close|plan|claim|release|prioritize|queue|metrics|lease> [--issue N --pr P] [--evidence path] [--manifest path] [--label name --limit N] [--since ISO] [--resource name --holder opaque --ttl-seconds N] [--apply] [--json]`);
   process.exit(ExitCode.operationalFailure);
 }
 
@@ -27,7 +31,7 @@ function issueNumber(flag: string, raw: string | undefined): number {
 
 function parseArgs(argv: string[]): Command {
   const name = argv.shift();
-  if (name !== "sync" && name !== "gate" && name !== "close" && name !== "plan" && name !== "claim" && name !== "release" && name !== "lease") usage(`unknown subcommand '${name ?? ""}'`);
+  if (name !== "sync" && name !== "gate" && name !== "close" && name !== "plan" && name !== "claim" && name !== "release" && name !== "prioritize" && name !== "queue" && name !== "metrics" && name !== "lease") usage(`unknown subcommand '${name ?? ""}'`);
   const operation = name === "lease" ? argv.shift() : undefined;
   if (name === "lease" && operation !== "acquire" && operation !== "release" && operation !== "status") usage("lease requires acquire, release, or status");
   let apply = false;
@@ -39,6 +43,9 @@ function parseArgs(argv: string[]): Command {
   let resource: string | undefined;
   let holder: string | undefined;
   let leaseTtl: number | undefined;
+  let label: string | undefined;
+  let limit: number | undefined;
+  let since: string | undefined;
   while (argv.length > 0) {
     const arg = argv.shift()!;
     if (arg === "--apply") apply = true;
@@ -50,11 +57,28 @@ function parseArgs(argv: string[]): Command {
     else if (arg === "--resource") resource = argv.shift() ?? usage("--resource needs a name");
     else if (arg === "--holder") holder = argv.shift() ?? usage("--holder needs an opaque value");
     else if (arg === "--ttl-seconds") leaseTtl = ttlSeconds(argv.shift());
+    else if (arg === "--label") label = argv.shift() ?? usage("--label needs a name");
+    else if (arg === "--limit") limit = ttlSeconds(argv.shift());
+    else if (arg === "--since") since = argv.shift() ?? usage("--since needs an ISO timestamp");
     else usage(`unknown argument '${arg}'`);
   }
   if (name === "sync") {
     if (issue !== undefined || pr !== undefined || evidencePath !== undefined || manifestPath !== undefined || resource !== undefined || holder !== undefined || leaseTtl !== undefined) usage("sync does not accept command-specific flags");
     return { name, apply, json };
+  }
+  if (name === "prioritize") {
+    if (!manifestPath) usage("prioritize requires --manifest path");
+    if (issue !== undefined || pr !== undefined || evidencePath !== undefined || resource !== undefined || holder !== undefined || leaseTtl !== undefined || label !== undefined || limit !== undefined || since !== undefined) usage("prioritize only accepts --manifest, --apply, and --json");
+    return { name, manifestPath, apply, json };
+  }
+  if (name === "queue") {
+    if (apply || issue !== undefined || pr !== undefined || evidencePath !== undefined || manifestPath !== undefined || resource !== undefined || holder !== undefined || leaseTtl !== undefined || since !== undefined) usage("queue only accepts --label, --limit, and --json");
+    return { name, label, limit, json };
+  }
+  if (name === "metrics") {
+    if (!since || Number.isNaN(Date.parse(since))) usage("metrics requires --since ISO timestamp");
+    if (apply || issue !== undefined || pr !== undefined || evidencePath !== undefined || manifestPath !== undefined || resource !== undefined || holder !== undefined || leaseTtl !== undefined || label !== undefined || limit !== undefined) usage("metrics only accepts --since and --json");
+    return { name, since, json };
   }
   if (name === "plan" || name === "claim" || name === "release") {
     if (!manifestPath) usage(`${name} requires --manifest path`);
@@ -89,7 +113,7 @@ function exitCode(result: Evaluation): number {
 }
 
 function output(command: Command, result: Evaluation, details?: unknown): void {
-  const report = { schemaVersion: REPORT_SCHEMA_VERSION, command: command.name, operation: command.name === "lease" ? command.operation : undefined, apply: command.apply, findings: result.findings, violations: result.violations, refusals: result.refusals, actions: result.safeActions };
+  const report = { schemaVersion: REPORT_SCHEMA_VERSION, command: command.name, operation: command.name === "lease" ? command.operation : undefined, apply: "apply" in command ? command.apply : false, findings: result.findings, violations: result.violations, refusals: result.refusals, actions: result.safeActions };
   if (command.json) {
     console.log(JSON.stringify(details === undefined ? report : { ...report, details }));
     return;
@@ -106,6 +130,21 @@ async function main(): Promise<void> {
   if (command.name === "sync") result = await sync(runner, command.apply);
   else if (command.name === "gate") result = await gate(runner, command.issue, command.pr, parseGateEvidence(JSON.parse(await Bun.file(command.evidencePath).text()), `evidence ${command.evidencePath}`), command.apply);
   else if (command.name === "close") result = await close(runner, command.issue, command.pr, command.apply);
+  else if (command.name === "prioritize") {
+    const prioritized = await prioritize(runner, parsePriorityManifest(JSON.parse(await Bun.file(command.manifestPath).text()), `manifest ${command.manifestPath}`), command.apply);
+    output(command, prioritized, { accepted: prioritized.accepted, assessment: prioritized.assessment, score: prioritized.score });
+    process.exit(exitCode(prioritized));
+  } else if (command.name === "queue") {
+    const queued = await queue(runner, command.label, command.limit);
+    result = { findings: [], violations: [], refusals: [], safeActions: [] };
+    output(command, result, queued);
+    process.exit(ExitCode.success);
+  } else if (command.name === "metrics") {
+    const measured = await metrics(runner, command.since);
+    result = { findings: [], violations: [], refusals: [], safeActions: [] };
+    output(command, result, measured);
+    process.exit(ExitCode.success);
+  }
   else if (command.name === "plan") {
     const planned = await plan(runner, parseClaimManifest(JSON.parse(await Bun.file(command.manifestPath).text()), `manifest ${command.manifestPath}`));
     result = planned.evaluation;

--- a/tests/unit/backlog-priority.test.ts
+++ b/tests/unit/backlog-priority.test.ts
@@ -257,6 +257,29 @@ describe("conveyor priority boundaries", () => {
     await expect(metrics(runner, "2026-08-01T00:00:00Z", new Date("2026-08-03T00:00:00Z"))).rejects.toThrow("reached pagination cap");
   });
 
+  test("treats non-sole closing issues as ungated and skips GraphQL without a candidate gate", async () => {
+    const head = "a".repeat(40);
+    let graphCalls = 0;
+    const runner = priorityRunner((argv) => {
+      if (argv[1] === "repo") return { nameWithOwner: "o/r", defaultBranchRef: { name: "main" } };
+      if ((argv[2] ?? "").includes("/issues?state=all")) return [];
+      if ((argv[2] ?? "").includes("/pulls?state=all")) return [
+        { number: 1, created_at: "2026-08-01T00:00:00Z", merged_at: null, state: "OPEN", labels: [], head: { sha: head } },
+        { number: 2, created_at: "2026-08-01T00:00:00Z", merged_at: null, state: "OPEN", labels: [], head: { sha: head } },
+      ];
+      if ((argv[2] ?? "").includes("issues/1/comments")) return [];
+      if ((argv[2] ?? "").includes("issues/2/comments")) return [{ id: 1, created_at: "2026-08-01T01:00:00Z", author_association: "OWNER", body: gateMarker(20, 2, head) }];
+      if (argv[2] === "graphql") {
+        graphCalls += 1;
+        return { data: { repository: { pullRequest: { closingIssuesReferences: { nodes: [{ number: 20 }, { number: 21 }], pageInfo: { hasNextPage: true } } } } } };
+      }
+      throw new Error(`unexpected argv ${argv.join(" ")}`);
+    });
+    const result = await metrics(runner, "2026-08-01T00:00:00Z", new Date("2026-08-02T00:00:00Z"));
+    expect(result.gatedPullRequests).toBe(0);
+    expect(graphCalls).toBe(1);
+  });
+
   test("refuses malformed issue and trusted comment timestamps before queue ordering", async () => {
     const malformedIssue = priorityRunner((argv) => {
       if (argv[1] === "repo") return { nameWithOwner: "o/r", defaultBranchRef: { name: "main" } };

--- a/tests/unit/backlog-priority.test.ts
+++ b/tests/unit/backlog-priority.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
 import {
   computePriorityScore,
   encodePriorityMarker,
@@ -8,7 +9,7 @@ import {
   sortQueue,
   type PriorityAssessment,
 } from "../../scripts/backlog-priority";
-import { metrics, prioritize, queue, type Runner } from "../../scripts/backlog-conveyor";
+import { encodeGateMarker, mapBounded, metrics, prioritize, queue, type Runner } from "../../scripts/backlog-conveyor";
 
 const assessment: PriorityAssessment = {
   version: 1,
@@ -28,6 +29,8 @@ describe("backlog priority", () => {
     expect(computePriorityScore(assessment)).toBe(84);
     expect(() => parsePriorityManifest({ ...assessment, score: 999 })).toThrow("must not include score");
     expect(() => parsePriorityManifest({ ...assessment, impact: 6 })).toThrow("impact must be an integer between 0 and 5");
+    expect(() => parsePriorityManifest({ ...assessment, provider: "   " })).toThrow("provider must not have surrounding whitespace");
+    expect(() => parsePriorityManifest({ ...assessment, rationale: "   " })).toThrow("rationale must not have surrounding whitespace");
   });
 
   test("newest trusted marker supersedes an older marker without treating provider as identity", () => {
@@ -119,7 +122,25 @@ function priorityRunner(respond: (argv: string[]) => unknown): Runner {
   return { async run(argv) { return { exitCode: 0, stderr: "", stdout: JSON.stringify(respond(argv)) }; } };
 }
 
+function gateMarker(issue: number, pr: number, headSha: string): string {
+  const evidence = { version: 1 as const, provider: "opaque", verdict: "APPROVED" as const, headSha, uri: "https://example.test/gate" };
+  return encodeGateMarker({ version: 1, issue, pr, evidence: { ...evidence, digest: createHash("sha256").update(JSON.stringify(evidence)).digest("hex") } });
+}
+
 describe("conveyor priority boundaries", () => {
+  test("bounds Phase 3 GitHub work without changing input order", async () => {
+    let active = 0;
+    let peak = 0;
+    const result = await mapBounded([1, 2, 3, 4, 5, 6], 2, async (value) => {
+      active += 1;
+      peak = Math.max(peak, active);
+      await Promise.resolve();
+      active -= 1;
+      return value * 2;
+    });
+    expect(peak).toBe(2);
+    expect(result).toEqual([2, 4, 6, 8, 10, 12]);
+  });
   test("requires an existing open issue before an applied assessment can publish", async () => {
     const calls: string[][] = [];
     const runner: Runner = {
@@ -179,5 +200,85 @@ describe("conveyor priority boundaries", () => {
     });
 
     await expect(metrics(runner, "2026-08-01T00:00:00Z", new Date("2026-08-03T00:00:00Z"))).rejects.toThrow("trusted gate marker is malformed");
+  });
+
+  test("uses a REST second pull page and only the latest valid gate marker for each PR", async () => {
+    const head = "a".repeat(40);
+    const firstPage = Array.from({ length: 100 }, (_, index) => ({ number: index + 1, created_at: "2026-08-01T00:00:00Z", merged_at: null, state: "CLOSED", labels: [], head: { sha: head } }));
+    const runner = priorityRunner((argv) => {
+      if (argv[1] === "repo") return { nameWithOwner: "o/r", defaultBranchRef: { name: "main" } };
+      const target = argv[2] ?? "";
+      if (target.includes("/issues?state=all")) return [];
+      if (target.includes("/pulls?state=all") && target.endsWith("page=1")) return firstPage;
+      if (target.includes("/pulls?state=all") && target.endsWith("page=2")) return [{ number: 101, created_at: "2026-08-01T00:00:00Z", merged_at: "2026-08-02T00:00:00Z", state: "CLOSED", labels: [], head: { sha: head } }];
+      if (target === "graphql") {
+        const number = Number(argv.find((value) => value.startsWith("number="))?.slice("number=".length));
+        return { data: { repository: { pullRequest: { closingIssuesReferences: { nodes: [{ number: number === 101 ? 500 : number }], pageInfo: { hasNextPage: false } } } } } };
+      }
+      if (target.includes("comments")) {
+        const pr = Number(/issues\/(\d+)\/comments/.exec(target)?.[1]);
+        if (pr === 101) return [
+          { id: 1, created_at: "2026-08-01T01:00:00Z", author_association: "OWNER", body: gateMarker(500, 101, "b".repeat(40)) },
+          { id: 2, created_at: "2026-08-01T02:00:00Z", author_association: "OWNER", body: gateMarker(999, 102, head) },
+          { id: 3, created_at: "2026-08-01T03:00:00Z", author_association: "OWNER", body: gateMarker(500, 101, head) },
+          { id: 4, created_at: "2026-08-01T03:00:00Z", author_association: "COLLABORATOR", body: gateMarker(500, 101, head) },
+        ];
+        return [];
+      }
+      throw new Error(`unexpected argv ${argv.join(" ")}`);
+    });
+
+    const result = await metrics(runner, "2026-08-01T00:00:00Z", new Date("2026-08-03T00:00:00Z"));
+    expect(result.mergedPullRequests).toBe(1);
+    expect(result.gatedPullRequests).toBe(1);
+    expect(result.durations.openToGate).toEqual({ sampleSize: 1, median: 10800, p90: 10800 });
+  });
+
+  test("refuses a REST pull pagination cap instead of returning partial metrics", async () => {
+    const page = Array.from({ length: 100 }, (_, index) => ({ number: index + 1, created_at: "2026-08-01T00:00:00Z", merged_at: null, state: "OPEN", labels: [], head: { sha: "a".repeat(40) } }));
+    const runner = priorityRunner((argv) => {
+      if (argv[1] === "repo") return { nameWithOwner: "o/r", defaultBranchRef: { name: "main" } };
+      if ((argv[2] ?? "").includes("/issues?state=all")) return [];
+      if ((argv[2] ?? "").includes("/pulls?state=all")) return page;
+      throw new Error(`unexpected argv ${argv.join(" ")}`);
+    });
+
+    await expect(metrics(runner, "2026-08-01T00:00:00Z", new Date("2026-08-03T00:00:00Z"))).rejects.toThrow("reached pagination cap");
+  });
+
+  test("refuses malformed issue and trusted comment timestamps before queue ordering", async () => {
+    const malformedIssue = priorityRunner((argv) => {
+      if (argv[1] === "repo") return { nameWithOwner: "o/r", defaultBranchRef: { name: "main" } };
+      if ((argv[2] ?? "").includes("/issues?state=open")) return [{ number: 1, state: "OPEN", labels: [], createdAt: "not-a-time" }];
+      throw new Error(`unexpected argv ${argv.join(" ")}`);
+    });
+    await expect(queue(malformedIssue)).rejects.toThrow("must be an ISO timestamp");
+
+    const malformedComment = priorityRunner((argv) => {
+      if (argv[1] === "repo") return { nameWithOwner: "o/r", defaultBranchRef: { name: "main" } };
+      if ((argv[2] ?? "").includes("/issues?state=open")) return [{ number: 1, state: "OPEN", labels: [], createdAt: "2026-08-01T00:00:00Z" }];
+      if ((argv[2] ?? "").includes("comments")) return [{ id: 1, created_at: "not-a-time", author_association: "OWNER", body: encodePriorityMarker(assessment) }];
+      throw new Error(`unexpected argv ${argv.join(" ")}`);
+    });
+    await expect(queue(malformedComment)).rejects.toThrow("must be an ISO timestamp");
+  });
+
+  test("reports a concurrent priority write as superseded when its POST id is no longer current", async () => {
+    const marker = encodePriorityMarker({ ...assessment, rationale: "Concurrent update." });
+    let reads = 0;
+    const runner: Runner = {
+      async run(argv) {
+        if (argv[1] === "repo") return { exitCode: 0, stderr: "", stdout: JSON.stringify({ nameWithOwner: "o/r", defaultBranchRef: { name: "main" } }) };
+        if (argv[2] === "repos/o/r/issues/1036") return { exitCode: 0, stderr: "", stdout: JSON.stringify({ number: 1036, state: "open" }) };
+        if ((argv[2] ?? "").includes("comments") && argv.includes("--method")) return { exitCode: 0, stderr: "", stdout: JSON.stringify({ id: 1 }) };
+        if ((argv[2] ?? "").includes("comments")) {
+          reads += 1;
+          return { exitCode: 0, stderr: "", stdout: JSON.stringify(reads === 1 ? [] : [{ id: 2, created_at: "2026-08-02T00:00:00Z", author_association: "OWNER", body: marker }]) };
+        }
+        throw new Error(`unexpected argv ${argv.join(" ")}`);
+      },
+    };
+
+    await expect(prioritize(runner, assessment, true)).resolves.toMatchObject({ accepted: false, violations: ["priority assessment was superseded before confirmation"] });
   });
 });

--- a/tests/unit/backlog-priority.test.ts
+++ b/tests/unit/backlog-priority.test.ts
@@ -8,6 +8,7 @@ import {
   sortQueue,
   type PriorityAssessment,
 } from "../../scripts/backlog-priority";
+import { metrics, prioritize, queue, type Runner } from "../../scripts/backlog-conveyor";
 
 const assessment: PriorityAssessment = {
   version: 1,
@@ -62,13 +63,13 @@ describe("backlog lifecycle metrics", () => {
       now: "2026-08-20T00:00:00Z",
       issues: [
         { number: 1, state: "OPEN", labels: ["WIP"], createdAt: "2026-08-02T00:00:00Z" },
-        { number: 2, state: "OPEN", labels: ["merge-ready"], createdAt: "2026-08-03T00:00:00Z" },
+        { number: 2, state: "OPEN", labels: [], createdAt: "2026-08-03T00:00:00Z" },
       ],
       pullRequests: [
-        { number: 1, createdAt: "2026-08-01T00:00:00Z", mergedAt: "2026-08-02T01:00:00Z", gateAt: "2026-08-01T01:00:00Z" },
+        { number: 1, createdAt: "2026-08-01T00:00:00Z", mergedAt: "2026-08-02T01:00:00Z", gateAt: "2026-08-01T01:00:00Z", state: "CLOSED", labels: [] },
         { number: 2, createdAt: "2026-08-01T00:00:00Z", mergedAt: "2026-08-02T03:00:00Z", gateAt: "2026-08-01T02:00:00Z" },
         { number: 3, createdAt: "2026-08-01T00:00:00Z", mergedAt: "2026-08-02T06:00:00Z", gateAt: "2026-08-01T03:00:00Z" },
-        { number: 4, createdAt: "2026-08-01T00:00:00Z", mergedAt: "2026-08-02T10:00:00Z", gateAt: "2026-08-01T04:00:00Z" },
+        { number: 4, createdAt: "2026-08-01T00:00:00Z", mergedAt: "2026-08-02T10:00:00Z", gateAt: "2026-08-01T04:00:00Z", state: "OPEN", labels: ["merge-ready"] },
       ],
     });
 
@@ -97,10 +98,10 @@ describe("backlog lifecycle metrics", () => {
     const result = evaluateMetrics({
       since: "2026-08-10T00:00:00Z",
       now: "2026-08-20T00:00:00Z",
-      issues: [{ number: 1, state: "OPEN", labels: ["WIP", "merge-ready"], createdAt: "2026-08-01T00:00:00Z" }],
+      issues: [{ number: 1, state: "OPEN", labels: ["WIP"], createdAt: "2026-08-01T00:00:00Z" }],
       pullRequests: [
         { number: 1, createdAt: "2026-08-01T00:00:00Z", gateAt: "2026-08-09T00:00:00Z", mergedAt: "2026-08-11T00:00:00Z" },
-        { number: 2, createdAt: "2026-08-01T00:00:00Z", gateAt: "2026-08-11T00:00:00Z", mergedAt: null },
+        { number: 2, createdAt: "2026-08-01T00:00:00Z", gateAt: "2026-08-11T00:00:00Z", mergedAt: null, state: "OPEN", labels: ["merge-ready"] },
       ],
     });
 
@@ -111,5 +112,70 @@ describe("backlog lifecycle metrics", () => {
     expect(result.durations.openToGate?.sampleSize).toBe(1);
     expect(result.durations.gateToMerge?.sampleSize).toBe(1);
     expect(() => evaluateMetrics({ since: "2026-08-21T00:00:00Z", now: "2026-08-20T00:00:00Z", issues: [], pullRequests: [] })).toThrow("since must not be after now");
+  });
+});
+
+function priorityRunner(respond: (argv: string[]) => unknown): Runner {
+  return { async run(argv) { return { exitCode: 0, stderr: "", stdout: JSON.stringify(respond(argv)) }; } };
+}
+
+describe("conveyor priority boundaries", () => {
+  test("requires an existing open issue before an applied assessment can publish", async () => {
+    const calls: string[][] = [];
+    const runner: Runner = {
+      async run(argv) {
+        calls.push(argv);
+        if (argv[1] === "repo") return { exitCode: 0, stderr: "", stdout: JSON.stringify({ nameWithOwner: "o/r", defaultBranchRef: { name: "main" } }) };
+        if (argv[1] === "api" && argv[2] === "repos/o/r/issues/1036") return { exitCode: 0, stderr: "", stdout: JSON.stringify({ number: 1036, state: "closed" }) };
+        throw new Error(`unexpected argv ${argv.join(" ")}`);
+      },
+    };
+
+    await expect(prioritize(runner, assessment, true)).resolves.toMatchObject({ violations: ["issue #1036 must be open"] });
+    expect(calls.some((argv) => argv.includes("--method"))).toBe(false);
+  });
+
+  test("queues all comment pages, ignores untrusted lookalikes, and rejects malformed trusted markers", async () => {
+    const older = encodePriorityMarker({ ...assessment, rationale: "Earlier." });
+    const newer = encodePriorityMarker({ ...assessment, urgency: 5, rationale: "Newer." });
+    const runner = priorityRunner((argv) => {
+      if (argv[1] === "repo") return { nameWithOwner: "o/r", defaultBranchRef: { name: "main" } };
+      if ((argv[2] ?? "").includes("/issues?state=open")) return [
+        { number: 10, state: "OPEN", labels: [], createdAt: "2026-08-02T00:00:00Z" },
+        { number: 11, state: "OPEN", labels: [], createdAt: "2026-08-01T00:00:00Z" },
+        { number: 12, state: "OPEN", labels: [{ name: "WIP" }], createdAt: "2026-08-01T00:00:00Z" },
+      ];
+      const target = argv[2] ?? "";
+      if (target.includes("issues/10/comments") && target.endsWith("page=1")) return Array.from({ length: 100 }, (_, index) => ({ id: index + 1, created_at: "2026-08-01T00:00:00Z", author_association: "MEMBER", body: index === 99 ? older : "ordinary" }));
+      if (target.includes("issues/10/comments") && target.endsWith("page=2")) return [
+        { id: 101, created_at: "2026-08-03T00:00:00Z", author_association: "NONE", body: newer },
+        { id: 102, created_at: "2026-08-03T00:00:00Z", author_association: "COLLABORATOR", body: newer },
+      ];
+      if (target.includes("issues/11/comments")) return [];
+      throw new Error(`unexpected argv ${argv.join(" ")}`);
+    });
+
+    expect(await queue(runner)).toMatchObject({ entries: [{ number: 10, assessed: true, score: 90 }, { number: 11, assessed: false, score: 0 }] });
+
+    const malformed = priorityRunner((argv) => {
+      if (argv[1] === "repo") return { nameWithOwner: "o/r", defaultBranchRef: { name: "main" } };
+      if ((argv[2] ?? "").includes("/issues?state=open")) return [{ number: 10, state: "OPEN", labels: [], createdAt: "2026-08-02T00:00:00Z" }];
+      if ((argv[2] ?? "").includes("comments")) return [{ id: 1, created_at: "2026-08-01T00:00:00Z", author_association: "OWNER", body: "<!-- kesha-backlog-priority:v1 {broken -->" }];
+      throw new Error(`unexpected argv ${argv.join(" ")}`);
+    });
+    await expect(queue(malformed)).rejects.toThrow("priority marker is malformed");
+  });
+
+  test("aggregates only trusted gate markers and refuses malformed trusted gate state", async () => {
+    const gate = "<!-- kesha-backlog-gate:v1 {\"version\":1,\"issue\":1,\"pr\":2,\"evidence\":{\"version\":1,\"provider\":\"opaque\",\"verdict\":\"APPROVED\",\"headSha\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"uri\":\"https://example.test\",\"digest\":\"not-a-real-digest\"}} -->";
+    const runner = priorityRunner((argv) => {
+      if (argv[1] === "repo") return { nameWithOwner: "o/r", defaultBranchRef: { name: "main" } };
+      if ((argv[2] ?? "").includes("/issues?state=all")) return [];
+      if (argv[1] === "pr") return [{ number: 2, createdAt: "2026-08-01T00:00:00Z", mergedAt: null, state: "OPEN", labels: [], headRefOid: "a".repeat(40), closingIssuesReferences: [] }];
+      if ((argv[2] ?? "").includes("comments")) return [{ id: 1, created_at: "2026-08-02T00:00:00Z", author_association: "OWNER", body: gate }];
+      throw new Error(`unexpected argv ${argv.join(" ")}`);
+    });
+
+    await expect(metrics(runner, "2026-08-01T00:00:00Z", new Date("2026-08-03T00:00:00Z"))).rejects.toThrow("trusted gate marker is malformed");
   });
 });

--- a/tests/unit/backlog-priority.test.ts
+++ b/tests/unit/backlog-priority.test.ts
@@ -24,8 +24,8 @@ const assessment: PriorityAssessment = {
 
 describe("backlog priority", () => {
   test("derives the documented score and rejects caller supplied scores", () => {
-    expect(computePriorityScore(assessment)).toBe(73);
-    expect(parsePriorityManifest({ ...assessment, score: 999 })).toThrow("must not include score");
+    expect(computePriorityScore(assessment)).toBe(84);
+    expect(() => parsePriorityManifest({ ...assessment, score: 999 })).toThrow("must not include score");
     expect(() => parsePriorityManifest({ ...assessment, impact: 6 })).toThrow("impact must be an integer between 0 and 5");
   });
 
@@ -78,8 +78,8 @@ describe("backlog lifecycle metrics", () => {
     expect(result.currentWip).toBe(1);
     expect(result.currentMergeReady).toBe(1);
     expect(result.durations.openToGate).toEqual({ sampleSize: 4, median: 9000, p90: 14400 });
-    expect(result.durations.gateToMerge).toEqual({ sampleSize: 4, median: 95400, p90: 108000 });
-    expect(result.durations.openToMerge).toEqual({ sampleSize: 4, median: 122400, p90: 122400 });
+    expect(result.durations.gateToMerge).toEqual({ sampleSize: 4, median: 93600, p90: 108000 });
+    expect(result.durations.openToMerge).toEqual({ sampleSize: 4, median: 102600, p90: 122400 });
   });
 
   test("returns null for empty samples and rejects negative chronology instead of clamping it", () => {
@@ -100,7 +100,7 @@ describe("backlog lifecycle metrics", () => {
       issues: [{ number: 1, state: "OPEN", labels: ["WIP", "merge-ready"], createdAt: "2026-08-01T00:00:00Z" }],
       pullRequests: [
         { number: 1, createdAt: "2026-08-01T00:00:00Z", gateAt: "2026-08-09T00:00:00Z", mergedAt: "2026-08-11T00:00:00Z" },
-        { number: 2, createdAt: "2026-08-01T00:00:00Z", gateAt: "2026-08-11T00:00:00Z", mergedAt: "2026-08-09T00:00:00Z" },
+        { number: 2, createdAt: "2026-08-01T00:00:00Z", gateAt: "2026-08-11T00:00:00Z", mergedAt: null },
       ],
     });
 

--- a/tests/unit/backlog-priority.test.ts
+++ b/tests/unit/backlog-priority.test.ts
@@ -144,6 +144,7 @@ describe("conveyor priority boundaries", () => {
         { number: 10, state: "OPEN", labels: [], createdAt: "2026-08-02T00:00:00Z" },
         { number: 11, state: "OPEN", labels: [], createdAt: "2026-08-01T00:00:00Z" },
         { number: 12, state: "OPEN", labels: [{ name: "WIP" }], createdAt: "2026-08-01T00:00:00Z" },
+        { number: 13, state: "OPEN", labels: [], createdAt: "2026-08-01T00:00:00Z", pull_request: { url: "https://example.test/pr/13" } },
       ];
       const target = argv[2] ?? "";
       if (target.includes("issues/10/comments") && target.endsWith("page=1")) return Array.from({ length: 100 }, (_, index) => ({ id: index + 1, created_at: "2026-08-01T00:00:00Z", author_association: "MEMBER", body: index === 99 ? older : "ordinary" }));
@@ -171,7 +172,8 @@ describe("conveyor priority boundaries", () => {
     const runner = priorityRunner((argv) => {
       if (argv[1] === "repo") return { nameWithOwner: "o/r", defaultBranchRef: { name: "main" } };
       if ((argv[2] ?? "").includes("/issues?state=all")) return [];
-      if (argv[1] === "pr") return [{ number: 2, createdAt: "2026-08-01T00:00:00Z", mergedAt: null, state: "OPEN", labels: [], headRefOid: "a".repeat(40), closingIssuesReferences: [] }];
+      if ((argv[2] ?? "").includes("/pulls?state=all")) return [{ number: 2, created_at: "2026-08-01T00:00:00Z", merged_at: null, state: "OPEN", labels: [], head: { sha: "a".repeat(40) } }];
+      if (argv[2] === "graphql") return { data: { repository: { pullRequest: { closingIssuesReferences: { nodes: [], pageInfo: { hasNextPage: false } } } } } };
       if ((argv[2] ?? "").includes("comments")) return [{ id: 1, created_at: "2026-08-02T00:00:00Z", author_association: "OWNER", body: gate }];
       throw new Error(`unexpected argv ${argv.join(" ")}`);
     });

--- a/tests/unit/backlog-priority.test.ts
+++ b/tests/unit/backlog-priority.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test";
+import {
+  computePriorityScore,
+  encodePriorityMarker,
+  evaluateMetrics,
+  parsePriorityManifest,
+  selectCurrentAssessment,
+  sortQueue,
+  type PriorityAssessment,
+} from "../../scripts/backlog-priority";
+
+const assessment: PriorityAssessment = {
+  version: 1,
+  issue: 1036,
+  provider: "opaque-scheduler",
+  impact: 5,
+  urgency: 4,
+  unblock: 3,
+  riskReduction: 2,
+  confidence: 4,
+  effort: 2,
+  rationale: "Unblocks a visible lifecycle decision.",
+};
+
+describe("backlog priority", () => {
+  test("derives the documented score and rejects caller supplied scores", () => {
+    expect(computePriorityScore(assessment)).toBe(73);
+    expect(parsePriorityManifest({ ...assessment, score: 999 })).toThrow("must not include score");
+    expect(() => parsePriorityManifest({ ...assessment, impact: 6 })).toThrow("impact must be an integer between 0 and 5");
+  });
+
+  test("newest trusted marker supersedes an older marker without treating provider as identity", () => {
+    const older = { ...assessment, provider: "one", rationale: "Earlier assessment." };
+    const newest = { ...assessment, provider: "anything-opaque", urgency: 5, rationale: "Newer assessment." };
+    const result = selectCurrentAssessment([
+      { marker: encodePriorityMarker(older), authorAssociation: "OWNER", createdAt: "2026-08-10T00:00:00Z", databaseId: 1 },
+      { marker: encodePriorityMarker(newest), authorAssociation: "COLLABORATOR", createdAt: "2026-08-10T00:00:00Z", databaseId: 2 },
+      { marker: encodePriorityMarker({ ...assessment, rationale: "Untrusted." }), authorAssociation: "NONE", createdAt: "2026-08-11T00:00:00Z", databaseId: 3 },
+    ]);
+
+    expect(result?.assessment).toMatchObject({ provider: "anything-opaque", urgency: 5 });
+  });
+
+  test("orders assessed work before visible unassessed work and uses age then number as tie breaks", () => {
+    const entries = sortQueue([
+      { number: 12, createdAt: "2026-08-03T00:00:00Z", labels: [], assessment: null },
+      { number: 11, createdAt: "2026-08-02T00:00:00Z", labels: [], assessment: { ...assessment, issue: 11, rationale: "Same score." } },
+      { number: 10, createdAt: "2026-08-01T00:00:00Z", labels: [], assessment: { ...assessment, issue: 10, rationale: "Same score." } },
+      { number: 9, createdAt: "2026-08-04T00:00:00Z", labels: [], assessment: { ...assessment, issue: 9, effort: 1, rationale: "Highest score." } },
+    ]);
+
+    expect(entries.map((entry) => entry.number)).toEqual([9, 10, 11, 12]);
+    expect(entries[0]).toMatchObject({ assessed: true, components: { impact: 5, urgency: 4 } });
+    expect(entries[3]).toMatchObject({ assessed: false, score: 0 });
+  });
+});
+
+describe("backlog lifecycle metrics", () => {
+  test("uses nearest-rank p90 and average-even median with a deterministic upper bound", () => {
+    const result = evaluateMetrics({
+      since: "2026-08-01T00:00:00Z",
+      now: "2026-08-20T00:00:00Z",
+      issues: [
+        { number: 1, state: "OPEN", labels: ["WIP"], createdAt: "2026-08-02T00:00:00Z" },
+        { number: 2, state: "OPEN", labels: ["merge-ready"], createdAt: "2026-08-03T00:00:00Z" },
+      ],
+      pullRequests: [
+        { number: 1, createdAt: "2026-08-01T00:00:00Z", mergedAt: "2026-08-02T01:00:00Z", gateAt: "2026-08-01T01:00:00Z" },
+        { number: 2, createdAt: "2026-08-01T00:00:00Z", mergedAt: "2026-08-02T03:00:00Z", gateAt: "2026-08-01T02:00:00Z" },
+        { number: 3, createdAt: "2026-08-01T00:00:00Z", mergedAt: "2026-08-02T06:00:00Z", gateAt: "2026-08-01T03:00:00Z" },
+        { number: 4, createdAt: "2026-08-01T00:00:00Z", mergedAt: "2026-08-02T10:00:00Z", gateAt: "2026-08-01T04:00:00Z" },
+      ],
+    });
+
+    expect(result.bounds).toEqual({ since: "2026-08-01T00:00:00.000Z", until: "2026-08-20T00:00:00.000Z" });
+    expect(result.mergedPullRequests).toBe(4);
+    expect(result.gatedPullRequests).toBe(4);
+    expect(result.currentWip).toBe(1);
+    expect(result.currentMergeReady).toBe(1);
+    expect(result.durations.openToGate).toEqual({ sampleSize: 4, median: 9000, p90: 14400 });
+    expect(result.durations.gateToMerge).toEqual({ sampleSize: 4, median: 95400, p90: 108000 });
+    expect(result.durations.openToMerge).toEqual({ sampleSize: 4, median: 122400, p90: 122400 });
+  });
+
+  test("returns null for empty samples and rejects negative chronology instead of clamping it", () => {
+    const empty = evaluateMetrics({ since: "2026-08-01T00:00:00Z", now: "2026-08-02T00:00:00Z", issues: [], pullRequests: [] });
+    expect(empty.durations.openToGate).toBeNull();
+    expect(() => evaluateMetrics({
+      since: "2026-08-01T00:00:00Z",
+      now: "2026-08-02T00:00:00Z",
+      issues: [],
+      pullRequests: [{ number: 1, createdAt: "2026-08-01T03:00:00Z", gateAt: "2026-08-01T01:00:00Z", mergedAt: null }],
+    })).toThrow("PR #1 has negative open-to-gate duration");
+  });
+
+  test("uses event-specific windows and scans current labels independently of since", () => {
+    const result = evaluateMetrics({
+      since: "2026-08-10T00:00:00Z",
+      now: "2026-08-20T00:00:00Z",
+      issues: [{ number: 1, state: "OPEN", labels: ["WIP", "merge-ready"], createdAt: "2026-08-01T00:00:00Z" }],
+      pullRequests: [
+        { number: 1, createdAt: "2026-08-01T00:00:00Z", gateAt: "2026-08-09T00:00:00Z", mergedAt: "2026-08-11T00:00:00Z" },
+        { number: 2, createdAt: "2026-08-01T00:00:00Z", gateAt: "2026-08-11T00:00:00Z", mergedAt: "2026-08-09T00:00:00Z" },
+      ],
+    });
+
+    expect(result.mergedPullRequests).toBe(1);
+    expect(result.gatedPullRequests).toBe(1);
+    expect(result.currentWip).toBe(1);
+    expect(result.currentMergeReady).toBe(1);
+    expect(result.durations.openToGate?.sampleSize).toBe(1);
+    expect(result.durations.gateToMerge?.sampleSize).toBe(1);
+    expect(() => evaluateMetrics({ since: "2026-08-21T00:00:00Z", now: "2026-08-20T00:00:00Z", issues: [], pullRequests: [] })).toThrow("since must not be after now");
+  });
+});

--- a/tests/unit/backlog-priority.test.ts
+++ b/tests/unit/backlog-priority.test.ts
@@ -45,6 +45,17 @@ describe("backlog priority", () => {
     expect(result?.assessment).toMatchObject({ provider: "anything-opaque", urgency: 5 });
   });
 
+  test("orders offsets by instant and refuses a trusted marker on the wrong issue", () => {
+    const earlierInstant = { ...assessment, rationale: "Earlier instant." };
+    const laterInstant = { ...assessment, urgency: 5, rationale: "Later instant." };
+    const selected = selectCurrentAssessment([
+      { marker: encodePriorityMarker(earlierInstant), authorAssociation: "OWNER", createdAt: "2026-08-01T01:00:00+02:00", databaseId: 1 },
+      { marker: encodePriorityMarker(laterInstant), authorAssociation: "OWNER", createdAt: "2026-08-01T00:30:00Z", databaseId: 2 },
+    ], 1036);
+    expect(selected?.assessment.rationale).toBe("Later instant.");
+    expect(() => selectCurrentAssessment([{ marker: encodePriorityMarker({ ...assessment, issue: 1037 }), authorAssociation: "OWNER", createdAt: "2026-08-01T00:00:00Z", databaseId: 1 }], 1036)).toThrow("does not match comment container");
+  });
+
   test("orders assessed work before visible unassessed work and uses age then number as tie breaks", () => {
     const entries = sortQueue([
       { number: 12, createdAt: "2026-08-03T00:00:00Z", labels: [], assessment: null },
@@ -157,8 +168,8 @@ describe("conveyor priority boundaries", () => {
   });
 
   test("queues all comment pages, ignores untrusted lookalikes, and rejects malformed trusted markers", async () => {
-    const older = encodePriorityMarker({ ...assessment, rationale: "Earlier." });
-    const newer = encodePriorityMarker({ ...assessment, urgency: 5, rationale: "Newer." });
+    const older = encodePriorityMarker({ ...assessment, issue: 10, rationale: "Earlier." });
+    const newer = encodePriorityMarker({ ...assessment, issue: 10, urgency: 5, rationale: "Newer." });
     const runner = priorityRunner((argv) => {
       if (argv[1] === "repo") return { nameWithOwner: "o/r", defaultBranchRef: { name: "main" } };
       if ((argv[2] ?? "").includes("/issues?state=open")) return [
@@ -280,5 +291,24 @@ describe("conveyor priority boundaries", () => {
     };
 
     await expect(prioritize(runner, assessment, true)).resolves.toMatchObject({ accepted: false, violations: ["priority assessment was superseded before confirmation"] });
+  });
+
+  test("normalizes lowercase REST pull state for current merge-ready metrics", async () => {
+    const runner = priorityRunner((argv) => {
+      if (argv[1] === "repo") return { nameWithOwner: "o/r", defaultBranchRef: { name: "main" } };
+      if ((argv[2] ?? "").includes("/issues?state=all")) return [];
+      if ((argv[2] ?? "").includes("/pulls?state=all")) return [{ number: 1, created_at: "2026-08-01T00:00:00Z", merged_at: null, state: "open", labels: [{ name: "merge-ready" }], head: { sha: "a".repeat(40) } }];
+      if (argv[2] === "graphql") return { data: { repository: { pullRequest: { closingIssuesReferences: { nodes: [], pageInfo: { hasNextPage: false } } } } } };
+      if ((argv[2] ?? "").includes("comments")) return [];
+      throw new Error(`unexpected argv ${argv.join(" ")}`);
+    });
+    expect((await metrics(runner, "2026-08-01T00:00:00Z", new Date("2026-08-02T00:00:00Z"))).currentMergeReady).toBe(1);
+  });
+
+  test("retains legacy command flag rejection", () => {
+    for (const args of [["sync", "--label", "x"], ["plan", "--manifest", "x", "--limit", "1"], ["lease", "status", "--resource", "preflight", "--since", "2026-08-01T00:00:00Z"]]) {
+      const child = Bun.spawnSync(["bun", "scripts/backlog.ts", ...args], { cwd: process.cwd(), stdout: "pipe", stderr: "pipe" });
+      expect(child.exitCode).toBe(3);
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Adds provider-neutral priority assessments, deterministic queue ordering, and aggregate lifecycle metrics.
- Preserves dry-run/read-only safety and trusted-marker boundaries.

## Validation

- `bun test tests/unit/backlog-priority.test.ts tests/unit/backlog-conveyor.test.ts`
- `bun run lint`
- `bun run check:specs`
- `bunx @fission-ai/openspec@1.4.1 validate backlog-conveyor-priority-metrics --strict`
- `just preflight` under a released conveyor lease

Closes #1036
