### PR TITLE
test(workflows): require a pipefail shell for every run step

### DIFF
--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -350,6 +350,50 @@ export function requireBashOnWindowsRunSteps(path: string, document: unknown): s
 }
 
 /**
+ * Fails when a `run:` step on a non-Windows runner resolves to a shell without pipefail.
+ *
+ * GitHub's *unspecified* default is `bash -e {0}`; only naming `bash` selects
+ * `bash --noprofile --norc -eo pipefail {0}`. So an undeclared step takes its pipeline's **last**
+ * stage exit status: `{ bun run check:versions; ... } | tee` recorded a failed check as ordinary
+ * output and went green (#1083). `shell: sh` is the same trap spelled out. An explicit non-POSIX
+ * shell has no pipelines to get wrong and passes. Windows defaults to pwsh instead, which is
+ * `requireBashOnWindowsRunSteps`'s lane (#850, #1084).
+ */
+const PIPEFAIL_SHELLS = new Set(["bash", "pwsh", "powershell", "python", "cmd"]);
+
+export function requirePipefailShell(path: string, document: unknown): string[] {
+  const jobs = (document as { jobs?: Record<string, Job> })?.jobs;
+  if (!jobs || typeof jobs !== "object") return [];
+
+  const workflowShell = (document as { defaults?: { run?: { shell?: unknown } } })?.defaults?.run?.shell;
+  const errors: string[] = [];
+
+  for (const [name, job] of Object.entries(jobs)) {
+    if (!Array.isArray(job?.steps)) continue;
+    const labels = runnerLabels(job);
+    if (labels.length > 0 && labels.every((label) => /windows/i.test(label))) continue;
+
+    for (const [at, step] of (job.steps as Step[]).entries()) {
+      if (typeof step?.run !== "string") continue;
+      const shell = step.shell ?? job.defaults?.run?.shell ?? workflowShell;
+      if (typeof shell === "string" && PIPEFAIL_SHELLS.has(shell)) continue;
+      const label = typeof step.name === "string" ? `\`${step.name}\`` : `${at + 1}`;
+      const found =
+        shell === undefined
+          ? "has no `shell:`, so it runs under the unspecified default `bash -e {0}`"
+          : `sets \`shell: ${String(shell)}\``;
+      errors.push(
+        `${path}: \`${name}\` step ${label} ${found} — no pipefail there, so a pipeline reports ` +
+          `only its last stage and a failed command inside one passes silently. Name \`shell: bash\`, ` +
+          `or set \`defaults.run.shell: bash\` once for the workflow (#1084)`,
+      );
+    }
+  }
+
+  return errors;
+}
+
+/**
  * Fails when a restore-only model cache has no writer, or has one that disagrees about the entry.
  *
  * `cache-write: "false"` hands the whole responsibility for an entry to cache-seed.yml (#661). Nothing
@@ -523,6 +567,7 @@ function checkFile(
       ...requireNpmPublishAfterPackaging(path, document),
       ...requirePactVerificationCoversEveryTarget(path, document),
       ...requireBashOnWindowsRunSteps(path, document),
+      ...requirePipefailShell(path, document),
       ...requireDepsBeforeBunTest(path, document),
       ...requireRestoreOnlyCachesHaveAWriter(path, document, cacheWriters),
       ...requireTestedScriptsInCodeFilter(path, document, testedScripts),

--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -355,11 +355,11 @@ export function requireBashOnWindowsRunSteps(path: string, document: unknown): s
  * GitHub's *unspecified* default is `bash -e {0}`; only naming `bash` selects
  * `bash --noprofile --norc -eo pipefail {0}`. So an undeclared step takes its pipeline's **last**
  * stage exit status: `{ bun run check:versions; ... } | tee` recorded a failed check as ordinary
- * output and went green (#1083). `shell: sh` is the same trap spelled out. An explicit non-POSIX
- * shell has no pipelines to get wrong and passes. Windows defaults to pwsh instead, which is
- * `requireBashOnWindowsRunSteps`'s lane (#850, #1084).
+ * output and went green (#1083). `shell: sh` is the same trap spelled out, and so is `cmd`, which
+ * exits with the last program's error level. An explicit non-POSIX shell has no pipelines to get
+ * wrong and passes. Windows defaults to pwsh, which is `requireBashOnWindowsRunSteps`'s lane (#850).
  */
