### PR TITLE
ci(release): gate draft and npm install smokes

### DIFF
--- a/.github/scripts/engine-release-notes.mjs
+++ b/.github/scripts/engine-release-notes.mjs
@@ -25,10 +25,17 @@ cosign verify-blob \\
   --certificate-identity "https://github.com/${REPO}/.github/workflows/build-engine.yml@refs/tags/${tag}" \\
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \\
   kesha-engine-darwin-arm64
+
+# Before gh release edit --draft=false, require the authenticated install smoke to pass:
+gh workflow run release-install-smoke.yml -R ${REPO} -f tag=${tag} -f mode=draft-engine
 \`\`\`
 
 The release also includes packaging metadata in \`kesha-release-manifest.json\`
 and a source SBOM in \`kesha-voice-kit-${tag}.spdx.json\`.
+
+The smoke downloads this draft with GitHub authentication into an isolated cache, checks the
+Linux artifact's version and capabilities, warms ASR, then transcribes and synthesises. If it
+fails, do not un-draft; inspect its log and rebuild or replace the draft with a new patch tag.
 `;
 }
 

--- a/.github/scripts/release-install-smoke.sh
+++ b/.github/scripts/release-install-smoke.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Exercise only distributed artifacts in a private scratch directory.  A draft asset cannot be
+# fetched through its public URL, so the draft mode deliberately uses authenticated `gh release
+# download`; the npm mode deliberately uses the registry package, never this checkout's binary.
+set -euo pipefail
+
+mode=${1:?usage: release-install-smoke.sh <draft-engine|npm>}
+repo_root=${GITHUB_WORKSPACE:-$PWD}
+scratch_base=${RUNNER_TEMP:-/tmp}
+scratch=$(mktemp -d "$scratch_base/kesha-release-install-smoke.XXXXXX")
+
+cleanup() {
+  rm -rf -- "$scratch"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "::error::$*" >&2
+  exit 1
+}
+
+require() {
+  local name=$1
+  [ -n "${!name:-}" ] || fail "$name must be set"
+}
+
+run_draft_engine() {
+  require TAG
+  require ENGINE_VERSION
+
+  [ "$(gh release view "$TAG" --json isDraft --jq .isDraft)" = "true" ] ||
+    fail "$TAG is no longer a draft; draft verification must finish before undrafting"
+
+  local asset=kesha-engine-linux-x64
+  local assets="$scratch/assets"
+  mkdir -p "$assets"
+  gh release download "$TAG" --repo drakulavich/kesha-voice-kit \
+    --pattern "$asset" --pattern SHA256SUMS --dir "$assets"
+
+  (
+    cd "$assets"
+    sha256sum --ignore-missing --check SHA256SUMS
+  )
+  [ -s "$assets/$asset" ] || fail "draft $TAG did not provide a non-empty $asset"
+  chmod 755 "$assets/$asset"
+
+  local actual_version
+  actual_version=$("$assets/$asset" --version)
+  [ "$actual_version" = "kesha-engine $ENGINE_VERSION" ] ||
+    fail "draft binary version was '$actual_version', expected 'kesha-engine $ENGINE_VERSION'"
+
+  "$assets/$asset" --capabilities-json > "$scratch/capabilities.json"
+  jq -e '.backend == "onnx" and (.features | index("tts"))' "$scratch/capabilities.json" >/dev/null ||
+    fail "draft Linux engine does not advertise the required onnx + tts capabilities"
+
+  # This is the marker `kesha install` writes after its normal download.  We stage the authenticated
+  # draft asset at that final location so the CLI can perform the user-facing model install without
+  # attempting an anonymous (and necessarily 404) re-download of the same draft.
+  printf '%s\n' "$ENGINE_VERSION" > "$assets/$asset.version"
+  export KESHA_ENGINE_BIN="$assets/$asset"
+  export KESHA_CACHE_DIR="$scratch/cache"
+  export KESHA_COMMAND="$repo_root/bin/kesha.js"
+
+  "$KESHA_COMMAND" --version
+  "$KESHA_COMMAND" install --onnx --tts en 2>&1 | tee "$scratch/install.log"
+  bun "$repo_root/.github/scripts/assert-install-warmup.ts" "$scratch/install.log"
+  "$KESHA_COMMAND" --json "$repo_root/tests/fixtures/benchmark-en/01-check-email.ogg" > "$scratch/transcript.json"
+  bun "$repo_root/.github/scripts/assert-transcript.ts" "$scratch/transcript.json"
+  bun "$repo_root/.github/scripts/smoke-synthesis.ts" "$scratch/synthesis"
+
+  echo "draft-engine smoke passed: tag=$TAG engine=$ENGINE_VERSION artifact=$asset"
+}
+
+run_npm() {
+  require VERSION
+
+  local package=@drakulavich/kesha-voice-kit
+  local prefix="$scratch/npm-prefix"
+  local metadata="$scratch/npm-metadata.json"
+  export npm_config_cache="$scratch/npm-cache"
+  export NPM_CONFIG_PREFIX="$prefix"
+
+  npm view "$package@$VERSION" --json version,dist.integrity,dist.attestations > "$metadata"
+  jq -e --arg version "$VERSION" '
+    .version == $version
+    and (.dist.integrity | type == "string" and startswith("sha512-"))
+    and (.dist.attestations.provenance.predicateType == "https://slsa.dev/provenance/v1")
+  ' "$metadata" >/dev/null ||
+    fail "npm metadata for $package@$VERSION lacks the expected version, integrity, or provenance"
+
+  npm install --global "$package@$VERSION"
+  local kesha="$prefix/bin/kesha"
+  [ -x "$kesha" ] || fail "npm installed $package@$VERSION without the kesha executable"
+
+  local installed_version
+  installed_version=$(node -p "require('$prefix/lib/node_modules/$package/package.json').version")
+  [ "$installed_version" = "$VERSION" ] ||
+    fail "installed npm package version was $installed_version, expected $VERSION"
+  "$kesha" --version | grep -F "$VERSION" >/dev/null ||
+    fail "installed kesha CLI did not report version $VERSION"
+
+  export KESHA_CACHE_DIR="$scratch/cache"
+  "$kesha" install --onnx 2>&1 | tee "$scratch/install.log"
+  bun "$repo_root/.github/scripts/assert-install-warmup.ts" "$scratch/install.log"
+  "$kesha" --json "$repo_root/tests/fixtures/benchmark-en/01-check-email.ogg" > "$scratch/transcript.json"
+  bun "$repo_root/.github/scripts/assert-transcript.ts" "$scratch/transcript.json"
+
+  echo "npm smoke passed: package=$package version=$VERSION"
+}
+
+case "$mode" in
+  draft-engine) run_draft_engine ;;
+  npm) run_npm ;;
+  *) fail "unsupported smoke mode: $mode" ;;
+esac

