### PR TITLE
refactor(engine): serialize stdout fd ownership

### DIFF
--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -491,11 +491,12 @@ jobs:
           # "this guard did not run" line is exactly that (#841).
           # `system_diarize` rides along because `transcribe::diarize` compiles under no other
           # lane, so its tests only ever got clippy'd; they are pure and cost 0.14 s (#999).
+          # `fluid_stdout` builds under no other lane, so without these two the fd 1 locks are unpinned in CI (#951).
           cargo nextest run \
             --no-default-features --features coreml,system_diarize \
             --run-ignored all \
             --success-output immediate \
-            -E 'test(transcribe_samples_is_stateless_across_calls) + test(debug_routes_silenced_chatter_to_stderr) + test(a_sub_second_file_transcribes_instead_of_erroring) + test(transcribe::diarize::)'
+            -E 'test(transcribe_samples_is_stateless_across_calls) + test(debug_routes_silenced_chatter_to_stderr) + test(a_sub_second_file_transcribes_instead_of_erroring) + test(transcribe::diarize::) + test(scoped_guards_serialize_stdout_ownership) + test(permanent_shield_waits_for_a_live_scoped_guard)'
 
       - name: 📤 Upload JUnit
         if: always()

--- a/rust/src/fluid_stdout.rs
+++ b/rust/src/fluid_stdout.rs
@@ -25,6 +25,8 @@ use std::io::Write;
 use std::os::fd::OwnedFd;
 use std::sync::{Mutex, MutexGuard, OnceLock};
 
+/// Not reentrant: a nested call, or a FluidAudio callback that re-enters a
+/// guard, hangs forever with no error and no log line.
 fn stdout_ownership() -> MutexGuard<'static, ()> {
     static OWNER: OnceLock<Mutex<()>> = OnceLock::new();
     OWNER
@@ -315,45 +317,64 @@ mod tests {
         unsafe { libc::fflush(std::ptr::null_mut()) };
     }
 
+    /// Drives the real guard, not `stdout_ownership` directly: deleting the lock
+    /// from `with_silenced_stdout` lets the second thread run its closure while
+    /// the first is still inside, which `overlapped` records independently of any
+    /// timeout. `StdoutShield::new`'s own lock has no in-process counterpart —
+    /// that guard never restores fd 1 by design, so building one would silence
+    /// the rest of the test binary.
     #[test]
-    fn stdout_ownership_serializes_concurrent_guards() {
+    fn scoped_guards_serialize_stdout_ownership() {
+        use std::sync::atomic::{AtomicBool, Ordering};
         use std::sync::{mpsc, Arc};
         use std::time::Duration;
 
-        let (started_tx, started_rx) = mpsc::channel();
+        let inside = Arc::new(AtomicBool::new(false));
+        let overlapped = Arc::new(AtomicBool::new(false));
+        let (first_in_tx, first_in_rx) = mpsc::channel();
         let (release_tx, release_rx) = mpsc::channel();
         let (attempting_tx, attempting_rx) = mpsc::channel();
         let (entered_tx, entered_rx) = mpsc::channel();
-        let release_rx = Arc::new(std::sync::Mutex::new(release_rx));
 
         let first = std::thread::spawn({
-            let release_rx = Arc::clone(&release_rx);
+            let inside = Arc::clone(&inside);
             move || {
-                let _owner = stdout_ownership();
-                started_tx.send(()).expect("report first owner");
-                release_rx
-                    .lock()
-                    .expect("lock release receiver")
-                    .recv()
-                    .expect("release first owner");
+                with_silenced_stdout(None, || {
+                    inside.store(true, Ordering::SeqCst);
+                    first_in_tx.send(()).expect("report first guard");
+                    release_rx.recv().expect("release first guard");
+                    inside.store(false, Ordering::SeqCst);
+                });
             }
         });
-        started_rx.recv().expect("wait for first owner");
+        first_in_rx.recv().expect("wait for first guard");
 
-        let second = std::thread::spawn(move || {
-            attempting_tx.send(()).expect("report second owner attempt");
-            let _owner = stdout_ownership();
-            entered_tx.send(()).expect("report second owner");
+        let second = std::thread::spawn({
+            let inside = Arc::clone(&inside);
+            let overlapped = Arc::clone(&overlapped);
+            move || {
+                attempting_tx.send(()).expect("report second attempt");
+                with_silenced_stdout(None, || {
+                    if inside.load(Ordering::SeqCst) {
+                        overlapped.store(true, Ordering::SeqCst);
+                    }
+                    entered_tx.send(()).expect("report second guard");
+                });
+            }
         });
-        attempting_rx.recv().expect("wait for second owner attempt");
+        attempting_rx.recv().expect("wait for second attempt");
         assert!(entered_rx.recv_timeout(Duration::from_millis(100)).is_err());
 
-        release_tx.send(()).expect("release first owner");
-        first.join().expect("first owner joins");
+        release_tx.send(()).expect("release first guard");
+        first.join().expect("first guard joins");
         entered_rx
-            .recv_timeout(Duration::from_secs(1))
-            .expect("second owner enters after the first exits");
-        second.join().expect("second owner joins");
+            .recv_timeout(Duration::from_secs(5))
+            .expect("second guard enters after the first exits");
+        second.join().expect("second guard joins");
+        assert!(
+            !overlapped.load(Ordering::SeqCst),
+            "second guard ran its closure while the first still owned fd 1"
+        );
     }
 
     /// #841: the bridge collapses every transcribe throw to "Transcription

--- a/rust/src/fluid_stdout.rs
+++ b/rust/src/fluid_stdout.rs
@@ -362,16 +362,18 @@ mod tests {
             }
         });
         attempting_rx.recv().expect("wait for second attempt");
-        assert!(entered_rx.recv_timeout(Duration::from_millis(100)).is_err());
+        let entered_early = entered_rx.recv_timeout(Duration::from_millis(100)).is_ok();
 
         release_tx.send(()).expect("release first guard");
         first.join().expect("first guard joins");
-        entered_rx
-            .recv_timeout(Duration::from_secs(5))
-            .expect("second guard enters after the first exits");
+        if !entered_early {
+            entered_rx
+                .recv_timeout(Duration::from_secs(5))
+                .expect("second guard enters after the first exits");
+        }
         second.join().expect("second guard joins");
         assert!(
-            !overlapped.load(Ordering::SeqCst),
+            !overlapped.load(Ordering::SeqCst) && !entered_early,
             "second guard ran its closure while the first still owned fd 1"
         );
     }

