### PR TITLE
ci(canary): measure sizes the host will not report on HEAD

### DIFF
--- a/.github/scripts/check-model-plan-sizes.ts
+++ b/.github/scripts/check-model-plan-sizes.ts
@@ -13,8 +13,9 @@
  * and a plan entry whose `relPath` resolves to no URL fails the run rather than being skipped,
  * which is what stops a parser regression from going quietly green.
  *
- * HEAD only: no downloads, no cache impact. `KESHA_MODEL_MIRROR` is deliberately not honoured —
- * the subject here is upstream truth.
+ * HEAD first, falling back to a one-byte range request for hosts that answer HEAD without a
+ * Content-Length: no downloads either way, no cache impact. `KESHA_MODEL_MIRROR` is deliberately
+ * not honoured — the subject here is upstream truth.
  */
 import { readFileSync } from "node:fs";
 import { humanBytes } from "../../src/format";
@@ -172,6 +173,44 @@ export interface LiveSizeOptions {
   backoffMs?: number;
 }
 
+/** The whole resource length a 206 reports, which is not the length of the bytes it served. */
+export function rangeTotal(headers: Headers): number | null {
+  const total = /\/(\d+)$/.exec(headers.get("content-range")?.trim() ?? "")?.[1];
+  const bytes = total === undefined ? Number.NaN : Number(total);
+  return Number.isInteger(bytes) ? bytes : null;
+}
+
+// The size lives on the far side of HuggingFace's 302, and only in an identity encoding.
+const HEAD_PROBE: RequestInit = { method: "HEAD", headers: { "accept-encoding": "identity" } };
+const RANGE_PROBE: RequestInit = {
+  method: "GET",
+  headers: { "accept-encoding": "identity", range: "bytes=0-0" },
+};
+
+async function probeSize(
+  url: string,
+  { fetchImpl, attempts, backoffMs }: Required<LiveSizeOptions>,
+  init: RequestInit,
+  sizeOf: (res: Response) => number | null,
+): Promise<number | null> {
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    if (attempt > 1) await Bun.sleep(backoffMs * 2 ** (attempt - 2));
+    try {
+      const res = await fetchImpl(url, {
+        redirect: "follow",
+        signal: AbortSignal.timeout(30_000),
+        ...init,
+      });
+      // Retried like a dropped connection: a CDN omitting Content-Length intermittently would otherwise spend its one attempt and file the drift issue.
+      const bytes = res.ok ? sizeOf(res) : null;
+      if (bytes !== null) return bytes;
+    } catch {
+      // Swallowed so the loop can retry; a transient blip must never read as a wrong size.
+    }
+  }
+  return null;
+}
+
 /**
  * Bytes the URL serves, or null if the run could not find out.
  *
@@ -185,24 +224,15 @@ export async function liveSize(
   url: string,
   { fetchImpl = fetch, attempts = 4, backoffMs = 1000 }: LiveSizeOptions = {},
 ): Promise<number | null> {
-  for (let attempt = 1; attempt <= attempts; attempt++) {
-    if (attempt > 1) await Bun.sleep(backoffMs * 2 ** (attempt - 2));
-    try {
-      // The size lives on the far side of HuggingFace's 302, and only in an identity encoding.
-      const res = await fetchImpl(url, {
-        method: "HEAD",
-        redirect: "follow",
-        headers: { "accept-encoding": "identity" },
-        signal: AbortSignal.timeout(30_000),
-      });
-      // Retried like a dropped connection: a CDN omitting Content-Length intermittently would otherwise spend its one attempt and file the drift issue.
-      const bytes = res.ok ? contentLength(res.headers) : null;
-      if (bytes !== null) return bytes;
-    } catch {
-      // Swallowed so the loop can retry; a transient blip must never read as a wrong size.
-    }
-  }
-  return null;
+  const options = { fetchImpl, attempts, backoffMs };
+  const head = await probeSize(url, options, HEAD_PROBE, (res) => contentLength(res.headers));
+  if (head !== null) return head;
+  // raw.githubusercontent.com answers HEAD 200 with no Content-Length at all, which left the
+  // plan's one non-HuggingFace entry permanently unmeasurable (#1054). Asking for a single
+  // byte costs no download and reports the whole length in Content-Range.
+  return probeSize(url, options, RANGE_PROBE, (res) =>
+    res.status === 206 ? rangeTotal(res.headers) : contentLength(res.headers),
+  );
 }
 
 export function compareEntry(entry: PlanEntry, live: number | null): Verdict {

--- a/.github/workflows/model-plan-size-canary.yml
+++ b/.github/workflows/model-plan-size-canary.yml
@@ -10,7 +10,8 @@ name: "📏 Model-Plan Size Canary"
 #
 # So this job asks the only question that settles it: for every entry in
 # model-plan.json, does the pinned URL serve exactly the recorded number of bytes?
-# HEAD requests only — no downloads, no cache writes, seconds of runtime.
+# A HEAD, or a one-byte range request where HEAD carries no length (#1054) — no downloads
+# either way, no cache writes, seconds of runtime.
 #
 # Exact match is the bar. Sizes are pinned like the SHA-256s beside them, and a
 # "close enough" tolerance would have passed the 72.9 MB under-report that started

--- a/tests/unit/check-model-plan-sizes.test.ts
+++ b/tests/unit/check-model-plan-sizes.test.ts
@@ -224,6 +224,24 @@ describe("liveSize", () => {
     expect(await liveSize(url, { fetchImpl: omitsLengthOnce, backoffMs: 0 })).toBe(2327524);
   });
 
+  test("learns the length from a one-byte range when HEAD carries no length at all", async () => {
+    // raw.githubusercontent.com answers HEAD 200 with no Content-Length header (#1054), which
+    // left silero_vad.onnx — the plan's only non-HuggingFace entry — permanently unmeasurable.
+    const ranges: string[] = [];
+    const rawGithub: FetchLike = async (_input, init) => {
+      if (init?.method === "HEAD") return new Response(null, { status: 200 });
+      ranges.push(new Headers(init?.headers).get("range") ?? "");
+      return new Response("x", {
+        status: 206,
+        headers: { "content-range": "bytes 0-0/2327524", "content-length": "1" },
+      });
+    };
+
+    // The total the range reports, never the single byte it served.
+    expect(await liveSize(url, { fetchImpl: rawGithub, backoffMs: 0 })).toBe(2327524);
+    expect(ranges).toEqual(["bytes=0-0"]);
+  });
+
   test("gives up rather than guessing when the host keeps failing", async () => {
     const dead: FetchLike = async () => new Response(null, { status: 404 });
 


### PR DESCRIPTION
## What

`liveSize` falls back to a one-byte range request when HEAD yields no usable length, reading the resource length out of `Content-Range`. A 206's own `Content-Length` describes the byte it served, never the resource, so only the range total is accepted; a 200 (server ignoring the range) still goes through `contentLength`. Both passes keep the existing 4-attempt, seconds-of-backoff retry policy, and an entry nothing can measure stays `unchecked`.

The two doc comments that promised "HEAD only — no downloads" now say what the job actually does. No download either way: the fallback transfers one byte.

## Why

Closes #1054.

That issue is a false alarm, and the log in it proves it: 26 entries `ok`, zero `DRIFT`, one `UNCHECKED`. The unmeasurable entry is `models/silero-vad/silero_vad.onnx` — the plan's only non-HuggingFace URL.

Verified against the live host:

- `HEAD https://raw.githubusercontent.com/snakers4/silero-vad/v6.2.1/…/silero_vad.onnx` → `HTTP/2 200` carrying `etag`, `content-type` and no `content-length` at all.
- The same URL with `Range: bytes=0-0` → `HTTP/2 206`, `content-range: bytes 0-0/2327524`, `content-length: 1`.
- A full GET → `content-length: 2327524`, 2327524 bytes on disk.

So `model-plan.json`'s recorded 2327524 is correct and nothing drifted. Without this the canary cannot ever measure that entry, and the weekly run would keep filing it as drift — the "train everyone to ignore it" failure the retry policy above it was written to avoid.

Out of scope, worth its own issue: a run whose only finding is `UNCHECKED` still exits 1 and is filed under the `pact-drift` title, even though the body says the plan is not implicated. Worth separating so `pact-drift` keeps meaning "a recorded size is wrong".

## Testing

- `bun test tests/unit/check-model-plan-sizes.test.ts` — 20 pass. The new case fails on the parent commit (`liveSize` returns `null`) and passes here; it feeds a HEAD with no length and a 206 whose `content-length: 1` sits beside `content-range: bytes 0-0/2327524`, so returning 2327524 proves the byte count is not mistaken for the size, and it asserts the fallback asked for `bytes=0-0` rather than the body.
- `bun run test` — 1496 pass, 45 skip, 1 fail; `bun run lint` clean. The failure is `collectDoctorReport > reports diagnostic log collection errors without throwing`, which fails identically on unmodified `main` in this container and passes in CI — environment, not this change.
- Rust untouched, so the Rust gate does not apply.
- Not verified here: the fallback running against the real URL end-to-end. This sandbox's egress policy scopes GitHub to this repository, and bun's `fetch` cannot reach the host through the proxy at all (`socket connection was closed unexpectedly`), so the live evidence above was gathered with `curl`. CI runs the real thing.

## Checklist

- [x] `bun run check` passes (lint + version drift + fast tests)
- [x] Tests added/updated for the change
- [ ] Rust changes: n/a
- [ ] Docs/CHANGELOG updated if user-facing — n/a, CI-only


---
_Generated by [Claude Code](https://claude.ai/code/session_01HVcW1dnLF56SYQnde3bESb)_