--- a/.github/scripts/smoke-synthesis.ts
+++ b/.github/scripts/smoke-synthesis.ts
@@ -57,7 +57,10 @@ async function run(
   args: string[],
   timeoutMs = 300_000,
 ): Promise<{ stdout: string; stderr: string; code: number }> {
-  const proc = Bun.spawn(["kesha", ...args], { stdout: "pipe", stderr: "pipe" });
+  // Release smoke stages a draft binary behind a tag checkout rather than a global link.  The
+  // override preserves the ordinary `kesha` default while making that exact CLI path observable.
+  const command = process.env.KESHA_COMMAND || "kesha";
+  const proc = Bun.spawn([command, ...args], { stdout: "pipe", stderr: "pipe" });
   const timer = setTimeout(() => proc.kill(), timeoutMs);
   try {
     const [stdout, stderr] = await Promise.all([

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -123,3 +123,11 @@ jobs:
           TAG: ${{ needs.plan.outputs.tag }}
         run: |
           echo "::error::npm publish failed for $TAG while its GitHub release is already public. Re-run the publish alone — it is idempotent, an already-published version exits 0 without republishing: gh workflow run npm-publish.yml --ref $TAG -f tag=$TAG"
+
+  published-install-smoke:
+    name: Smoke the published npm install
+    needs: [plan, publish-npm]
+    uses: ./.github/workflows/release-install-smoke.yml
+    with:
+      tag: ${{ needs.plan.outputs.tag }}
+      version: ${{ needs.plan.outputs.version }}

--- a/.github/workflows/release-install-smoke.yml
+++ b/.github/workflows/release-install-smoke.yml
@@ -1,0 +1,75 @@
+name: "🚬 Release install smoke"
+
+# The draft path is intentionally manual: only an authenticated GitHub token can download a
+# draft asset, and a failed run is an explicit stop sign before a maintainer un-drafts it.  The
+# reusable npm path is called by the CLI release only after the registry says the exact version is
+# live, so it cannot accidentally smoke the checkout or a prior global installation.
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Engine or CLI release tag to verify (for example v1.30.0)"
+        required: true
+        type: string
+      mode:
+        description: "draft-engine verifies a still-draft engine release; npm verifies a published CLI package"
+        required: true
+        default: draft-engine
+        type: choice
+        options: [draft-engine, npm]
+      version:
+        description: "Required for npm mode: exact CLI package version"
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+      version:
+        required: true
+        type: string
+      mode:
+        required: false
+        default: npm
+        type: string
+
+jobs:
+  draft-engine:
+    if: inputs.mode == 'draft-engine'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    # GitHub hides drafts from read-only tokens; this job never writes despite the visibility scope.
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.tag }}
+          lfs: true
+      - uses: ./.github/actions/setup-bun
+      - name: Read the engine pin from the release tag
+        run: echo "ENGINE_VERSION=$(jq -er '.keshaEngine.version | strings' package.json)" >> "$GITHUB_ENV"
+      - name: Verify the draft artifact through an isolated user path
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
+        run: .github/scripts/release-install-smoke.sh draft-engine
+
+  npm:
+    if: inputs.mode == 'npm'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.tag }}
+          lfs: true
+      - uses: ./.github/actions/setup-bun
+      - name: Verify the exact published npm package through an isolated user path
+        env:
+          TAG: ${{ inputs.tag }}
+          VERSION: ${{ inputs.version }}
+        run: .github/scripts/release-install-smoke.sh npm

