### PR TITLE
docs(conveyor): gate merge-ready on Grok and simplify

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,8 +98,7 @@ Greptile reviews on open and on every new commit. **P1/P2 findings are merge blo
 
 ### BACKLOG CONVEYOR REVIEW GATE
 
-
-Every conveyor PR MUST follow the [backlog conveyor review runbook](docs/runbooks/backlog-conveyor-review.md): a risk-specific Grok review with a durable PR comment, a later fix-and-re-review pass for confirmed blockers, and `/simplify <PR>` only after the current head is otherwise ready. `merge-ready` is forbidden until that full sequence is recorded for the current head; an unavailable or inconclusive step is a blocker, not permission to proceed.
+Every conveyor PR MUST follow the [backlog conveyor review runbook](docs/runbooks/backlog-conveyor-review.md): a risk-specific Grok review with a durable PR comment, a later fix-and-re-review pass for confirmed blockers, and a final simplify pass only after the current head is otherwise ready. `merge-ready` is forbidden until that full sequence is recorded for the current head; an unavailable or inconclusive step is a blocker, not permission to proceed.
 
 ### ERROR HANDLING
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,14 @@ A test that spawns a stub owns its death. `bunfig.toml` preloads `tests/helpers/
 
 Greptile reviews on open and on every new commit. **P1/P2 findings are merge blockers.** Do not stop at the PR URL: wait for CI and Greptile to cover the latest head SHA, then report whether it is green. Clear false positives may be dismissed with a PR comment explaining why — rare in practice. Re-review and auto-merge mechanics: the `release-mechanics` skill.
 
+### BACKLOG CONVEYOR REVIEW GATE
+
+Every conveyor PR has an additional, mandatory adversarial Grok pass. Give Grok a risk-specific prompt, not a generic review request. The orchestrator MUST post one `**grok review**` PR comment with the verdict and every material finding (or an explicit clean verdict), so a later fresh-context fix agent can act from GitHub rather than private agent state.
+
+Confirmed Grok P1/P2 findings are merge blockers. Hand them to a subsequent fix pass, push its changes, and repeat Grok, Greptile, and CI for the new head SHA; a false positive needs a PR comment explaining why it was rejected. Remove `merge-ready` before reopening this loop if it was ever present.
+
+Only after the current head is otherwise fully ready — required CI has passed, Greptile has covered that SHA, and Grok is clean or all its blockers have been fixed and re-reviewed — run `/simplify <PR>`. Record its outcome in the PR. Any simplify finding or resulting change reopens the same fix-and-review loop on the new head. The conveyor MUST NOT add `merge-ready` until this simplify pass is complete for the current head; if `/simplify` is unavailable or inconclusive, leave the PR out of `merge-ready` and record the blocker.
+
 ### ERROR HANDLING
 
 Human-readable messages with context: what failed, why, what to do. Never swallow errors; never return success on failure.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,11 +98,8 @@ Greptile reviews on open and on every new commit. **P1/P2 findings are merge blo
 
 ### BACKLOG CONVEYOR REVIEW GATE
 
-Every conveyor PR has an additional, mandatory adversarial Grok pass. Give Grok a risk-specific prompt, not a generic review request. The orchestrator MUST post one `**grok review**` PR comment with the verdict and every material finding (or an explicit clean verdict), so a later fresh-context fix agent can act from GitHub rather than private agent state.
 
-Confirmed Grok P1/P2 findings are merge blockers. Hand them to a subsequent fix pass, push its changes, and repeat Grok, Greptile, and CI for the new head SHA; a false positive needs a PR comment explaining why it was rejected. Remove `merge-ready` before reopening this loop if it was ever present.
-
-Only after the current head is otherwise fully ready — required CI has passed, Greptile has covered that SHA, and Grok is clean or all its blockers have been fixed and re-reviewed — run `/simplify <PR>`. Record its outcome in the PR. Any simplify finding or resulting change reopens the same fix-and-review loop on the new head. The conveyor MUST NOT add `merge-ready` until this simplify pass is complete for the current head; if `/simplify` is unavailable or inconclusive, leave the PR out of `merge-ready` and record the blocker.
+Every conveyor PR MUST follow the [backlog conveyor review runbook](docs/runbooks/backlog-conveyor-review.md): a risk-specific Grok review with a durable PR comment, a later fix-and-re-review pass for confirmed blockers, and `/simplify <PR>` only after the current head is otherwise ready. `merge-ready` is forbidden until that full sequence is recorded for the current head; an unavailable or inconclusive step is a blocker, not permission to proceed.
 
 ### ERROR HANDLING
 

--- a/docs/runbooks/backlog-conveyor-review.md
+++ b/docs/runbooks/backlog-conveyor-review.md
@@ -23,7 +23,11 @@ Confirmed Grok P1/P2 findings block `merge-ready`. Remove that label first if
 it is present, then give the finding comment verbatim to a subsequent fix pass.
 The fix pass pushes its own changes; the new head must repeat Grok review,
 Greptile review, and CI. A rejected finding needs a PR comment explaining the
-evidence for rejecting it.
+evidence for rejecting it and naming the current head SHA. On that SHA, a
+rejection closes the finding only when its evidence is sufficient for a fresh
+agent to verify it. A clean review means there are no outstanding *confirmed*
+P1/P2 findings on the current head; it does not require deleting or rewriting
+the original review comment.
 
 After three unresolved fix rounds, post the remaining blocker, add
 `needs-decision` to the issue, and do not mark the PR ready. P3 findings are
@@ -34,23 +38,27 @@ follow-up; they do not silently disappear.
 
 Before simplification, verify all evidence refers to the same current PR head:
 
-- required CI is green and a real applicable gate ran, rather than a
-  path-filtered no-op;
-- Greptile has covered that head when its review service is available; and
+- the provider-neutral conveyor gate's required checks are green on that head;
+- Greptile has covered that head, as required by `CLAUDE.md`; and
 - the current-head Grok comment is clean, or every confirmed P1/P2 was fixed
-  and re-reviewed on this head.
+  or rejected with SHA-bound evidence on this head.
 
-## 4. Run `/simplify` last
+## 4. Run a simplify pass last
 
-Only after step 3, run `/simplify <PR>`. Post a `**simplify**` PR comment with
-the reviewed head SHA, verdict, and any material suggestion. If simplification
-identifies a change or causes one, that new head restarts at step 1; it needs
-fresh Grok, Greptile, CI, and a new simplify pass. If `/simplify` is unavailable
-or inconclusive, record the blocker and leave the PR without `merge-ready`.
+Only after step 3, run a behavior-preserving simplify pass. Use `/simplify <PR>`
+when the provider offers it; otherwise use an equivalent provider-neutral pass.
+Post a `**simplify**` PR comment with the reviewed head SHA, verdict, and any
+material suggestion. If simplification identifies a change or causes one, that
+new head restarts at step 1; it needs fresh Grok, Greptile, CI, and a new
+simplify pass. If no capable simplify pass is available or its result is
+inconclusive, record the blocker and leave the PR without `merge-ready`.
 
 ## 5. Mark `merge-ready`
 
-Add `merge-ready` only when the current head has the evidence from steps 1–4.
-The final PR and ledger note should state that Grok, CI, Greptile, and simplify
-all covered that exact SHA. Any subsequent push removes `merge-ready` and
-restarts this runbook.
+After steps 1–4, apply `merge-ready` only through
+`bun run conveyor -- gate --issue <N> --pr <PR> --evidence <path> --apply`
+with the existing provider-neutral, SHA-bound evidence object. Do not add the
+label by hand, and do not teach the conveyor CLI to parse Grok or simplify
+comments. The final PR and ledger note should state that Grok, CI, Greptile,
+and simplify all covered that exact SHA. Any subsequent push removes
+`merge-ready` and restarts this runbook.

--- a/docs/runbooks/backlog-conveyor-review.md
+++ b/docs/runbooks/backlog-conveyor-review.md
@@ -1,0 +1,56 @@
+# Backlog Conveyor Review Runbook
+
+This runbook is the mandatory review sequence for every PR produced by the
+backlog conveyor. `CLAUDE.md` contains the binding invariant; this document
+defines the durable GitHub evidence and the order of operations for both Codex
+and Claude.
+
+## 1. Grok review and durable evidence
+
+Run one independent, risk-specific Grok review against the PR's current head.
+Do not ask only for a generic review: name the invariant, regression, contract,
+or boundary that needs adversarial scrutiny. A private ask artifact is not
+enough. Post one PR comment headed `**grok review**` that contains:
+
+- the full reviewed head SHA;
+- Grok's verdict; and
+- every material finding with severity and enough context for a fresh fix agent
+  to act on it, or an explicit `No material findings` verdict.
+
+## 2. Resolve findings in a later pass
+
+Confirmed Grok P1/P2 findings block `merge-ready`. Remove that label first if
+it is present, then give the finding comment verbatim to a subsequent fix pass.
+The fix pass pushes its own changes; the new head must repeat Grok review,
+Greptile review, and CI. A rejected finding needs a PR comment explaining the
+evidence for rejecting it.
+
+After three unresolved fix rounds, post the remaining blocker, add
+`needs-decision` to the issue, and do not mark the PR ready. P3 findings are
+recorded in the Grok comment and handled only when their risk warrants a
+follow-up; they do not silently disappear.
+
+## 3. Establish full readiness on one head
+
+Before simplification, verify all evidence refers to the same current PR head:
+
+- required CI is green and a real applicable gate ran, rather than a
+  path-filtered no-op;
+- Greptile has covered that head when its review service is available; and
+- the current-head Grok comment is clean, or every confirmed P1/P2 was fixed
+  and re-reviewed on this head.
+
+## 4. Run `/simplify` last
+
+Only after step 3, run `/simplify <PR>`. Post a `**simplify**` PR comment with
+the reviewed head SHA, verdict, and any material suggestion. If simplification
+identifies a change or causes one, that new head restarts at step 1; it needs
+fresh Grok, Greptile, CI, and a new simplify pass. If `/simplify` is unavailable
+or inconclusive, record the blocker and leave the PR without `merge-ready`.
+
+## 5. Mark `merge-ready`
+
+Add `merge-ready` only when the current head has the evidence from steps 1–4.
+The final PR and ledger note should state that Grok, CI, Greptile, and simplify
+all covered that exact SHA. Any subsequent push removes `merge-ready` and
+restarts this runbook.


### PR DESCRIPTION
## Summary

Closes #1045.

Adds a shared, fail-closed backlog-conveyor review contract:

1. `CLAUDE.md` carries the short binding invariant that every agent reads;
2. the tracked [`docs/runbooks/backlog-conveyor-review.md`](docs/runbooks/backlog-conveyor-review.md) defines durable GitHub evidence and the exact order;
3. every conveyor PR receives a risk-specific Grok review and a durable `**grok review**` PR comment;
4. confirmed Grok P1/P2 findings go through a later fix pass and fresh CI/review on the new head;
5. only then does `/simplify <PR>` run; its outcome is recorded before `merge-ready` may be added.

The implementation gate remains provider-neutral and SHA-bound. This change governs orchestration only; it does not change product runtime code, the CLI gate, or release workflows.

## Validation

- `just preflight`
- `bun run check:recipes`

## Review focus

Check that the order is unambiguous and fails closed: Grok review and its published result, fix/re-review where needed, complete current-head readiness, `/simplify`, then `merge-ready`.
