### PR TITLE
chore(release): v1.24.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     }
   },
   "keshaEngine": {
-    "version": "1.24.9"
+    "version": "1.24.10"
   },
   "scripts": {
     "test": "bun test --timeout 30000",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "kesha-engine"
-version = "1.24.9"
+version = "1.24.10"
 dependencies = [
  "anyhow",
  "audioadapter-buffers",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesha-engine"
-version = "1.24.9"
+version = "1.24.10"
 edition = "2021"
 description = "Inference engine for Kesha Voice Kit: ASR + language detection"
 # Not for crates.io. The library target (`src/lib.rs`) exists only for the


### PR DESCRIPTION
## Engine release preparation: v1.24.10

This PR advances only the engine line:

- `rust/Cargo.toml` and `rust/Cargo.lock`: `1.24.9` → `1.24.10`
- `package.json#keshaEngine.version`: `1.24.9` → `1.24.10`
- `package.json#version` remains `1.28.0`; the subsequent `v1.28.0-cli` marker will deliver this pin to npm.

Validation completed before the bump:

- main CI and Rust Tests green
- feature matrix audited: CoreML row intentionally uses `coreml` in place of `onnx`; all rows include `tts`
- TypeScript preflight: 1,531 passed, 0 failed
- Rust nextest: 610 passed, 0 failed
- `cargo fmt --check`, clippy with warnings denied, CoreML check, and `check:versions` passed

After merge, the engine release flow will create an annotated `v1.24.10` tag, validate the GitHub Release draft assets directly, publish it, then ship the existing `1.28.0` CLI line through the `v1.28.0-cli` marker.
