### PR TITLE
feat(conveyor): build gate evidence with one command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ Greptile reviews on open and on every new commit. **P1/P2 findings are merge blo
 
 ### BACKLOG CONVEYOR REVIEW GATE
 
-Every conveyor PR MUST follow the [backlog conveyor review runbook](docs/runbooks/backlog-conveyor-review.md): `just review "<claim>"` the moment the PR exists, a durable comment carrying the full head SHA and every finding, and a fix pass for confirmed blockers that restarts the review on the new head. `merge-ready` comes only from `bun run conveyor -- gate … --apply`, never by hand. 43% of merged PRs used to skip the review entirely — that gap cost more than any wording did, which is why the recipe takes the claim as a required argument.
+Every conveyor PR MUST follow the [backlog conveyor review runbook](docs/runbooks/backlog-conveyor-review.md): `just review "<claim>"` the moment the PR exists, a durable comment carrying the full head SHA and every finding, and a fix pass for confirmed blockers that restarts the review on the new head. `merge-ready` comes only from `bun run conveyor -- gate … --apply`, never by hand — `just gate <issue> <pr> <provider> <uri>` builds the SHA-bound evidence and calls it, reading the head immediately before binding to it. 43% of merged PRs used to skip the review entirely — that gap cost more than any wording did, which is why the recipe takes the claim as a required argument.
 
 ### ERROR HANDLING
 

--- a/justfile
+++ b/justfile
@@ -94,6 +94,15 @@ review CLAIM:
 mutate file find replace +test:
     bun scripts/mutate.ts "$@"
 
+# Earn merge-ready: build SHA-bound evidence for this PR and hand it to the conveyor gate (#1078)
+[positional-arguments]
+gate issue pr provider uri:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    evidence="$(bun scripts/gate-evidence.ts "$3" "$4" --pr "$2")"
+    echo "==> evidence: $evidence"
+    bun run conveyor -- gate --issue "$1" --pr "$2" --evidence "$evidence" --apply
+
 # Run all tests
 test:
     bun run test:unit

