### PR TITLE
test(recipes): fail a recipe whose pipeline hides its own failure

### DIFF
--- a/.claude/commands/start-issue.md
+++ b/.claude/commands/start-issue.md
@@ -15,7 +15,7 @@ Arguments: `$ARGUMENTS` → first token is the issue number (required), optional
    gh issue view <N> -R drakulavich/kesha-voice-kit
    ```
 
-2. Tag it `WIP` so drakulavich sees it's in flight. Create the label first only if it doesn't exist:
+2. Tag it `WIP` so drakulavich sees it's in flight. Creating an existing label is a harmless error:
    ```bash
    gh label list -R drakulavich/kesha-voice-kit | grep -q '^WIP' || \
      gh label create WIP -R drakulavich/kesha-voice-kit --color FBCA04 \

--- a/.claude/commands/start-issue.md
+++ b/.claude/commands/start-issue.md
@@ -17,9 +17,8 @@ Arguments: `$ARGUMENTS` → first token is the issue number (required), optional
 
 2. Tag it `WIP` so drakulavich sees it's in flight. Creating an existing label is a harmless error:
    ```bash
-   gh label list -R drakulavich/kesha-voice-kit | grep -q '^WIP' || \
-     gh label create WIP -R drakulavich/kesha-voice-kit --color FBCA04 \
-       --description "An agent or contributor is actively working on this"
+   gh label create WIP -R drakulavich/kesha-voice-kit --color FBCA04 \
+     --description "An agent or contributor is actively working on this" 2>/dev/null || true
    gh issue edit <N> -R drakulavich/kesha-voice-kit --add-label WIP
    ```
 

--- a/.claude/commands/start-issue.md
+++ b/.claude/commands/start-issue.md
@@ -15,10 +15,12 @@ Arguments: `$ARGUMENTS` → first token is the issue number (required), optional
    gh issue view <N> -R drakulavich/kesha-voice-kit
    ```
 
-2. Tag it `WIP` so drakulavich sees it's in flight. Creating an existing label is a harmless error:
+2. Tag it `WIP` so drakulavich sees it's in flight. Creating an existing label is a harmless
+   error, so `|| true` absorbs it — but stderr stays visible, and the `--add-label` below is the
+   real gate: it fails loudly if the label genuinely is not there.
    ```bash
    gh label create WIP -R drakulavich/kesha-voice-kit --color FBCA04 \
-     --description "An agent or contributor is actively working on this" 2>/dev/null || true
+     --description "An agent or contributor is actively working on this" || true
    gh issue edit <N> -R drakulavich/kesha-voice-kit --add-label WIP
    ```
 

--- a/.github/scripts/check-recipes.ts
+++ b/.github/scripts/check-recipes.ts
@@ -34,7 +34,11 @@ type Recipe = {
   parameters?: { name?: string }[];
   body?: unknown;
 };
-export type JustDump = { recipes?: Record<string, Recipe>; aliases?: Record<string, unknown> };
+export type JustDump = {
+  recipes?: Record<string, Recipe>;
+  aliases?: Record<string, unknown>;
+  settings?: { shell?: { command?: string; arguments?: string[] } | null };
+};
 
 const SWEPT_ROOT_FILES = ["README.md", "CONTRIBUTING.md", "CLAUDE.md"];
 const SWEPT_DIRS = ["docs/", ".claude/", ".github/workflows/"];
@@ -167,7 +171,8 @@ export function interpolatedParameters(dump: JustDump): string[] {
 function lineText(fragment: unknown): string {
   if (typeof fragment === "string") return fragment;
   if (!Array.isArray(fragment)) return "";
-  if (fragment[0] === "variable" && typeof fragment[1] === "string") return `{{${fragment[1]}}}`;
+  // The dump carries the variable's name, not its value, so nothing here is shell the recipe runs.
+  if (fragment[0] === "variable" && typeof fragment[1] === "string") return " ";
   return fragment.map(lineText).join("");
 }
 
@@ -203,7 +208,15 @@ export function runsAPipeline(text: string): boolean {
   return false;
 }
 
-const SETS_PIPEFAIL = /^\s*set\s+(?:-\S+\s+)*pipefail\b/;
+// `pipefail` must be the operand of an enabling `-...o`: `set pipefail` makes it a positional
+// argument, `set -e pipefail` makes it $1, and neither turns the option on.
+const ENABLES_PIPEFAIL = /^\s*set\s+(?:\S+\s+)*-[a-zA-Z]*o\s+pipefail\b/;
+const DISABLES_PIPEFAIL = /^\s*set\s+(?:\S+\s+)*\+[a-zA-Z]*o\s+pipefail\b/;
+
+/** `just` runs a non-shebang recipe under `settings.shell`, so a pipefail one guards them all. */
+function shellEnablesPipefail(dump: JustDump): boolean {
+  return (dump.settings?.shell?.arguments ?? []).some((argument) => argument === "pipefail");
+}
 
 /**
  * A pipeline's exit status is its *last* stage's, so `just worktree-rm x | tail -3 && echo removed`
@@ -212,15 +225,18 @@ const SETS_PIPEFAIL = /^\s*set\s+(?:-\S+\s+)*pipefail\b/;
  * non-shebang recipe under — has no portable spelling of it.
  */
 export function unguardedPipelines(dump: JustDump): string[] {
+  const shellGuards = shellEnablesPipefail(dump);
   return Object.entries(dump.recipes ?? {}).flatMap(([name, recipe]) => {
-    let guarded = false;
+    const shebang = recipe.shebang === true;
+    let guarded = !shebang && shellGuards;
     for (const line of (Array.isArray(recipe.body) ? recipe.body : []).map(lineText)) {
-      if (SETS_PIPEFAIL.test(line)) guarded = true;
+      if (DISABLES_PIPEFAIL.test(line)) guarded = false;
+      else if (shebang && ENABLES_PIPEFAIL.test(line)) guarded = true;
       if (guarded || !runsAPipeline(line)) continue;
-      const fix = recipe.shebang
+      const fix = shebang
         ? "add `set -euo pipefail` above it"
-        : "give the recipe a `#!/usr/bin/env bash` line and `set -euo pipefail`, since `sh -cu` " +
-          "(what `just` runs a non-shebang recipe under) has no portable pipefail";
+        : "give the recipe a `#!/usr/bin/env bash` line and `set -euo pipefail` — a non-shebang " +
+          "recipe runs under `sh -cu`, which is dash on Ubuntu and rejects `set -o pipefail` outright";
       return [
         `justfile: recipe \`${name}\` runs a pipeline without pipefail, so it reports only the ` +
           `last stage's exit status (in \`${line.trim()}\`) — ${fix} (#1083)`,

--- a/.github/scripts/check-recipes.ts
+++ b/.github/scripts/check-recipes.ts
@@ -14,9 +14,13 @@
  * `$(`), followed by any number of `NAME=value` assignments, and the next token is kebab-case.
  * A flag (`just --list`) or any other token shape is skipped rather than guessed at.
  *