--- a/rust/src/fluid_stdout.rs
+++ b/rust/src/fluid_stdout.rs
@@ -319,10 +319,9 @@ mod tests {
 
     /// Drives the real guard, not `stdout_ownership` directly: deleting the lock
     /// from `with_silenced_stdout` lets the second thread run its closure while
-    /// the first is still inside, which `overlapped` records independently of any
-    /// timeout. `StdoutShield::new`'s own lock has no in-process counterpart —
-    /// that guard never restores fd 1 by design, so building one would silence
-    /// the rest of the test binary.
+    /// the first is still inside. `overlapped` turns that into a statement about
+    /// ordering rather than about elapsed time, which the deadline alone cannot
+    /// make.
     #[test]
     fn scoped_guards_serialize_stdout_ownership() {
         use std::sync::atomic::{AtomicBool, Ordering};
@@ -475,6 +474,76 @@ mod tests {
         assert_eq!(
             contents, "transcript\n",
             "shielded stdout must carry only the payload"
+        );
+    }
+
+    /// The shield holds the lock only across its descriptor swap, so what is on
+    /// test is the entry: `new()` must not swap fd 1 out from under a live scoped
+    /// guard. `RestoreFd` puts the real stdout back afterwards — the shield never
+    /// does, by design.
+    #[cfg(all(
+        any(feature = "system_diarize", feature = "coreml"),
+        target_os = "macos"
+    ))]
+    #[test]
+    fn permanent_shield_waits_for_a_live_scoped_guard() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::{mpsc, Arc};
+        use std::time::Duration;
+
+        let capture = tempfile::tempfile().expect("capture tempfile");
+        let _restore = redirect(libc::STDOUT_FILENO, &capture);
+
+        let inside = Arc::new(AtomicBool::new(false));
+        let overlapped = Arc::new(AtomicBool::new(false));
+        let (holding_tx, holding_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let (attempting_tx, attempting_rx) = mpsc::channel();
+        let (built_tx, built_rx) = mpsc::channel();
+
+        let holder = std::thread::spawn({
+            let inside = Arc::clone(&inside);
+            move || {
+                with_silenced_stdout(None, || {
+                    inside.store(true, Ordering::SeqCst);
+                    holding_tx.send(()).expect("report holder");
+                    release_rx.recv().expect("release holder");
+                    inside.store(false, Ordering::SeqCst);
+                });
+            }
+        });
+        holding_rx.recv().expect("wait for holder");
+
+        let builder = std::thread::spawn({
+            let inside = Arc::clone(&inside);
+            let overlapped = Arc::clone(&overlapped);
+            move || {
+                attempting_tx.send(()).expect("report shield attempt");
+                let shield = StdoutShield::new();
+                if inside.load(Ordering::SeqCst) {
+                    overlapped.store(true, Ordering::SeqCst);
+                }
+                built_tx.send(()).expect("report shield built");
+                shield
+            }
+        });
+        attempting_rx.recv().expect("wait for shield attempt");
+        let built_early = built_rx.recv_timeout(Duration::from_millis(100)).is_ok();
+
+        release_tx.send(()).expect("release holder");
+        holder.join().expect("holder joins");
+        if !built_early {
+            built_rx
+                .recv_timeout(Duration::from_secs(5))
+                .expect("shield builds once the scoped guard exits");
+        }
+        let shield = builder.join().expect("builder joins");
+        drop(shield);
+        drop(_restore);
+
+        assert!(
+            !overlapped.load(Ordering::SeqCst) && !built_early,
+            "StdoutShield::new swapped fd 1 while a scoped guard still owned it"
         );
     }
 }