--- a/scripts/gate-evidence.ts
+++ b/scripts/gate-evidence.ts
@@ -1,0 +1,52 @@
+#!/usr/bin/env bun
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { digestGateEvidence, type GateEvidence } from "./backlog-conveyor";
+
+export type EvidenceInput = { provider: string; headSha: string; uri: string };
+
+/// Builds the SHA-bound evidence the conveyor gate verifies, through the gate's own digest
+/// helper so the two cannot drift. `verdict` and `version` are literals by contract (#1078).
+export function buildGateEvidence(input: EvidenceInput): GateEvidence {
+  for (const [name, value] of Object.entries(input)) {
+    if (!value) throw new Error(`${name} must be a non-empty string`);
+  }
+  if (!/^[0-9a-f]{40}$/.test(input.headSha)) throw new Error(`headSha must be a full 40-character SHA, got '${input.headSha}'`);
+  const payload = { version: 1 as const, provider: input.provider, verdict: "APPROVED" as const, headSha: input.headSha, uri: input.uri };
+  return { ...payload, digest: digestGateEvidence(payload) };
+}
+
+function usage(message: string): never {
+  console.error(`${message}\nusage: bun scripts/gate-evidence.ts <provider> <uri> [--pr N]`);
+  process.exit(2);
+}
+
+async function headSha(pr: string): Promise<string> {
+  const proc = Bun.spawn(["gh", "pr", "view", pr, "--json", "headRefOid", "-q", ".headRefOid"], { stdout: "pipe", stderr: "pipe" });
+  const sha = (await new Response(proc.stdout).text()).trim();
+  if ((await proc.exited) !== 0 || !sha) throw new Error(`could not read the head SHA of pull request ${pr}`);
+  return sha;
+}
+
+async function main(): Promise<void> {
+  const [provider, uri, flag, pr] = process.argv.slice(2);
+  if (!provider || !uri) usage("provider and uri are required");
+  if (flag !== undefined && flag !== "--pr") usage(`unknown argument '${flag}'`);
+  if (flag === "--pr" && !pr) usage("--pr needs a pull request number");
+  // Read the head immediately before binding to it: a push between the two would otherwise
+  // produce evidence for a superseded head, which is the staleness the digest exists to prevent.
+  const evidence = buildGateEvidence({ provider, uri, headSha: await headSha(pr ?? "") });
+  // A unique directory, because two lanes sharing one /tmp path already shipped a PR with
+  // another PR's body (#1007).
+  const path = join(mkdtempSync(join(tmpdir(), "kesha-gate-")), "evidence.json");
+  writeFileSync(path, `${JSON.stringify(evidence, null, 2)}\n`);
+  console.log(path);
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error(`gate-evidence: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(2);
+  });
+}

--- a/tests/unit/check-recipes.test.ts
+++ b/tests/unit/check-recipes.test.ts
@@ -234,6 +234,7 @@ describe("the repository's own references", () => {
     const found = new Set(names("CLAUDE.md", readRepoFile("CLAUDE.md")));
     expect([...found].sort()).toEqual([
       "dev-setup",
+      "gate",
       "mutate",
       "preflight",
       "release",

--- a/tests/unit/gate-evidence.test.ts
+++ b/tests/unit/gate-evidence.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { buildGateEvidence } from "../../scripts/gate-evidence";
+import { canonicalGateEvidencePayload, digestGateEvidence, parseGateEvidence } from "../../scripts/backlog-conveyor";
+
+const SHA = "693cd6dbbe180a81dd75732ade0160e373ed43d0";
+const base = { provider: "grok", headSha: SHA, uri: "https://example.invalid/pr/1#c1" };
+
+describe("gate evidence", () => {
+  test("is accepted by the gate's own parser", () => {
+    // The point of building it here is that the gate verifies it there; a shape only this file
+    // agrees with would pass its own tests and be refused in the one place that matters.
+    expect(() => parseGateEvidence(JSON.parse(JSON.stringify(buildGateEvidence(base))))).not.toThrow();
+  });
+
+  test("carries the literals the contract fixes, not remembered ones", () => {
+    const evidence = buildGateEvidence(base);
+    expect(evidence.version).toBe(1);
+    expect(evidence.verdict).toBe("APPROVED");
+    expect(evidence.headSha).toBe(SHA);
+  });
+
+  test("its digest covers the payload, so an edited field invalidates it", () => {
+    const evidence = buildGateEvidence(base);
+    const { digest: _drop, ...payload } = evidence;
+    expect(evidence.digest).toBe(digestGateEvidence(payload));
+    // Build the neighbour by construction: `replace(/.$/, "0")` on a SHA already ending in 0
+    // is a mutation that never applies, which is exactly what `just mutate` refuses to do (#1075).
+    const neighbour = `${SHA.slice(0, 39)}${SHA.endsWith("0") ? "1" : "0"}`;
+    expect(neighbour).not.toBe(SHA);
+    expect(digestGateEvidence({ ...payload, headSha: neighbour })).not.toBe(evidence.digest);
+    expect(canonicalGateEvidencePayload(payload)).toContain(SHA);
+  });
+
+  test("refuses an abbreviated SHA, which the gate would bind to nothing", () => {
+    expect(() => buildGateEvidence({ ...base, headSha: SHA.slice(0, 8) })).toThrow("40-character");
+    expect(() => buildGateEvidence({ ...base, provider: "" })).toThrow("provider");
+  });
+});


### PR DESCRIPTION
Closes #1078.

`merge-ready` may only be applied through `bun run conveyor -- gate … --apply` — the label is bound to a head SHA, and a hand-applied one is reported as stale evidence within minutes. But producing the `--evidence` file was hand work, done twice today with an inline `bun -e`.

Three things went wrong in that by-hand shape, and each is now closed:

- **The head SHA was read separately from the gate that verifies it.** A push in between produces evidence for a superseded head — the exact staleness the digest exists to prevent. `just gate` reads the head immediately before binding to it.
- **The temp path was chosen on the spot.** Two lanes sharing one `/tmp` path already shipped a PR carrying another PR's body (#1007). It now writes under `mkdtemp`.
- **`verdict: APPROVED` and `version: 1` were remembered, not enforced**, and the digest was recomputed by a copy of the gate's logic. Both now come from the gate's own exported helpers, so they cannot drift.

An abbreviated SHA is refused outright — the gate would bind the label to nothing.

## Verification

Against the **real gate**, not a mock: evidence built for #1076's current head (`dce34d5`) and passed to `conveyor gate` dry-run returns `would apply: create-marker, add-merge-ready`.

`just preflight` green, 1522 tests; `bunx tsc --noEmit` clean.

One of the new tests initially passed a mutation that never applied — `SHA.replace(/.\$/, "0")` on a SHA already ending in `0` — which is precisely the failure `just mutate` was added to refuse in #1076. The neighbour SHA is now built by construction and asserted to differ before it is used.