### PR TITLE
test: refresh engine capability pacts

### DIFF
--- a/tests/fixtures/capabilities/darwin-arm64.json
+++ b/tests/fixtures/capabilities/darwin-arm64.json
@@ -4,15 +4,19 @@
   "features": [
     "transcribe",
     "transcribe.segments",
+    "transcribe.itn",
     "detect-lang",
     "vad",
     "detect-text-lang",
+    "record.live",
+    "record.live.auto-stop",
     "tts",
     "tts.ru_acronym_expansion",
     "tts.en_acronym_expansion",
     "tts.ru_emphasis_marker",
     "tts.prosody_rate",
-    "transcribe.diarize"
+    "transcribe.diarize",
+    "transcribe.words"
   ],
   "tts": {
     "languages": [

--- a/tests/fixtures/capabilities/darwin-arm64.provenance.json
+++ b/tests/fixtures/capabilities/darwin-arm64.provenance.json
@@ -1,6 +1,6 @@
 {
-  "engineVersion": "1.24.9",
+  "engineVersion": "1.24.10",
   "assetName": "kesha-engine-darwin-arm64",
-  "sha256": "96635497a69d247f041a29ba1e34d3abf632e7eaaf4d4e7a9e7d171c1dd87859",
-  "recordedFrom": "kesha-engine-darwin-arm64 downloaded from release v1.24.9 with `gh release download` and executed locally"
+  "sha256": "9ad642d63ec170fffa5371391b92af9346bf8ead2b3b927012788493f284bd58",
+  "recordedFrom": "kesha-engine-darwin-arm64 from release v1.24.10"
 }

--- a/tests/fixtures/capabilities/linux-x64.json
+++ b/tests/fixtures/capabilities/linux-x64.json
@@ -4,13 +4,15 @@
   "features": [
     "transcribe",
     "transcribe.segments",
+    "transcribe.itn",
     "detect-lang",
     "vad",
     "tts",
     "tts.ru_acronym_expansion",
     "tts.en_acronym_expansion",
     "tts.ru_emphasis_marker",
-    "tts.prosody_rate"
+    "tts.prosody_rate",
+    "transcribe.words"
   ],
   "tts": {
     "languages": [

--- a/tests/fixtures/capabilities/linux-x64.provenance.json
+++ b/tests/fixtures/capabilities/linux-x64.provenance.json
@@ -1,6 +1,6 @@
 {
-  "engineVersion": "1.24.9",
+  "engineVersion": "1.24.10",
   "assetName": "kesha-engine-linux-x64",
-  "sha256": "32298e355135d7a0ae468bb934ca14d179b31d54d6ba8e3b3c127074a26966bf",
-  "recordedFrom": "kesha-engine-linux-x64 smoke-tested pre-upload in build-engine run 31274041934 job 93144639950 (tag v1.24.9); sha256 from the release SHA256SUMS"
+  "sha256": "562da15e9996377e99a9c8ac103a4e7deac7145b3e1aafee268026a1f9d2b83c",
+  "recordedFrom": "kesha-engine-linux-x64 from release v1.24.10"
 }

--- a/tests/fixtures/capabilities/win32-x64.json
+++ b/tests/fixtures/capabilities/win32-x64.json
@@ -4,13 +4,15 @@
   "features": [
     "transcribe",
     "transcribe.segments",
+    "transcribe.itn",
     "detect-lang",
     "vad",
     "tts",
     "tts.ru_acronym_expansion",
     "tts.en_acronym_expansion",
     "tts.ru_emphasis_marker",
-    "tts.prosody_rate"
+    "tts.prosody_rate",
+    "transcribe.words"
   ],
   "tts": {
     "languages": [

--- a/tests/fixtures/capabilities/win32-x64.provenance.json
+++ b/tests/fixtures/capabilities/win32-x64.provenance.json
@@ -1,6 +1,6 @@
 {
-  "engineVersion": "1.24.9",
+  "engineVersion": "1.24.10",
   "assetName": "kesha-engine-windows-x64.exe",
-  "sha256": "c3c2b61f7e381c99b68b745e27f61cd04a151f65e0c936df9df6a05f346f8de3",
-  "recordedFrom": "kesha-engine-windows-x64.exe smoke-tested pre-upload in build-engine run 31274041934 job 93144639921 (tag v1.24.9); sha256 from the release SHA256SUMS"
+  "sha256": "35c2c7f2708eb6021ef897c7b051f5be01fe97362c22f6d5eab27e37a41b9022",
+  "recordedFrom": "kesha-engine-windows-x64.exe from release v1.24.10"
 }


### PR DESCRIPTION
## Summary

Re-records every platform capability pact from the published `v1.24.10` engine. Updating Linux and Windows alone violates the cross-platform version invariant, so the required darwin-arm64 recording is included too.

The refreshed pacts record new `transcribe.itn` and `transcribe.words` capabilities on all targets; darwin-arm64 additionally records `record.live` and `record.live.auto-stop`.

## Verification

- `bun test tests/unit/capabilities-pact.test.ts`
- `just preflight`
- GitHub Capability Pact record run: https://github.com/drakulavich/kesha-voice-kit/actions/runs/32037012201

Closes #1050
Closes #1051
Closes #1052