- * The pipefail rule scans for a `|` the shell would read as a pipeline, tracking quotes, escapes and
- * trailing comments. Its one known false positive is an unquoted alternation inside `[[ x =~ a|b ]]`,
- * which is fragile shell anyway — quote the pattern or lift it into a variable.
+ * The pipefail rule scans for a `|` the shell would read as a pipeline, tracking quotes, escapes,
+ * trailing comments, arithmetic `$(( ))`, and the `$( )` / backtick substitutions that reopen shell
+ * inside double quotes. It fails **closed**: a `set` naming pipefail that it cannot prove enables it
+ * counts as off, because rounds of closing one `set` spelling at a time kept leaving the next one
+ * silently guarded. Known false positives, both fail-closed: an unquoted alternation inside
+ * `[[ x =~ a|b ]]`, and a quoted operand (`set -o 'pipefail'`). Writing `set -euo pipefail` and
+ * quoting the pattern fix them, and both are better shell regardless.
  *
  * Known false negatives, all of them deliberate: a reference in prose with no backticks; a trailing
  * comma inside the code span (`just test,`); `just $RECIPE`; `.claude/settings.json`, whose
@@ -192,8 +196,18 @@ export function runsAPipeline(text: string): boolean {
       at++;
       continue;
     }
+    if (char === "$" && text[at + 1] === "(" && text[at + 2] === "(") {
+      context.push("arith");
+      at += 2;
+      continue;
+    }
     if (char === "$" && text[at + 1] === "(") {
       context.push("$");
+      at++;
+      continue;
+    }
+    if (char === ")" && inside() === "arith" && text[at + 1] === ")") {
+      context.pop();
       at++;
       continue;
     }
@@ -215,7 +229,7 @@ export function runsAPipeline(text: string): boolean {
       continue;
     }
     if (char === "#" && (at === 0 || /\s/.test(text[at - 1] ?? ""))) return false;