-const PIPEFAIL_SHELLS = new Set(["bash", "pwsh", "powershell", "python", "cmd"]);
+const PIPEFAIL_SHELLS = new Set(["bash", "pwsh", "powershell", "python"]);
 
 export function requirePipefailShell(path: string, document: unknown): string[] {
   const jobs = (document as { jobs?: Record<string, Job> })?.jobs;
@@ -550,7 +550,7 @@ function describeUnreadable(path: string, err: unknown): string {
   return `${path}: ${err instanceof Error ? err.message : String(err)}`;
 }
 
-function checkFile(
+export function checkFile(
   path: string,
   testedScripts: string[],
   cacheWriters: CacheEntry[],

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -30,6 +30,10 @@ permissions:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   # Lets sandboxed automation cut a release without local tag-push rights (#306).
   tag:

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -27,6 +27,10 @@ on:
 
 permissions: {}
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   reclaim:
     runs-on: ubuntu-latest

--- a/.github/workflows/cache-seed.yml
+++ b/.github/workflows/cache-seed.yml
@@ -45,6 +45,10 @@ concurrency:
   group: cache-seed
   cancel-in-progress: false
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   kokoro:
     name: Kokoro models (${{ matrix.os }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   update:
     runs-on: macos-latest

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -38,6 +38,10 @@ concurrency:
   group: npm-publish
   queue: max
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   # The alpha lane. Reserving a tag needs `contents: write`, so it is granted here and never
   # alongside `id-token: write` — tagging and provenance publishing stay in separate jobs.

--- a/.github/workflows/prune-alpha-releases.yml
+++ b/.github/workflows/prune-alpha-releases.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   prune:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -27,6 +27,10 @@ on:
 # No workflow-level `permissions`: a called workflow may only maintain or reduce what the
 # caller granted, so a `contents: read` default here could be read as capping `reserve-tag`
 # below the write it needs. Every job below states its own instead.
+defaults:
+  run:
+    shell: bash
+
 jobs:
   decide:
     name: Decide and derive

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -23,6 +23,10 @@ permissions:
 concurrency:
   group: release-cli-${{ inputs.tag || github.ref_name }}
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   plan:
     name: Classify the tag

--- a/.github/workflows/release-install-smoke.yml
+++ b/.github/workflows/release-install-smoke.yml
@@ -34,6 +34,10 @@ on:
         default: npm
         type: string
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   draft-engine:
     if: inputs.mode == 'draft-engine'

--- a/.github/workflows/release-npm-publish.yml
+++ b/.github/workflows/release-npm-publish.yml
@@ -27,6 +27,10 @@ permissions:
   contents: read
   id-token: write
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -17,6 +17,10 @@ on:
 permissions:
   contents: read
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   # Always runs (even on docs PRs) so the workflow concludes successfully and
   # its required check reports; outputs gate the heavy rust jobs below.

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,6 +25,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   # Always runs so the required checks always report; outputs gate the audits.
   changes:

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -1,6 +1,9 @@
-import { readdirSync } from "node:fs";
+import { mkdtempSync, readdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 import {
+  checkFile,
   collectCacheWriters,
   forbidLinuxPackaging,
   requireBashOnWindowsRunSteps,
@@ -408,6 +411,11 @@ describe("requirePipefailShell", () => {
     }
   });
 
+  // GitHub runs cmd with the last program's error level and no fail-fast, which is sh's trap.
+  test("fails on cmd, which reports the last program's error level", () => {
+    expect(errorsFor(smoke({ steps: [{ ...PIPED, shell: "cmd" }] }))).toHaveLength(1);
+  });
+
   // Windows defaults to pwsh, not `bash -e`; that lane is requireBashOnWindowsRunSteps (#850).
   test("leaves a windows-only job alone", () => {
     expect(errorsFor(smoke({ "runs-on": "windows-latest" }))).toEqual([]);
@@ -423,6 +431,15 @@ describe("requirePipefailShell", () => {
 
   test("ignores steps that only `uses` an action", () => {
     expect(errorsFor(smoke({ steps: [{ uses: "actions/checkout@v5" }] }))).toEqual([]);
+  });
+
+  // A gate is only a gate if checkFile still calls it, and the live suite cannot notice a
+  // dropped check because the tree it reads is already clean.
+  test("the file gate actually runs it", () => {
+    const yaml = "on: push\njobs:\n  smoke:\n    runs-on: ubuntu-latest\n    steps:\n      - run: a | b\n";
+    const path = join(mkdtempSync(join(tmpdir(), "kesha-wf-")), "probe.yml");
+    writeFileSync(path, yaml);
+    expect(checkFile(path, [], [], undefined).filter((e) => e.includes("#1084"))).toHaveLength(1);
   });
 });
 

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -4,6 +4,7 @@ import {
   collectCacheWriters,
   forbidLinuxPackaging,
   requireBashOnWindowsRunSteps,
+  requirePipefailShell,
   requireRestoreOnlyCachesHaveAWriter,
   requireDarwinSmokeCoversBothEngines,
   requireDepsBeforeBunTest,
@@ -359,6 +360,69 @@ describe("requireBashOnWindowsRunSteps", () => {
 
   test("a matrix it cannot resolve is not treated as windows", () => {
     expect(errorsFor(matrixJob({ os: "${{ fromJSON(needs.plan.outputs.os) }}" }))).toEqual([]);
+  });
+});
+
+describe("requirePipefailShell", () => {
+  const PIPED = { name: "record", run: "bun run check:versions | tee log" };
+  const smoke = (job: Record<string, unknown>, top: Record<string, unknown> = {}) => ({
+    ...top,
+    jobs: { smoke: { "runs-on": "ubuntu-latest", steps: [PIPED], ...job } },
+  });
+  const errorsFor = (document: unknown) => requirePipefailShell(CI, document);
+
+  test("passes on every workflow in the repo", () => {
+    for (const file of readdirSync(repoPath(".github/workflows"))) {
+      const path = `.github/workflows/${file}`;
+      expect([path, requirePipefailShell(path, parseRepoYaml(path))]).toEqual([path, []]);
+    }
+  });
+
+  test("fails when a run step is left on the unspecified default", () => {
+    const errors = errorsFor(smoke({}));
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("`smoke` step `record` has no `shell:`");
+    expect(errors[0]).toContain("pipefail");
+  });
+
+  test("names an unnamed step by position", () => {
+    expect(errorsFor(smoke({ steps: [{ run: "ls" }] }))[0]).toContain("step 1");
+  });
+
+  test("passes when the step, the job, or the workflow names bash", () => {
+    expect(errorsFor(smoke({ steps: [{ ...PIPED, shell: "bash" }] }))).toEqual([]);
+    expect(errorsFor(smoke({ defaults: { run: { shell: "bash" } } }))).toEqual([]);
+    expect(errorsFor(smoke({}, { defaults: { run: { shell: "bash" } } }))).toEqual([]);
+  });
+
+  // `sh` is the one explicit choice that looks deliberate and still behaves like the default.
+  test("fails on an explicit sh, which is the default trap spelled out", () => {
+    const errors = errorsFor(smoke({ steps: [{ ...PIPED, shell: "sh" }] }));
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("sets `shell: sh`");
+  });
+
+  test("passes on a shell that has no POSIX pipelines to get wrong", () => {
+    for (const shell of ["pwsh", "powershell", "python"]) {
+      expect(errorsFor(smoke({ steps: [{ ...PIPED, shell }] }))).toEqual([]);
+    }
+  });
+
+  // Windows defaults to pwsh, not `bash -e`; that lane is requireBashOnWindowsRunSteps (#850).
+  test("leaves a windows-only job alone", () => {
+    expect(errorsFor(smoke({ "runs-on": "windows-latest" }))).toEqual([]);
+  });
+
+  test("checks a matrix job for its non-windows legs", () => {
+    const matrix = {
+      "runs-on": "${{ matrix.os }}",
+      strategy: { matrix: { os: ["ubuntu-latest", "windows-latest"] } },
+    };
+    expect(errorsFor(smoke(matrix))).toHaveLength(1);
+  });
+
+  test("ignores steps that only `uses` an action", () => {
+    expect(errorsFor(smoke({ steps: [{ uses: "actions/checkout@v5" }] }))).toEqual([]);
   });
 });
 


### PR DESCRIPTION
Sibling of #1083, which gated the justfile. GitHub's **unspecified** default shell is `bash -e {0}` — no pipefail. Only naming `bash` selects `bash --noprofile --norc -eo pipefail {0}` ([workflow syntax](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax)). An undeclared `run:` step therefore takes its pipeline's **last** stage exit status, which is how `post-engine-release.yml`'s step named *"Validate and record output"* could not fail.

**93 of the repo's 182 `run:` steps were in that state**, across 13 workflows.

## Why gate the shell rather than the pipe

The issue offered two shapes. Running #1083's `runsAPipeline` scanner over `run:` blocks gave 3 hits, **2 of them false positives**:

- `build-engine.yml` — `[[ "$INPUT_TAG" =~ …(-(beta|alpha)…) ]]`, an alternation inside `[[ =~ ]]`
- `post-engine-release.yml` — a `|` inside a jq program in a quoted string **spanning lines** of a block scalar

Closing those needs `[[ ]]` context and quote state carried across lines. Requiring a *declared* shell needs no shell parsing at all: no false positives, and it covers every pipeline rather than the ones a scanner happens to recognise.

`shell: sh` fails too — it is the same trap spelled out, the one explicit choice that looks deliberate and still behaves like the default. An explicit `pwsh` / `powershell` / `python` has no POSIX pipelines to get wrong and passes.

## What changed

Thirteen workflows gained one `defaults.run.shell: bash` block each. **All 182 run steps now resolve to a declared shell** (verified by walking step → job `defaults` → workflow `defaults`).

One live bug goes with it: `homebrew-tap.yml` derives

```bash
tap_branch="$(git symbolic-ref --short refs/remotes/origin/HEAD | sed 's#^origin/##')"
```

A failed `symbolic-ref` yielded an **empty branch name to push at** rather than an error.

## Safety checks done before enabling pipefail

| risk | check | result |
|---|---|---|
| pipefail turns SIGPIPE into a job failure | scanned every step **that gains pipefail** for an early-exiting consumer (`\| head`, `\| grep -q`, `\| read`) | none — only 3 pipeline lines are affected at all, and the other two are `printf \|` and the `[[ =~ ]]` false positive |
| a Windows step silently switches pwsh → bash | listed Windows jobs with a bare `run:` step, before and after | none exist; there is no `# pwsh-ok` marker anywhere, and all six explicit `shell: pwsh` steps stay explicit |
| YAML validity / placement | `bun run check:workflows`, `just preflight` | green |

> **Scope of that first row, made explicit.** `build-engine.yml` does contain `find … | head -1` and `echo "$caps" | grep -q …`. Those steps already declared `shell: bash` on `origin/main`, so they have been running under `-eo pipefail` all along and this PR changes nothing for them — verified by resolving each step's effective shell on both revisions, not by reading. The `find … | head -1` pair is a genuine pre-existing SIGPIPE landmine and is now #1088; folding a release-build edit into a linting PR would be the wrong trade.

## Interaction with #850

`requireBashOnWindowsRunSteps` stops checking a job once a job- or workflow-level default exists, so these 13 workflows are no longer inspected by it. That is not a regression: a declared `shell: bash` **is** the decision #850 wanted, and PowerShell written into such a step now fails loudly instead of expanding `"$VAR"` to empty in silence. Its own repo-wide test stays green.

## Proof

| mutation | result |
|---|---|
| accept `sh` as a pipefail shell | `PINNED` |
| skip a job when *any* runner is windows (rather than all) | `PINNED` |
| ignore the workflow-level default when resolving | `PINNED` |
| production: drop the `defaults` block from `ci.yml` | `PINNED` |

| reject `cmd`, which reports the last program's error level | `PINNED` |
| drop `...requirePipefailShell(path, document)` from `checkFile` | `PINNED` |

The last two were **not** pinned in the first round, and review caught both. `cmd` was in the pass set with no assertion on either mutation; it now fails like `sh`. And the claim that `bun run check:workflows` was the live pin for the call site was simply wrong — a check cannot notice that it is no longer called, and the tree it reads is already clean. `checkFile` is now exported and driven over a temporary workflow that violates the rule.

## Test reach

New cases in `tests/unit/check-workflows.test.ts` run in `unit-tests` (`ci.yml` → `🧪 CI`) on ubuntu/windows/macos via `bun run test:unit`. The gate itself runs against every real workflow in `workflow-lint` (`bun run check:workflows`) and in `just preflight`.

Closes #1084
