### PR TITLE
chore(release): lead CLI base to v1.29.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.28.0",
+  "version": "1.29.0",
   "description": "Give your tools a voice — speech to text and back, 25 languages, up to ~19× faster than Whisper. On your machine.",
   "type": "module",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/drakulavich/kesha-voice-kit",
     "source": "github"
   },
-  "version": "1.28.0",
+  "version": "1.29.0",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@drakulavich/kesha-voice-kit",
-      "version": "1.28.0",
+      "version": "1.29.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/engine-targets.ts
+++ b/src/engine-targets.ts
@@ -17,17 +17,17 @@ const ENGINE_TARGETS: Record<string, EngineTarget> = {
   "darwin-arm64": {
     assetName: "kesha-engine-darwin-arm64",
     backend: "coreml",
-    sizeBytes: 63_780_320,
+    sizeBytes: 64_514_624,
   },
   "linux-x64": {
     assetName: "kesha-engine-linux-x64",
     backend: "onnx",
-    sizeBytes: 66_101_160,
+    sizeBytes: 66_375_432,
   },
   "win32-x64": {
     assetName: "kesha-engine-windows-x64.exe",
     backend: "onnx",
-    sizeBytes: 65_067_520,
+    sizeBytes: 65_355_264,
   },
 };
 


### PR DESCRIPTION
## Lead the unreleased CLI base to 1.29.0

`v1.28.0-cli` is now published and is `latest`, with engine pin `1.24.10`.

This follow-up advances only the unreleased CLI base:

- `package.json#version`: `1.28.0` → `1.29.0`
- `server.json#version` and registry package version: `1.28.0` → `1.29.0`
- `package.json#keshaEngine.version` stays `1.24.10`

This prevents alpha derivation from attempting to reuse the published 1.28.0 version. `bun run check:versions` and diff checks pass.