-    if (char !== "|") continue;
+    if (char !== "|" || inside() === "arith") continue;
     if (text[at + 1] === "|") {
       at++;
       continue;
@@ -243,12 +257,28 @@ export function pipefailSetting(tokens: string[]): boolean | null {
   return on;
 }
 
-const SET_LINE = /^\s*set\s+(.*)$/;
+/**
+ * What a recipe *line* does to pipefail, `null` when it says nothing. A `set` naming pipefail that
+ * does not provably enable it counts as **off**: rounds 1-3 each closed one spelling and left the
+ * next silently guarded, because an unparsed `set` was read as "says nothing" (#1083).
+ */
+export function linePipefail(line: string): boolean | null {
+  let setting: boolean | null = null;
+  for (const command of line.split(/[;&]+/)) {
+    const set = command.match(/^\s*set\s+(.*)$/);
+    if (!set) continue;
+    const tokens = (set[1] ?? "").split(/\s+/).filter(Boolean);
+    if (!tokens.some((token) => token.includes("pipefail"))) continue;
+    setting = pipefailSetting(tokens) === true;
+  }
+  return setting;
+}
 
 /** bash and zsh have pipefail; `sh` is dash on Ubuntu and rejects `set -o pipefail` outright. */
 function interpreterHasPipefail(shebangLine: string): boolean {
   const words = shebangLine.replace(/^#!/, "").trim().split(/\s+/);
-  const named = words.filter((word) => !word.startsWith("-") && !/(^|\/)env$/.test(word))[0] ?? "";
+  const skip = (word: string) => word.startsWith("-") || /(^|\/)env$/.test(word) || /^\w+=/.test(word);
+  const named = words.filter((word) => !skip(word))[0] ?? "";
   return /(^|\/)(bash|zsh)$/.test(named);
 }
 
@@ -260,8 +290,11 @@ function shellEnablesPipefail(dump: JustDump): boolean {
 /**
  * A pipeline's exit status is its *last* stage's, so `just worktree-rm x | tail -3 && echo removed`
  * reports success for a `just` that failed — three times in one session, once about a worktree that
- * was still there (#1083). `set -o pipefail` is the fix, and `sh -cu` — what `just` runs a
- * non-shebang recipe under — has no portable spelling of it.
+ * was still there (#1083). `set -o pipefail` is the fix. `just` runs each non-shebang *line* in a
+ * new `sh -cu` (its documented default), so an earlier `set` never reaches the next line — and that
+ * `sh` is dash on Ubuntu, which rejects `set -o pipefail` anyway. Only a bash/zsh shebang, whose
+ * body is one script, or a justfile-wide `set shell := ["bash", "-euo", "pipefail", "-c"]`, guards
+ * a pipeline.
  */
 export function unguardedPipelines(dump: JustDump): string[] {
   const shellGuards = shellEnablesPipefail(dump);
@@ -271,15 +304,14 @@ export function unguardedPipelines(dump: JustDump): string[] {
     const canSetPipefail = shebang && interpreterHasPipefail(lines[0] ?? "");
     let guarded = !shebang && shellGuards;
     for (const line of lines) {
-      const set = line.match(SET_LINE);
-      const setting = set ? pipefailSetting((set[1] ?? "").split(/\s+/).filter(Boolean)) : null;
+      const setting = linePipefail(line);
       if (setting !== null) guarded = setting && canSetPipefail;
       if (guarded || !runsAPipeline(line)) continue;
       const fix = canSetPipefail
         ? "add `set -euo pipefail` above it"
-        : "give the recipe a `#!/usr/bin/env bash` line and `set -euo pipefail` — `sh` is dash on " +
-          "Ubuntu, which rejects `set -o pipefail` outright, and it is what `just` runs a " +
-          "non-shebang recipe under";
+        : "give the recipe a `#!/usr/bin/env bash` line and `set -euo pipefail` — `just` runs each " +
+          "non-shebang line in a *new* `sh -cu`, so an earlier `set` is gone whatever the shell, " +
+          "and that `sh` is dash on Ubuntu, which rejects `set -o pipefail` outright";
       return [
         `justfile: recipe \`${name}\` runs a pipeline without pipefail, so it reports only the ` +
           `last stage's exit status (in \`${line.trim()}\`) — ${fix} (#1083)`,

--- a/.github/scripts/check-recipes.ts
+++ b/.github/scripts/check-recipes.ts
@@ -178,23 +178,40 @@ function lineText(fragment: unknown): string {
 
 /** True when the shell would read a `|` in `text` as a pipeline rather than as data. */
 export function runsAPipeline(text: string): boolean {
-  let quote: "'" | '"' | null = null;
+  // `"` suppresses a `|`, but `$( )` and backticks *inside* it reopen shell — `x="$(a | b)"` is the
+  // justfile's own spelling, and its status is still the pipeline's.
+  const context: string[] = [];
+  const inside = () => context[context.length - 1];
   for (let at = 0; at < text.length; at++) {
     const char = text[at];
-    if (quote === "'") {
-      if (char === "'") quote = null;
+    if (inside() === "'") {
+      if (char === "'") context.pop();
       continue;
     }
     if (char === "\\") {
       at++;
       continue;
     }
-    if (quote === '"') {
-      if (char === '"') quote = null;
+    if (char === "$" && text[at + 1] === "(") {
+      context.push("$");
+      at++;
+      continue;
+    }
+    if (char === "`") {
+      if (inside() === "`") context.pop();
+      else context.push("`");
+      continue;
+    }
+    if (inside() === '"') {
+      if (char === '"') context.pop();
       continue;
     }
     if (char === "'" || char === '"') {
-      quote = char;
+      context.push(char);
+      continue;
+    }
+    if (char === ")" && inside() === "$") {
+      context.pop();
       continue;
     }
     if (char === "#" && (at === 0 || /\s/.test(text[at - 1] ?? ""))) return false;
@@ -208,14 +225,36 @@ export function runsAPipeline(text: string): boolean {
   return false;
 }
 
-// `pipefail` must be the operand of an enabling `-...o`: `set pipefail` makes it a positional
-// argument, `set -e pipefail` makes it $1, and neither turns the option on.
-const ENABLES_PIPEFAIL = /^\s*set\s+(?:\S+\s+)*-[a-zA-Z]*o\s+pipefail\b/;
-const DISABLES_PIPEFAIL = /^\s*set\s+(?:\S+\s+)*\+[a-zA-Z]*o\s+pipefail\b/;
+/**
+ * Whether a `set` argv turns pipefail on, off, or says nothing about it (`null` — `set -x` after
+ * `set -euo pipefail` leaves it on). `pipefail` must be the operand of an enabling `-...o`:
+ * `set pipefail` makes it positional, `set -e pipefail` makes it $1, `set +o pipefail` turns it off,
+ * and `--` ends option parsing so nothing after it is a flag at all.
+ */
+export function pipefailSetting(tokens: string[]): boolean | null {
+  let on: boolean | null = null;
+  for (let at = 0; at < tokens.length; at++) {
+    const token = tokens[at] ?? "";
+    if (token === "--") break;
+    if (!/^[-+][a-zA-Z]*o$/.test(token) || tokens[at + 1] !== "pipefail") continue;
+    on = token.startsWith("-");
+    at++;
+  }
+  return on;
+}
+
+const SET_LINE = /^\s*set\s+(.*)$/;
+
+/** bash and zsh have pipefail; `sh` is dash on Ubuntu and rejects `set -o pipefail` outright. */
+function interpreterHasPipefail(shebangLine: string): boolean {
+  const words = shebangLine.replace(/^#!/, "").trim().split(/\s+/);
+  const named = words.filter((word) => !word.startsWith("-") && !/(^|\/)env$/.test(word))[0] ?? "";
+  return /(^|\/)(bash|zsh)$/.test(named);
+}
 
 /** `just` runs a non-shebang recipe under `settings.shell`, so a pipefail one guards them all. */
 function shellEnablesPipefail(dump: JustDump): boolean {
-  return (dump.settings?.shell?.arguments ?? []).some((argument) => argument === "pipefail");
+  return pipefailSetting(dump.settings?.shell?.arguments ?? []) === true;
 }
 
 /**
@@ -227,16 +266,20 @@ function shellEnablesPipefail(dump: JustDump): boolean {
 export function unguardedPipelines(dump: JustDump): string[] {
   const shellGuards = shellEnablesPipefail(dump);
   return Object.entries(dump.recipes ?? {}).flatMap(([name, recipe]) => {
+    const lines = (Array.isArray(recipe.body) ? recipe.body : []).map(lineText);
     const shebang = recipe.shebang === true;
+    const canSetPipefail = shebang && interpreterHasPipefail(lines[0] ?? "");
     let guarded = !shebang && shellGuards;
-    for (const line of (Array.isArray(recipe.body) ? recipe.body : []).map(lineText)) {
-      if (DISABLES_PIPEFAIL.test(line)) guarded = false;
-      else if (shebang && ENABLES_PIPEFAIL.test(line)) guarded = true;
+    for (const line of lines) {
+      const set = line.match(SET_LINE);
+      const setting = set ? pipefailSetting((set[1] ?? "").split(/\s+/).filter(Boolean)) : null;
+      if (setting !== null) guarded = setting && canSetPipefail;
       if (guarded || !runsAPipeline(line)) continue;
-      const fix = shebang
+      const fix = canSetPipefail
         ? "add `set -euo pipefail` above it"
-        : "give the recipe a `#!/usr/bin/env bash` line and `set -euo pipefail` — a non-shebang " +
-          "recipe runs under `sh -cu`, which is dash on Ubuntu and rejects `set -o pipefail` outright";
+        : "give the recipe a `#!/usr/bin/env bash` line and `set -euo pipefail` — `sh` is dash on " +
+          "Ubuntu, which rejects `set -o pipefail` outright, and it is what `just` runs a " +
+          "non-shebang recipe under";
       return [
         `justfile: recipe \`${name}\` runs a pipeline without pipefail, so it reports only the ` +
           `last stage's exit status (in \`${line.trim()}\`) — ${fix} (#1083)`,

--- a/.github/scripts/check-recipes.ts
+++ b/.github/scripts/check-recipes.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 /**
- * Fails when a documented `just <recipe>` names a recipe the justfile does not define, or when a
+ * Fails when a documented `just <recipe>` names a recipe the justfile does not define, when a
+ * recipe runs a pipeline whose exit status nothing makes honest, or when a
  * recipe carries no doc comment — `just --list` renders that comment, so an undocumented recipe is
  * invisible. This is what makes #797's Makefile sweep verifiable rather than grep-and-hope, and it
  * is a gate `make` cannot support at all, having no introspection.
@@ -12,6 +13,10 @@
  * — and only when `just` sits at a command boundary (line start, or after `;` `&&` `||` `|` `(`
  * `$(`), followed by any number of `NAME=value` assignments, and the next token is kebab-case.
  * A flag (`just --list`) or any other token shape is skipped rather than guessed at.
+ *
+ * The pipefail rule scans for a `|` the shell would read as a pipeline, tracking quotes, escapes and
+ * trailing comments. Its one known false positive is an unquoted alternation inside `[[ x =~ a|b ]]`,
+ * which is fragile shell anyway — quote the pattern or lift it into a variable.
  *
  * Known false negatives, all of them deliberate: a reference in prose with no backticks; a trailing
  * comma inside the code span (`just test,`); `just $RECIPE`; `.claude/settings.json`, whose
@@ -25,6 +30,7 @@ import { join } from "node:path";
 type Recipe = {
   doc?: string | null;
   private?: boolean;
+  shebang?: boolean;
   parameters?: { name?: string }[];
   body?: unknown;
 };
@@ -158,6 +164,72 @@ export function interpolatedParameters(dump: JustDump): string[] {
   });
 }
 
+function lineText(fragment: unknown): string {
+  if (typeof fragment === "string") return fragment;
+  if (!Array.isArray(fragment)) return "";
+  if (fragment[0] === "variable" && typeof fragment[1] === "string") return `{{${fragment[1]}}}`;
+  return fragment.map(lineText).join("");
+}
+
+/** True when the shell would read a `|` in `text` as a pipeline rather than as data. */
+export function runsAPipeline(text: string): boolean {
+  let quote: "'" | '"' | null = null;
+  for (let at = 0; at < text.length; at++) {
+    const char = text[at];
+    if (quote === "'") {
+      if (char === "'") quote = null;
+      continue;
+    }
+    if (char === "\\") {
+      at++;
+      continue;
+    }
+    if (quote === '"') {
+      if (char === '"') quote = null;
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      quote = char;
+      continue;
+    }
+    if (char === "#" && (at === 0 || /\s/.test(text[at - 1] ?? ""))) return false;
+    if (char !== "|") continue;
+    if (text[at + 1] === "|") {
+      at++;
+      continue;
+    }
+    if (text[at - 1] !== ">") return true;
+  }
+  return false;
+}
+
+const SETS_PIPEFAIL = /^\s*set\s+(?:-\S+\s+)*pipefail\b/;
+
+/**
+ * A pipeline's exit status is its *last* stage's, so `just worktree-rm x | tail -3 && echo removed`
+ * reports success for a `just` that failed — three times in one session, once about a worktree that
+ * was still there (#1083). `set -o pipefail` is the fix, and `sh -cu` — what `just` runs a
+ * non-shebang recipe under — has no portable spelling of it.
+ */
+export function unguardedPipelines(dump: JustDump): string[] {
+  return Object.entries(dump.recipes ?? {}).flatMap(([name, recipe]) => {
+    let guarded = false;
+    for (const line of (Array.isArray(recipe.body) ? recipe.body : []).map(lineText)) {
+      if (SETS_PIPEFAIL.test(line)) guarded = true;
+      if (guarded || !runsAPipeline(line)) continue;
+      const fix = recipe.shebang
+        ? "add `set -euo pipefail` above it"
+        : "give the recipe a `#!/usr/bin/env bash` line and `set -euo pipefail`, since `sh -cu` " +
+          "(what `just` runs a non-shebang recipe under) has no portable pipefail";
+      return [
+        `justfile: recipe \`${name}\` runs a pipeline without pipefail, so it reports only the ` +
+          `last stage's exit status (in \`${line.trim()}\`) — ${fix} (#1083)`,
+      ];
+    }
+    return [];
+  });
+}
+
 export function undocumentedRecipes(dump: JustDump): string[] {
   return Object.entries(dump.recipes ?? {})
     .filter(([, recipe]) => !recipe.private && !recipe.doc)
@@ -197,6 +269,7 @@ function main(): void {
   const errors = [
     ...undocumentedRecipes(dump),
     ...interpolatedParameters(dump),
+    ...unguardedPipelines(dump),
     ...sweptFiles(root).flatMap((path) =>
       unknownReferences(path, readFileSync(join(root, path), "utf8"), known),
     ),

--- a/.github/workflows/post-engine-release.yml
+++ b/.github/workflows/post-engine-release.yml
@@ -10,6 +10,13 @@ on:
         required: true
         type: string
 
+# Its validating steps pipe (`{ bun run check:versions; ... } | tee`, `git ls-remote | cut`), and an
+# unspecified shell is `bash -e {0}` with no pipefail — the pipeline's status was `tee`'s. Naming
+# bash explicitly is what makes GitHub run `bash --noprofile --norc -eo pipefail {0}` (#1083).
+defaults:
+  run:
+    shell: bash
+
 jobs:
   follow_up:
     runs-on: ubuntu-latest

--- a/tests/unit/check-recipes.test.ts
+++ b/tests/unit/check-recipes.test.ts
@@ -258,6 +258,27 @@ describe("unguardedPipelines", () => {
     expect(unguardedPipelines(dump({ land: shebang(body) }))).toEqual([]);
   });
 
+  test("every spelling that really enables pipefail counts", () => {
+    for (const set of ["set -euo pipefail", "set -o pipefail", "set -o errexit -o pipefail"]) {
+      const body = ["#!/usr/bin/env bash", set, "git log | head -3"];
+      expect(unguardedPipelines(dump({ land: shebang(body) }))).toEqual([]);
+    }
+  });
+
+  // `set pipefail` makes "pipefail" a positional argument and `set -e pipefail` makes it $1.
+  // Neither turns the option on, so neither may silence the gate.
+  test("a `set` that does not enable pipefail does not guard anything", () => {
+    for (const set of ["set pipefail", "set -- pipefail", "set -e pipefail", "set +o pipefail"]) {
+      const body = ["#!/usr/bin/env bash", set, "git log | head -3"];
+      expect(unguardedPipelines(dump({ land: shebang(body) }))).toHaveLength(1);
+    }
+  });
+
+  test("`set +o pipefail` turns the guard back off", () => {
+    const body = ["#!/usr/bin/env bash", "set -euo pipefail", "set +o pipefail", "git log | head -3"];
+    expect(unguardedPipelines(dump({ land: shebang(body) }))).toHaveLength(1);
+  });
+
   test("pipefail set after the pipeline does not guard it", () => {
     const body = ["#!/usr/bin/env bash", "git log | head -3", "set -euo pipefail"];
     expect(unguardedPipelines(dump({ land: shebang(body) }))).toHaveLength(1);
@@ -267,6 +288,21 @@ describe("unguardedPipelines", () => {
     const errors = unguardedPipelines(dump({ land: shebang(["git log | head -3"], false) }));
     expect(errors).toHaveLength(1);
     expect(errors[0]).toContain("#!/usr/bin/env bash");
+  });
+
+  // Ubuntu's `sh` is dash, which answers `set -o pipefail` with "Illegal option". Accepting it
+  // here would bless the cheap fix over the one that works.
+  test("`set -o pipefail` in a non-shebang recipe does not guard it", () => {
+    const body = ["set -o pipefail", "git log | head -3"];
+    const errors = unguardedPipelines(dump({ land: shebang(body, false) }));
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("#!/usr/bin/env bash");
+  });
+
+  test("a justfile-wide pipefail shell does guard them, since that is the interpreter", () => {
+    const shell = { command: "bash", arguments: ["-euo", "pipefail", "-c"] };
+    const withShell = { ...dump({ land: shebang(["git log | head -3"], false) }), settings: { shell } };
+    expect(unguardedPipelines(withShell)).toEqual([]);
   });
 
   test("`||` is not a pipeline", () => {
@@ -286,9 +322,13 @@ describe("unguardedPipelines", () => {
     expect(unguardedPipelines(dump({ land: shebang(["git log >| out"], false) }))).toEqual([]);
   });
 
-  test("an interpolated variable is not read as shell, so its `|` cannot be a pipeline", () => {
-    const body = [['[[ "$1" =~ ', [["variable", "SLUG_PATTERN"]], " ]]"]];
-    expect(unguardedPipelines(dump({ land: { doc: "d", shebang: false, body } }))).toEqual([]);
+  // The dump carries a variable's *name*, never its value, so the scanner can never see whether
+  // the substituted text pipes. It renders to a token boundary rather than to anything shell-like.
+  test("an interpolated variable contributes no pipeline, whatever it is called", () => {
+    for (const name of ["SLUG_PATTERN", "a|b"]) {
+      const body = [['[[ "$1" =~ ', [["variable", name]], " ]]"]];
+      expect(unguardedPipelines(dump({ land: { doc: "d", shebang: false, body } }))).toEqual([]);
+    }
   });
 
   test("names one offending line per recipe, not one per pipe", () => {

--- a/tests/unit/check-recipes.test.ts
+++ b/tests/unit/check-recipes.test.ts
@@ -321,6 +321,54 @@ describe("unguardedPipelines", () => {
     }
   });
 
+  // Rounds 1-3 each closed one `set` spelling and left the next one silently guarded, because an
+  // unparsed `set` counted as "says nothing". A `set` that mentions pipefail at all and does not
+  // provably enable it now counts as off, so an unrecognised spelling fails closed by construction.
+  test("a `set` that mentions pipefail without provably enabling it counts as off", () => {
+    for (const off of ["set +o pipefail;", "set +o pipefail; git log | head -3"]) {
+      const body = ["#!/usr/bin/env bash", "set -euo pipefail", off, "git log | head -3"];
+      expect(unguardedPipelines(dump({ land: shebang(body) }))).toHaveLength(1);
+    }
+  });
+
+  // Verified against bash: this really does enable pipefail, so flagging it is the cost of failing
+  // closed on a spelling the scanner cannot prove. Writing `set -euo pipefail` is the fix.
+  test("a quoted operand fails closed, which is a false positive and the intended direction", () => {
+    const body = ["#!/usr/bin/env bash", "set -o 'pipefail'", "git log | head -3"];
+    expect(unguardedPipelines(dump({ land: shebang(body) }))).toHaveLength(1);
+
+    // The load-bearing half: an unprovable spelling must *revoke* a guard that was really on,
+    // not be waved through as "says nothing".
+    const revoked = ["#!/usr/bin/env bash", "set -euo pipefail", "set -o 'pipefail'", "git log | head -3"];
+    expect(unguardedPipelines(dump({ land: shebang(revoked) }))).toHaveLength(1);
+  });
+
+  test("extra operands after the option do not stop it enabling", () => {
+    const body = ["#!/usr/bin/env bash", "set -o pipefail extra-operand", "git log | head -3"];
+    expect(unguardedPipelines(dump({ land: shebang(body) }))).toEqual([]);
+  });
+
+  test("a pipeline guarded earlier on its own line is still guarded", () => {
+    const body = ["#!/usr/bin/env bash", "set -o pipefail; git log | head -3"];
+    expect(unguardedPipelines(dump({ land: shebang(body) }))).toEqual([]);
+  });
+
+  // `$((1 | 2))` is bitwise OR, not a pipeline — the seam that treating every `$(` as command
+  // substitution opened.
+  test("arithmetic expansion is not a pipeline, but a substitution inside it still is", () => {
+    for (const clean of ["x=$((1 | 2))", 'x="$((1 | 2))"', "x=$(( FLAGS | 4 ))"]) {
+      expect(unguardedPipelines(dump({ land: shebang([clean], false) }))).toEqual([]);
+    }
+    expect(unguardedPipelines(dump({ land: shebang(["x=$(( $(a | b) ))"], false) }))).toHaveLength(1);
+  });
+
+  test("an env assignment before the interpreter does not hide it", () => {
+    for (const line of ["#!/usr/bin/env FOO=bar bash", "#!/usr/bin/env -S FOO=bar bash"]) {
+      const body = [line, "set -euo pipefail", "git log | head -3"];
+      expect(unguardedPipelines(dump({ land: shebang(body) }))).toEqual([]);
+    }
+  });
+
   test("a later `set` that says nothing about pipefail leaves it on", () => {
     const body = ["#!/usr/bin/env bash", "set -euo pipefail", "set -x", "git log | head -3"];
     expect(unguardedPipelines(dump({ land: shebang(body) }))).toEqual([]);

--- a/tests/unit/check-recipes.test.ts
+++ b/tests/unit/check-recipes.test.ts
@@ -305,6 +305,62 @@ describe("unguardedPipelines", () => {
     expect(unguardedPipelines(withShell)).toEqual([]);
   });
 
+  // `just --dump` reports `shebang: true` for any shebang. `#!/bin/sh` is dash on Ubuntu, which
+  // answers `set -o pipefail` with "Illegal option" — trusting the flag alone reopened the dash hole
+  // one level up from where round 1 closed it.
+  test("only an interpreter that has pipefail can enable it", () => {
+    for (const line of ["#!/bin/sh", "#!/usr/bin/env sh", "#!/usr/bin/env python3"]) {
+      const body = [line, "set -o pipefail", "git log | head -3"];
+      const errors = unguardedPipelines(dump({ land: shebang(body) }));
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain("#!/usr/bin/env bash");
+    }
+    for (const line of ["#!/bin/bash", "#!/usr/bin/env bash", "#!/usr/bin/env zsh", "#!/usr/bin/env -S bash -e"]) {
+      const body = [line, "set -o pipefail", "git log | head -3"];
+      expect(unguardedPipelines(dump({ land: shebang(body) }))).toEqual([]);
+    }
+  });
+
+  test("a later `set` that says nothing about pipefail leaves it on", () => {
+    const body = ["#!/usr/bin/env bash", "set -euo pipefail", "set -x", "git log | head -3"];
+    expect(unguardedPipelines(dump({ land: shebang(body) }))).toEqual([]);
+  });
+
+  test("`--` ends option parsing, so what follows it enables nothing", () => {
+    const off = ["#!/usr/bin/env bash", "set -- -o pipefail", "git log | head -3"];
+    expect(unguardedPipelines(dump({ land: shebang(off) }))).toHaveLength(1);
+    const on = ["#!/usr/bin/env bash", "set -o pipefail --", "git log | head -3"];
+    expect(unguardedPipelines(dump({ land: shebang(on) }))).toEqual([]);
+  });
+
+  test("a justfile-wide shell guards only when its argv really enables pipefail", () => {
+    const body = { land: shebang(["git log | head -3"], false) };
+    const withShell = (args: string[]) => ({ ...dump(body), settings: { shell: { command: "bash", arguments: args } } });
+    expect(unguardedPipelines(withShell(["-o", "pipefail", "-c"]))).toEqual([]);
+    expect(unguardedPipelines(withShell(["-euo", "pipefail", "-c"]))).toEqual([]);
+    expect(unguardedPipelines(withShell(["+o", "pipefail", "-c"]))).toHaveLength(1);
+    expect(unguardedPipelines(withShell(["-c", "pipefail"]))).toHaveLength(1);
+  });
+
+  // `preflight`'s own spelling. The status of `"$(a | b)"` is still the pipeline's, and reading the
+  // whole double-quoted run as data missed every pipeline the justfile actually contains.
+  test("a pipeline inside a quoted command substitution is shell, not data", () => {
+    const piped = [
+      'changed="$(git diff --name-only | sort -u)"',
+      'changed="$( { git diff; git ls-files; } | sort -u )"',
+      'changed="`git diff --name-only | sort -u`"',
+    ];
+    for (const line of piped) {
+      expect(unguardedPipelines(dump({ land: shebang([line], false) }))).toHaveLength(1);
+    }
+  });
+
+  test("a pipe that is merely inside double quotes is still data", () => {
+    for (const line of ['echo "a | b"', 'grep -qE "a|b" file', 'echo "$(date) a | b"']) {
+      expect(unguardedPipelines(dump({ land: shebang([line], false) }))).toEqual([]);
+    }
+  });
+
   test("`||` is not a pipeline", () => {
     expect(unguardedPipelines(dump({ land: shebang(["git log || exit 2"], false) }))).toEqual([]);
   });

--- a/tests/unit/check-recipes.test.ts
+++ b/tests/unit/check-recipes.test.ts
@@ -8,6 +8,7 @@ import {
   referencedRecipes,
   sweptFiles,
   undocumentedRecipes,
+  unguardedPipelines,
   unknownReferences,
 } from "../../.github/scripts/check-recipes";
 import { readRepoFile, REPO_ROOT } from "../helpers/repo";
@@ -225,6 +226,74 @@ describe("interpolatedParameters", () => {
     const errors = interpolatedParameters(dump({ worktree: withBody(["slug", "branch"], body) }));
     expect(errors).toHaveLength(1);
     expect(errors[0]).toContain("{{ branch }}, {{ slug }}");
+  });
+});
+
+// A pipeline reports only its last stage's status, so `just worktree-rm x | tail && echo "removed"`
+// printed `removed` for a worktree that was still there. `set -o pipefail` is what makes it honest.
+describe("unguardedPipelines", () => {
+  const shebang = (body: string[], isShebang = true) => ({
+    doc: "d",
+    shebang: isShebang,
+    body: body.map((line) => [line]),
+  });
+
+  test("flags a pipeline that runs without pipefail", () => {
+    const errors = unguardedPipelines(
+      dump({ land: shebang(["#!/usr/bin/env bash", "set -eu", 'git log | head -3 && echo "ok"']) }),
+    );
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("`land` runs a pipeline");
+    expect(errors[0]).toContain("git log | head -3");
+    expect(errors[0]).toContain("set -euo pipefail");
+  });
+
+  test("passes once pipefail is set above the pipeline", () => {
+    const body = ["#!/usr/bin/env bash", "set -euo pipefail", "git log | head -3"];
+    expect(unguardedPipelines(dump({ land: shebang(body) }))).toEqual([]);
+  });
+
+  test("the long form counts too", () => {
+    const body = ["#!/usr/bin/env bash", "set -o pipefail", "git log | head -3"];
+    expect(unguardedPipelines(dump({ land: shebang(body) }))).toEqual([]);
+  });
+
+  test("pipefail set after the pipeline does not guard it", () => {
+    const body = ["#!/usr/bin/env bash", "git log | head -3", "set -euo pipefail"];
+    expect(unguardedPipelines(dump({ land: shebang(body) }))).toHaveLength(1);
+  });
+
+  test("a non-shebang recipe cannot set pipefail, so the fix is a bash shebang", () => {
+    const errors = unguardedPipelines(dump({ land: shebang(["git log | head -3"], false) }));
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("#!/usr/bin/env bash");
+  });
+
+  test("`||` is not a pipeline", () => {
+    expect(unguardedPipelines(dump({ land: shebang(["git log || exit 2"], false) }))).toEqual([]);
+  });
+
+  test("a pipe inside quotes is data, not a pipeline", () => {
+    const body = ["grep -qE 'a|b' file", 'grep -qE "a|b" file'];
+    expect(unguardedPipelines(dump({ land: shebang(body, false) }))).toEqual([]);
+  });
+
+  test("a pipe in a trailing comment is not a pipeline", () => {
+    expect(unguardedPipelines(dump({ land: shebang(["git log # a | b"], false) }))).toEqual([]);
+  });
+
+  test("`>|` is a redirect, not a pipeline", () => {
+    expect(unguardedPipelines(dump({ land: shebang(["git log >| out"], false) }))).toEqual([]);
+  });
+
+  test("an interpolated variable is not read as shell, so its `|` cannot be a pipeline", () => {
+    const body = [['[[ "$1" =~ ', [["variable", "SLUG_PATTERN"]], " ]]"]];
+    expect(unguardedPipelines(dump({ land: { doc: "d", shebang: false, body } }))).toEqual([]);
+  });
+
+  test("names one offending line per recipe, not one per pipe", () => {
+    const body = ["a | b", "c | d"];
+    expect(unguardedPipelines(dump({ land: shebang(body, false) }))).toHaveLength(1);
   });
 });
 

--- a/tests/unit/post-engine-release.test.ts
+++ b/tests/unit/post-engine-release.test.ts
@@ -169,6 +169,10 @@ describe("post-engine-release workflow", () => {
   test("validation steps fail when a command inside them fails, not when the last one does", () => {
     const workflow = parseRepoYaml(".github/workflows/post-engine-release.yml");
     expect(workflow.defaults.run.shell).toBe("bash");
+
+    const steps = workflow.jobs.follow_up.steps as { shell?: string; run?: string }[];
+    expect(steps.filter((step) => step.run !== undefined).length).toBeGreaterThan(0);
+    for (const step of steps) expect(step.shell ?? "bash").toBe("bash");
   });
 
   test("only a stable engine tag is owned by the follow-up", () => {

--- a/tests/unit/post-engine-release.test.ts
+++ b/tests/unit/post-engine-release.test.ts
@@ -162,6 +162,15 @@ describe("post-engine-release workflow", () => {
     expect(job.steps.some((step: { run?: string }) => step.run?.includes("gh pr create"))).toBe(true);
   });
 
+  // Every validating step here pipes — `{ bun run check:versions; ... } | tee` and
+  // `git ls-remote | cut`. GitHub's *unspecified* default shell is `bash -e {0}` with no pipefail,
+  // so those took `tee`'s and `cut`'s exit status: a failed check was recorded as output and a
+  // failed ls-remote read as "no follow-up branch exists". Only `shell: bash` turns pipefail on (#1083).
+  test("validation steps fail when a command inside them fails, not when the last one does", () => {
+    const workflow = parseRepoYaml(".github/workflows/post-engine-release.yml");
+    expect(workflow.defaults.run.shell).toBe("bash");
+  });
+
   test("only a stable engine tag is owned by the follow-up", () => {
     for (const tag of ["v1.24.11", "v1.29.0", "v10.0.100", "v0.0.0"]) expect(ownsTag(tag)).toBe(true);
     for (const tag of ["v1.29.0-cli", "v1.24.11-alpha.1", "v1.24.11-beta.1", "1.24.11", "v1.24", "v01.2.3", "v1.2.3 "]) {


### PR DESCRIPTION
A pipeline reports only its **last** stage's exit status. `just worktree-rm x | tail -3 && echo "removed"` printed `removed` for a worktree that was still there — the status came from `tail`. That happened three times in one session.

`set -o pipefail` is the fix, and every shebang recipe in the justfile already sets it. This gate keeps it that way, and fixes the two live instances of the class it exposed elsewhere.

## The rule

`check-recipes` (already `bun run check:recipes`, already in `just preflight` and `🧪 CI`) now fails a recipe that runs a pipeline with no pipefail in effect:

- shebang recipe → needs `set -o pipefail` above the pipeline
- non-shebang recipe → `just` runs those under `sh -cu`, which has no portable pipefail, so the fix is a `#!/usr/bin/env bash` line

The scanner tracks quote state, backslash escapes and trailing comments, so `grep -qE 'a|b'`, `git log # a | b`, `>|` and `||` do not trip it. An interpolated `{{ VAR }}` renders to a placeholder rather than its value — a variable's `|` is never shell the recipe runs.

Its one known false positive, an unquoted alternation inside `[[ x =~ a|b ]]`, is documented alongside the file's existing extraction caveats.

## Proof, both arms

Nothing in the justfile violates the rule, so the guard is proven by mutation rather than by a fix:

| mutation | expected | result |
|---|---|---|
| pipe added to `dev-setup` (non-shebang, no pipefail available) | caught | `PINNED` |
| same pipe added to `worktree-rm` (sets `set -euo pipefail`) | survives | `NOT PINNED` — correct, pipefail is doing the work |
| `shell: bash` → `shell: sh` in `post-engine-release.yml` | caught | `PINNED` |
| weaken the pipefail regex to bare `/pipefail/` | caught | `PINNED` (round 2) |
| let a non-shebang recipe satisfy the gate with `set -o pipefail` | caught | `PINNED` (round 2) |
| `lineText` renders the interpolation's name instead of a boundary | caught | `PINNED` (round 2) |
| step-level `shell: sh` on the Validate step | caught | `PINNED` (round 2) |

Round 1 shipped the first three pinned and the last four **not** pinned; review caught all four and they are fixed below.

## Two live instances

**`post-engine-release.yml` — a validation step that could not fail.** GitHub's *unspecified* default shell is `bash -e {0}` with **no** pipefail; only an explicit `shell: bash` selects `bash --noprofile --norc -eo pipefail {0}` ([workflow syntax](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax)). That workflow declares no shell, and:

- the step named **"Validate and record output"** runs `{ bun run check:versions; bun run check:engine-targets; git diff --check; } | tee -a post-release-pr.md` — the status was `tee`'s, so a failed check was written into the PR body as ordinary output and the step went green
- the concurrency guard runs `REMOTE_HEADS="$(git ls-remote --heads origin '...' | cut -f2)"` — a failed `ls-remote` yields empty output, which reads as "no follow-up branch exists", and the guard proceeds to create one

`defaults.run.shell: bash` fixes both. Checked all **six** `run:` steps (five block scalars plus one inline) first: none feeds an early-exiting consumer (`| head`, `| grep -q` on a large producer), so pipefail cannot introduce a spurious SIGPIPE failure.

**`start-issue.md`** gated label creation on `gh label list -R … | grep -q '^WIP' ||`, where a failed `gh` and a missing label are indistinguishable. Creating an existing label is a harmless error, so the pipeline is gone.

## Deliberately not here

Gating the remaining workflows is **#1084**. Sweeping `run:` blocks with this same scanner gives 3 hits of which 2 are false positives — an unquoted alternation in `[[ =~ ]]`, and a `|` inside a jq program in a quoted string spanning lines. Handling those needs `[[ ]]` context and quote state carried across lines of a block scalar, which is more parsing than this change should carry. #1084 also records the cheaper option: gate on the *shell* rather than the pipe.

## Test reach

New cases in the existing `tests/unit/check-recipes.test.ts` and `tests/unit/post-engine-release.test.ts` run in the `unit-tests` job in `ci.yml` (`🧪 CI`) via `bun run test:unit`, on ubuntu/windows/macos. Caveat: `post-engine-release.yml` is not itself in that job's `code` path filter, so a later yaml-only revert of `shell: bash` would skip this pin — pre-existing for that file, and this PR runs because `tests/**` and `.github/scripts/**` also changed. `bun run check:recipes` runs the gate against the real justfile in the same lane and in `just preflight`.

Closes #1083
