### PR TITLE
perf(conveyor): quiet the gates and cut the rituals the loop performs by hand

### DIFF
--- a/.claude/commands/await-review.md
+++ b/.claude/commands/await-review.md
@@ -10,17 +10,25 @@ Arguments: `$ARGUMENTS` → optional PR number. If omitted, resolve the PR for t
 
 ## Steps
 
-1. Resolve the PR number and capture the **current head SHA**:
+1. Read the PR and its **current head SHA** in one call (`<N>` is the PR number):
    ```bash
    gh pr view <N> -R drakulavich/kesha-voice-kit --json number,headRefOid,mergeStateStatus
    ```
 
-2. Poll until both CI and Greptile are non-pending **on that head SHA**. Use a background poll so you don't block the session — re-check every ~50s, up to ~20 min. Parse `gh pr checks <N>` (tab-separated: name TAB state); for Greptile, also confirm via `gh pr view --json statusCheckRollup` that its `conclusion` is set (an empty conclusion = still reviewing the new SHA, even if a stale pass shows). Do **not** trust a pass whose timestamp predates the latest push.
+2. Block on the checks rather than polling them — each poll's table is context you pay for, and `--watch` returns once they settle:
+   ```bash
+   gh pr checks <N> -R drakulavich/kesha-voice-kit --watch --fail-fast --interval 30 > /dev/null
+   ```
 
-3. When both settle, summarize:
-   - CI: which jobs passed / failed / were skipped (path-filtered jobs skipping is normal for docs-only PRs).
-   - Greptile: the top-level summary and every inline **P1/P2** finding (treat these as merge blockers). Pull them via `gh pr view <N> --json reviews,comments` filtering authors matching `greptile`.
+3. Ask once for what is not green, and for Greptile's state on **that same SHA**:
+   ```bash
+   gh pr checks <N> -R drakulavich/kesha-voice-kit --json name,state,link \
+     --jq '.[] | select(.state != "SUCCESS" and .state != "SKIPPED")'
+   gh pr view <N> -R drakulavich/kesha-voice-kit --json reviews,comments \
+     --jq '[.reviews[], .comments[] | select(.author.login | test("greptile"; "i"))] | .[-3:]'
+   ```
+   An empty Greptile `conclusion` means it is still reading the new SHA even if a stale pass shows; do **not** trust a pass whose timestamp predates the latest push. If the head SHA changed while you waited, start again at step 1 — the answer is about the old commit.
 
-4. State plainly: is the **latest head SHA** green + reviewed, or still waiting? If there are P1/P2 findings, list them as the blockers to fix before merge (or note a clear false positive to dismiss with a comment).
+4. State plainly: is the **latest head SHA** green + reviewed, or still waiting? List every **P1/P2** as a merge blocker (or note a clear false positive to dismiss with a comment). **Never gate on the Confidence Score** — 9 of 30 PRs scored 5/5 while carrying Greptile's own P1/P2. Greptile silent → say so and carry on.
 
 Reference: CLAUDE.md "GREPTILE PR REVIEW IS A GATE".

--- a/.claude/commands/land.md
+++ b/.claude/commands/land.md
@@ -1,43 +1,41 @@
 ---
 description: Land a green PR — verify CI+Greptile on head SHA, confirm issue linkage, merge, and clean up the worktree.
 argument-hint: "[pr-number] (defaults to the current branch's PR)"
-allowed-tools: Bash(gh pr view:*), Bash(gh pr checks:*), Bash(gh pr merge:*), Bash(gh issue view:*), Bash(gh issue close:*), Bash(just:*), Bash(git rev-parse:*)
+allowed-tools: Bash(gh pr view:*), Bash(gh pr checks:*), Bash(gh pr merge:*), Bash(gh issue view:*), Bash(gh issue close:*), Bash(bun run:*), Bash(just:*), Bash(git rev-parse:*)
 ---
 
