### PR TITLE
docs: correct the commands CONTRIBUTING.md describes

### DIFF
--- a/.claude/commands/start-issue.md
+++ b/.claude/commands/start-issue.md
@@ -17,8 +17,9 @@ Arguments: `$ARGUMENTS` → first token is the issue number (required), optional
 
 2. Tag it `WIP` so drakulavich sees it's in flight. Create the label first only if it doesn't exist:
    ```bash
-   gh label create WIP -R drakulavich/kesha-voice-kit --color FBCA04 \
-     --description "An agent or contributor is actively working on this" 2>/dev/null || true
+   gh label list -R drakulavich/kesha-voice-kit | grep -q '^WIP' || \
+     gh label create WIP -R drakulavich/kesha-voice-kit --color FBCA04 \
+       --description "An agent or contributor is actively working on this"
    gh issue edit <N> -R drakulavich/kesha-voice-kit --add-label WIP
    ```
 

--- a/.claude/commands/start-issue.md
+++ b/.claude/commands/start-issue.md
@@ -17,9 +17,8 @@ Arguments: `$ARGUMENTS` → first token is the issue number (required), optional
 
 2. Tag it `WIP` so drakulavich sees it's in flight. Create the label first only if it doesn't exist:
    ```bash
-   gh label list -R drakulavich/kesha-voice-kit | grep -q '^WIP' || \
-     gh label create WIP -R drakulavich/kesha-voice-kit --color FBCA04 \
-       --description "An agent or contributor is actively working on this"
+   gh label create WIP -R drakulavich/kesha-voice-kit --color FBCA04 \
+     --description "An agent or contributor is actively working on this" 2>/dev/null || true
    gh issue edit <N> -R drakulavich/kesha-voice-kit --add-label WIP
    ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ kesha install --vad      # opt-in: Silero VAD model
 The CLI is a Bun/TypeScript wrapper around `kesha-engine`, a Rust binary
 downloaded from GitHub Releases at the version pinned in
 `package.json#keshaEngine.version`. CLI and engine are versioned
-independently — see [`CLAUDE.md`](./CLAUDE.md) "RELEASE PROCESS" for the
+independently — see [`CLAUDE.md`](./CLAUDE.md) "Releases" for the
 full split.
 
 ### Trying an engine build without editing the pin
@@ -65,18 +65,20 @@ where tests live, and a "where to change X" table.
 ## Development
 
 ```bash
-bun run check       # typecheck + version drift + deterministic CLI tests (the fast path)
+bun run check       # tsc + versions + recipes + test:cli-fast (the fast path; needs just)
 just test           # bun unit + integration tests
 bun run lint        # bunx tsc --noEmit
 just smoke-test     # bun link → kesha install → run against fixtures
-just release        # lint + test + smoke-test
+just release        # check (lint + versions + recipes + all Bun tests) + smoke-test
 ```
 
 **Keep the fast path sacred.** `bun run check` (and `bun run test:cli-fast`)
 must stay free of engine downloads, model installs, and heavy e2e. Use it for
-every CLI-only change. Engine-backed integration, TTS e2e, diarization, and
-smoke tests live on the slower explicit path (`just test`, `just smoke-test`,
-CI). Do not pull network or multi-GB dependencies into the fast loop.
+every CLI-only change. Real-engine e2e, TTS e2e, diarization, and smoke tests
+are not on this path: `just test` runs unit plus `tests/integration/` (real-
+engine cases self-skip unless an engine is already installed), `just smoke-test`
+is the explicit install-and-fixtures path, and TTS e2e / diarization live in
+CI. Do not pull network or multi-GB dependencies into the fast loop.
 
 Use `bun run check` for a quick local confidence pass before
 opening small CLI-only PRs. It avoids the engine-backed E2E lanes while still
@@ -87,7 +89,7 @@ Rust engine work happens in `rust/`:
 
 ```bash
 cd rust
-cargo test --no-default-features --features onnx,tts --lib
+cargo nextest run --no-default-features --features onnx,tts --lib
 cargo clippy --all-targets --no-default-features --features onnx,tts -- -D warnings
 cargo fmt --check
 ```
@@ -136,7 +138,7 @@ kesha-voice-kit/
 ├── scripts/                    # benchmark.ts, smoke-test.ts
 ├── .github/workflows/
 │   ├── ci.yml                  # PR: unit + integration + tts-e2e + type check
