### PR TITLE
feat(test): add a mutation harness that refuses to run empty

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,8 @@ The rule behind that audit: a test pays off when the **contract is stable and th
 - Prefer `tests/integration/` the moment behaviour crosses the CLI or the engine boundary; that is where the highest-value coverage lives.
 - New behaviour gets coverage next to the code that changed. Do not lean on a broad e2e test that happens to walk the branch.
 
+A guard is only a guard if removing it goes red. `just mutate <file> <find> <replace> <test>` proves that in seconds — it refuses when the text does not occur, restores the file in a `finally`, and exits 0 only when the mutation was *caught*. A hand-rolled `perl -0pi` that matches nothing exits 0 and reads as "the pin is useless" (#1075).
+
 **Fix a flaky test before doing anything else.** A suite that fails at random teaches everyone to re-run it, and the next genuine failure gets re-run too. Never `skip` a flaky or failing test to force green — fix it, or quarantine it behind an issue. That ban is about hiding red; the environmental guards below are the opposite and must stay.
 
 When deciding whether some change caused a flake, one run per arm settles nothing — check CI on the same SHA first, then repeat each arm enough times to separate signal from noise. Background for install timeouts in `cli-contracts`: macOS scans every freshly written executable on first exec, which cost these scenarios 2–9 s. #649 widened `cli-scenario.ts`'s `DEFAULT_TIMEOUT_MS` from 4 s to 15 s to cover it, so a timeout there is no longer explained away as that flake — treat it as real until proven otherwise.

--- a/justfile
+++ b/justfile
@@ -89,6 +89,11 @@ review CLAIM:
     nohup ${reviewer} "${prompt}" > "${log}" 2>&1 &
     echo "==> launched in background; post the findings as one **grok review** comment carrying the full head SHA"
 
+# Prove a guard is pinned: replace text, run the tests, restore. Refuses when the text does not occur (#1075)
+[positional-arguments]
+mutate file find replace +test:
+    bun scripts/mutate.ts "$@"
+
 # Run all tests
 test:
     bun run test:unit

--- a/scripts/mutate.ts
+++ b/scripts/mutate.ts
@@ -1,0 +1,52 @@
+#!/usr/bin/env bun
+import { readFileSync, writeFileSync } from "node:fs";
+
+export type MutationResult = { replacements: number; source: string };
+
+/// Literal, not regex: the caller names the exact text to neutralise, and a regex that
+/// silently matches nothing is the failure this whole script exists to prevent (#1075).
+export function mutate(source: string, find: string, replace: string): MutationResult {
+  if (find.length === 0) throw new Error("the text to replace must not be empty");
+  const replacements = source.split(find).length - 1;
+  return { replacements, source: replacements === 0 ? source : source.split(find).join(replace) };
+}
+
+function usage(message: string): never {
+  console.error(`${message}\nusage: bun scripts/mutate.ts <file> <find> <replace> <test-command>`);
+  process.exit(2);
+}
+
+async function main(): Promise<void> {
+  const [file, find, replace, ...command] = process.argv.slice(2);
+  if (!file || find === undefined || replace === undefined || command.length === 0) usage("missing argument");
+
+  const original = readFileSync(file, "utf8");
+  const { replacements, source } = mutate(original, find, replace);
+  if (replacements === 0) {
+    console.error(`refusing: '${find}' does not occur in ${file} — an unapplied mutation proves nothing`);
+    process.exit(2);
+  }
+
+  let survived = false;
+  try {
+    writeFileSync(file, source);
+    console.error(`==> mutated ${file} (${replacements} occurrence${replacements === 1 ? "" : "s"}); running: ${command.join(" ")}`);
+    survived = (await Bun.spawn(command, { stdout: "inherit", stderr: "inherit" }).exited) === 0;
+  } finally {
+    writeFileSync(file, original);
+    console.error(`==> restored ${file}`);
+  }
+
+  if (survived) {
+    console.error(`NOT PINNED: the mutation survived — nothing failed when '${find}' was replaced`);
+    process.exit(1);
+  }
+  console.error("PINNED: the mutation was caught");
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error(`mutate: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(2);
+  });
+}

--- a/tests/unit/check-recipes.test.ts
+++ b/tests/unit/check-recipes.test.ts
@@ -234,6 +234,7 @@ describe("the repository's own references", () => {
     const found = new Set(names("CLAUDE.md", readRepoFile("CLAUDE.md")));
     expect([...found].sort()).toEqual([
       "dev-setup",
+      "mutate",
       "preflight",
       "release",
       "release-tag",

--- a/tests/unit/mutate.test.ts
+++ b/tests/unit/mutate.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { mutate } from "../../scripts/mutate";
+
+describe("mutate", () => {
+  // A perl one-liner whose pattern misses exits 0 and changes nothing, so the test passes and the
+  // run reads as "the pin is useless" — that false verdict is what this counts away (#1075).
+  test("reports zero replacements rather than a silent no-op", () => {
+    const source = "let owner = lock();";
+    expect(mutate(source, "absent", "x")).toEqual({ replacements: 0, source });
+  });
+
+  test("counts and applies every occurrence", () => {
+    const result = mutate("a; b; a;", "a", "z");
+    expect(result).toEqual({ replacements: 2, source: "z; b; z;" });
+  });
+
+  test("treats the needle as literal text, not a pattern", () => {
+    // `.` and `(` are the common case in real guards; a regex would match far too much.
+    expect(mutate("if (x) { drop(); }", "drop()", "keep()").source).toBe("if (x) { keep(); }");
+    expect(mutate("a.b", ".", "!")).toEqual({ replacements: 1, source: "a!b" });
+  });
+
+  test("refuses an empty needle instead of splitting every character", () => {
+    expect(() => mutate("abc", "", "x")).toThrow("must not be empty");
+  });
+});


### PR DESCRIPTION
Closes #1075.

Proving a guard actually catches its regression is currently `cp` + `perl -0pi` + a test run, and it has two failure modes that both produce a **confident wrong answer**.

**A pattern that matches nothing exits 0 and changes nothing.** The test then passes — because the code is unmutated — and the run reads as *the pin is useless*. That verdict was recorded while proving the #1041 guards: one of five mutations never applied and was reported as `STILL GREEN` until the substitution count was checked by hand.

**An interrupted run leaves the tree mutated**, looking like an ordinary edit. The repo already knows this shape from `cargo-mutants --in-place`.

## What it does

`just mutate <file> <find> <replace> <test…>`

- **refuses when the text does not occur** — the whole point;
- restores the file in a `finally`, so a throw or an interrupt cannot leave it mutated;
- prints how many occurrences it replaced;
- **inverts the verdict**: exit 0 means `PINNED` (the mutation was caught), exit 1 means `NOT PINNED` (the guard survived its own removal).

The needle is **literal text, not a regex** — real guards are named by strings containing `.` and `(`, where a regex matches far more than intended.

## Verification

All four paths exercised end to end against real files:

| path | result |
| --- | --- |
| pattern absent | `refusing: … does not occur`, exit 2 |
| guard is pinned (renamed `pickVoiceForLang`) | `PINNED`, exit 0 |
| mutation survives (comment-only change) | `NOT PINNED`, exit 1 |
| file after each run | restored, `git status` clean |

`just preflight` green; `bunx tsc --noEmit` clean. Unit tests cover zero-match reporting, multi-occurrence counting, literal-not-regex handling, and the empty-needle refusal.