--- a/rust/src/fluid_stdout.rs
+++ b/rust/src/fluid_stdout.rs
@@ -14,9 +14,24 @@
 //!   asynchronous `E5RT` prints — diarization teardown, and anything CoreML
 //!   emits between two streaming ASR calls — which fire after the call returns,
 //!   where a scoped guard has already put fd 1 back.
+//!
+//! File descriptor 1 belongs to the whole process, not a Rust thread. The
+//! internal ownership lock serializes every redirect/restore transition here;
+//! while a scoped guard owns it, unrelated threads still must not write to
+//! stdout because their bytes would be intentionally discarded. Worker callers
+//! send progress over channels and leave reporting to the stdout-owning thread.
 
 use std::io::Write;
 use std::os::fd::OwnedFd;
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+fn stdout_ownership() -> MutexGuard<'static, ()> {
+    static OWNER: OnceLock<Mutex<()>> = OnceLock::new();
+    OWNER
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
 
 /// `dup` a descriptor into an owned handle, or `None` when the call failed.
 /// Every caller here treats failure as best-effort: run unguarded rather than
@@ -39,6 +54,8 @@ fn dup_owned(fd: std::os::fd::RawFd) -> Option<OwnedFd> {
 /// when opening /dev/null failed).
 pub(crate) fn with_silenced_stdout<R>(devnull: Option<&OwnedFd>, f: impl FnOnce() -> R) -> R {
     use std::os::fd::AsRawFd;
+
+    let _owner = stdout_ownership();
 
     struct StdoutGuard {
         saved: Option<OwnedFd>,
@@ -208,6 +225,8 @@ impl StdoutShield {
     pub(crate) fn new() -> Self {
         use std::os::fd::AsRawFd;
 
+        let _owner = stdout_ownership();
+
         // The original stdout — the pipe the parent reads — stays referenced by this dup.
         let real_stdout: Option<std::fs::File> =
             dup_owned(libc::STDOUT_FILENO).map(std::fs::File::from);
@@ -294,6 +313,47 @@ mod tests {
     fn c_flush() {
         // SAFETY: fflush(NULL) flushes every open C output stream and borrows nothing.
         unsafe { libc::fflush(std::ptr::null_mut()) };
+    }
+
+    #[test]
+    fn stdout_ownership_serializes_concurrent_guards() {
+        use std::sync::{mpsc, Arc};
+        use std::time::Duration;
+
+        let (started_tx, started_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let (attempting_tx, attempting_rx) = mpsc::channel();
+        let (entered_tx, entered_rx) = mpsc::channel();
+        let release_rx = Arc::new(std::sync::Mutex::new(release_rx));
+
+        let first = std::thread::spawn({
+            let release_rx = Arc::clone(&release_rx);
+            move || {
+                let _owner = stdout_ownership();
+                started_tx.send(()).expect("report first owner");
+                release_rx
+                    .lock()
+                    .expect("lock release receiver")
+                    .recv()
+                    .expect("release first owner");
+            }
+        });
+        started_rx.recv().expect("wait for first owner");
+
+        let second = std::thread::spawn(move || {
+            attempting_tx.send(()).expect("report second owner attempt");
+            let _owner = stdout_ownership();
+            entered_tx.send(()).expect("report second owner");
+        });
+        attempting_rx.recv().expect("wait for second owner attempt");
+        assert!(entered_rx.recv_timeout(Duration::from_millis(100)).is_err());
+
+        release_tx.send(()).expect("release first owner");
+        first.join().expect("first owner joins");
+        entered_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("second owner enters after the first exits");
+        second.join().expect("second owner joins");
     }
 
     /// #841: the bridge collapses every transcribe throw to "Transcription

--- a/rust/src/transcribe/diarize.rs
+++ b/rust/src/transcribe/diarize.rs
@@ -417,8 +417,8 @@ fn spawn_worker(
     let progress_tx = tx.clone();
 
     std::thread::spawn(move || {
-        // Oneshot guard silences sync CoreML stdout; async E5RT teardown print is
-        // handled by `StdoutShield` at the CLI layer (fd 1 stays redirected past exit). (#259/#397/#434)
+        // Progress crosses the channel rather than stdout: fluid_stdout owns fd 1 for this
+        // call, while the CLI's StdoutShield catches later E5RT teardown output. (#259/#397/#434/#951)
         let result = crate::fluid_stdout::with_silenced_stdout_oneshot(
             || -> Result<Option<Vec<DiarizeSpan>>> {
                 let audio = crate::models::fluidaudio_bridge(


### PR DESCRIPTION
Closes #951.

Serializes temporary and permanent stdout redirection around the process-global fd 1. The scoped guard now owns that lock through its entire redirected lifetime; the permanent shield owns it while swapping descriptors. The diarization worker documentation makes the channel-only reporting invariant explicit.

Validation:

- `just preflight`
- Targeted concurrent ownership regression test
- `just verify-darwin-full`
