### PR TITLE
ci(release): add verified stable tag helper

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,6 +167,8 @@ Three invariants worth knowing before you touch a release:
 
 Full procedure, `bun link` gotchas, and re-review mechanics: the **`release-mechanics`** skill (loads on demand). To cut one, invoke **`release-engine`** (engine, bare `vX.Y.Z`) or **`release-cli`** (CLI to npm, `vX.Y.Z-cli`); a full ship is the engine first, then the CLI that carries its pin.
 
+When an authorized maintainer needs a verified stable tag creation sequence, use `just release-tag vX.Y.Z notes.md` from the clean root checkout. The deliberate GitHub API fallback is `just release-tag vX.Y.Z notes.md api`; do not switch to it after a timed-out Git push until the remote tag state is known. Details: [release tag helper](docs/runbooks/release-tag-helper.md).
+
 ## Build Commands
 
 ```bash

--- a/docs/runbooks/release-tag-helper.md
+++ b/docs/runbooks/release-tag-helper.md
@@ -1,0 +1,28 @@
+# Stable release-tag helper
+
+Create a stable engine tag only from a clean, current root checkout:
+
+```bash
+just release-tag vX.Y.Z notes.md
+```
+
+The helper fetches `origin/main`, refuses a used local or remote tag, makes the annotated tag
+target that exact commit, pushes it, then reads the remote ref and tag object back. It verifies the
+annotation, target, tagger identity, and the `build-engine.yml` push-triggered run.
+
+If an SSH push cannot be attempted, choose the GitHub API path before creating anything:
+
+```bash
+just release-tag vX.Y.Z notes.md api
+```
+
+The fallback uses the authenticated maintainer's `gh` session. It creates the annotated tag object
+and only then `refs/tags/vX.Y.Z`, as required by GitHub's Git database API. Because an API-created
+ref does not provide the human `push` event used by the normal release lane, the helper explicitly
+dispatches `build-engine.yml` at the new tag and verifies that run.
+
+Never retry through `api` after a failed `push` without first proving the remote tag is absent. A
+timeout can mean the remote accepted the tag; tags are one-use, so the helper fails closed instead
+of guessing. This helper creates no release and does not publish npm packages.
+
+Sources: [Create a tag object](https://docs.github.com/en/rest/git/tags?apiVersion=2022-11-28#create-a-tag-object), [Create a reference](https://docs.github.com/en/rest/git/refs?apiVersion=2022-11-28#create-a-reference).

--- a/justfile
+++ b/justfile
@@ -119,6 +119,13 @@ preflight:
       echo "==> CoreML check skipped: no rust/src/backend/ changes"
     fi
 
+# Create and verify a human-authorized stable engine tag. The `api` mode is an explicit fallback
+# for an SSH push that cannot be used; it never follows an uncertain push failure automatically.
+# Usage: just release-tag vX.Y.Z notes.md [push|api]
+[positional-arguments]
+release-tag tag notes mode="push": root-checkout-only
+    bun scripts/release-tag.ts --tag "$1" --notes "$2" --mode "$3"
+
 # The default nextest run builds only onnx,tts, so system_kokoro / system_diarize /
 # system_text_lang never compile locally; rust-test.yml calls this recipe rather than repeat the set.
 # Lint the full darwin release feature set (macOS 14+ arm64)

--- a/scripts/release-tag.ts
+++ b/scripts/release-tag.ts
@@ -1,0 +1,188 @@
+#!/usr/bin/env bun
+/**
+ * Create one stable, annotated engine tag from current origin/main.
+ *
+ * The API fallback deliberately creates an annotated Git tag object before its ref: GitHub's
+ * REST API does not turn a tag object into a tag until `refs/tags/<tag>` is created.
+ * Source: https://docs.github.com/en/rest/git/tags?apiVersion=2022-11-28#create-a-tag-object
+ *         https://docs.github.com/en/rest/git/refs?apiVersion=2022-11-28#create-a-reference
+ */
+import { readFile } from "node:fs/promises";
+
+const REPO = "drakulavich/kesha-voice-kit";
+const TAG = /^v\d+\.\d+\.\d+$/;
+
+export type Mode = "push" | "api";
+export type Options = { tag: string; notesPath: string; mode: Mode };
+export type CommandResult = { code: number; stdout: string; stderr: string };
+export type CommandRunner = (argv: string[], input?: string) => Promise<CommandResult>;
+
+function fail(message: string): never {
+  throw new Error(`release-tag: ${message}`);
+}
+
+function requireSuccess(result: CommandResult, display: string): string {
+  if (result.code !== 0) fail(`${display} failed${result.stderr ? `: ${result.stderr.trim()}` : ""}`);
+  return result.stdout.trim();
+}
+
+export function parseArgs(argv: string[]): Options {
+  let tag = "";
+  let notesPath = "";
+  let mode: Mode = "push";
+  for (let i = 0; i < argv.length; i++) {
+    const flag = argv[i];
+    const value = argv[i + 1];
+    if (flag === "--tag") tag = value ?? "";
+    else if (flag === "--notes") notesPath = value ?? "";
+    else if (flag === "--mode") {
+      if (value === "push" || value === "api") mode = value;
+      else fail("--mode must be push or api");
+    } else fail(`unknown argument ${flag}`);
+    i++;
+  }
+  if (!TAG.test(tag)) fail("--tag must be a stable vX.Y.Z tag (no prerelease or -cli suffix)");
+  if (!notesPath) fail("--notes must name the release-notes file");
+  return { tag, notesPath, mode };
+}
+
+async function shell(runner: CommandRunner, ...argv: string[]): Promise<string> {
+  return requireSuccess(await runner(argv), argv.join(" "));
+}
+
+async function remoteTagAbsent(runner: CommandRunner, tag: string): Promise<void> {
+  const result = await runner(["gh", "api", `repos/${REPO}/git/ref/tags/${tag}`]);
+  if (result.code === 0) fail(`remote tag ${tag} already exists; tags are one-use`);
+  if (!/404|not found/i.test(result.stderr)) {
+    fail(`could not prove remote tag ${tag} is absent${result.stderr ? `: ${result.stderr.trim()}` : ""}`);
+  }
+}
+
+async function localTagAbsent(runner: CommandRunner, tag: string): Promise<void> {
+  const result = await runner(["git", "show-ref", "--verify", "--quiet", `refs/tags/${tag}`]);
+  if (result.code === 0) fail(`local tag ${tag} already exists; resolve its remote state before retrying`);
+  if (result.code !== 1) fail(`could not inspect local tag ${tag}${result.stderr ? `: ${result.stderr.trim()}` : ""}`);
+}
+
+function parseJson<T>(value: string, label: string): T {
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    fail(`${label} returned invalid JSON`);
+  }
+}
+
+async function verifyRemoteTag(
+  runner: CommandRunner,
+  tag: string,
+  target: string,
+  notes: string,
+  identity: { name: string; email: string },
+): Promise<void> {
+  const ref = parseJson<{ ref?: string; object?: { type?: string; sha?: string } }>(
+    await shell(runner, "gh", "api", `repos/${REPO}/git/ref/tags/${tag}`),
+    "tag reference",
+  );
+  if (ref.ref !== `refs/tags/${tag}` || ref.object?.type !== "tag" || !ref.object.sha) {
+    fail(`remote ref for ${tag} is not an annotated tag object`);
+  }
+  const object = parseJson<{
+    tag?: string;
+    message?: string;
+    object?: { type?: string; sha?: string };
+    tagger?: { name?: string; email?: string };
+  }>(await shell(runner, "gh", "api", `repos/${REPO}/git/tags/${ref.object.sha}`), "tag object");
+  if (object.tag !== tag || object.message !== notes || object.object?.type !== "commit" || object.object.sha !== target) {
+    fail(`remote annotated tag ${tag} does not match the requested target or notes`);
+  }
+  if (object.tagger?.name !== identity.name || object.tagger.email !== identity.email) {
+    fail(`remote annotated tag ${tag} has an unexpected tagger identity`);
+  }
+}
+
+async function waitForWorkflow(
+  runner: CommandRunner,
+  tag: string,
+  target: string,
+  event: "push" | "workflow_dispatch",
+): Promise<void> {
+  for (let attempt = 0; attempt < 15; attempt++) {
+    const raw = await shell(
+      runner,
+      "gh",
+      "run",
+      "list",
+      "--repo",
+      REPO,
+      "--workflow",
+      "build-engine.yml",
+      "--branch",
+      tag,
+      "--limit",
+      "10",
+      "--json",
+      "databaseId,headSha,event,url",
+    );
+    const runs = parseJson<Array<{ headSha?: string; event?: string }>>(raw, "workflow runs");
+    if (runs.some((run) => run.headSha === target && run.event === event)) return;
+    await Bun.sleep(2_000);
+  }
+  fail(`no ${event} build-engine workflow run appeared for ${tag} at ${target}`);
+}
+
+export async function createStableTag(options: Options, notes: string, runner: CommandRunner): Promise<void> {
+  if (!notes.trim()) fail("release notes must not be empty");
+  await shell(runner, "git", "fetch", "origin", "main");
+  const target = await shell(runner, "git", "rev-parse", "origin/main");
+  if (!/^[0-9a-f]{40}$/i.test(target)) fail("origin/main did not resolve to a commit SHA");
+  if ((await shell(runner, "git", "status", "--porcelain")) !== "") fail("working tree is not clean");
+  await remoteTagAbsent(runner, options.tag);
+  await localTagAbsent(runner, options.tag);
+  const identity = {
+    name: await shell(runner, "git", "config", "user.name"),
+    email: await shell(runner, "git", "config", "user.email"),
+  };
+  if (!identity.name || !identity.email) fail("git user.name and user.email must be configured");
+
+  if (options.mode === "push") {
+    await shell(runner, "git", "tag", "-a", options.tag, target, "--cleanup=verbatim", "-F", options.notesPath);
+    const pushed = await runner(["git", "push", "origin", `refs/tags/${options.tag}`]);
+    if (pushed.code !== 0) {
+      fail(`standard tag push failed; remote state is uncertain, so API fallback was not attempted. Verify ${options.tag} remotely before retrying`);
+    }
+  } else {
+    const tagObject = requireSuccess(
+      await runner(
+        ["gh", "api", "--method", "POST", `repos/${REPO}/git/tags`, "--input", "-"],
+        JSON.stringify({ tag: options.tag, message: notes, object: target, type: "commit", tagger: { ...identity, date: new Date().toISOString() } }),
+      ),
+      "create annotated tag object",
+    );
+    const tagSha = parseJson<{ sha?: string }>(tagObject, "created tag object").sha;
+    if (!tagSha || !/^[0-9a-f]{40}$/i.test(tagSha)) fail("GitHub did not return an annotated tag object SHA");
+    await shell(runner, "gh", "api", "--method", "POST", `repos/${REPO}/git/refs`, "-f", `ref=refs/tags/${options.tag}`, "-f", `sha=${tagSha}`);
+  }
+
+  await verifyRemoteTag(runner, options.tag, target, notes, identity);
+  if (options.mode === "api") {
+    await shell(runner, "gh", "workflow", "run", "build-engine.yml", "--repo", REPO, "--ref", options.tag);
+  }
+  await waitForWorkflow(runner, options.tag, target, options.mode === "push" ? "push" : "workflow_dispatch");
+  console.log(`Verified annotated tag ${options.tag} at ${target}; build-engine workflow was triggered.`);
+}
+
+async function run(argv: string[], input?: string): Promise<CommandResult> {
+  const proc = Bun.spawn(argv, { stdin: input ? "pipe" : "ignore", stdout: "pipe", stderr: "pipe" });
+  if (input && proc.stdin) {
+    proc.stdin.write(input);
+    proc.stdin.end();
+  }
+  const [stdout, stderr, code] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text(), proc.exited]);
+  return { code, stdout, stderr };
+}
+
+if (import.meta.main) {
+  const options = parseArgs(process.argv.slice(2));
+  const notes = await readFile(options.notesPath, "utf8");
+  await createStableTag(options, notes, run);
+}

--- a/tests/unit/check-recipes.test.ts
+++ b/tests/unit/check-recipes.test.ts
@@ -236,6 +236,7 @@ describe("the repository's own references", () => {
       "dev-setup",
       "preflight",
       "release",
+      "release-tag",
       "rust-test",
       "smoke-test",
       "test",

--- a/tests/unit/release-tag.test.ts
+++ b/tests/unit/release-tag.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import { createStableTag, parseArgs, type CommandResult, type CommandRunner } from "../../scripts/release-tag";
+
+const target = "a".repeat(40);
+const tagObject = "b".repeat(40);
+const tag = "v1.30.0";
+const notes = "## Release\n\n- safer tagging\n";
+
+const success = (stdout = ""): CommandResult => ({ code: 0, stdout, stderr: "" });
+
+function fakeRunner(mode: "push" | "api", failPush = false): { runner: CommandRunner; calls: string[][] } {
+  const calls: string[][] = [];
+  const runner: CommandRunner = async (argv) => {
+    calls.push(argv);
+    const command = argv.join(" ");
+    if (command === "git fetch origin main") return success();
+    if (command === "git rev-parse origin/main") return success(`${target}\n`);
+    if (command === "git status --porcelain") return success();
+    if (command === `gh api repos/drakulavich/kesha-voice-kit/git/ref/tags/${tag}`) {
+      const reads = calls.filter((call) => call.join(" ") === command).length;
+      return reads === 1
+        ? { code: 1, stdout: "", stderr: "HTTP 404: Not Found" }
+        : success(JSON.stringify({ ref: `refs/tags/${tag}`, object: { type: "tag", sha: tagObject } }));
+    }
+    if (command === `git show-ref --verify --quiet refs/tags/${tag}`) return { code: 1, stdout: "", stderr: "" };
+    if (command === "git config user.name") return success("Release Maintainer\n");
+    if (command === "git config user.email") return success("release@example.com\n");
+    if (command.startsWith("git tag -a")) return success();
+    if (command === `git push origin refs/tags/${tag}`) return failPush ? { code: 1, stdout: "", stderr: "timeout" } : success();
+    if (command === "gh api --method POST repos/drakulavich/kesha-voice-kit/git/tags --input -") return success(JSON.stringify({ sha: tagObject }));
+    if (command.startsWith("gh api --method POST repos/drakulavich/kesha-voice-kit/git/refs ")) return success();
+    if (command === `gh api repos/drakulavich/kesha-voice-kit/git/tags/${tagObject}`) {
+      return success(JSON.stringify({ tag, message: notes, object: { type: "commit", sha: target }, tagger: { name: "Release Maintainer", email: "release@example.com" } }));
+    }
+    if (command === "gh workflow run build-engine.yml --repo drakulavich/kesha-voice-kit --ref v1.30.0") return success();
+    if (command.includes("gh run list") && command.includes("build-engine.yml")) {
+      return success(JSON.stringify([{ headSha: target, event: mode === "push" ? "push" : "workflow_dispatch" }]));
+    }
+    throw new Error(`unexpected command: ${command}`);
+  };
+  return { runner, calls };
+}
+
+describe("release tag helper", () => {
+  test("accepts only a stable tag, notes file, and explicit mode", () => {
+    expect(parseArgs(["--tag", tag, "--notes", "notes.md"])).toEqual({ tag, notesPath: "notes.md", mode: "push" });
+    expect(parseArgs(["--tag", tag, "--notes", "notes.md", "--mode", "api"]).mode).toBe("api");
+    expect(() => parseArgs(["--tag", "v1.30.0-beta.1", "--notes", "notes.md"])).toThrow("stable vX.Y.Z");
+  });
+
+  test("uses the ordinary annotated git push path and verifies the remote object and workflow", async () => {
+    const { runner, calls } = fakeRunner("push");
+
+    await createStableTag({ tag, notesPath: "notes.md", mode: "push" }, notes, runner);
+
+    expect(calls.some((call) => call.join(" ") === `git tag -a ${tag} ${target} --cleanup=verbatim -F notes.md`)).toBe(true);
+    expect(calls.some((call) => call.join(" ") === `git push origin refs/tags/${tag}`)).toBe(true);
+    expect(calls.some((call) => call.includes("repos/drakulavich/kesha-voice-kit/git/tags"))).toBe(false);
+  });
+
+  test("uses the documented two-step GitHub API fallback and explicitly dispatches the build", async () => {
+    const { runner, calls } = fakeRunner("api");
+
+    await createStableTag({ tag, notesPath: "notes.md", mode: "api" }, notes, runner);
+
+    expect(calls.some((call) => call.join(" ") === "gh api --method POST repos/drakulavich/kesha-voice-kit/git/tags --input -")).toBe(true);
+    expect(calls.some((call) => call.join(" ") === `gh api --method POST repos/drakulavich/kesha-voice-kit/git/refs -f ref=refs/tags/${tag} -f sha=${tagObject}`)).toBe(true);
+    expect(calls.some((call) => call.join(" ") === "gh workflow run build-engine.yml --repo drakulavich/kesha-voice-kit --ref v1.30.0")).toBe(true);
+  });
+
+  test("does not switch to the API path after an uncertain push failure", async () => {
+    const { runner, calls } = fakeRunner("push", true);
+
+    await expect(createStableTag({ tag, notesPath: "notes.md", mode: "push" }, notes, runner)).rejects.toThrow("remote state is uncertain");
+    expect(calls.some((call) => call.join(" ") === "gh api --method POST repos/drakulavich/kesha-voice-kit/git/tags --input -")).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #1042.

Adds one root-checkout recipe for a stable annotated tag, with explicit standard-push and authenticated API modes. Both paths verify the remote ref, annotation, target, tagger, and build workflow; an uncertain push fails closed without automatic fallback.

Validation: `just preflight`; helper contract tests; workflow and recipe checks.