### PR TITLE
ci(release): automate post-release follow-up

### DIFF
--- a/.github/scripts/post-engine-release.ts
+++ b/.github/scripts/post-engine-release.ts
@@ -1,0 +1,264 @@
+#!/usr/bin/env bun
+import { readFileSync, writeFileSync } from "node:fs";
+import { engineTargetEntries } from "../../src/engine-targets";
+import { cmp, isStableVersion, parseSemver } from "../../src/semver.mjs";
+
+const REPO = "drakulavich/kesha-voice-kit";
+
+export type ReleaseAsset = { name: string; size: number; browser_download_url?: string };
+
+type Release = {
+  isDraft: boolean;
+  isPrerelease: boolean;
+  assets: ReleaseAsset[];
+};
+
+type Manifest = {
+  tag: string;
+  engineVersion: string;
+  assets: Array<{ name: string; signatureBundle: string }>;
+};
+
+type FollowupInput = {
+  tag: string;
+  release: Release;
+  manifest: Manifest;
+  targetSource: string;
+  packageSource: string;
+  serverSource: string;
+};
+
+export type Followup = {
+  nextCliVersion: string;
+  targetSource: string;
+  packageSource: string;
+  serverSource: string;
+  prBody: string;
+};
+
+function asRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function stringAt(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.length === 0) throw new Error(`${label} must be a non-empty string`);
+  return value;
+}
+
+function booleanAt(value: unknown, label: string): boolean {
+  if (typeof value !== "boolean") throw new Error(`${label} must be a boolean`);
+  return value;
+}
+
+function parseManifest(value: unknown): Manifest {
+  const raw = asRecord(value, "release manifest");
+  if (!Array.isArray(raw.assets)) throw new Error("release manifest assets must be an array");
+  return {
+    tag: stringAt(raw.tag, "release manifest tag"),
+    engineVersion: stringAt(raw.engineVersion, "release manifest engineVersion"),
+    assets: raw.assets.map((entry) => {
+      const asset = asRecord(entry, "release manifest asset");
+      return {
+        name: stringAt(asset.name, "release manifest asset name"),
+        signatureBundle: stringAt(asset.signatureBundle, "release manifest asset signatureBundle"),
+      };
+    }),
+  };
+}
+
+function assetMap(assets: ReleaseAsset[]): Map<string, ReleaseAsset> {
+  const byName = new Map<string, ReleaseAsset>();
+  for (const asset of assets) {
+    if (!asset || typeof asset.name !== "string" || !Number.isSafeInteger(asset.size) || asset.size <= 0) {
+      throw new Error("release assets must have unique names and positive integer sizes");
+    }
+    if (byName.has(asset.name)) throw new Error(`release has duplicate asset ${asset.name}`);
+    byName.set(asset.name, asset);
+  }
+  return byName;
+}
+
+function requireSignedAssets(manifest: Manifest, releaseAssets: Map<string, ReleaseAsset>): void {
+  const manifestNames = new Set<string>();
+  for (const asset of manifest.assets) {
+    if (!asset || typeof asset.name !== "string" || typeof asset.signatureBundle !== "string") {
+      throw new Error("release manifest has an invalid asset entry");
+    }
+    if (manifestNames.has(asset.name)) throw new Error(`release manifest has duplicate asset ${asset.name}`);
+    manifestNames.add(asset.name);
+    if (!releaseAssets.has(asset.name) || !releaseAssets.has(asset.signatureBundle)) {
+      throw new Error(`release is missing signed asset ${asset.name} (${asset.signatureBundle})`);
+    }
+  }
+}
+
+function replaceTargetSize(source: string, assetName: string, size: number): string {
+  const escaped = assetName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp(
+    `(assetName:\\s*"${escaped}",\\s*\\n\\s*backend:\\s*"[^"]+",\\s*\\n\\s*sizeBytes:\\s*)\\d[\\d_]*`,
+    "g",
+  );
+  const matches = [...source.matchAll(pattern)];
+  if (matches.length !== 1) {
+    throw new Error(`src/engine-targets.ts must contain exactly one editable row for ${assetName}`);
+  }
+  return source.replace(pattern, `$1${size.toLocaleString("en-US").replaceAll(",", "_")}`);
+}
+
+function parsePackage(source: string): { version: string; keshaEngine: { version: string } } {
+  const pkg = asRecord(JSON.parse(source), "package.json");
+  const engine = asRecord(pkg.keshaEngine, "package.json#keshaEngine");
+  return {
+    version: stringAt(pkg.version, "package.json#version"),
+    keshaEngine: { version: stringAt(engine.version, "package.json#keshaEngine.version") },
+  };
+}
+
+function replaceServerVersions(source: string, currentCliVersion: string, version: string): string {
+  const server = asRecord(JSON.parse(source), "server.json");
+  const current = stringAt(server.version, "server.json#version");
+  if (current !== currentCliVersion) {
+    throw new Error(`server.json#version (${current}) does not match package.json#version (${currentCliVersion})`);
+  }
+  const packages = server.packages;
+  if (!Array.isArray(packages) || packages.length === 0) throw new Error("server.json#packages must be a non-empty array");
+  for (const [index, entry] of packages.entries()) {
+    const pkg = asRecord(entry, `server.json#packages[${index}]`);
+    if (stringAt(pkg.version, `server.json#packages[${index}].version`) !== current) {
+      throw new Error("server.json package versions must match server.json#version before a release follow-up");
+    }
+    pkg.version = version;
+  }
+  server.version = version;
+  return `${JSON.stringify(server, null, 2)}\n`;
+}
+
+function formatProvenance(tag: string, nextCliVersion: string, releaseAssets: Map<string, ReleaseAsset>): string {
+  const lines = engineTargetEntries().map(({ target }) => {
+    const size = releaseAssets.get(target.assetName)?.size;
+    if (size === undefined) throw new Error(`release is missing engine asset ${target.assetName}`);
+    return `- \`${target.assetName}\`: ${size.toLocaleString("en-US")} bytes`;
+  });
+  return `Automated post-release follow-up for engine [\`${tag}\`](https://github.com/${REPO}/releases/tag/${tag}).
+
+## Provenance
+
+- Published engine tag: \`${tag}\`
+- CLI/server transition: next development baseline \`${nextCliVersion}\`
+${lines.join("\n")}
+
+## Validation
+
+- \`bun run check:versions\`
+- \`bun run check:engine-targets\`
+`;
+}
+
+export function buildPostEngineReleaseFollowup(input: FollowupInput): Followup {
+  const version = input.tag.startsWith("v") ? input.tag.slice(1) : "";
+  if (!isStableVersion(version)) throw new Error(`published tag ${input.tag} is not a stable engine version`);
+  if (input.release.isDraft) throw new Error(`release ${input.tag} is still a draft`);
+  if (input.release.isPrerelease) throw new Error(`release ${input.tag} is a prerelease`);
+  if (input.manifest.tag !== input.tag || input.manifest.engineVersion !== version) {
+    throw new Error(`release manifest does not identify published tag ${input.tag}`);
+  }
+
+  const releaseAssets = assetMap(input.release.assets);
+  requireSignedAssets(input.manifest, releaseAssets);
+  let targetSource = input.targetSource;
+  for (const { target } of engineTargetEntries()) {
+    const asset = releaseAssets.get(target.assetName);
+    if (!asset) throw new Error(`release is missing engine asset ${target.assetName}`);
+    if (!input.manifest.assets.some((entry) => entry.name === target.assetName)) {
+      throw new Error(`release manifest is missing engine asset ${target.assetName}`);
+    }
+    targetSource = replaceTargetSize(targetSource, target.assetName, asset.size);
+  }
+
+  const pkg = parsePackage(input.packageSource);
+  if (pkg.keshaEngine.version !== version) {
+    throw new Error(
+      `package.json#keshaEngine.version (${pkg.keshaEngine.version}) does not match published tag ${input.tag}`,
+    );
+  }
+  const cli = parseSemver(pkg.version, "package.json#version");
+  const engine = parseSemver(version, "published engine tag");
+  if (cmp(cli, engine) < 0 || cli.prerelease.length > 0 || cli.build.length > 0) {
+    throw new Error(`package.json#version (${pkg.version}) is not an unambiguous stable CLI baseline`);
+  }
+  const nextCliVersion = `${cli.major}.${cli.minor + 1}.0`;
+  const packageSource = `${JSON.stringify({ ...JSON.parse(input.packageSource), version: nextCliVersion }, null, 2)}\n`;
+  const serverSource = replaceServerVersions(input.serverSource, pkg.version, nextCliVersion);
+
+  return {
+    nextCliVersion,
+    targetSource,
+    packageSource,
+    serverSource,
+    prBody: formatProvenance(input.tag, nextCliVersion, releaseAssets),
+  };
+}
+
+function option(name: string): string {
+  const index = process.argv.indexOf(name);
+  const value = index === -1 ? undefined : process.argv[index + 1];
+  if (!value || value.startsWith("-")) throw new Error(`usage: bun .github/scripts/post-engine-release.ts --tag vX.Y.Z`);
+  return value;
+}
+
+async function fetchJson(url: string, token: string): Promise<unknown> {
+  const response = await fetch(url, {
+    headers: { accept: "application/vnd.github+json", authorization: `Bearer ${token}` },
+  });
+  if (!response.ok) throw new Error(`GitHub API request failed (${response.status}) for ${url}`);
+  return response.json();
+}
+
+async function main(): Promise<void> {
+  const tag = option("--tag");
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) throw new Error("GITHUB_TOKEN is required to read the published release");
+  const raw = asRecord(await fetchJson(`https://api.github.com/repos/${REPO}/releases/tags/${encodeURIComponent(tag)}`, token), "release");
+  if (raw.published_at === null || typeof raw.published_at !== "string") {
+    throw new Error(`release ${tag} is not published`);
+  }
+  if (!Array.isArray(raw.assets)) throw new Error("release assets must be an array");
+  const assets = raw.assets.map((entry) => {
+    const asset = asRecord(entry, "release asset");
+    return {
+      name: stringAt(asset.name, "release asset name"),
+      size: asset.size as number,
+      browser_download_url: stringAt(asset.browser_download_url, "release asset download URL"),
+    };
+  });
+  const manifestAsset = assets.find((asset) => asset.name === "kesha-release-manifest.json");
+  if (!manifestAsset?.browser_download_url) throw new Error(`release ${tag} has no kesha-release-manifest.json asset`);
+  const manifest = parseManifest(await fetchJson(manifestAsset.browser_download_url, token));
+  const result = buildPostEngineReleaseFollowup({
+    tag,
+    release: {
+      isDraft: booleanAt(raw.draft, "release draft"),
+      isPrerelease: booleanAt(raw.prerelease, "release prerelease"),
+      assets,
+    },
+    manifest,
+    targetSource: readFileSync("src/engine-targets.ts", "utf8"),
+    packageSource: readFileSync("package.json", "utf8"),
+    serverSource: readFileSync("server.json", "utf8"),
+  });
+  writeFileSync("src/engine-targets.ts", result.targetSource);
+  writeFileSync("package.json", result.packageSource);
+  writeFileSync("server.json", result.serverSource);
+  writeFileSync("post-release-pr.md", result.prBody);
+  console.log(`prepared follow-up for ${tag}: CLI/server → ${result.nextCliVersion}`);
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/.github/scripts/post-engine-release.ts
+++ b/.github/scripts/post-engine-release.ts
@@ -21,6 +21,7 @@ type Manifest = {
 
 type FollowupInput = {
   tag: string;
+  cliReleasePublished: boolean;
   release: Release;
   manifest: Manifest;
   targetSource: string;
@@ -189,6 +190,11 @@ export function buildPostEngineReleaseFollowup(input: FollowupInput): Followup {
   if (cmp(cli, engine) < 0 || cli.prerelease.length > 0 || cli.build.length > 0) {
     throw new Error(`package.json#version (${pkg.version}) is not an unambiguous stable CLI baseline`);
   }
+  if (!input.cliReleasePublished) {
+    throw new Error(
+      `CLI marker release v${pkg.version}-cli is not published; publish it before leading the next CLI baseline`,
+    );
+  }
   const nextCliVersion = `${cli.major}.${cli.minor + 1}.0`;
   const packageSource = `${JSON.stringify({ ...JSON.parse(input.packageSource), version: nextCliVersion }, null, 2)}\n`;
   const serverSource = replaceServerVersions(input.serverSource, pkg.version, nextCliVersion);
@@ -217,6 +223,20 @@ async function fetchJson(url: string, token: string): Promise<unknown> {
   return response.json();
 }
 
+async function releaseIsPublished(token: string, tag: string): Promise<boolean> {
+  const response = await fetch(`https://api.github.com/repos/${REPO}/releases/tags/${encodeURIComponent(tag)}`, {
+    headers: { accept: "application/vnd.github+json", authorization: `Bearer ${token}` },
+  });
+  if (response.status === 404) return false;
+  if (!response.ok) throw new Error(`GitHub API request failed (${response.status}) for CLI marker ${tag}`);
+  const release = asRecord(await response.json(), "CLI marker release");
+  return (
+    !booleanAt(release.draft, "CLI marker release draft") &&
+    !booleanAt(release.prerelease, "CLI marker release prerelease") &&
+    typeof release.published_at === "string"
+  );
+}
+
 async function main(): Promise<void> {
   const tag = option("--tag");
   const token = process.env.GITHUB_TOKEN;
@@ -237,17 +257,22 @@ async function main(): Promise<void> {
   const manifestAsset = assets.find((asset) => asset.name === "kesha-release-manifest.json");
   if (!manifestAsset?.browser_download_url) throw new Error(`release ${tag} has no kesha-release-manifest.json asset`);
   const manifest = parseManifest(await fetchJson(manifestAsset.browser_download_url, token));
+  const targetSource = readFileSync("src/engine-targets.ts", "utf8");
+  const packageSource = readFileSync("package.json", "utf8");
+  const serverSource = readFileSync("server.json", "utf8");
+  const cliReleasePublished = await releaseIsPublished(token, `v${parsePackage(packageSource).version}-cli`);
   const result = buildPostEngineReleaseFollowup({
     tag,
+    cliReleasePublished,
     release: {
       isDraft: booleanAt(raw.draft, "release draft"),
       isPrerelease: booleanAt(raw.prerelease, "release prerelease"),
       assets,
     },
     manifest,
-    targetSource: readFileSync("src/engine-targets.ts", "utf8"),
-    packageSource: readFileSync("package.json", "utf8"),
-    serverSource: readFileSync("server.json", "utf8"),
+    targetSource,
+    packageSource,
+    serverSource,
   });
   writeFileSync("src/engine-targets.ts", result.targetSource);
   writeFileSync("package.json", result.packageSource);

--- a/.github/scripts/post-release-guard.ts
+++ b/.github/scripts/post-release-guard.ts
@@ -1,0 +1,61 @@
+#!/usr/bin/env bun
+
+/// Decides whether a published tag belongs to the post-engine-release follow-up.
+/// `release: published` also fires for `-cli` markers and prereleases, which the
+/// follow-up script rejects — one red run per CLI publish unless they skip here.
+export function ownsTag(tag: string): boolean {
+  return /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.test(tag);
+}
+
+export type FollowupRefs = { branch: string; openHeads: string[]; remoteHeads: string[] };
+
+/// Refuses while any other follow-up exists, returning the reason or null to proceed.
+/// Every follow-up leads the CLI from main's current baseline, so two of them —
+/// for different engine tags — otherwise compute and apply the same next version.
+/// A branch exists before its pull request does, so both lists are consulted.
+export function refuseConcurrentFollowup(refs: FollowupRefs): string | null {
+  const prefix = "automation/post-release-";
+  const others = new Set<string>();
+  for (const head of [...refs.openHeads, ...refs.remoteHeads]) {
+    const name = head.startsWith("refs/heads/") ? head.slice("refs/heads/".length) : head;
+    if (name.startsWith(prefix) && name !== refs.branch) others.add(name);
+  }
+  if (others.size === 0) return null;
+  return `another post-release follow-up exists (${[...others].sort().join(", ")}); land it before leading the CLI again`;
+}
+
+export type GuardEnv = { TAG_NAME?: string; BRANCH?: string; OPEN_HEADS?: string; REMOTE_HEADS?: string };
+export type GuardDecision = { skip: true } | { skip: false } | { refuse: string };
+
+function refs(value: string | undefined): string[] {
+  return (value ?? "").split("\n").map((line) => line.trim().split(/\s+/).pop() ?? "").filter((line) => line.length > 0);
+}
+
+/// The whole decision, so a test pins the branch taken rather than only the predicates.
+export function decideFollowup(env: GuardEnv): GuardDecision {
+  const tag = env.TAG_NAME;
+  if (!tag) return { refuse: "TAG_NAME is required" };
+  if (!ownsTag(tag)) return { skip: true };
+  const branch = env.BRANCH;
+  if (!branch) return { refuse: "BRANCH is required" };
+  const refusal = refuseConcurrentFollowup({
+    branch,
+    openHeads: refs(env.OPEN_HEADS),
+    remoteHeads: refs(env.REMOTE_HEADS),
+  });
+  return refusal ? { refuse: refusal } : { skip: false };
+}
+
+if (import.meta.main) {
+  const decision = decideFollowup({
+    TAG_NAME: process.env.TAG_NAME,
+    BRANCH: process.env.BRANCH,
+    OPEN_HEADS: process.env.OPEN_HEADS,
+    REMOTE_HEADS: process.env.REMOTE_HEADS,
+  });
+  if ("refuse" in decision) {
+    console.error(`::error::${decision.refuse}`);
+    process.exit(1);
+  }
+  console.log(`skip=${decision.skip}`);
+}

--- a/.github/workflows/post-engine-release.yml
+++ b/.github/workflows/post-engine-release.yml
@@ -33,16 +33,14 @@ jobs:
       - name: Setup Bun workspace
         uses: ./.github/actions/setup-bun
 
-      # `release: published` fires for `-cli` and prerelease tags too, which the script rejects — one red run per CLI publish (#1041).
-      - name: Skip a tag this workflow does not own
+      - name: Decide whether this tag is ours and no other follow-up is in flight
         id: shape
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          if [[ ! "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "Not a stable engine tag, nothing to follow up: $TAG_NAME"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
+          OPEN_HEADS="$(gh pr list --repo "$REPOSITORY" --state open --json headRefName -q '.[].headRefName')" \
+          REMOTE_HEADS="$(git ls-remote --heads origin 'refs/heads/automation/post-release-*' | cut -f2)" \
+          bun .github/scripts/post-release-guard.ts >> "$GITHUB_OUTPUT"
 
       - name: Refuse an existing follow-up branch or PR
         id: existing
@@ -50,15 +48,6 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # A second follow-up opened before the first merges reads the same baseline and leads the CLI to the same version twice (#1041).
-          others="$(gh pr list --repo "$REPOSITORY" --state open --search 'head:automation/post-release-' --json headRefName \
-            | jq --arg branch "$BRANCH" '[.[] | select(.headRefName != $branch)] | length')"
-          stale="$(git ls-remote --heads origin 'refs/heads/automation/post-release-*' \
-            | awk -v keep="refs/heads/$BRANCH" '$2 != keep' | wc -l | tr -d ' ')"
-          if [ "$others" != "0" ] || [ "$stale" != "0" ]; then
-            echo "::error::Another post-release follow-up branch or PR exists; land it before leading the CLI again." >&2
-            exit 1
-          fi
           existing="$(gh pr list --repo "$REPOSITORY" --head "$BRANCH" --state all --json title,body)"
           count="$(printf '%s' "$existing" | jq 'length')"
           if [ "$count" = "1" ]; then
@@ -76,10 +65,6 @@ jobs:
           fi
           if [ "$count" != "0" ]; then
             echo "::error::More than one open PR uses $BRANCH; refusing an ambiguous follow-up." >&2
-            exit 1
-          fi
-          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
-            echo "::error::Branch $BRANCH already exists without an open follow-up PR; refusing to overwrite it." >&2
             exit 1
           fi
           echo "skip=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/post-engine-release.yml
+++ b/.github/workflows/post-engine-release.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
       pull-requests: write
     concurrency:
-      group: post-engine-release-${{ github.event.release.tag_name || inputs.tag }}
+      group: post-engine-release
       cancel-in-progress: false
     env:
       REPOSITORY: drakulavich/kesha-voice-kit
@@ -53,8 +53,10 @@ jobs:
           # A second follow-up opened before the first merges reads the same baseline and leads the CLI to the same version twice (#1041).
           others="$(gh pr list --repo "$REPOSITORY" --state open --search 'head:automation/post-release-' --json headRefName \
             | jq --arg branch "$BRANCH" '[.[] | select(.headRefName != $branch)] | length')"
-          if [ "$others" != "0" ]; then
-            echo "::error::Another post-release follow-up is still open; merge it before leading the CLI again." >&2
+          stale="$(git ls-remote --heads origin 'refs/heads/automation/post-release-*' \
+            | awk -v keep="refs/heads/$BRANCH" '$2 != keep' | wc -l | tr -d ' ')"
+          if [ "$others" != "0" ] || [ "$stale" != "0" ]; then
+            echo "::error::Another post-release follow-up branch or PR exists; land it before leading the CLI again." >&2
             exit 1
           fi
           existing="$(gh pr list --repo "$REPOSITORY" --head "$BRANCH" --state all --json title,body)"

--- a/.github/workflows/post-engine-release.yml
+++ b/.github/workflows/post-engine-release.yml
@@ -33,11 +33,30 @@ jobs:
       - name: Setup Bun workspace
         uses: ./.github/actions/setup-bun
 
+      # `release: published` fires for `-cli` and prerelease tags too, which the script rejects — one red run per CLI publish (#1041).
+      - name: Skip a tag this workflow does not own
+        id: shape
+        run: |
+          if [[ ! "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Not a stable engine tag, nothing to follow up: $TAG_NAME"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Refuse an existing follow-up branch or PR
         id: existing
+        if: steps.shape.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # A second follow-up opened before the first merges reads the same baseline and leads the CLI to the same version twice (#1041).
+          others="$(gh pr list --repo "$REPOSITORY" --state open --search 'head:automation/post-release-' --json headRefName \
+            | jq --arg branch "$BRANCH" '[.[] | select(.headRefName != $branch)] | length')"
+          if [ "$others" != "0" ]; then
+            echo "::error::Another post-release follow-up is still open; merge it before leading the CLI again." >&2
+            exit 1
+          fi
           existing="$(gh pr list --repo "$REPOSITORY" --head "$BRANCH" --state all --json title,body)"
           count="$(printf '%s' "$existing" | jq 'length')"
           if [ "$count" = "1" ]; then
@@ -64,13 +83,13 @@ jobs:
           echo "skip=false" >> "$GITHUB_OUTPUT"
 
       - name: Read published release and prepare follow-up
-        if: steps.existing.outputs.skip != 'true'
+        if: steps.shape.outputs.skip != 'true' && steps.existing.outputs.skip != 'true'
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: bun .github/scripts/post-engine-release.ts --tag "$TAG_NAME"
 
       - name: Validate and record output
-        if: steps.existing.outputs.skip != 'true'
+        if: steps.shape.outputs.skip != 'true' && steps.existing.outputs.skip != 'true'
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
@@ -83,7 +102,7 @@ jobs:
           } | tee -a post-release-pr.md
 
       - name: Commit and push follow-up branch
-        if: steps.existing.outputs.skip != 'true'
+        if: steps.shape.outputs.skip != 'true' && steps.existing.outputs.skip != 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -95,7 +114,7 @@ jobs:
           git push origin "$BRANCH"
 
       - name: Open follow-up pull request
-        if: steps.existing.outputs.skip != 'true'
+        if: steps.shape.outputs.skip != 'true' && steps.existing.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/post-engine-release.yml
+++ b/.github/workflows/post-engine-release.yml
@@ -1,0 +1,108 @@
+name: Post-engine release follow-up
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Published stable engine tag to replay (vX.Y.Z)
+        required: true
+        type: string
+
+jobs:
+  follow_up:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: post-engine-release-${{ github.event.release.tag_name || inputs.tag }}
+      cancel-in-progress: false
+    env:
+      REPOSITORY: drakulavich/kesha-voice-kit
+      TAG_NAME: ${{ github.event.release.tag_name || inputs.tag }}
+      BRANCH: automation/post-release-${{ github.event.release.tag_name || inputs.tag }}
+    steps:
+      - name: Checkout current main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Setup Bun workspace
+        uses: ./.github/actions/setup-bun
+
+      - name: Refuse an existing follow-up branch or PR
+        id: existing
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          existing="$(gh pr list --repo "$REPOSITORY" --head "$BRANCH" --state open --json title,body)"
+          count="$(printf '%s' "$existing" | jq 'length')"
+          if [ "$count" = "1" ]; then
+            expected="$(printf '%s' "$existing" | jq --arg tag "$TAG_NAME" '
+              ((.[0].title | startswith("chore(release): record " + $tag + " assets and lead CLI to v"))
+              and (.[0].body | contains("Published engine tag: `" + $tag + "`")))
+            ')"
+            if [ "$expected" = "true" ]; then
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              echo "A matching follow-up PR for $TAG_NAME is already open; leaving it untouched."
+              exit 0
+            fi
+            echo "::error::An unrelated PR already uses $BRANCH; refusing to touch it." >&2
+            exit 1
+          fi
+          if [ "$count" != "0" ]; then
+            echo "::error::More than one open PR uses $BRANCH; refusing an ambiguous follow-up." >&2
+            exit 1
+          fi
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "::error::Branch $BRANCH already exists without an open follow-up PR; refusing to overwrite it." >&2
+            exit 1
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Read published release and prepare follow-up
+        if: steps.existing.outputs.skip != 'true'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: bun .github/scripts/post-engine-release.ts --tag "$TAG_NAME"
+
+      - name: Validate and record output
+        if: steps.existing.outputs.skip != 'true'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          {
+            printf '\n## Validation output\n\n```text\n'
+            bun run check:versions
+            bun run check:engine-targets
+            git diff --check
+            printf 'git diff --check: passed\n```\n'
+          } | tee -a post-release-pr.md
+
+      - name: Commit and push follow-up branch
+        if: steps.existing.outputs.skip != 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "$BRANCH"
+          git add package.json server.json src/engine-targets.ts
+          git diff --cached --quiet && { echo "::error::No post-release changes were generated." >&2; exit 1; }
+          next_cli="$(bun -e 'console.log(JSON.parse(await Bun.file("package.json").text()).version)')"
+          git commit -m "chore(release): lead CLI base to v$next_cli"
+          git push origin "$BRANCH"
+
+      - name: Open follow-up pull request
+        if: steps.existing.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          next_cli="$(bun -e 'console.log(JSON.parse(await Bun.file("package.json").text()).version)')"
+          gh pr create \
+            --repo "$REPOSITORY" \
+            --base main \
+            --head "$BRANCH" \
+            --title "chore(release): record $TAG_NAME assets and lead CLI to v$next_cli" \
+            --body-file post-release-pr.md

--- a/.github/workflows/post-engine-release.yml
+++ b/.github/workflows/post-engine-release.yml
@@ -38,7 +38,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          existing="$(gh pr list --repo "$REPOSITORY" --head "$BRANCH" --state open --json title,body)"
+          existing="$(gh pr list --repo "$REPOSITORY" --head "$BRANCH" --state all --json title,body)"
           count="$(printf '%s' "$existing" | jq 'length')"
           if [ "$count" = "1" ]; then
             expected="$(printf '%s' "$existing" | jq --arg tag "$TAG_NAME" '

--- a/tests/unit/post-engine-release.test.ts
+++ b/tests/unit/post-engine-release.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from "bun:test";
+import { buildPostEngineReleaseFollowup } from "../../.github/scripts/post-engine-release";
+import { parseRepoYaml } from "../helpers/repo";
+
+const targetSource = `const ENGINE_TARGETS: Record<string, EngineTarget> = {
+  "darwin-arm64": {
+    assetName: "kesha-engine-darwin-arm64",
+    backend: "coreml",
+    sizeBytes: 1,
+  },
+  "linux-x64": {
+    assetName: "kesha-engine-linux-x64",
+    backend: "onnx",
+    sizeBytes: 2,
+  },
+  "win32-x64": {
+    assetName: "kesha-engine-windows-x64.exe",
+    backend: "onnx",
+    sizeBytes: 3,
+  },
+};
+`;
+
+const packageSource = JSON.stringify({
+  name: "kesha",
+  version: "1.29.0",
+  keshaEngine: { version: "1.24.11" },
+});
+
+const serverSource = JSON.stringify({
+  version: "1.29.0",
+  packages: [{ version: "1.29.0" }],
+});
+
+function manifest() {
+  return {
+    tag: "v1.24.11",
+    engineVersion: "1.24.11",
+    assets: [
+      { name: "kesha-engine-darwin-arm64", signatureBundle: "kesha-engine-darwin-arm64.sigstore.json" },
+      { name: "kesha-engine-linux-x64", signatureBundle: "kesha-engine-linux-x64.sigstore.json" },
+      { name: "kesha-engine-windows-x64.exe", signatureBundle: "kesha-engine-windows-x64.exe.sigstore.json" },
+      { name: "SHA256SUMS", signatureBundle: "SHA256SUMS.sigstore.json" },
+      { name: "kesha-release-manifest.json", signatureBundle: "kesha-release-manifest.json.sigstore.json" },
+    ],
+  };
+}
+
+function assets() {
+  return [
+    { name: "kesha-engine-darwin-arm64", size: 64_000_001 },
+    { name: "kesha-engine-darwin-arm64.sigstore.json", size: 100 },
+    { name: "kesha-engine-linux-x64", size: 65_000_002 },
+    { name: "kesha-engine-linux-x64.sigstore.json", size: 100 },
+    { name: "kesha-engine-windows-x64.exe", size: 66_000_003 },
+    { name: "kesha-engine-windows-x64.exe.sigstore.json", size: 100 },
+    { name: "SHA256SUMS", size: 100 },
+    { name: "SHA256SUMS.sigstore.json", size: 100 },
+    { name: "kesha-release-manifest.json", size: 100 },
+    { name: "kesha-release-manifest.json.sigstore.json", size: 100 },
+  ];
+}
+
+describe("buildPostEngineReleaseFollowup", () => {
+  test("records published engine sizes and leads the CLI and registry by one minor", () => {
+    const result = buildPostEngineReleaseFollowup({
+      tag: "v1.24.11",
+      release: { isDraft: false, isPrerelease: false, assets: assets() },
+      manifest: manifest(),
+      targetSource,
+      packageSource,
+      serverSource,
+    });
+
+    expect(result.nextCliVersion).toBe("1.30.0");
+    expect(result.targetSource).toContain("sizeBytes: 64_000_001");
+    expect(result.targetSource).toContain("sizeBytes: 65_000_002");
+    expect(result.targetSource).toContain("sizeBytes: 66_000_003");
+    expect(JSON.parse(result.packageSource)).toMatchObject({
+      version: "1.30.0",
+      keshaEngine: { version: "1.24.11" },
+    });
+    expect(JSON.parse(result.serverSource)).toMatchObject({
+      version: "1.30.0",
+      packages: [{ version: "1.30.0" }],
+    });
+  });
+
+  test("refuses an incomplete release instead of guessing an asset size", () => {
+    const publishedAssets = assets().filter((asset) => asset.name !== "kesha-engine-linux-x64.sigstore.json");
+
+    expect(() =>
+      buildPostEngineReleaseFollowup({
+        tag: "v1.24.11",
+        release: { isDraft: false, isPrerelease: false, assets: publishedAssets },
+        manifest: manifest(),
+        targetSource,
+        packageSource,
+        serverSource,
+      }),
+    ).toThrow(/missing signed asset/i);
+  });
+
+  test("refuses a source pin that does not identify the published tag", () => {
+    expect(() =>
+      buildPostEngineReleaseFollowup({
+        tag: "v1.24.11",
+        release: { isDraft: false, isPrerelease: false, assets: assets() },
+        manifest: manifest(),
+        targetSource,
+        packageSource: packageSource.replace("1.24.11", "1.24.12"),
+        serverSource,
+      }),
+    ).toThrow(/does not match published tag/i);
+  });
+
+  test("refuses a server registry that is already out of step with the CLI baseline", () => {
+    expect(() =>
+      buildPostEngineReleaseFollowup({
+        tag: "v1.24.11",
+        release: { isDraft: false, isPrerelease: false, assets: assets() },
+        manifest: manifest(),
+        targetSource,
+        packageSource,
+        serverSource: serverSource.replaceAll("1.29.0", "1.28.0"),
+      }),
+    ).toThrow(/does not match package\.json#version/i);
+  });
+});
+
+describe("post-engine-release workflow", () => {
+  test("runs only after publication or an explicit maintainer replay and never updates main directly", () => {
+    const workflow = parseRepoYaml(".github/workflows/post-engine-release.yml");
+    const job = workflow.jobs.follow_up;
+
+    expect(workflow.on.release.types).toEqual(["published"]);
+    expect(workflow.on.workflow_dispatch.inputs.tag.required).toBe(true);
+    expect(job.permissions).toMatchObject({ contents: "write", "pull-requests": "write" });
+    expect(job.concurrency.group).toContain("post-engine-release");
+    expect(job.steps.some((step: { run?: string }) => step.run?.includes("post-engine-release.ts"))).toBe(true);
+    expect(job.steps.some((step: { run?: string }) => step.run?.includes("git switch -c"))).toBe(true);
+    expect(job.steps.some((step: { run?: string }) => step.run?.includes("gh pr create"))).toBe(true);
+  });
+});

--- a/tests/unit/post-engine-release.test.ts
+++ b/tests/unit/post-engine-release.test.ts
@@ -65,6 +65,7 @@ describe("buildPostEngineReleaseFollowup", () => {
   test("records published engine sizes and leads the CLI and registry by one minor", () => {
     const result = buildPostEngineReleaseFollowup({
       tag: "v1.24.11",
+      cliReleasePublished: true,
       release: { isDraft: false, isPrerelease: false, assets: assets() },
       manifest: manifest(),
       targetSource,
@@ -92,6 +93,7 @@ describe("buildPostEngineReleaseFollowup", () => {
     expect(() =>
       buildPostEngineReleaseFollowup({
         tag: "v1.24.11",
+        cliReleasePublished: true,
         release: { isDraft: false, isPrerelease: false, assets: publishedAssets },
         manifest: manifest(),
         targetSource,
@@ -105,6 +107,7 @@ describe("buildPostEngineReleaseFollowup", () => {
     expect(() =>
       buildPostEngineReleaseFollowup({
         tag: "v1.24.11",
+        cliReleasePublished: true,
         release: { isDraft: false, isPrerelease: false, assets: assets() },
         manifest: manifest(),
         targetSource,
@@ -118,6 +121,7 @@ describe("buildPostEngineReleaseFollowup", () => {
     expect(() =>
       buildPostEngineReleaseFollowup({
         tag: "v1.24.11",
+        cliReleasePublished: true,
         release: { isDraft: false, isPrerelease: false, assets: assets() },
         manifest: manifest(),
         targetSource,
@@ -125,6 +129,20 @@ describe("buildPostEngineReleaseFollowup", () => {
         serverSource: serverSource.replaceAll("1.29.0", "1.28.0"),
       }),
     ).toThrow(/does not match package\.json#version/i);
+  });
+
+  test("waits until the current CLI marker release has published before leading its base", () => {
+    expect(() =>
+      buildPostEngineReleaseFollowup({
+        tag: "v1.24.11",
+        cliReleasePublished: false,
+        release: { isDraft: false, isPrerelease: false, assets: assets() },
+        manifest: manifest(),
+        targetSource,
+        packageSource,
+        serverSource,
+      }),
+    ).toThrow(/CLI marker release.*not published/i);
   });
 });
 
@@ -137,6 +155,7 @@ describe("post-engine-release workflow", () => {
     expect(workflow.on.workflow_dispatch.inputs.tag.required).toBe(true);
     expect(job.permissions).toMatchObject({ contents: "write", "pull-requests": "write" });
     expect(job.concurrency.group).toContain("post-engine-release");
+    expect(job.steps.some((step: { run?: string }) => step.run?.includes("--state all"))).toBe(true);
     expect(job.steps.some((step: { run?: string }) => step.run?.includes("post-engine-release.ts"))).toBe(true);
     expect(job.steps.some((step: { run?: string }) => step.run?.includes("git switch -c"))).toBe(true);
     expect(job.steps.some((step: { run?: string }) => step.run?.includes("gh pr create"))).toBe(true);

--- a/tests/unit/post-engine-release.test.ts
+++ b/tests/unit/post-engine-release.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { buildPostEngineReleaseFollowup } from "../../.github/scripts/post-engine-release";
+import { decideFollowup, ownsTag, refuseConcurrentFollowup } from "../../.github/scripts/post-release-guard";
 import { parseRepoYaml } from "../helpers/repo";
 
 const targetSource = `const ENGINE_TARGETS: Record<string, EngineTarget> = {
@@ -161,37 +162,50 @@ describe("post-engine-release workflow", () => {
     expect(job.steps.some((step: { run?: string }) => step.run?.includes("gh pr create"))).toBe(true);
   });
 
-  // Both guards were added without a pin, and deleting either left the suite green (#1041 review).
-  test("only a stable engine tag reaches the script", () => {
-    const workflow = parseRepoYaml(".github/workflows/post-engine-release.yml");
-    const shape = workflow.jobs.follow_up.steps.find((step: { id?: string }) => step.id === "shape");
-    const pattern = /\^v\[0-9\]\+\\\.\[0-9\]\+\\\.\[0-9\]\+\$/.exec(shape.run);
-    expect(pattern).not.toBeNull();
-    const anchored = new RegExp(String(pattern));
-    for (const tag of ["v1.24.11", "v1.29.0", "v10.0.100"]) expect(anchored.test(tag)).toBe(true);
-    for (const tag of ["v1.29.0-cli", "v1.24.11-alpha.1", "v1.24.11-beta.1", "1.24.11", "v1.24"]) {
-      expect(anchored.test(tag)).toBe(false);
+  test("only a stable engine tag is owned by the follow-up", () => {
+    for (const tag of ["v1.24.11", "v1.29.0", "v10.0.100", "v0.0.0"]) expect(ownsTag(tag)).toBe(true);
+    for (const tag of ["v1.29.0-cli", "v1.24.11-alpha.1", "v1.24.11-beta.1", "1.24.11", "v1.24", "v01.2.3", "v1.2.3 "]) {
+      expect(ownsTag(tag)).toBe(false);
     }
   });
 
-  test("a second follow-up cannot lead the CLI while another is in flight", () => {
-    const workflow = parseRepoYaml(".github/workflows/post-engine-release.yml");
-    const job = workflow.jobs.follow_up;
+  test("a follow-up refuses while another one exists as a branch or an open pull request", () => {
+    const branch = "automation/post-release-v1.24.12";
+    expect(refuseConcurrentFollowup({ branch, openHeads: [], remoteHeads: [] })).toBeNull();
+    expect(refuseConcurrentFollowup({ branch, openHeads: [branch], remoteHeads: [`refs/heads/${branch}`] })).toBeNull();
+    // Unrelated work must not block a release follow-up.
+    expect(refuseConcurrentFollowup({ branch, openHeads: ["fix/issue-1", "docs/issue-2"], remoteHeads: [] })).toBeNull();
+    // A branch exists before its pull request does, so either list alone must refuse.
+    const viaPr = refuseConcurrentFollowup({ branch, openHeads: ["automation/post-release-v1.24.11"], remoteHeads: [] });
+    expect(viaPr).toContain("automation/post-release-v1.24.11");
+    const viaBranch = refuseConcurrentFollowup({ branch, openHeads: [], remoteHeads: ["refs/heads/automation/post-release-v1.24.11"] });
+    expect(viaBranch).toContain("automation/post-release-v1.24.11");
+  });
+
+  test("the decision itself skips a foreign tag and refuses a concurrent follow-up", () => {
+    const base = { TAG_NAME: "v1.24.12", BRANCH: "automation/post-release-v1.24.12" };
+    expect(decideFollowup(base)).toEqual({ skip: false });
+    expect(decideFollowup({ ...base, TAG_NAME: "v1.29.0-cli" })).toEqual({ skip: true });
+    expect(decideFollowup({ ...base, TAG_NAME: "v1.24.12-beta.1" })).toEqual({ skip: true });
+    const busy = decideFollowup({ ...base, OPEN_HEADS: "automation/post-release-v1.24.11" });
+    expect(busy).toMatchObject({ refuse: expect.stringContaining("automation/post-release-v1.24.11") });
+    const pushed = decideFollowup({ ...base, REMOTE_HEADS: "abc123\trefs/heads/automation/post-release-v1.24.11" });
+    expect(pushed).toMatchObject({ refuse: expect.stringContaining("automation/post-release-v1.24.11") });
+    expect(decideFollowup({ BRANCH: base.BRANCH })).toMatchObject({ refuse: expect.stringContaining("TAG_NAME") });
+  });
+
+  test("the workflow delegates both guards instead of restating them", () => {
+    const job = parseRepoYaml(".github/workflows/post-engine-release.yml").jobs.follow_up;
     // Per-tag serialization let two tags read main's baseline at once, so the group carries no tag.
     expect(job.concurrency.group).toBe("post-engine-release");
     expect(job.concurrency["cancel-in-progress"]).toBe(false);
-    const guard = job.steps.find((step: { id?: string }) => step.id === "existing").run;
-    expect(guard).toContain("head:automation/post-release-");
-    expect(guard).toContain("refs/heads/automation/post-release-*");
-  });
-
-  test("every mutating step is skipped for a tag this workflow does not own", () => {
-    const workflow = parseRepoYaml(".github/workflows/post-engine-release.yml");
-    // A skipped step has no output, and "" != 'true' would otherwise let these run anyway.
-    const mutating = workflow.jobs.follow_up.steps.filter((step: { id?: string; run?: string }) =>
+    const guard = job.steps.find((step: { id?: string }) => step.id === "shape").run;
+    expect(guard).toContain("post-release-guard.ts");
+    const mutating = job.steps.filter((step: { id?: string; run?: string }) =>
       step.id !== "shape" && step.id !== "existing" && step.run !== undefined,
     );
     expect(mutating.length).toBeGreaterThan(0);
+    // A skipped step has no output, and "" != 'true' would otherwise let these run anyway.
     for (const step of mutating) expect(step.if).toContain("steps.shape.outputs.skip != 'true'");
   });
 });

--- a/tests/unit/post-engine-release.test.ts
+++ b/tests/unit/post-engine-release.test.ts
@@ -160,4 +160,38 @@ describe("post-engine-release workflow", () => {
     expect(job.steps.some((step: { run?: string }) => step.run?.includes("git switch -c"))).toBe(true);
     expect(job.steps.some((step: { run?: string }) => step.run?.includes("gh pr create"))).toBe(true);
   });
+
+  // Both guards were added without a pin, and deleting either left the suite green (#1041 review).
+  test("only a stable engine tag reaches the script", () => {
+    const workflow = parseRepoYaml(".github/workflows/post-engine-release.yml");
+    const shape = workflow.jobs.follow_up.steps.find((step: { id?: string }) => step.id === "shape");
+    const pattern = /\^v\[0-9\]\+\\\.\[0-9\]\+\\\.\[0-9\]\+\$/.exec(shape.run);
+    expect(pattern).not.toBeNull();
+    const anchored = new RegExp(String(pattern));
+    for (const tag of ["v1.24.11", "v1.29.0", "v10.0.100"]) expect(anchored.test(tag)).toBe(true);
+    for (const tag of ["v1.29.0-cli", "v1.24.11-alpha.1", "v1.24.11-beta.1", "1.24.11", "v1.24"]) {
+      expect(anchored.test(tag)).toBe(false);
+    }
+  });
+
+  test("a second follow-up cannot lead the CLI while another is in flight", () => {
+    const workflow = parseRepoYaml(".github/workflows/post-engine-release.yml");
+    const job = workflow.jobs.follow_up;
+    // Per-tag serialization let two tags read main's baseline at once, so the group carries no tag.
+    expect(job.concurrency.group).toBe("post-engine-release");
+    expect(job.concurrency["cancel-in-progress"]).toBe(false);
+    const guard = job.steps.find((step: { id?: string }) => step.id === "existing").run;
+    expect(guard).toContain("head:automation/post-release-");
+    expect(guard).toContain("refs/heads/automation/post-release-*");
+  });
+
+  test("every mutating step is skipped for a tag this workflow does not own", () => {
+    const workflow = parseRepoYaml(".github/workflows/post-engine-release.yml");
+    // A skipped step has no output, and "" != 'true' would otherwise let these run anyway.
+    const mutating = workflow.jobs.follow_up.steps.filter((step: { id?: string; run?: string }) =>
+      step.id !== "shape" && step.id !== "existing" && step.run !== undefined,
+    );
+    expect(mutating.length).toBeGreaterThan(0);
+    for (const step of mutating) expect(step.if).toContain("steps.shape.outputs.skip != 'true'");
+  });
 });


### PR DESCRIPTION
Closes #1041.

Adds a post-release workflow that reads the published stable engine release and opens a separate, reviewable follow-up PR. It refuses drafts, prereleases, incomplete manifest/signature sets, pin or registry drift, and any existing unrelated branch/PR.

The generated PR body is written through a file and contains the release tag, exact asset names/sizes, CLI/server version transition, and validation output.

Validation:

- `just preflight`
- Focused contract tests for release validation and workflow safety
- `bun run check:workflows`