--- a/tests/unit/release-install-smoke.test.ts
+++ b/tests/unit/release-install-smoke.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { parseRepoYaml, readRepoFile } from "../helpers/repo";
+
+const WORKFLOW = ".github/workflows/release-install-smoke.yml";
+const SCRIPT = ".github/scripts/release-install-smoke.sh";
+
+describe("release install smoke", () => {
+  test("keeps the draft gate manual and makes the post-npm path reusable", () => {
+    const workflow = parseRepoYaml(WORKFLOW);
+
+    expect(workflow.on.workflow_dispatch.inputs.mode.default).toBe("draft-engine");
+    expect(workflow.on.workflow_call.inputs.version.required).toBe(true);
+    expect(workflow.on.workflow_call.inputs.mode.default).toBe("npm");
+    expect(workflow.jobs["draft-engine"].permissions).toEqual({ contents: "write" });
+    expect(workflow.jobs.npm.permissions).toEqual({ contents: "read" });
+  });
+
+  test("downloads the authenticated draft artifact into a disposable private cache", () => {
+    const script = readRepoFile(SCRIPT);
+    const synthesisSmoke = readRepoFile(".github/scripts/smoke-synthesis.ts");
+
+    expect(script).toContain('gh release download "$TAG"');
+    expect(script).toContain('[ "$(gh release view "$TAG" --json isDraft --jq .isDraft)" = "true" ]');
+    expect(script).toContain('KESHA_ENGINE_BIN="$assets/$asset"');
+    expect(script).toContain('KESHA_CACHE_DIR="$scratch/cache"');
+    expect(script).toContain('bun "$repo_root/.github/scripts/assert-install-warmup.ts"');
+    expect(script).toContain('bun "$repo_root/.github/scripts/smoke-synthesis.ts"');
+    expect(script).toContain('trap cleanup EXIT');
+    expect(synthesisSmoke).toContain('process.env.KESHA_COMMAND || "kesha"');
+  });
+
+  test("installs an exact npm package and requires provenance metadata", () => {
+    const script = readRepoFile(SCRIPT);
+
+    expect(script).toContain('npm view "$package@$VERSION" --json version,dist.integrity,dist.attestations');
+    expect(script).toContain('https://slsa.dev/provenance/v1');
+    expect(script).toContain('npm install --global "$package@$VERSION"');
+    expect(script).toContain('NPM_CONFIG_PREFIX="$prefix"');
+    expect(script).toContain('installed npm package version was $installed_version, expected $VERSION');
+  });
+
+  test("runs the npm smoke only after the release lane has observed the published version", () => {
+    const cliRelease = parseRepoYaml(".github/workflows/release-cli.yml");
+    const job = cliRelease.jobs["published-install-smoke"];
+
+    expect(job.needs).toEqual(["plan", "publish-npm"]);
+    expect(job.uses).toBe("./.github/workflows/release-install-smoke.yml");
+    expect(job.with).toEqual({
+      tag: "${{ needs.plan.outputs.tag }}",
+      version: "${{ needs.plan.outputs.version }}",
+    });
+  });
+});


### PR DESCRIPTION
Closes #1043.\n\nAdds an authenticated draft-engine smoke in a disposable cache plus a post-publication npm smoke for the exact package version, integrity and provenance. The draft release notes now require the gate before undraft.\n\nValidation: just preflight; focused workflow/release-note tests; isolated npm-prefix installation of the published 1.28.0 package.