### PR TITLE
feat(review): send a standing sweep alongside the claim

### DIFF
--- a/docs/runbooks/backlog-conveyor-review.md
+++ b/docs/runbooks/backlog-conveyor-review.md
@@ -11,6 +11,13 @@ Run `just review "<claim>"` the moment the PR exists. Measured over
 every P1/P2 the reviews did raise led to a code change — 6 for 6. Coverage,
 not wording, is what the gate was losing.
 
+The prompt is a claim **plus a standing sweep**. The claim focuses; measured over three PRs on
+2026-08-18 it also *narrowed*, and every later round found what a different question would have
+surfaced first rather than what a closer reading would have. The sweep — second-order
+consequences, both mutations per guard, the lane that runs each new test, this repo's recurring
+classes, and an explicit statement of what went unexamined — is what stops the claim bounding
+the review. It lives in `scripts/review-prompt.ts` so it can be pinned by a test.
+
 `CLAIM` is required by the recipe on purpose. Reviews framed as *refute this
 specific claim* found defects that "review this PR" did not, including two false
 assertions their own author had written down with confidence.

--- a/justfile
+++ b/justfile
@@ -70,21 +70,7 @@ review CLAIM:
     branch="$(git rev-parse --abbrev-ref HEAD)"
     log=".omc/review-${pr}-${head:0:8}.log"
     mkdir -p .omc
-    read -r -d '' prompt <<EOF || true
-    Adversarial review of pull request #${pr} at head ${head} (branch ${branch} vs ${base}).
-
-    Prove or refute this claim, and say which assertion fires if it is wrong:
-    ${claim}
-
-    Where a claim can be settled by running something, run it: mutate the code, execute the
-    test, report the failure, restore the file. Do not settle it by reading.
-    If you still agree with the claim after examining it, say so plainly — agreement and
-    non-examination look identical otherwise.
-    If the diff touches tests, state whether any existing assertion was changed, deleted or
-    renamed, and whether each change is justified or re-points a pin at broken output.
-
-    Output findings with severity P1/P2/P3.
-    EOF
+    prompt="$(bun scripts/review-prompt.ts "$pr" "$head" "$branch" "$base" "$claim")"
     echo "==> reviewing #${pr} at ${head:0:8}; output -> ${log}"
     nohup ${reviewer} "${prompt}" > "${log}" 2>&1 &
     echo "==> launched in background; post the findings as one **grok review** comment carrying the full head SHA"

--- a/scripts/review-prompt.ts
+++ b/scripts/review-prompt.ts
@@ -1,0 +1,50 @@
+#!/usr/bin/env bun
+
+export type ReviewTarget = { pr: string; head: string; branch: string; base: string; claim: string };
+
+/// The claim focuses the review; the sweep stops it narrowing to only what was asked. Three PRs
+/// reviewed on 2026-08-18 needed 2–4 rounds each, and every later round found what a *different
+/// question* would have surfaced first — not what a more careful reading would have (#1077).
+const SWEEP = [
+  "Second-order: for each finding, name what fixing it the obvious way would open. Then check whether this diff's own fixes already did that to an earlier finding — every blocker in one PR's second round was a seam its first round's fix created.",
+  "Guards, at full depth: for every guard this diff adds, run BOTH mutations. Delete it, and separately neutralise it while leaving its shape in place — keep the query and drop the refusal, keep the pattern and flip the branch it feeds. Report which assertion fires for each. A guard whose test only catches deletion is unpinned against the mutation that actually happens.",
+  "Reach: for every test this diff adds or changes, name the CI lane that executes it. A test compiled everywhere and run nowhere has already shipped twice here.",
+  "Recurring classes in this repository, each of which has recurred: a closing keyword naming the wrong issue; a consumer-facing document left stale while the spec was updated; an assertion re-pointed at broken output rather than the change being wrong; a fix that recreates its defect one level up; a new branch that swallows an unrelated failure.",
+  "Completeness: end with what you did NOT examine and what you would need in order to. If that list is empty, say so explicitly — an unstated gap reads identically to no gap.",
+];
+
+export function buildReviewPrompt(target: ReviewTarget): string {
+  if (!target.claim.trim()) throw new Error("a claim is required — a generic review finds generic things");
+  return [
+    `Adversarial review of pull request #${target.pr} at head ${target.head} (branch ${target.branch} vs ${target.base}).`,
+    "",
+    "Prove or refute this claim, and say which assertion fires if it is wrong:",
+    target.claim,
+    "",
+    "Where a claim can be settled by running something, run it: mutate the code, execute the test, report the failure, restore the file. Do not settle it by reading.",
+    "If you still agree with the claim after examining it, say so plainly — agreement and non-examination look identical otherwise.",
+    "",
+    "Then, regardless of that claim, sweep for the following. Report `none` per item rather than omitting it.",
+    "",
+    ...SWEEP.map((item, index) => `${index + 1}. ${item}`),
+    "",
+    "If the diff touches tests, state whether any existing assertion was changed, deleted or renamed, and whether each change is justified or re-points a pin at broken output.",
+    "",
+    "Output findings with severity P1/P2/P3.",
+  ].join("\n");
+}
+
+function usage(message: string): never {
+  console.error(`${message}\nusage: bun scripts/review-prompt.ts <pr> <head> <branch> <base> <claim>`);
+  process.exit(2);
+}
+
+if (import.meta.main) {
+  const [pr, head, branch, base, claim] = process.argv.slice(2);
+  if (!pr || !head || !branch || !base || claim === undefined) usage("missing argument");
+  try {
+    console.log(buildReviewPrompt({ pr, head, branch, base, claim }));
+  } catch (error) {
+    usage(error instanceof Error ? error.message : String(error));
+  }
+}