-│   ├── rust-test.yml           # PR touching rust/: cargo test/fmt/clippy across 3 OSes
+│   ├── rust-test.yml           # PR touching rust/: nextest/fmt/clippy across 3 OSes
 │   └── build-engine.yml        # tag push (v*, excluding -cli): build 3 binaries + draft release
 ├── raycast/                    # Raycast extension (separate npm tree, vendored)
 ├── openclaw.plugin.json        # OpenClaw manifest
@@ -147,8 +149,9 @@ kesha-voice-kit/
 ## Pull requests
 
 - Branch from `main`. Don't pile unrelated changes into one PR.
-- Run `just test && bun run lint` before pushing. For Rust changes, also `cd
-  rust && cargo fmt && cargo clippy --all-targets -- -D warnings && cargo test`.
+- Run `just test && bun run lint` before pushing. For Rust changes, also `just
+  rust-test` and `cd rust && cargo fmt && cargo clippy --all-targets -- -D warnings`.
+  Do not use plain `cargo test` for the suite.
 - CI must pass before merging. `main` is protected.
 - Squash-merge preferred. Greptile reviews are advisory but their P1/P2
   findings should be addressed before merge.
@@ -181,10 +184,11 @@ kesha-voice-kit/
 - Unit tests in `tests/unit/` — no external deps, run on
   Linux/Windows/macOS. Prefer these for pure functions and deterministic CLI
   contracts.
-- Integration tests in `tests/integration/` — exercise the actual engine
-  binary, run on macos-14 in CI. Prefer these the moment behaviour crosses the
-  CLI or engine boundary.
-- Rust integration tests in `rust/tests/` — `cargo nextest` / `just rust-test`
+- Integration tests in `tests/integration/` — most drive a fake engine and run
+  everywhere; real-engine suites self-skip when no engine is present. CI's fast
+  `integration-tests` job is macos-latest and does not install an engine. Prefer
+  these the moment behaviour crosses the CLI or engine boundary.
+- Rust integration tests in `rust/tests/` — `cargo nextest run` / `just rust-test`
   (matches CI). Do not rely on plain `cargo test` for the suite.
 - `audio-quality-check` agent runs after every commit touching
   `rust/src/tts/**` (see `.claude/agents/audio-quality-check.md`).
@@ -193,8 +197,8 @@ kesha-voice-kit/
 
 | Path | Command | What it is for |
 |------|---------|----------------|
-| **Fast (sacred)** | `bun run check` / `bun run test:cli-fast` | Design feedback while coding. No engine download, no models, no network. Must stay seconds-fast. |
-| **Full local** | `just test` | Unit + integration (still avoids the heaviest model-dependent e2e). |
+| **Fast (sacred)** | `bun run check` / `bun run test:cli-fast` | Design feedback while coding. No engine download, no models, no network. Keep it that way; do not confuse it with `just check`, which runs all integration tests. |
+| **Full local** | `just test` | Unit + `tests/integration/`. Fake-engine suites always run; real-engine e2e runs only if an engine is already installed. This recipe never downloads the 2.4 GB bundle. |
 | **Smoke / release** | `just smoke-test`, `just release` | Real install + fixtures. Explicit and slower. |
 | **CI** | `ci.yml`, `rust-test.yml` | Authoritative gates; model-heavy jobs are path-filtered or self-skipping. |
 
@@ -212,20 +216,28 @@ Scoped runs stay usable because they only re-run the suites that reach the
 mutated file:
 
 ```bash
-just mutants-ts src/voice-routing.ts          # TypeScript (Stryker + Bun)
-just mutants-ts src/engine.ts src/cli/main.ts # several files
+just mutants-ts src/voice-routing.ts                           # TypeScript (Stryker + Bun)
+just mutants-ts --with-integration src/engine.ts src/cli/main.ts # several files
 just mutants-ts --with-integration src/foo.ts # include integration suites (slower)
 
-just mutants-rust src/errors.rs               # Rust (cargo-mutants; needs clean tree)
+just mutants-rust src/errors.rs # Rust: cargo-mutants; clean rust/ tree required
 ```
 
 Or via npm scripts: `bun run mutants:ts -- src/voice-routing.ts`.
 
+The default TypeScript roots are `tests/unit/` only. For engine spawn, CLI
+contracts, or install hints, pass `--with-integration` so the relevant
+integration suites are measured. `mutants-rust` runs in place: install its tool
+once with `cargo install --locked cargo-mutants`, keep `rust/` clean, and
+override its default `tts,system_kokoro,system_diarize` features with `just
+FEATURES=tts mutants-rust …` when appropriate.
+
 Treat survivors on critical paths (engine spawn, capability checks, install
 hints, stdout/stderr contracts, voice routing) as real design debt. Leave
 equivalent or intentionally untestable mutants alone; the goal is stronger
