### PR TITLE
ci: run every CI check in preflight and notice a stale checkout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ just worktree-rm <slug>
 
 ### VERIFY BEFORE PUSHING
 
-- `just preflight` before every push — the executable definition of the default gate: TS always, the Rust gate when `rust/**` changed, the CoreML check when `rust/src/backend/**` changed; `just ALL=1 preflight` runs every gate regardless of the diff. Read it rather than reconstructing the commands.
+- `just preflight` before every push — the executable definition of the default gate: TS and every `check:*` CI runs, always; the Rust gate when `rust/**` changed; the CoreML check when `rust/src/backend/**` changed; `just ALL=1 preflight` runs every gate regardless of the diff. `tests/unit/preflight-parity.test.ts` keeps that list equal to what the pull-request workflows invoke, because a shell-injecting recipe once passed a green preflight and was caught only in CI. Read the recipe rather than reconstructing the commands.
 - Always nextest for the suite — the only sanctioned plain `cargo test` calls are `--doc` and the pin-bump's `models::manifest_tests`; always `--all-targets`, or CI catches `#[cfg(test)]` dead code you didn't.
 - `preflight` does **not** build the darwin feature set, so it goes green on code that never compiled: touching `rust/src/tts/**` or anything fluidaudio-rs-adjacent (`system_kokoro` / `system_diarize` / `system_text_lang`) also needs `just verify-darwin-full`, the recipe `rust-test.yml` runs.
 - Do NOT push broken code.

--- a/justfile
+++ b/justfile
@@ -131,12 +131,20 @@ preflight:
     if [ -n "{{ ALL }}" ] || grep -q '^rust/' <<<"$changed"; then rust=1; fi
     if [ -n "{{ ALL }}" ] || grep -q '^rust/src/backend/' <<<"$changed"; then backend=1; fi
 
+    behind="$(git rev-list --count HEAD..origin/main)"
+    # A checkout that quietly fell 14 commits behind had an agent reading a stale CLAUDE.md for nine hours (#1070).
+    [ "$behind" = "0" ] || echo "==> NOTE: this checkout is $behind commit(s) behind origin/main — read instructions with: git show origin/main:<path>"
+
     echo "==> TS gate (always)"
     bun run test
     bun run lint
-    # CI runs these two and preflight did not, so a shell-injecting recipe reached CI green locally (#1065).
+    # tests/unit/preflight-parity.test.ts holds this list equal to what CI runs (#1070).
     bun run check:recipes
     bun run check:workflows
+    bun run check:versions
+    bun run check:specs
+    bun run check:engine-targets
+    bun run check:release-manifest
 
     if [ -n "$rust" ]; then
       echo "==> Rust gate"

--- a/tests/unit/preflight-parity.test.ts
+++ b/tests/unit/preflight-parity.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { readdirSync } from "node:fs";
+
+const ROOT = join(import.meta.dir, "..", "..");
+
+function read(relative: string): string {
+  return readFileSync(join(ROOT, relative), "utf8");
+}
+
+function checksIn(source: string): Set<string> {
+  return new Set([...source.matchAll(/bun run (check:[a-z-]+)/g)].map((match) => match[1]!));
+}
+
+function preflightBody(): string {
+  const justfile = read("justfile");
+  const start = justfile.indexOf("\npreflight:");
+  expect(start).toBeGreaterThan(-1);
+  const rest = justfile.slice(start + 1);
+  const end = rest.search(/\n[^\s#]/);
+  return end === -1 ? rest : rest.slice(0, end);
+}
+
+// A `just` recipe that interpolated a caller's value — shell injection — passed a green preflight
+// and was caught only by check:recipes in CI, because preflight ran two of the six checks (#1070).
+describe("preflight is the gate CLAUDE.md claims it is", () => {
+  test("it runs every check the pull-request workflows run", () => {
+    const workflows = readdirSync(join(ROOT, ".github", "workflows"))
+      .filter((name) => name.endsWith(".yml"))
+      // post-engine-release runs on a published tag, not on a pull request, and its checks
+      // verify the release it just read rather than the tree a contributor is about to push.
+      .filter((name) => name !== "post-engine-release.yml");
+
+    const required = new Set<string>();
+    for (const name of workflows) {
+      for (const check of checksIn(read(join(".github", "workflows", name)))) required.add(check);
+    }
+    expect(required.size).toBeGreaterThan(0);
+
+    const covered = checksIn(preflightBody());
+    const missing = [...required].filter((check) => !covered.has(check)).sort();
+    expect(missing).toEqual([]);
+  });
+
+  test("it reports a stale checkout rather than staying silent about it", () => {
+    // The number is already computed for the gate selection; a checkout 14 commits behind had an
+    // agent reading a stale CLAUDE.md for nine hours before anyone noticed (#1070).
+    const body = preflightBody();
+    expect(body).toContain("HEAD..origin/main");
+    expect(body).toContain("behind origin/main");
+  });
+});


### PR DESCRIPTION
Closes #1070.

## The gap, measured

`CLAUDE.md` calls `just preflight` "the executable definition of the default gate". It ran **two** of the **six** `check:*` scripts the pull-request workflows run — and only two since #1066; before that, none.

That description-versus-implementation gap has a cost on the record: a `just` recipe that interpolated a caller's value into its body — shell injection, the same class as #291 — passed a green `just preflight` and was caught by `check:recipes` in CI. Nothing local could have found it.

| check | CI job | was in preflight | cost |
| --- | --- | --- | --- |
| `check:recipes` | `workflow-lint` | ✅ | 0.1 s |
| `check:workflows` | `workflow-lint` | ✅ | 0.1 s |
| `check:release-manifest` | `workflow-lint` | ❌ | 0.1 s |
| `check:engine-targets` | `workflow-lint` | ❌ | 0.5 s |
| `check:versions` | `unit-tests` | ❌ | 0.1 s |
| `check:specs` | `openspec-validate` | ❌ | 1.6 s |

2.3 s for all four. preflight now runs all six.

## Why a test and not a shared recipe

The obvious fix is to have CI call the same `just` recipes so the two cannot diverge. **They already share one definition per check** — both CI and preflight invoke the `package.json` scripts, so there is no command-level drift to remove; a wrapper recipe would add indirection without removing anything.

What drifts is the **list**. And it cannot be fixed by collapsing the checks into one job either: `workflow-lint` is path-filtered on `workflows || recipes || schedule`, so moving `check:versions` and `check:specs` there would stop them running on a PR that touches only `package.json` or `openspec/` — weakening CI to tidy the Justfile.

So the single source of truth for the list is the workflows themselves. `tests/unit/preflight-parity.test.ts` reads every pull-request workflow, collects the `check:*` scripts, and fails naming any the `preflight` recipe does not run. `post-engine-release.yml` is excluded with its reason in the code: it runs on a published tag and verifies the release it just read, not the tree a contributor is about to push.

## The stale checkout

`preflight` already computes `HEAD..origin/main` for its own gate selection and said nothing about it. A root checkout that quietly fell **14 commits behind** had an agent reading a stale `CLAUDE.md` for nine hours, never seeing a mandatory runbook that had landed in #1046. It now prints the count and the way to read instructions correctly (`git show origin/main:<path>`) — a note, not a failure, since being behind is normal mid-session.

## Verification

`just preflight` green, 1518 tests, with all six checks visible in the run. Both new assertions were verified to fail when what they pin is removed: dropping one check from the recipe, and deleting the staleness line.