-Finish and merge a PR safely, enforcing the repo's review gate, issue-linkage, and worktree-cleanup rules. **Do not merge** unless CI and Greptile are both green on the latest head SHA.
+Finish and merge a PR safely. The mergeability rules are **code**, not prose here: `just gate` refuses an unmerged head that fails any of them. Do not re-derive them with `gh` — run the gate and read its violations.
 
 Arguments: `$ARGUMENTS` → optional PR number (defaults to the current branch's PR).
 
 ## Steps
 
-1. Resolve the PR and its current head SHA (`<PR_N>` is the PR number from `$ARGUMENTS`):
+1. Resolve the PR (`<PR_N>`), its head SHA, and the issue it closes:
    ```bash
-   gh pr view <PR_N> -R drakulavich/kesha-voice-kit --json number,headRefOid,mergeStateStatus,body,headRefName,closingIssuesReferences
+   gh pr view <PR_N> -R drakulavich/kesha-voice-kit --json number,headRefOid,mergeStateStatus,headRefName,closingIssuesReferences
    ```
+   No closing issue (a dependabot bump, say)? `gate` cannot express that PR: check it by hand, put the verdict in a comment, and apply no label.
 
-2. **Gate — refuse to merge if not satisfied:**
-   - CI checks all passing/skipped on the head SHA (`gh pr checks <PR_N>`).
-   - Greptile review `conclusion` is success **on that head SHA** (not a stale pass — see `/await-review`). If P1/P2 findings are open, stop and list them.
-   - `mergeStateStatus` is `CLEAN`.
-   If any fails, report what's blocking and stop.
+2. **Gate.** `<PROVIDER>`/`<URI>` are the review that approved this head — the `**grok review**` comment's source and URL:
+   ```bash
+   just gate <ISSUE_N> <PR_N> <PROVIDER> <URI>
+   ```
+   It reads the head immediately before binding evidence to it and refuses unless the PR is open, non-draft, mergeable, based on the default branch, closes exactly `[<ISSUE_N>]`, carries no current-head `CHANGES_REQUESTED`, and every required check is terminally green. Any violation it prints is the blocker — report it and stop.
 
-3. **Issue linkage:** confirm the PR body/commits contain a `Closes #N` / `Fixes #N` / `Resolves #N` keyword so the issue auto-closes. If the work fully addresses an issue but the keyword is missing, tell the user (don't silently merge a partial link). `Refs #N` is correct for partial work — in that case the issue should stay open.
+3. **Greptile is a separate gate** the conveyor does not see: open **P1/P2** findings on the current head block the merge whatever the gate said, and never gate on the Confidence Score. See `/await-review`.
 
-4. **Merge** (match the repo's convention — squash unless told otherwise). `--delete-branch` removes the remote feature branch regardless of the repo's auto-delete setting:
+4. **Merge** (squash unless told otherwise). `--delete-branch` removes the remote feature branch regardless of the repo's auto-delete setting:
    ```bash
    gh pr merge <PR_N> -R drakulavich/kesha-voice-kit --squash --delete-branch
    ```
 
-5. **Clean up the worktree** for the merged branch — from the root checkout, which the recipe enforces:
+5. **Close** — from the **root checkout**, never from inside the worktree being removed:
    ```bash
-   just worktree-rm <slug>
+   bun run conveyor -- close --issue <ISSUE_N> --pr <PR_N> --apply
    ```
-
-6. **Verify the issue actually closed** (auto-close can lag for partial links). If it should be closed but isn't (`<ISSUE_N>` is the issue, `<PR_N>` is the PR that landed it):
+   It removes the `WIP` label and the clean managed worktree, and refuses a dirty or unmanaged one rather than forcing it. It requires the issue to be closed already; GitHub's auto-close can lag a merge, so re-run it, or close by hand when the link was `Refs #N` rather than `Closes #N`:
    ```bash
-   gh issue view <ISSUE_N> -R drakulavich/kesha-voice-kit --json state
    gh issue close <ISSUE_N> -R drakulavich/kesha-voice-kit --comment "Landed in #<PR_N>."
    ```
-   The `WIP` label is removed automatically on merge; if it lingers, remove it.
 
-Reference: CLAUDE.md "GREPTILE PR REVIEW IS A GATE", "LINK PRS TO ISSUES", "MAIN STAYS IN THE ROOT CHECKOUT".
+Reference: CLAUDE.md "GREPTILE PR REVIEW IS A GATE", "BACKLOG CONVEYOR REVIEW GATE", "MAIN STAYS IN THE ROOT CHECKOUT".

--- a/.claude/commands/preflight.md
+++ b/.claude/commands/preflight.md
@@ -6,7 +6,7 @@ allowed-tools: Bash(just:*)
 
 Run `just preflight` — or `just ALL=1 preflight` when `$ARGUMENTS` contains `--all` — and report a concise PASS/FAIL summary with the actual command output. Do **not** claim success on any failure: surface the failing output verbatim and stop.
 
-The recipe owns which gates run and with which flags; do not reconstruct the commands here or reach past it to raw `cargo`.
+The recipe owns which gates run and with which flags; do not reconstruct the commands here or reach past it to raw `cargo`. It prints one line per passing gate and the failing gate's log verbatim, so relay what it printed — re-running a gate loudly to see more only reprints what it already gave you.
 
 - If `cargo fmt` reformatted anything, mention the whitespace diff to commit.
 - If clippy fails only because CI's rustc is newer, point at `gh run view <id> --log-failed`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ Greptile reviews on open and on every new commit. **P1/P2 findings are merge blo
 
 ### BACKLOG CONVEYOR REVIEW GATE
 
-Every conveyor PR MUST follow the [backlog conveyor review runbook](docs/runbooks/backlog-conveyor-review.md): `just review "<claim>"` the moment the PR exists, a durable comment carrying the full head SHA and every finding, and a fix pass for confirmed blockers that restarts the review on the new head. `merge-ready` comes only from `bun run conveyor -- gate … --apply`, never by hand — `just gate <issue> <pr> <provider> <uri>` builds the SHA-bound evidence and calls it, reading the head immediately before binding to it. 43% of merged PRs used to skip the review entirely — that gap cost more than any wording did, which is why the recipe takes the claim as a required argument.
+Every conveyor PR MUST follow the [backlog conveyor review runbook](docs/runbooks/backlog-conveyor-review.md): `just review "<claim>"` the moment the PR exists and `just review-wait <log>` to collect it, a durable comment carrying the full head SHA and every finding, and a fix pass for confirmed blockers that restarts the review on the new head. `merge-ready` comes only from `bun run conveyor -- gate … --apply`, never by hand — `just gate <issue> <pr> <provider> <uri>` builds the SHA-bound evidence and calls it, reading the head immediately before binding to it. 43% of merged PRs used to skip the review entirely — that gap cost more than any wording did, which is why the recipe takes the claim as a required argument.
 
 ### ERROR HANDLING
 

--- a/docs/runbooks/backlog-conveyor-review.md
+++ b/docs/runbooks/backlog-conveyor-review.md
@@ -6,7 +6,9 @@ GitHub evidence must contain.
 
 ## 1. Review every PR, aimed at a claim
 
-Run `just review "<claim>"` the moment the PR exists. Measured over
+Run `just review "<claim>"` the moment the PR exists, and block on it with the
+`just review-wait <log>` line it prints — the reviewer detaches, and polling its
+growing log costs the whole file every time you look. Measured over
 #1016–#1064, **13 of 30 merged PRs (43%) were never reviewed at all**, while
 every P1/P2 the reviews did raise led to a code change — 6 for 6. Coverage,
 not wording, is what the gate was losing.

--- a/docs/runbooks/backlog-conveyor.md
+++ b/docs/runbooks/backlog-conveyor.md
@@ -14,8 +14,8 @@ Claude and Codex read this, not a client-specific command file.
 2. **Work** — `just worktree issue-<N>`, then one fresh-context agent, never
    reused across tickets. The brief gives coordinates rather than a search:
    `src/engine.ts:120-180` and the exact failing command, not "look at the
-   engine code". Gates run to a file and you read the tail — `bun run test`
-   prints 332 lines and no flag shortens it.
+   engine code". `just preflight` prints one line per gate and the failing
+   gate's output verbatim, so read what it prints rather than redirecting it.
    Blocked mid-flight? Push what exists, open a draft PR, comment the blocker,
    report `BLOCKED: <reason>`. Do not spin.
 

--- a/docs/runbooks/backlog-conveyor.md
+++ b/docs/runbooks/backlog-conveyor.md
@@ -7,7 +7,9 @@ Claude and Codex read this, not a client-specific command file.
 ## Loop
 
 1. **Select** — `bun run conveyor -- sync` (`--apply` if it proposes repairs).
-   Take the oldest open issue carrying neither `WIP` nor `needs-decision`.
+   It ends with `next ticket: #N` — the oldest open issue carrying neither `WIP`
+   nor `needs-decision` — computed from facts it already holds, so the selection
+   rule costs no second query.
    A question only the maintainer can answer gets a comment, `needs-decision`,
    and the next ticket — not an implementation run.
 

--- a/justfile
+++ b/justfile
@@ -135,22 +135,26 @@ preflight:
     # A checkout that quietly fell 14 commits behind had an agent reading a stale CLAUDE.md for nine hours (#1070).
     [ "$behind" = "0" ] || echo "==> NOTE: this checkout is $behind commit(s) behind origin/main — read instructions with: git show origin/main:<path>"
 
+    # A green gate's output is never read, and handing it to an agent costs thousands of tokens
+    # per run; quiet-gate buffers it and prints it verbatim only when the gate fails.
+    gate() { bun scripts/quiet-gate.ts "$1" -- "${@:2}"; }
+
     echo "==> TS gate (always)"
-    bun run test
-    bun run lint
+    gate test bun run test
+    gate lint bun run lint
     # tests/unit/preflight-parity.test.ts holds this list equal to what CI runs (#1070).
-    bun run check:recipes
-    bun run check:workflows
-    bun run check:versions
-    bun run check:specs
-    bun run check:engine-targets
-    bun run check:release-manifest
+    gate check:recipes bun run check:recipes
+    gate check:workflows bun run check:workflows
+    gate check:versions bun run check:versions
+    gate check:specs bun run check:specs
+    gate check:engine-targets bun run check:engine-targets
+    gate check:release-manifest bun run check:release-manifest
 
     if [ -n "$rust" ]; then
       echo "==> Rust gate"
       # `cargo fmt` formats in place rather than checking, so this can leave a whitespace diff to commit.
-      (cd rust && cargo fmt && cargo clippy --all-targets -- -D warnings)
-      {{ just_executable() }} rust-test
+      gate clippy bash -c 'cd rust && cargo fmt && cargo clippy --all-targets -- -D warnings'
+      gate rust-test {{ just_executable() }} rust-test
     else
       echo "==> Rust gate skipped: no rust/ changes (force with just ALL=1 preflight)"
     fi
@@ -158,7 +162,7 @@ preflight:
     if [ -n "$backend" ]; then
       echo "==> CoreML build check"
       # --all-targets matches rust-test.yml's check so the #[cfg(feature = "coreml")] tests compile too (#708).
-      (cd rust && cargo check --features coreml --no-default-features --all-targets)
+      gate coreml bash -c 'cd rust && cargo check --features coreml --no-default-features --all-targets'
     else
       echo "==> CoreML check skipped: no rust/src/backend/ changes"
     fi

--- a/justfile
+++ b/justfile
@@ -63,17 +63,33 @@ review CLAIM:
     set -euo pipefail
     claim="$1"
     reviewer=${KESHA_REVIEWER:-omc ask grok -p}
-    pr="$(gh pr view --json number -q .number 2>/dev/null)" || {
+    # A detached reviewer that was never on PATH reports itself as launched and is discovered
+    # minutes later, in a log holding "command not found" where the findings should be.
+    command -v "${reviewer%% *}" >/dev/null || {
+      echo "refusing: reviewer '${reviewer%% *}' is not on PATH — install it or set KESHA_REVIEWER" >&2; exit 2; }
+    # One read: three separate gh calls can straddle a push and review a head the number never had.
+    facts="$(gh pr view --json number,headRefOid,baseRefName -q '"\(.number) \(.headRefOid) \(.baseRefName)"' 2>/dev/null)" || {
       echo "refusing: no pull request for this branch — open it first" >&2; exit 2; }
-    head="$(gh pr view --json headRefOid -q .headRefOid)"
-    base="$(gh pr view --json baseRefName -q .baseRefName)"
+    read -r pr head base <<<"$facts"
     branch="$(git rev-parse --abbrev-ref HEAD)"
     log=".omc/review-${pr}-${head:0:8}.log"
     mkdir -p .omc
+    # Truncate rather than remove: review-wait refuses a log that does not exist, and the detached
+    # subshell has not necessarily created it by the time this recipe returns.
+    rm -f "${log}.status"
+    : > "${log}"
     prompt="$(bun scripts/review-prompt.ts "$pr" "$head" "$branch" "$base" "$claim")"
     echo "==> reviewing #${pr} at ${head:0:8}; output -> ${log}"
-    nohup ${reviewer} "${prompt}" > "${log}" 2>&1 &
-    echo "==> launched in background; post the findings as one **grok review** comment carrying the full head SHA"
+    # $0 carries the log path so that ${reviewer} keeps the word splitting it needs, and the
+    # sentinel is the only signal that separates a finished review from a half-written one.
+    nohup bash -c 'set +e; "$@" > "$0" 2>&1; echo $? > "$0.status"' "${log}" ${reviewer} "${prompt}" >/dev/null 2>&1 &
+    echo "==> launched in background; block on it with: just review-wait ${log}"
+    echo "==> then post the findings as one **grok review** comment carrying the full head SHA"
+
+# Block until `just review` finishes and print its findings once, rather than re-reading a growing log
+[positional-arguments]
+review-wait LOG:
+    bun scripts/review-wait.ts "$@"
 
 # Prove a guard is pinned: replace text, run the tests, restore. Refuses when the text does not occur (#1075)
 [positional-arguments]

--- a/justfile
+++ b/justfile
@@ -68,8 +68,8 @@ review CLAIM:
     command -v "${reviewer%% *}" >/dev/null || {
       echo "refusing: reviewer '${reviewer%% *}' is not on PATH — install it or set KESHA_REVIEWER" >&2; exit 2; }
     # One read: three separate gh calls can straddle a push and review a head the number never had.
-    facts="$(gh pr view --json number,headRefOid,baseRefName -q '"\(.number) \(.headRefOid) \(.baseRefName)"' 2>/dev/null)" || {
-      echo "refusing: no pull request for this branch — open it first" >&2; exit 2; }
+    facts="$(gh pr view --json number,headRefOid,baseRefName -q '"\(.number) \(.headRefOid) \(.baseRefName)"')" || {
+      echo "refusing: gh could not read a pull request for this branch (its error is above) — open one first" >&2; exit 2; }
     read -r pr head base <<<"$facts"
     branch="$(git rev-parse --abbrev-ref HEAD)"
     log=".omc/review-${pr}-${head:0:8}.log"

--- a/scripts/backlog-conveyor.ts
+++ b/scripts/backlog-conveyor.ts
@@ -93,6 +93,9 @@ export interface Evaluation {
   findings: string[];
 }
 
+/// `sync` alone names the next ticket: `gate` and `close` act on one the caller already chose.
+export type SyncEvaluation = Evaluation & { nextIssue: number | null };
+
 export interface RunnerResult {
   exitCode: number;
   stdout: string;
@@ -305,7 +308,15 @@ export function evaluateGate(facts: GateFacts): Evaluation {
   return { violations, refusals: [], safeActions: uniqueActions(safeActions), findings: [] };
 }
 
-export function evaluateSync(facts: SyncFacts): Evaluation {
+/// The loop's selection rule, applied where the facts already are: the oldest open issue carrying
+/// neither `WIP` nor `needs-decision`. Issue numbers ascend with creation, so the lowest open
+/// number is the oldest — no `createdAt` and no second `gh issue list`.
+export function selectNextIssue(issues: SyncFacts["issues"]): number | null {
+  const available = issues.filter((issue) => issue.state === "OPEN" && !issue.labels.includes("WIP") && !issue.labels.includes("needs-decision"));
+  return available.length === 0 ? null : Math.min(...available.map((issue) => issue.number));
+}
+
+export function evaluateSync(facts: SyncFacts): SyncEvaluation {
   const findings: string[] = [];
   const safeActions: Evaluation["safeActions"] = [];
   for (const pr of facts.pullRequests) {
@@ -340,7 +351,7 @@ export function evaluateSync(facts: SyncFacts): Evaluation {
       findings.push(`worktree ${worktree.path} is orphaned`);
     }
   }
-  return { violations: [], refusals: [], safeActions: uniqueActions(safeActions), findings };
+  return { violations: [], refusals: [], safeActions: uniqueActions(safeActions), findings, nextIssue: selectNextIssue(facts.issues) };
 }
 
 export function evaluateClose(facts: CloseFacts): Evaluation {
@@ -611,7 +622,7 @@ function safeManagedWorktreePath(path: string): boolean {
   return isDirectManagedWorktree(path, resolve(root, ".worktrees"));
 }
 
-export async function sync(runner: Runner, apply: boolean): Promise<Evaluation> {
+export async function sync(runner: Runner, apply: boolean): Promise<SyncEvaluation> {
   const repo = await repository(runner);
   const facts: SyncFacts = { issues: await loadIssues(runner), pullRequests: await loadSyncPullRequests(runner, repo), worktrees: await loadWorktrees(runner) };
   const evaluation = evaluateSync(facts);

--- a/scripts/backlog-conveyor.ts
+++ b/scripts/backlog-conveyor.ts
@@ -467,39 +467,6 @@ export async function loadChecks(runner: Runner, repo: Pick<Repository, "owner" 
 }
 
 const trustedAssociations = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
-const pageCap = 100;
-const phase3Concurrency = 4;
-
-export async function mapBounded<T, U>(values: T[], limit: number, map: (value: T, index: number) => Promise<U>): Promise<U[]> {
-  const results = new Array<U>(values.length);
-  let next = 0;
-  await Promise.all(Array.from({ length: Math.min(limit, values.length) }, async () => {
-    for (;;) {
-      const index = next;
-      next += 1;
-      if (index >= values.length) return;
-      results[index] = await map(values[index]!, index);
-    }
-  }));
-  return results;
-}
-
-async function pagedArray(runner: Runner, endpoint: (page: number) => string, source: string): Promise<unknown[]> {
-  const values: unknown[] = [];
-  for (let page = 1; page <= pageCap; page += 1) {
-    const current = requiredArray(await runJson(runner, ["gh", "api", endpoint(page)], source), source);
-    values.push(...current);
-    if (current.length < 100) return values;
-  }
-  throw new OperationalError(`${source} reached pagination cap; refusing incomplete result`);
-}
-
-interface QueueIssue { number: number; state: string; labels: string[]; createdAt: string; isPullRequest: boolean }
-
-interface GateCandidate { issue: number; createdAt: string; databaseId: number }
-
-const metricClosingIssueQuery = `query($owner: String!, $name: String!, $number: Int!) { repository(owner: $owner, name: $name) { pullRequest(number: $number) { closingIssuesReferences(first: 2) { nodes { number } pageInfo { hasNextPage } } } } }`;
-
 export async function loadMarker(runner: Runner, repo: Pick<Repository, "owner" | "name">, pr: number): Promise<GateMarker | null> {
   const comments: unknown[] = [];
   for (let page = 1; ; page += 1) {
@@ -521,15 +488,6 @@ async function loadIssues(runner: Runner): Promise<SyncFacts["issues"]> {
   return raw.map((entry, index) => {
     const issue = requiredRecord(entry, `gh issue list[${index}]`);
     return { number: requiredNumber(issue.number, `gh issue list[${index}].number`), state: requiredString(issue.state, `gh issue list[${index}].state`), labels: labels(issue.labels, `gh issue list[${index}].labels`) };
-  });
-}
-
-async function loadCollisionIssues(runner: Runner): Promise<SyncFacts["issues"]> {
-  const raw = requiredArray(await runJson(runner, ["gh", "issue", "list", "--state", "open", "--label", "WIP", "--limit", "1000", "--json", "number,state,labels"], "gh collision issue list"), "gh collision issue list");
-  if (raw.length === 1000) throw new OperationalError("collision issue list reached limit; refusing incomplete graph");
-  return raw.map((entry, index) => {
-    const issue = requiredRecord(entry, `gh collision issue list[${index}]`);
-    return { number: requiredNumber(issue.number, `gh collision issue list[${index}].number`), state: requiredString(issue.state, `gh collision issue list[${index}].state`), labels: labels(issue.labels, `gh collision issue list[${index}].labels`) };
   });
 }
 

--- a/scripts/backlog.ts
+++ b/scripts/backlog.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env bun
-import { ExitCode, OperationalError, REPORT_SCHEMA_VERSION, bunRunner, close, gate, parseGateEvidence, sync, type Evaluation } from "./backlog-conveyor";
+import { ExitCode, OperationalError, REPORT_SCHEMA_VERSION, bunRunner, close, gate, parseGateEvidence, sync, type Evaluation, type SyncEvaluation } from "./backlog-conveyor";
 
 type Command =
   | { name: "sync"; apply: boolean; json: boolean }
@@ -52,8 +52,13 @@ function exitCode(result: Evaluation): number {
   return ExitCode.success;
 }
 
-function output(command: Command, result: Evaluation): void {
-  const report = { schemaVersion: REPORT_SCHEMA_VERSION, command: command.name, apply: command.apply, findings: result.findings, violations: result.violations, refusals: result.refusals, actions: result.safeActions };
+function nextTicket(result: Evaluation | SyncEvaluation): number | null | undefined {
+  return "nextIssue" in result ? result.nextIssue : undefined;
+}
+
+function output(command: Command, result: Evaluation | SyncEvaluation): void {
+  const next = nextTicket(result);
+  const report = { schemaVersion: REPORT_SCHEMA_VERSION, command: command.name, apply: command.apply, findings: result.findings, violations: result.violations, refusals: result.refusals, actions: result.safeActions, ...(next === undefined ? {} : { nextIssue: next }) };
   if (command.json) {
     console.log(JSON.stringify(report));
     return;
@@ -61,6 +66,7 @@ function output(command: Command, result: Evaluation): void {
   console.log(`backlog ${command.name}: ${exitCode(result) === 0 ? "ok" : "blocked"}`);
   for (const message of [...result.findings, ...result.violations, ...result.refusals]) console.log(`- ${message}`);
   for (const action of result.safeActions) console.log(`- ${command.apply ? "applied" : "would apply"}: ${action.kind}`);
+  if (next !== undefined) console.log(`- next ticket: ${next === null ? "none — the queue is empty" : `#${next}`}`);
 }
 
 async function main(): Promise<void> {

--- a/scripts/mutate.ts
+++ b/scripts/mutate.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env bun
 import { readFileSync, writeFileSync } from "node:fs";
+import { runQuiet } from "./quiet-gate";
 
 export type MutationResult = { replacements: number; source: string };
 
@@ -9,6 +10,17 @@ export function mutate(source: string, find: string, replace: string): MutationR
   if (find.length === 0) throw new Error("the text to replace must not be empty");
   const replacements = source.split(find).length - 1;
   return { replacements, source: replacements === 0 ? source : source.split(find).join(replace) };
+}
+
+export type MutationRun = { exitCode: number; log: string };
+export type MutationVerdict = { pinned: boolean; report: string };
+
+/// A caught mutation's output is the failure the run asked for, and nobody reads it — but a test
+/// command that never ran a test (a build error, a filterset matching nothing) also exits non-zero
+/// and reads identically, so the tail stays. A survivor is the surprising outcome: print it all.
+export function verdict(run: MutationRun, tailLines = 5): MutationVerdict {
+  if (run.exitCode === 0) return { pinned: false, report: run.log };
+  return { pinned: true, report: run.log.replace(/\n$/, "").split("\n").slice(-tailLines).join("\n") };
 }
 
 function usage(message: string): never {
@@ -27,17 +39,19 @@ async function main(): Promise<void> {
     process.exit(2);
   }
 
-  let survived = false;
+  let run: MutationRun = { exitCode: 0, log: "" };
   try {
     writeFileSync(file, source);
     console.error(`==> mutated ${file} (${replacements} occurrence${replacements === 1 ? "" : "s"}); running: ${command.join(" ")}`);
-    survived = (await Bun.spawn(command, { stdout: "inherit", stderr: "inherit" }).exited) === 0;
+    run = await runQuiet(command);
   } finally {
     writeFileSync(file, original);
     console.error(`==> restored ${file}`);
   }
 
-  if (survived) {
+  const result = verdict(run);
+  console.error(result.report);
+  if (!result.pinned) {
     console.error(`NOT PINNED: the mutation survived — nothing failed when '${find}' was replaced`);
     process.exit(1);
   }

--- a/scripts/mutate.ts
+++ b/scripts/mutate.ts
@@ -12,7 +12,7 @@ export function mutate(source: string, find: string, replace: string): MutationR
   return { replacements, source: replacements === 0 ? source : source.split(find).join(replace) };
 }
 
-export type MutationRun = { exitCode: number; log: string };
+export type MutationRun = { exitCode: number; log: string; discard?: () => void };
 export type MutationVerdict = { pinned: boolean; report: string };
 
 /// A caught mutation's output is the failure the run asked for, and nobody reads it — but a test
@@ -50,6 +50,7 @@ async function main(): Promise<void> {
   }
 
   const result = verdict(run);
+  run.discard?.();
   console.error(result.report);
   if (!result.pinned) {
     console.error(`NOT PINNED: the mutation survived — nothing failed when '${find}' was replaced`);

--- a/scripts/quiet-gate.ts
+++ b/scripts/quiet-gate.ts
@@ -1,26 +1,33 @@
 #!/usr/bin/env bun
-import { closeSync, mkdtempSync, openSync, readFileSync, rmSync } from "node:fs";
+import { closeSync, mkdtempSync, openSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-export type QuietResult = { exitCode: number; log: string; logPath: string; durationMs: number };
+/// `discard` removes the kept log; a caller that prints the log keeps the file so a large failure
+/// can be grepped instead of re-run.
+export type QuietResult = { exitCode: number; log: string; logPath: string; durationMs: number; discard: () => void };
 
 /// Both streams share one file descriptor so the log reads in the order the command wrote it:
 /// separate pipes reorder a failure's error relative to the output that followed it.
 export async function runQuiet(argv: string[], directory = mkdtempSync(join(tmpdir(), "kesha-gate-"))): Promise<QuietResult> {
   const logPath = join(directory, "gate.log");
   const started = Date.now();
+  const discard = () => rmSync(directory, { recursive: true, force: true });
   const fd = openSync(logPath, "w");
+  let log: string;
+  let exitCode: number;
   try {
-    const process = Bun.spawn(argv, { stdout: fd, stderr: fd });
-    const exitCode = await process.exited;
-    closeSync(fd);
-    return { exitCode, log: readFileSync(logPath, "utf8"), logPath, durationMs: Date.now() - started };
+    exitCode = await Bun.spawn(argv, { stdout: fd, stderr: fd }).exited;
   } catch (error) {
+    exitCode = 127;
+    log = `could not start ${argv[0]}: ${error instanceof Error ? error.message : String(error)}\n`;
     closeSync(fd);
-    const message = `could not start ${argv[0]}: ${error instanceof Error ? error.message : String(error)}\n`;
-    return { exitCode: 127, log: message, logPath, durationMs: Date.now() - started };
+    writeFileSync(logPath, log);
+    return { exitCode, log, logPath, durationMs: Date.now() - started, discard };
   }
+  closeSync(fd);
+  log = readFileSync(logPath, "utf8");
+  return { exitCode, log, logPath, durationMs: Date.now() - started, discard };
 }
 
 function usage(message: string): never {
@@ -41,7 +48,7 @@ async function main(): Promise<void> {
   if (process.stderr.isTTY) process.stderr.write(`… ${label}\n`);
   const result = await runQuiet(command);
   if (result.exitCode === 0) {
-    rmSync(result.logPath, { force: true });
+    result.discard();
     console.log(`✓ ${label} ${seconds(result.durationMs)}`);
     return;
   }

--- a/scripts/quiet-gate.ts
+++ b/scripts/quiet-gate.ts
@@ -1,0 +1,58 @@
+#!/usr/bin/env bun
+import { closeSync, mkdtempSync, openSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export type QuietResult = { exitCode: number; log: string; logPath: string; durationMs: number };
+
+/// Both streams share one file descriptor so the log reads in the order the command wrote it:
+/// separate pipes reorder a failure's error relative to the output that followed it.
+export async function runQuiet(argv: string[], directory = mkdtempSync(join(tmpdir(), "kesha-gate-"))): Promise<QuietResult> {
+  const logPath = join(directory, "gate.log");
+  const started = Date.now();
+  const fd = openSync(logPath, "w");
+  try {
+    const process = Bun.spawn(argv, { stdout: fd, stderr: fd });
+    const exitCode = await process.exited;
+    closeSync(fd);
+    return { exitCode, log: readFileSync(logPath, "utf8"), logPath, durationMs: Date.now() - started };
+  } catch (error) {
+    closeSync(fd);
+    const message = `could not start ${argv[0]}: ${error instanceof Error ? error.message : String(error)}\n`;
+    return { exitCode: 127, log: message, logPath, durationMs: Date.now() - started };
+  }
+}
+
+function usage(message: string): never {
+  console.error(`${message}\nusage: bun scripts/quiet-gate.ts <label> -- <command> [args...]`);
+  process.exit(2);
+}
+
+function seconds(durationMs: number): string {
+  return `${(durationMs / 1000).toFixed(1)}s`;
+}
+
+async function main(): Promise<void> {
+  const [label, separator, ...command] = process.argv.slice(2);
+  if (!label) usage("a label is required");
+  if (separator !== "--" || command.length === 0) usage("the command must follow a literal --");
+
+  // A buffered gate shows nothing while it runs, which matters only to someone watching it.
+  if (process.stderr.isTTY) process.stderr.write(`… ${label}\n`);
+  const result = await runQuiet(command);
+  if (result.exitCode === 0) {
+    rmSync(result.logPath, { force: true });
+    console.log(`✓ ${label} ${seconds(result.durationMs)}`);
+    return;
+  }
+  process.stderr.write(result.log);
+  process.stderr.write(`✗ ${label} failed (exit ${result.exitCode}) after ${seconds(result.durationMs)}; log kept at ${result.logPath}\n`);
+  process.exit(result.exitCode);
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error(`quiet-gate: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(2);
+  });
+}

--- a/scripts/review-wait.ts
+++ b/scripts/review-wait.ts
@@ -1,0 +1,62 @@
+#!/usr/bin/env bun
+import { existsSync, readFileSync } from "node:fs";
+
+export type ReviewState =
+  | { state: "finished"; reviewerExitCode: number; review: string }
+  | { state: "failed"; reviewerExitCode: number; review: string }
+  | { state: "waiting" };
+
+export type WaitOptions = { deadlineMs?: number; pollMs?: number };
+
+const DEFAULT_DEADLINE_MS = 30 * 60 * 1000;
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/// `just review` detaches, so the only honest completion signal is the sentinel its subshell writes
+/// after the reviewer exits. Polling the log itself reports a half-written review as a finished one.
+export async function awaitReview(logPath: string, options: WaitOptions = {}): Promise<ReviewState> {
+  const deadlineMs = options.deadlineMs ?? DEFAULT_DEADLINE_MS;
+  const pollMs = options.pollMs ?? 2000;
+  if (!existsSync(logPath)) throw new Error(`no review log at ${logPath} — launch one with: just review "<claim>"`);
+  const started = Date.now();
+  const sentinel = `${logPath}.status`;
+  for (;;) {
+    if (existsSync(sentinel)) {
+      const reviewerExitCode = Number.parseInt(readFileSync(sentinel, "utf8").trim(), 10);
+      const review = readFileSync(logPath, "utf8");
+      return reviewerExitCode === 0 ? { state: "finished", reviewerExitCode, review } : { state: "failed", reviewerExitCode, review };
+    }
+    if (Date.now() - started >= deadlineMs) return { state: "waiting" };
+    await sleep(pollMs);
+  }
+}
+
+function usage(message: string): never {
+  console.error(`${message}\nusage: bun scripts/review-wait.ts <log> [--deadline-minutes N]`);
+  process.exit(2);
+}
+
+async function main(): Promise<void> {
+  const [logPath, flag, minutes] = process.argv.slice(2);
+  if (!logPath) usage("a review log path is required");
+  if (flag !== undefined && flag !== "--deadline-minutes") usage(`unknown argument '${flag}'`);
+  if (flag === "--deadline-minutes" && !/^[1-9]\d*$/.test(minutes ?? "")) usage("--deadline-minutes needs a positive integer");
+
+  const result = await awaitReview(logPath, minutes ? { deadlineMs: Number(minutes) * 60 * 1000 } : {});
+  if (result.state === "waiting") {
+    console.error(`still reviewing after the deadline; it is still running — re-run: bun scripts/review-wait.ts ${logPath}`);
+    process.exit(3);
+  }
+  console.log(result.review);
+  if (result.state === "failed") {
+    console.error(`the reviewer exited ${result.reviewerExitCode}; the output above is not a review`);
+    process.exit(3);
+  }
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error(`review-wait: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(2);
+  });
+}

--- a/tests/unit/backlog-conveyor.test.ts
+++ b/tests/unit/backlog-conveyor.test.ts
@@ -14,6 +14,7 @@ import {
   loadMarker,
   parseGateEvidence,
   parseGateMarker,
+  selectNextIssue,
   sync,
   type CloseFacts,
   type GateEvidence,
@@ -351,6 +352,31 @@ describe("backlog sync", () => {
 
     await expect(sync(runner, true)).rejects.toThrow("gh api check runs failed (1): rate limited");
     expect(calls.some((argv) => argv[0] === "gh" && argv[1] === "pr" && argv[2] === "edit")).toBe(false);
+  });
+});
+
+// Step 1 of the loop is "take the oldest open issue carrying neither WIP nor needs-decision".
+// sync already holds every issue, so naming it costs no extra call — and an agent that has to
+// re-derive it from a second `gh issue list` reads "oldest" as "least recently updated".
+describe("next ticket selection", () => {
+  const issues = [
+    { number: 1032, state: "CLOSED", labels: [] },
+    { number: 1040, state: "OPEN", labels: ["WIP"] },
+    { number: 1041, state: "OPEN", labels: ["needs-decision"] },
+    { number: 1042, state: "OPEN", labels: ["enhancement"] },
+    { number: 1043, state: "OPEN", labels: [] },
+  ];
+
+  test("takes the oldest open issue that is neither in flight nor blocked on the maintainer", () => {
+    expect(selectNextIssue(issues)).toBe(1042);
+  });
+
+  test("reports no ticket rather than an arbitrary one when the queue is exhausted", () => {
+    expect(selectNextIssue(issues.filter((issue) => issue.state !== "OPEN"))).toBeNull();
+  });
+
+  test("orders by issue number, which is creation order, not by list order", () => {
+    expect(selectNextIssue([...issues].reverse())).toBe(1042);
   });
 });
 

--- a/tests/unit/check-recipes.test.ts
+++ b/tests/unit/check-recipes.test.ts
@@ -453,6 +453,7 @@ describe("the repository's own references", () => {
       "release",
       "release-tag",
       "review",
+      "review-wait",
       "rust-test",
       "smoke-test",
       "test",

--- a/tests/unit/mutate.test.ts
+++ b/tests/unit/mutate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mutate } from "../../scripts/mutate";
+import { mutate, verdict } from "../../scripts/mutate";
 
 describe("mutate", () => {
   // A perl one-liner whose pattern misses exits 0 and changes nothing, so the test passes and the
@@ -22,5 +22,32 @@ describe("mutate", () => {
 
   test("refuses an empty needle instead of splitting every character", () => {
     expect(() => mutate("abc", "", "x")).toThrow("must not be empty");
+  });
+});
+
+describe("verdict", () => {
+  const log = ["compiling", "running", "(fail) it refuses", "1 fail", "Ran 3 tests"].join("\n");
+
+  test("a caught mutation reports the run's last lines, not the failure it was asking for", () => {
+    const result = verdict({ exitCode: 1, log }, 2);
+
+    expect(result.pinned).toBe(true);
+    expect(result.report).toBe("1 fail\nRan 3 tests");
+    expect(result.report).not.toContain("compiling");
+  });
+
+  // A test command that never ran a test — a build error, a filter matching nothing — exits
+  // non-zero and would otherwise read exactly like a caught assertion.
+  test("keeps enough of a caught run to tell an assertion from a command that never ran", () => {
+    const result = verdict({ exitCode: 101, log: "error: could not compile `kesha-engine`" }, 2);
+
+    expect(result.report).toContain("could not compile");
+  });
+
+  test("a surviving mutation reports the whole run, because nothing failed to point at", () => {
+    const result = verdict({ exitCode: 0, log }, 2);
+
+    expect(result.pinned).toBe(false);
+    expect(result.report).toBe(log);
   });
 });

--- a/tests/unit/preflight-parity.test.ts
+++ b/tests/unit/preflight-parity.test.ts
@@ -43,6 +43,16 @@ describe("preflight is the gate CLAUDE.md claims it is", () => {
     expect(missing).toEqual([]);
   });
 
+  // A green gate's output is never read, and every line of it is context an agent pays for.
+  test("it runs every gate through the quiet wrapper", () => {
+    const loud = preflightBody()
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => /^(bun run |cargo |\{\{ just_executable\(\) \}\})/.test(line));
+
+    expect(loud).toEqual([]);
+  });
+
   test("it reports a stale checkout rather than staying silent about it", () => {
     // The number is already computed for the gate selection; a checkout 14 commits behind had an
     // agent reading a stale CLAUDE.md for nine hours before anyone noticed (#1070).

--- a/tests/unit/quiet-gate.test.ts
+++ b/tests/unit/quiet-gate.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import { runQuiet } from "../../scripts/quiet-gate";
+
+const SCRIPT = new URL("../../scripts/quiet-gate.ts", import.meta.url).pathname;
+
+async function cli(argv: string[]): Promise<{ code: number; stdout: string; stderr: string }> {
+  const proc = Bun.spawn(["bun", SCRIPT, ...argv], { stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr, code] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text(), proc.exited]);
+  return { code, stdout, stderr };
+}
+
+describe("runQuiet", () => {
+  test("keeps the two streams in the order the command wrote them", async () => {
+    // Separate pipes would report both streams whole, and a failing gate's error would read as
+    // if it happened after output that actually followed it.
+    const result = await runQuiet(["bash", "-c", "echo one; echo two >&2; echo three"]);
+
+    expect(result.log).toBe("one\ntwo\nthree\n");
+  });
+
+  test("propagates the command's exit code", async () => {
+    expect((await runQuiet(["bash", "-c", "exit 7"])).exitCode).toBe(7);
+  });
+
+  test("reports a command that could not start rather than calling it a pass", async () => {
+    const result = await runQuiet(["kesha-no-such-binary"]);
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.log).toContain("kesha-no-such-binary");
+  });
+});
+
+describe("quiet-gate cli", () => {
+  test("a passing gate reports one line and not the output it swallowed", async () => {
+    const result = await cli(["unit", "--", "bash", "-c", "echo 1339 pass; echo 9 skip"]);
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("unit");
+    expect(result.stdout).not.toContain("1339 pass");
+    expect(result.stderr).not.toContain("1339 pass");
+  });
+
+  test("a failing gate prints what it ran verbatim, so the failure is never swallowed", async () => {
+    const result = await cli(["unit", "--", "bash", "-c", "echo 1 fail; echo boom >&2; exit 3"]);
+
+    expect(result.code).toBe(3);
+    expect(`${result.stdout}${result.stderr}`).toContain("1 fail");
+    expect(`${result.stdout}${result.stderr}`).toContain("boom");
+  });
+
+  test("refuses a call with no command instead of reporting an empty gate as green", async () => {
+    const result = await cli(["unit"]);
+
+    expect(result.code).toBe(2);
+    expect(result.stderr).toContain("usage");
+  });
+});

--- a/tests/unit/quiet-gate.test.ts
+++ b/tests/unit/quiet-gate.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
 import { runQuiet } from "../../scripts/quiet-gate";
 
-const SCRIPT = new URL("../../scripts/quiet-gate.ts", import.meta.url).pathname;
+// process.execPath, not "bun": a bare name fails uv_spawn on Windows. import.meta.dir is
+// Bun-native and absolute, where a file URL's pathname keeps the leading slash Windows rejects.
+const SCRIPT = join(import.meta.dir, "..", "..", "scripts", "quiet-gate.ts");
 
 async function cli(argv: string[]): Promise<{ code: number; stdout: string; stderr: string }> {
-  const proc = Bun.spawn(["bun", SCRIPT, ...argv], { stdout: "pipe", stderr: "pipe" });
+  const proc = Bun.spawn([process.execPath, SCRIPT, ...argv], { stdout: "pipe", stderr: "pipe" });
   const [stdout, stderr, code] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text(), proc.exited]);
   return { code, stdout, stderr };
 }

--- a/tests/unit/review-wait.test.ts
+++ b/tests/unit/review-wait.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { awaitReview } from "../../scripts/review-wait";
+
+function logIn(directory: string, contents: string): string {
+  const path = join(directory, "review-1086-deadbeef.log");
+  writeFileSync(path, contents);
+  return path;
+}
+
+describe("awaitReview", () => {
+  test("returns the review once, rather than the caller re-reading a growing log", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "kesha-review-wait-"));
+    const path = logIn(directory, "P1: the guard is unpinned\n");
+    writeFileSync(`${path}.status`, "0\n");
+
+    await expect(awaitReview(path, { deadlineMs: 0, pollMs: 1 })).resolves.toEqual({
+      state: "finished",
+      reviewerExitCode: 0,
+      review: "P1: the guard is unpinned\n",
+    });
+  });
+
+  test("waits for the sentinel the reviewer writes when it exits", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "kesha-review-wait-"));
+    const path = logIn(directory, "partial");
+    setTimeout(() => {
+      writeFileSync(path, "complete\n");
+      writeFileSync(`${path}.status`, "0\n");
+    }, 30);
+
+    const result = await awaitReview(path, { deadlineMs: 5000, pollMs: 5 });
+
+    expect(result).toMatchObject({ state: "finished", review: "complete\n" });
+  });
+
+  // A reviewer that died owes the caller a review it will never write; reporting the log as a
+  // finished review would send its truncated output to the pull request as findings.
+  test("reports a reviewer that failed instead of passing its output off as findings", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "kesha-review-wait-"));
+    const path = logIn(directory, "omc: command not found\n");
+    writeFileSync(`${path}.status`, "127\n");
+
+    const result = await awaitReview(path, { deadlineMs: 0, pollMs: 1 });
+
+    expect(result).toMatchObject({ state: "failed", reviewerExitCode: 127 });
+  });
+
+  test("gives up at the deadline rather than blocking forever", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "kesha-review-wait-"));
+    const path = logIn(directory, "still thinking");
+
+    await expect(awaitReview(path, { deadlineMs: 10, pollMs: 5 })).resolves.toMatchObject({ state: "waiting" });
+  });
+
+  test("refuses a log no review ever wrote, rather than waiting out the deadline on a typo", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "kesha-review-wait-"));
+
+    await expect(awaitReview(join(directory, "absent.log"), { deadlineMs: 10, pollMs: 5 })).rejects.toThrow("absent.log");
+  });
+});


### PR DESCRIPTION
## What

Today's conveyor work made the loop's *decisions* cheap — one review command, one
gate command, one evidence builder. This does the same for what the loop **prints**
and for the steps an agent still performs by hand.

- **`scripts/quiet-gate.ts`** runs a labelled command with **one shared file
  descriptor for stdout and stderr**, so the buffered log keeps the order the
  command wrote it. `✓ label 54.4s` on a pass; on a failure the log **verbatim**,
  the kept log path, and the child's exit code. `preflight` runs every gate through
  it, so a green run prints one line per gate instead of ~600.
- **`just mutate`** reports a caught mutation by its **tail**, not in full. Not by
  zero lines: a build error or a filterset matching nothing also exits non-zero and
  would otherwise read exactly like a caught assertion. A survivor still prints
  whole, being the surprising outcome.
- **`just review`** refuses a reviewer that is not on PATH, writes a `<log>.status`
  sentinel holding the reviewer's exit code, and **`just review-wait <log>`** blocks
  on that sentinel and prints the review once — or reports that the reviewer died
  rather than passing its output off as findings. Its three `gh pr view` calls
  become one: read separately, the number and the head SHA can straddle a push.
- **`conveyor sync`** ends with `next ticket: #N` — the lowest open issue number
  carrying neither `WIP` nor `needs-decision` — from issues it already loaded, for
  no extra API call. Additive `nextIssue` under `--json`; the schema stays at 1.
- **`/land`** runs `just gate` and reads its violations instead of re-deriving them
  in prose, then closes through `conveyor close`. **`/await-review`** blocks with
  `gh pr checks --watch` and then asks once for what is not green.

## Why

Measured on a fresh checkout of `main` before the change:

| Step | Cost |
|---|---|
| `just preflight` | every gate's output, green or red — `bun run test` alone is 197 lines / 9.4 KB, and there are 8 TS gates plus up to 3 Rust ones |
| `just mutate` | a **caught** mutation printed the whole failing suite — the outcome it asked for |
| `just review` | detached with no completion signal, so the caller polls a growing log and pays for the whole file each look; a reviewer missing from PATH still printed "launched in background" |
| loop step 1 | `sync`, then a second `gh issue list` and the selection rule applied by hand, where "oldest" reads as "least recently updated" |
| `/await-review` | poll `gh pr checks` every ~50 s for up to 20 min, every poll's table into context |
| `/land` | the merge gate re-derived in prose that `just gate` already enforces in code, free to drift from it |

`docs/runbooks/backlog-conveyor.md` said "`bun run test` prints 332 lines and no
flag shortens it" — no longer true, so it is gone.

Refs #1068, #1071, #1079.

## Testing

- `bun run test` — 1541 pass, 1 fail. The one failure is `tests/unit/doctor.test.ts:342`,
  which `chmod 000`s a directory and asserts the read fails; it fails on any checkout
  run **as root** and is untouched by this diff. Reproduced on `origin/main` before
  the first edit here.
- Every other preflight gate green: `lint`, `check:recipes`, `check:workflows`,
  `check:versions`, `check:specs`, `check:engine-targets`, `check:release-manifest`.
  No `rust/` changes, so the Rust and CoreML gates were correctly skipped.
- `just preflight` end to end: on the failing gate it printed that gate's log
  verbatim and stopped; the surviving gates print one line each.
- `just review` / `just review-wait` exercised end to end against a stub `gh` and a
  stub reviewer: the sentinel path, the launch race (the log exists before the recipe
  returns), a reviewer missing from PATH (exit 2), and a reviewer that dies (exit 3,
  reported as not-a-review).
- New guards, each proved with `bun scripts/mutate.ts`: `tests/unit/quiet-gate.test.ts`,
  `tests/unit/review-wait.test.ts`, the `verdict` cases in `tests/unit/mutate.test.ts`,
  next-ticket selection in `tests/unit/backlog-conveyor.test.ts`, and a
  `preflight-parity` case that fails if any preflight gate runs loud again.

## Checklist

- [x] `bun run check` passes (lint + version drift + fast tests)
- [x] Tests added/updated for the change
- [ ] Rust changes — none in this PR
- [x] Docs updated: `CLAUDE.md`, both conveyor runbooks, and the `/land`,
      `/await-review`, `/preflight` command files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DiFrNwMupZF4oxxkkLkaRX

---
_Generated by [Claude Code](https://claude.ai/code/session_01DiFrNwMupZF4oxxkkLkaRX)_