--- a/tests/unit/review-prompt.test.ts
+++ b/tests/unit/review-prompt.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { buildReviewPrompt } from "../../scripts/review-prompt";
+
+const target = { pr: "1077", head: "a".repeat(40), branch: "feat/x", base: "main", claim: "the guard is pinned" };
+
+describe("the review prompt", () => {
+  test("carries the claim and the full head SHA", () => {
+    const prompt = buildReviewPrompt(target);
+    expect(prompt).toContain(target.claim);
+    expect(prompt).toContain(target.head);
+    expect(prompt).toContain("#1077");
+  });
+
+  // Each of these exists because a review round found what the previous round was never asked (#1077).
+  test("sweeps beyond the claim, so the claim cannot narrow the review", () => {
+    const prompt = buildReviewPrompt(target);
+    expect(prompt).toContain("Second-order");
+    expect(prompt).toContain("neutralise it");
+    expect(prompt).toContain("name the CI lane that executes it");
+    expect(prompt).toContain("Completeness");
+    expect(prompt).toContain("re-points a pin at broken output");
+  });
+
+  test("asks for an explicit `none` rather than an omission", () => {
+    // An omitted item and an examined-but-clean item read identically otherwise.
+    expect(buildReviewPrompt(target)).toContain("Report `none` per item rather than omitting it");
+  });
+
+  test("demands the mutation be run, not reasoned about", () => {
+    const prompt = buildReviewPrompt(target);
+    expect(prompt).toContain("Do not settle it by reading");
+    expect(prompt).toContain("restore the file");
+  });
+
+  test("refuses an empty claim", () => {
+    expect(() => buildReviewPrompt({ ...target, claim: "   " })).toThrow("a claim is required");
+  });
+});


### PR DESCRIPTION
Closes #1077.

Three PRs reviewed on 2026-08-18 needed **two to four rounds each**, and every round cost a fix, a push and a 6–9 minute re-review. Reading the transcripts back, the reviewer was not careless — each later round found what a *different question* would have surfaced in the first.

| PR | rounds | what each later round found |
| --- | --- | --- |
| #1058 | 3 | the test pins the helper → **no CI lane runs the test at all** → the overlap flag is unreachable |
| #1064 | 2 | three P2 → three *new* P2, each a seam opened by the first round's own fixes |
| #1057 | 4 | P1 + P2 → the fix closed the instance, not the class → the pins assert text, not control flow |

## Three causes, all in the prompt

**The fix opens the next finding.** Every P2 in #1064's second round was created by the first round's fix. The reviewer was never asked what the obvious fix would open.

**The claim scopes the review.** A claim-aimed ask finds what generic asks miss — that is measured, and is why `CLAIM` is required. It also *narrows*: #1058's first round was asked about deadlock, clobber and poisoning, answered all three, and never checked whether any lane executes the new test.

**Depth escalates round over round.** Round two asked "does deleting the guard fail?"; round three asked "does *neutralising* it fail?" — dropping an `if` while leaving its query in place. The sharper question only got asked once the blunter one was satisfied.

## What changes

The prompt is now claim **plus a standing sweep**: second-order consequences, **both** mutations per guard, the CI lane that executes each new test, this repo's recurring classes, and an explicit statement of what went unexamined. Every item asks for `none` rather than permitting an omission — an omitted item and an examined-clean one read identically.

It moves out of the recipe heredoc into `scripts/review-prompt.ts`, for the same reason the release guards moved into code in #1057: a prompt embedded in shell cannot be pinned by a test.

## How to know it worked

Rounds-to-clean per PR, countable from the review comments; the baseline above is 2–4. If the median does not drop, that is worth saying rather than keeping the change.

## Verification

`just preflight` green. Five tests pin the prompt: it carries the claim and the full head SHA, it contains each sweep item, it demands `none` over omission, it requires the mutation be run rather than reasoned about, and it refuses an empty claim.