### PR TITLE
test(ci): select lane-exclusive modules whole, and fail when one is orphaned

### DIFF
--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -491,12 +491,12 @@ jobs:
           # "this guard did not run" line is exactly that (#841).
           # `system_diarize` rides along because `transcribe::diarize` compiles under no other
           # lane, so its tests only ever got clippy'd; they are pure and cost 0.14 s (#999).
-          # `fluid_stdout` builds under no other lane, so without these two the fd 1 locks are unpinned in CI (#951).
+          # `fluid_stdout` and `transcribe::diarize` build under no other lane, so both are selected by module (#1072).
           cargo nextest run \
             --no-default-features --features coreml,system_diarize \
             --run-ignored all \
             --success-output immediate \
-            -E 'test(transcribe_samples_is_stateless_across_calls) + test(debug_routes_silenced_chatter_to_stderr) + test(a_sub_second_file_transcribes_instead_of_erroring) + test(transcribe::diarize::) + test(scoped_guards_serialize_stdout_ownership) + test(permanent_shield_waits_for_a_live_scoped_guard)'
+            -E 'test(transcribe_samples_is_stateless_across_calls) + test(a_sub_second_file_transcribes_instead_of_erroring) + test(transcribe::diarize::) + test(fluid_stdout::)'
 
       - name: 📤 Upload JUnit
         if: always()

--- a/tests/unit/lane-exclusive-tests.test.ts
+++ b/tests/unit/lane-exclusive-tests.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = join(import.meta.dir, "..", "..");
+const WORKFLOW = ".github/workflows/rust-test.yml";
+
+// Modules `cfg`-gated to features only `coreml-regression` builds: every other lane either
+// compiles default features, so these are gated out, or stops at cargo check / clippy. A
+// `#[test]` here that the lane's filter does not select executes in no lane at all (#951, #1072).
+const LANE_EXCLUSIVE = ["rust/src/fluid_stdout.rs", "rust/src/transcribe/diarize.rs"] as const;
+
+function read(relative: string): string {
+  return readFileSync(join(ROOT, relative), "utf8");
+}
+
+function laneFilter(): string {
+  const match = /-E '([^']+)'/.exec(read(WORKFLOW));
+  expect(match).not.toBeNull();
+  return match![1]!;
+}
+
+function testNames(source: string): string[] {
+  return [...source.matchAll(/#\[test\]\s*(?:\n\s*#\[[^\]]*\]\s*)*\n\s*fn\s+([a-z0-9_]+)/g)].map((m) => m[1]!);
+}
+
+function modulePath(relative: string): string {
+  return relative.replace(/^rust\/src\//, "").replace(/\.rs$/, "").replace(/\//g, "::");
+}
+
+describe("a lane-exclusive test cannot run nowhere", () => {
+  test("the modules really are gated to that lane's features", () => {
+    const lib = read("rust/src/lib.rs");
+    // If the gating ever widens, this file's premise is gone and its list must be revisited.
+    expect(lib).toContain("mod fluid_stdout;");
+    expect(/#\[cfg\(all\(\s*target_os = "macos",[\s\S]{0,200}?mod fluid_stdout;/.test(lib)).toBe(true);
+  });
+
+  test("every test in a lane-exclusive module is selected by the lane", () => {
+    const filter = laneFilter();
+    const orphans: string[] = [];
+    for (const relative of LANE_EXCLUSIVE) {
+      const selectedByModule = filter.includes(`test(${modulePath(relative)}::)`);
+      for (const name of testNames(read(relative))) {
+        if (!selectedByModule && !filter.includes(`test(${name})`)) orphans.push(`${modulePath(relative)}::${name}`);
+      }
+    }
+    expect(orphans).toEqual([]);
+  });
+
+  test("every name the lane selects still exists", () => {
+    const named = [...laneFilter().matchAll(/test\(([a-z0-9_]+)\)/g)].map((m) => m[1]!);
+    expect(named.length).toBeGreaterThan(0);
+    const sources = ["rust/src/backend/fluidaudio.rs", ...LANE_EXCLUSIVE].map((relative) => read(relative)).join("\n");
+    // A rename that empties the lane must fail here rather than quietly select nothing.
+    for (const name of named) expect(sources).toContain(`fn ${name}`);
+  });
+});


### PR DESCRIPTION
Closes #1072.

`coreml-regression` is the only lane that both compiles **and runs** `rust/src/fluid_stdout.rs` and `rust/src/transcribe/diarize.rs`; every other lane builds default features (so they are `cfg`-ed out) or stops at `cargo check` / clippy. It selected tests with an explicit `-E` list, and two tests were not on it:

- `shield_holds_fd1_through_drop`
- `silenced_scope_discards_buffered_c_stdio_before_restore`

Both **executed in no lane at all**. `cargo nextest list` under the lane's own feature set now returns all five `fluid_stdout` tests instead of three.

This has bitten twice already: in #951 a new concurrency guard compiled everywhere and ran nowhere, so deleting the lock it protected stayed green; the same shape recurred a level up in #1041.

## The fix, and the guard on the fix

The lane now selects `fluid_stdout` **by module**, the way `transcribe::diarize` already was — a list of names is what goes stale. The redundant named entry for `debug_routes_silenced_chatter_to_stderr` is dropped; the `--success-output immediate` comment above it explains the flag, not the filter entry, so nothing was lost.

`tests/unit/lane-exclusive-tests.test.ts` fails when a `#[test]` in either module is not selected, **and** when a name in the filter no longer exists — a rename would otherwise empty the lane in silence. It also asserts the modules are still `cfg`-gated to that lane's features, since that premise is what makes the rest of the file mean anything.

## Verification

`just preflight` green. Both drift directions verified to fail: dropping the module from the filter, and renaming a test the filter selects by name.