### PR TITLE
rust-test: give lint-ubuntu the timeout coverage already has

### DIFF
--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -295,6 +295,7 @@ export function requirePactVerificationCoversEveryTarget(path: string, document:
  */
 type Job = {
   "runs-on"?: unknown;
+  "timeout-minutes"?: number;
   steps?: unknown[];
   strategy?: { matrix?: unknown };
   defaults?: { run?: { shell?: unknown } };

--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -469,6 +469,43 @@ export function requireRestoreOnlyCachesHaveAWriter(
 }
 
 /**
+ * Fails when a job on Ubuntu invokes apt-get without a timeout bound strictly below 360 minutes.
+ * An apt mirror stall burns GitHub's full 6-hour default if unbounded; 30-60 minutes stops the burn (#1090).
+ */
+export function requireAptTimeouts(path: string, document: unknown): string[] {
+  if (!path.endsWith("rust-test.yml")) return [];
+
+  const jobs = (document as { jobs?: Record<string, Job> })?.jobs;
+  if (!jobs || typeof jobs !== "object") return [];
+
+  const errors: string[] = [];
+  for (const [name, job] of Object.entries(jobs)) {
+    const labels = runnerLabels(job);
+    if (labels.length === 0 || !labels.some((label) => /ubuntu/i.test(label))) continue;
+
+    const steps = Array.isArray(job?.steps) ? (job.steps as Step[]) : [];
+    const hasAptGet = steps.some((step) => typeof step?.run === "string" && /apt-get/i.test(step.run));
+    if (!hasAptGet) continue;
+
+    const timeout = job["timeout-minutes"];
+    if (timeout === undefined) {
+      errors.push(
+        `${path}: \`${name}\` runs on Ubuntu and invokes apt-get, but has no \`timeout-minutes\`; an apt stall burns 360 minutes unattended (#1090)`,
+      );
+    } else {
+      const timeoutNum = Number(timeout);
+      if (isNaN(timeoutNum) || timeoutNum >= 360) {
+        errors.push(
+          `${path}: \`${name}\` runs on Ubuntu and invokes apt-get, but \`timeout-minutes: ${timeout}\` is not strictly below 360; an apt stall exceeds this bound (#1090)`,
+        );
+      }
+    }
+  }
+
+  return errors;
+}
+
+/**
  * Fails when a script covered by a unit test sits outside ci.yml's `code` filter.
  * `check:versions` and the unit tests run inside `unit-tests`, which that filter gates,
  * so an uncovered script means edits to a gate skip the tests that prove it works.
@@ -568,6 +605,7 @@ export function checkFile(
       ...requirePactVerificationCoversEveryTarget(path, document),
       ...requireBashOnWindowsRunSteps(path, document),
       ...requirePipefailShell(path, document),
+      ...requireAptTimeouts(path, document),
       ...requireDepsBeforeBunTest(path, document),
       ...requireRestoreOnlyCachesHaveAWriter(path, document, cacheWriters),
       ...requireTestedScriptsInCodeFilter(path, document, testedScripts),

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -76,6 +76,7 @@ jobs:
     needs: changes
     if: github.event_name == 'pull_request' && needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -371,6 +371,7 @@ jobs:
       contents: read
       id-token: write
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -76,7 +76,7 @@ jobs:
     needs: changes
     if: github.event_name == 'pull_request' && needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
@@ -371,7 +371,7 @@ jobs:
       contents: read
       id-token: write
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -619,19 +619,19 @@ describe("requireAptTimeouts", () => {
     expect(errors[0]).toContain("not strictly below 360");
   });
 
-  test("passes when timeout-minutes is 30", () => {
+  test("passes when timeout-minutes is 10", () => {
     const doc = {
       jobs: {
-        lint: { "runs-on": "ubuntu-latest", "timeout-minutes": 30, steps: [{ run: "sudo apt-get install -y libopus-dev" }] },
+        lint: { "runs-on": "ubuntu-latest", "timeout-minutes": 10, steps: [{ run: "sudo apt-get install -y libopus-dev" }] },
       },
     };
     expect(requireAptTimeouts(RUST_TEST, doc)).toEqual([]);
   });
 
-  test("passes when timeout-minutes is 60", () => {
+  test("passes when timeout-minutes is 15", () => {
     const doc = {
       jobs: {
-        push: { "runs-on": "ubuntu-latest", "timeout-minutes": 60, steps: [{ run: "sudo apt-get install -y libopus-dev" }] },
+        push: { "runs-on": "ubuntu-latest", "timeout-minutes": 15, steps: [{ run: "sudo apt-get install -y libopus-dev" }] },
       },
     };
     expect(requireAptTimeouts(RUST_TEST, doc)).toEqual([]);

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -636,4 +636,14 @@ describe("requireAptTimeouts", () => {
     };
     expect(requireAptTimeouts(RUST_TEST, doc)).toEqual([]);
   });
+
+  // A gate is only a gate if checkFile still calls it, and the live suite cannot notice a
+  // dropped check because the tree it reads is already clean. This test names a rust-test.yml
+  // file so the endsWith check enables the rule.
+  test("the file gate actually runs it", () => {
+    const yaml = "on: push\njobs:\n  lint:\n    runs-on: ubuntu-latest\n    steps:\n      - run: sudo apt-get install -y libopus-dev\n";
+    const path = join(mkdtempSync(join(tmpdir(), "kesha-wf-")), "rust-test.yml");
+    writeFileSync(path, yaml);
+    expect(checkFile(path, [], [], undefined).filter((e) => e.includes("#1090"))).toHaveLength(1);
+  });
 });

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -6,6 +6,7 @@ import {
   checkFile,
   collectCacheWriters,
   forbidLinuxPackaging,
+  requireAptTimeouts,
   requireBashOnWindowsRunSteps,
   requirePipefailShell,
   requireRestoreOnlyCachesHaveAWriter,
@@ -559,5 +560,80 @@ describe("Rust toolchain pin", () => {
       const path = `.github/workflows/${file}`;
       expect([path, requirePinnedRustToolchain(path, parseRepoYaml(path), PIN)]).toEqual([path, []]);
     }
+  });
+});
+
+describe("requireAptTimeouts", () => {
+  const RUST_TEST = ".github/workflows/rust-test.yml";
+
+  test("passes on the real rust-test.yml", () => {
+    expect(requireAptTimeouts(RUST_TEST, parseRepoYaml(RUST_TEST))).toEqual([]);
+  });
+
+  test("ignores non-rust-test workflows", () => {
+    const doc = {
+      jobs: {
+        test: { "runs-on": "ubuntu-latest", steps: [{ run: "sudo apt-get install x" }] },
+      },
+    };
+    expect(requireAptTimeouts(CI, doc)).toEqual([]);
+  });
+
+  test("ignores jobs that do not run on ubuntu", () => {
+    const doc = {
+      jobs: {
+        test: { "runs-on": "macos-14", steps: [{ run: "sudo apt-get install x" }] },
+      },
+    };
+    expect(requireAptTimeouts(RUST_TEST, doc)).toEqual([]);
+  });
+
+  test("ignores jobs that do not invoke apt-get", () => {
+    const doc = {
+      jobs: {
+        test: { "runs-on": "ubuntu-latest", steps: [{ run: "bun test" }] },
+      },
+    };
+    expect(requireAptTimeouts(RUST_TEST, doc)).toEqual([]);
+  });
+
+  test("fails when a job on ubuntu runs apt-get with no timeout-minutes", () => {
+    const doc = {
+      jobs: {
+        lint: { "runs-on": "ubuntu-latest", steps: [{ run: "sudo apt-get install -y libopus-dev" }] },
+      },
+    };
+    const errors = requireAptTimeouts(RUST_TEST, doc);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("has no `timeout-minutes`");
+  });
+
+  test("fails when timeout-minutes is 360 or higher", () => {
+    const doc = {
+      jobs: {
+        lint: { "runs-on": "ubuntu-latest", "timeout-minutes": 360, steps: [{ run: "sudo apt-get install -y libopus-dev" }] },
+      },
+    };
+    const errors = requireAptTimeouts(RUST_TEST, doc);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("not strictly below 360");
+  });
+
+  test("passes when timeout-minutes is 30", () => {
+    const doc = {
+      jobs: {
+        lint: { "runs-on": "ubuntu-latest", "timeout-minutes": 30, steps: [{ run: "sudo apt-get install -y libopus-dev" }] },
+      },
+    };
+    expect(requireAptTimeouts(RUST_TEST, doc)).toEqual([]);
+  });
+
+  test("passes when timeout-minutes is 60", () => {
+    const doc = {
+      jobs: {
+        push: { "runs-on": "ubuntu-latest", "timeout-minutes": 60, steps: [{ run: "sudo apt-get install -y libopus-dev" }] },
+      },
+    };
+    expect(requireAptTimeouts(RUST_TEST, doc)).toEqual([]);
   });
 });


### PR DESCRIPTION
Closes #1090

## What changed

Added `timeout-minutes: 10` to `lint-ubuntu` job (line 79) and `timeout-minutes: 15` to `rust-push-gate` job (line 374). Added `requireAptTimeouts` rule to `.github/scripts/check-workflows.ts` that validates every job in rust-test.yml running on ubuntu with apt-get steps must have timeout-minutes strictly below 360.

**Incident**: The `Install system audio deps (Opus)` step stalled on an apt mirror for 41+ minutes (measured on PR #1086 @ 505ca262). rust-push-gate burned a full 360-minute default on 2026-08-18 — an unattended stall would burn 6 hours.

**Value choice**: lint-ubuntu gets 10 minutes (45s median healthy run, 13x headroom); rust-push-gate gets 15 minutes (90s-150s median healthy run, 6x headroom to cover cold cache). The new rule catches any future unbounded or 360-minute apt jobs via `bun run check:workflows`.

## Deviations from spec

Skipped: cheap aggregator jobs (changes/rust-tests/workflow-lint/ci) — not the apt-stall class; build-engine.yml build job — outside this ticket's named files.

## Docs updated

none

## Mutation evidence

Rule validated with three proofs via `requireAptTimeouts`:
1. Delete timeout-minutes from lint-ubuntu → RED ✓ (`has no \`timeout-minutes\``)
2. Set timeout-minutes to 360 → RED ✓ (`not strictly below 360`)
3. Restore timeout-minutes to 10 → GREEN ✓

Wiring validated (test(check-workflows): the file gate actually runs requireAptTimeouts):
- (a) Delete `...requireAptTimeouts(path, document),` from checkFile → RED ✓ (`requireAptTimeouts > the file gate actually runs it` fails)
- (b) Restore → GREEN ✓

Both jobs now bounded: `bun run check:workflows` passes; `bun test tests/unit/check-workflows.test.ts` passes (100 tests, 9 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vtfj6XSd9jT1b1ryS3SbcQ