-assertions, not 100% kill rate. Details and quality bar live in
-[`CLAUDE.md`](./CLAUDE.md) under "TESTS COME FIRST, AND ARE JUDGED BY WHAT THEY CATCH".
+assertions, not 100% kill rate. The behavioural, structure-insensitive test
+quality bar is in [`CLAUDE.md`](./CLAUDE.md) under "TESTS COME FIRST, AND ARE
+JUDGED BY WHAT THEY CATCH"; mutation commands and survivor triage live here.
 
 Handy loops:
 
@@ -236,12 +248,12 @@ Handy loops:
 ## CI workflows
 
 - `ci.yml` — runs on PRs: `changes` filter → unit-tests (3 OSes) +
-  integration-tests + tts-e2e + raycast-lint + pr-comment.
-  `integration-tests` is skipped on `release/*` branches (release
-  chicken-and-egg: pinned engine tag doesn't exist yet).
-- `rust-test.yml` — runs on PRs touching `rust/**`: `cargo test/fmt/clippy`
-  on 3 OSes + `cargo check --features coreml --no-default-features` on
-  macos-14.
+  `integration-tests` (macos-latest, no engine install) + path-filtered
+  `integration-tests-full`, `tts-e2e`, and `raycast-lint`. The full
+  integration and TTS jobs skip `release/*`; `integration-tests` does not.
+- `rust-test.yml` — runs on PRs touching `rust/**`: nextest plus fmt/clippy,
+  and macos-14 also runs the CoreML `cargo check --all-targets` and
+  `just verify-darwin-full` feature set.
 - `build-engine.yml` — runs on `v*` tag pushes (excluding `v*-cli`):
   builds 3 platform binaries, smoke-tests each with `--capabilities-json`,
   creates a draft release.
@@ -249,8 +261,8 @@ Handy loops:
 
 ## Releases
 
-The full release runbook lives in [`CLAUDE.md`](./CLAUDE.md) "RELEASE
-PROCESS". Quick orientation:
+The full release runbook lives in [`CLAUDE.md`](./CLAUDE.md) "Releases".
+Quick orientation:
 
 - **Engine release** (any change under `rust/`, or bumping
   `keshaEngine.version`): bump `rust/Cargo.toml` + `rust/Cargo.lock` +

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,8 @@ just release        # check (lint + versions + recipes + all Bun tests) + smoke-
 must stay free of engine downloads, model installs, and heavy e2e. Use it for
 every CLI-only change. Real-engine e2e, TTS e2e, diarization, and smoke tests
 are not on this path: `just test` runs unit plus `tests/integration/` (real-
-engine cases self-skip unless an engine is already installed), `just smoke-test`
+engine cases self-skip, on two different gates — see
+`tests/integration/README.md`), `just smoke-test`
 is the explicit install-and-fixtures path, and TTS e2e / diarization live in
 CI. Do not pull network or multi-GB dependencies into the fast loop.
 
@@ -185,7 +186,12 @@ kesha-voice-kit/
   Linux/Windows/macOS. Prefer these for pure functions and deterministic CLI
   contracts.
 - Integration tests in `tests/integration/` — most drive a fake engine and run
-  everywhere; real-engine suites self-skip when no engine is present. CI's fast
+  everywhere; real-engine suites self-skip, and not on one condition —
+  `e2e-engine` and `mcp-e2e` gate on an installed engine, while `say-e2e` and
+  `mcp-synthesis-e2e` gate on a source-built `rust/target/release/kesha-engine`
+  plus the committed Kokoro stand-in, so installing an engine does not run them.
+  `tests/integration/README.md` states the convention and
+  `tests/unit/model-suite-guards.test.ts` enforces it. CI's fast
   `integration-tests` job is macos-latest and does not install an engine. Prefer
   these the moment behaviour crosses the CLI or engine boundary.
 - Rust integration tests in `rust/tests/` — `cargo nextest run` / `just rust-test`
@@ -198,7 +204,7 @@ kesha-voice-kit/
 | Path | Command | What it is for |
 |------|---------|----------------|
 | **Fast (sacred)** | `bun run check` / `bun run test:cli-fast` | Design feedback while coding. No engine download, no models, no network. Keep it that way; do not confuse it with `just check`, which runs all integration tests. |
-| **Full local** | `just test` | Unit + `tests/integration/`. Fake-engine suites always run; real-engine e2e runs only if an engine is already installed. This recipe never downloads the 2.4 GB bundle. |
+| **Full local** | `just test` | Unit + `tests/integration/`. Fake-engine suites always run; real-engine e2e runs only where its own gate is satisfied — `kesha install` covers `e2e-engine`/`mcp-e2e`, not the synthesis suites. This recipe never downloads the 2.4 GB bundle. |
 | **Smoke / release** | `just smoke-test`, `just release` | Real install + fixtures. Explicit and slower. |
 | **CI** | `ci.yml`, `rust-test.yml` | Authoritative gates; model-heavy jobs are path-filtered or self-skipping. |
 
@@ -266,15 +272,20 @@ Quick orientation:
 
 - **Engine release** (any change under `rust/`, or bumping
   `keshaEngine.version`): bump `rust/Cargo.toml` + `rust/Cargo.lock` +
-  `package.json#version` + `package.json#keshaEngine.version` in lockstep
-  on a `release/X.Y.Z` branch → merge → tag `vX.Y.Z` → write release notes
-  on the **draft** release before publishing → independent validation
-  (download the binary, run end-to-end) → `npm publish --access public`.
+  `package.json#keshaEngine.version` — leave `package.json#version` alone, it
+  carries the next unreleased CLI — on a `release/X.Y.Z` branch → merge → tag
+  `vX.Y.Z` → write release notes on the **draft** release → validate the draft
+  binary with authenticated `gh release download` (draft assets 404 to anonymous
+  clients, so `curl` cannot check them) → un-draft. A bare engine tag publishes
+  nothing to npm; the bumped pin reaches users with the next `-cli` release.
 
-- **CLI-only patch** (docs, TS fix, plugin tweak): bump only
-  `package.json#version` → merge → `npm publish` → tag `vX.Y.Z-cli` (the
-  `-cli` suffix excludes the tag from `build-engine.yml` so no Rust
-  rebuild fires).
+- **CLI-only patch** (docs, TS fix, plugin tweak): bump `package.json#version`
+  and the two `server.json` versions with it, or `bun run check:versions`
+  rejects the commit → merge → create the `vX.Y.Z-cli` release. Publishing that
+  marker is what runs `npm publish --provenance` in GitHub Actions, and the
+  `-cli` suffix excludes the tag from `build-engine.yml` so no Rust rebuild
+  fires. **Do not publish from a laptop** — that loses the provenance
+  attestation.
 
 Tag names are one-shot — GitHub's immutable releases permanently reserve
 them after publish. Broken release → bump patch and cut a new tag. Never


### PR DESCRIPTION
Closes #1081.

`CONTRIBUTING.md` is the first file a new contributor reads, and four of its statements were false.

| it said | it is |
| --- | --- |
| see `CLAUDE.md` **"RELEASE PROCESS"** | that heading is gone; the content is under **"Releases"** |
| `bun run check` = typecheck + version drift + CLI tests | `lint && check:versions && check:recipes && test:cli-fast` — the recipe check was unmentioned, and it needs `just` on PATH because it parses `just --dump` |
| `just release` = lint + test + smoke-test | an alias for `release-preflight: check smoke-test`, where `check` is the **just recipe** (all Bun tests), not the npm script (`test:cli-fast`) |
| engine-backed integration lives off the fast path | real-engine cases **self-skip**, so `just test` is not the boundary the text implied — but on **two** gates, not one: `e2e-engine`/`mcp-e2e` on an installed engine, `say-e2e`/`mcp-synthesis-e2e` on a source-built binary plus the Kokoro stand-in (corrected in `88c4c6f` after round 1 refuted the single-gate wording) |

This is the class the review checklist already names — a consumer-facing document left stale while the thing it documents moved.

## Provenance, stated plainly

The change was **recovered from an uncommitted worktree during cleanup**, not written now. That worktree's PR (#1049) had merged months of context ago and left 41 insertions of unpushed documentation behind. Rather than trust it, every claim was re-checked against current `main` before committing — including the subtle one, that `bun run check` and `just check` are different sets, which the recovered text gets right.

## Verification

`just preflight` green. Each row of the table above was confirmed by reading the current `CLAUDE.md`, `package.json`, `justfile` and `tests/integration/`, not by reading the diff.
