### PR TITLE
fix(models): pin the Kokoro ANE manifest to an immutable upstream revision

### DIFF
--- a/.github/scripts/check-model-plan-sizes.ts
+++ b/.github/scripts/check-model-plan-sizes.ts
@@ -140,15 +140,32 @@ function expandModelFileMacros(source: string): string {
   return stripped;
 }
 
-/** `rel_path` → `url` for every `ModelFile` pinned in models.rs, `cfg` gating included. */
-export function parseManifestUrls(source: string): Map<string, string> {
-  const urls = new Map<string, string>();
+export interface ManifestEntry {
+  relPath: string;
+  url: string;
+}
+
+/**
+ * Every `ModelFile` pinned in models.rs, `cfg` gating included, in source order. English and
+ * Mandarin ANE bundles stage identical basenames into different directories, so `relPath` is
+ * not a unique key across the whole file — callers that need every entry (not just one per
+ * `relPath`) must use this rather than `parseManifestUrls`'s deduping map (#1096 review).
+ */
+export function parseManifestEntries(source: string): ManifestEntry[] {
+  const entries: ManifestEntry[] = [];
   const modelFile = /ModelFile\s*\{\s*rel_path:\s*([\s\S]*?),\s*url:\s*([\s\S]*?),\s*sha256:/g;
   for (const match of expandModelFileMacros(source).matchAll(modelFile)) {
     const relPath = literalValue(match[1] ?? "");
     const url = literalValue(match[2] ?? "");
-    if (relPath && url) urls.set(relPath, url);
+    if (relPath && url) entries.push({ relPath, url });
   }
+  return entries;
+}
+
+/** `rel_path` → `url` for every `ModelFile` pinned in models.rs, `cfg` gating included. */
+export function parseManifestUrls(source: string): Map<string, string> {
+  const urls = new Map<string, string>();
+  for (const { relPath, url } of parseManifestEntries(source)) urls.set(relPath, url);
   return urls;
 }
 

--- a/docs/mutation-evidence/issue-1093.md
+++ b/docs/mutation-evidence/issue-1093.md
@@ -1,12 +1,38 @@
 # Mutation evidence — #1093 (Kokoro ANE manifest pinned to a mutable ref)
 
-Guard: `rust/src/models.rs::manifest_tests::every_huggingface_url_pins_an_immutable_revision`
-asserts every `huggingface.co` URL in every model manifest resolves a 40-hex commit,
-never a mutable ref such as `main`.
+Two guards assert the same rule — no `huggingface.co` manifest URL may resolve through a
+mutable ref such as `main`, only a 40-hex commit — from two different angles, because they
+run in different lanes:
 
-Command used to prove it (matches `just mutate`'s default `FEATURES`, since the ANE
-manifests are `system_kokoro`-gated and never compile under the default `tts`-only
-feature set):
+| Guard | Where it runs | What it sees |
+|---|---|---|
+| `rust/src/models.rs::manifest_tests::every_huggingface_url_pins_an_immutable_revision` | `🧪 Rust Tests` (every PR, default `--features tts` build) | 6 of 7 pinned repos — every manifest **except** the `system_kokoro`-gated ANE ones. Those five macros (`ane_en_file!`, `kokoro_g2p_file!`, `ane_zh_file!`, `ane_zh_asset!`, `ane_kokoro_voice!`) only compile under `--features system_kokoro,target_os=macos,target_arch=aarch64`, and no CI job runs `cargo test`/`nextest` with that combination — the per-PR macos-14 leg only `cargo clippy`s it (`just verify-darwin-full`), which type-checks but never executes `#[test]` bodies. This is the gap Greptile's #1096 review flagged: the guard for the ANE manifests — where the #1093 regression actually lived — was real but CI-invisible. |
+| `tests/unit/check-model-plan-sizes.test.ts > parseManifestUrls > no huggingface.co url in the real manifest resolves through a mutable ref` | `🧪 CI` (every PR, plain `bun test`, no feature gating at all) | **All 7 repos, including the ANE manifests.** Reads `rust/src/models.rs` as text via `parseManifestEntries` (a new export, alongside the existing `parseManifestUrls`), which expands the `ModelFile`-building macros and lists every entry — it isn't compiling Rust, so `#[cfg(...)]` is invisible to it. This is the guard that closes the CI-reach gap: it runs on every PR and would have caught #1093 without needing a macOS `system_kokoro` test lane. |
+
+Keeping both: the Rust guard is the typed one and stays useful wherever it does run
+(local `system_kokoro` builds, `just mutate` locally); the TS guard buys reach without
+adding a new CI lane.
+
+## Why `parseManifestEntries`, not the existing `parseManifestUrls`
+
+`parseManifestUrls` returns a `Map<relPath, url>`. The English (`ANE/`) and Mandarin
+(`ANE-zh/`) ANE bundles stage identical basenames — e.g.
+`KokoroAlbert.mlmodelc/analytics/coremldata.bin` — into different directories at install
+time (`stage_into(&fluidaudio_ane_kokoro_dir()?, ANE_EN_FILES, …)` vs
+`stage_into(&zh, ANE_ZH_FILES, …)`), so `relPath` is not a unique key across the whole
+manifest. Building the URL-pin guard on top of the deduping map would let `ANE_ZH_FILES`
+(declared after `ANE_EN_FILES` in `models.rs`) silently shadow the English entry for every
+colliding key — a guard that looked like it covered "all 7 repos" while actually skipping
+half of one of them. `parseManifestEntries` returns every `{relPath, url}` pair in source
+order instead, with no deduping; `parseManifestUrls` is now defined in terms of it
+(behaviour-preserving for existing callers — same "last declaration wins" map).
+`keeps colliding rel_paths as separate entries rather than letting one shadow the other`
+in `check-model-plan-sizes.test.ts` pins this directly.
+
+## Rust guard — mutation proof
+
+Command (matches `just mutate`'s default `FEATURES`, since the ANE manifests only compile
+under it):
 
 ```
 just mutate rust/src/models.rs \
@@ -19,7 +45,7 @@ just mutate rust/src/models.rs \
 
 | Mutation | Occurrences | Guard result |
 |---|---|---|
-| Revert the `FluidInference/kokoro-82m-coreml` pin from the immutable commit `c94edcb4b6…` back to `main` | 5 | **PINNED** — `every_huggingface_url_pins_an_immutable_revision` fails: `pins mutable ref "main" instead of a 40-hex commit` |
+| Revert the `FluidInference/kokoro-82m-coreml` pin from the immutable commit `c94edcb4b6…` back to `main` | 5 | **PINNED** — fails: `pins mutable ref "main" instead of a 40-hex commit` |
 
 Restore-to-green: `just mutate` restores the file in a `finally` regardless of outcome;
 `cargo nextest run --features tts,system_kokoro,system_diarize --no-default-features --features onnx manifest_tests::every_huggingface_url_pins_an_immutable_revision`
@@ -28,6 +54,45 @@ passes again on the restored file (1 passed, 0 failed).
 The same guard also covers the other 6 pinned repos (`istupakov/parakeet-tdt-0.6b-v3-onnx`,
 `FluidInference/diar-streaming-sortformer-coreml`, `drakulavich/SpeechBrain-coreml`,
 `onnx-community/Kokoro-82M-v1.0-ONNX`, `klebster/g2p_multilingual_byT5_tiny_onnx`,
-`drakulavich/vosk-tts-ru-0.9-multi`) under the default `--features tts` build; only the
-`FluidInference/kokoro-82m-coreml` mutation above was exercised end-to-end because it is
-the repo the ticket's regression came from.
+`drakulavich/vosk-tts-ru-0.9-multi`) under the default `--features tts` build, which is the
+build `🧪 Rust Tests` actually runs.
+
+## TS guard — mutation proof
+
+Both commands run exactly as `🧪 CI` would — no feature flags, no macOS requirement.
+
+**All four ANE macros reverted at once** (the literal shared verbatim across
+`ane_en_file!`, `kokoro_g2p_file!`, `ane_zh_file!`, `ane_zh_asset!`, plus the
+`staged_manifests_are_pinned_and_contained` Rust test assertion — 5 occurrences):
+
+```
+just mutate rust/src/models.rs \
+  'FluidInference/kokoro-82m-coreml/resolve/c94edcb4b671856795458645cd389c0a9184e8bb/' \
+  'FluidInference/kokoro-82m-coreml/resolve/main/' \
+  bun test tests/unit/check-model-plan-sizes.test.ts -t "mutable ref"
+```
+
+| Mutation | Occurrences | Guard result |
+|---|---|---|
+| Revert all four ANE macros' pin to `main` | 5 | **PINNED** — fails, naming all 94 affected manifest entries (37 `ANE/` + 12 shared G2P + 43 `ANE-zh/` + 2 pinyin assets) |
+
+**English-only regression** — reverts *only* `ane_en_file!`'s pin, leaving `ane_zh_file!`
+correctly pinned. This is the mutation that specifically exercises the `relPath` collision
+fix: against the old `parseManifestUrls`-backed test, the later-declared, still-correctly-pinned
+`ANE_ZH_FILES` entry would have shadowed every colliding `ANE_EN_FILES` key in the map and
+the guard would have missed this regression entirely.
+
+```
+just mutate rust/src/models.rs \
+  $'"https://huggingface.co/FluidInference/kokoro-82m-coreml/resolve/c94edcb4b671856795458645cd389c0a9184e8bb/",\n                "ANE/",' \
+  $'"https://huggingface.co/FluidInference/kokoro-82m-coreml/resolve/main/",\n                "ANE/",' \
+  bun test tests/unit/check-model-plan-sizes.test.ts -t "mutable ref"
+```
+
+| Mutation | Occurrences | Guard result |
+|---|---|---|
+| Revert only `ane_en_file!`'s pin to `main` (`ANE_ZH_FILES` stays correctly pinned) | 1 | **PINNED** — fails, naming all 37 `ANE_EN_FILES` entries; `ANE_ZH_FILES`'s 43 entries correctly report their still-pinned commit |
+
+Restore-to-green after each: `just mutate` restores the file in a `finally`; `bun test
+tests/unit/check-model-plan-sizes.test.ts -t "mutable ref"` passes again on the restored
+file (1 passed, 0 failed).

--- a/docs/mutation-evidence/issue-1093.md
+++ b/docs/mutation-evidence/issue-1093.md
@@ -32,10 +32,10 @@ into a hard `E_CACHE_CORRUPT` at install rather than a silent swap, which is the
 working as designed — and is also precisely the outage class this ticket is about, so it
 is tempting to fold them in. Deliberately out of scope: the silero-vad tag *could* be
 repinned to a commit SHA (a GitHub tag resolves to one, same as a Hugging Face revision) —
-tracked as a follow-up issue, referenced here once filed. The kokoro-onnx release asset has
-no immutable URL form at all (GitHub release assets are addressed by tag, not commit), so
-for that one file the SHA-256 pin is the only guard there will ever be; widening the "must
-be a 40-hex ref" rule to it would be asserting something that can never hold.
+tracked as #1099. The kokoro-onnx release asset has no immutable URL form at all (GitHub
+release assets are addressed by tag, not commit), so for that one file the SHA-256 pin is
+the only guard there will ever be; widening the "must be a 40-hex ref" rule to it would be
+asserting something that can never hold.
 
 ## Why `parseManifestEntries`, not the existing `parseManifestUrls`
 

--- a/docs/mutation-evidence/issue-1093.md
+++ b/docs/mutation-evidence/issue-1093.md
@@ -70,27 +70,36 @@ fails the `len() == 40` check — proven below rather than assumed.
 
 Every row: `just mutate <file> <find> <replace> <test command>`, restored in a `finally`
 regardless of outcome; every restore was confirmed with a clean `git status --short`
-afterward and a green re-run of the named test.
+afterward and a green re-run of the named test. Every Rust row names the exact
+`cargo nextest` feature flags it ran under, because the guard's reach depends on them:
+rows 2–4 target `VOSK_RU_FILES`, which compiles under the plain `--features tts`
+`🧪 Rust Tests` actually runs, so `PINNED` there is a real CI result. Row 1 targets the
+`system_kokoro`-gated ANE manifest, which does not compile under that flag at all — its
+`PINNED` result is real too, but only for the wider local build the row names, matching
+the `none` reach already recorded in the table above; do not read it as CI coverage.
 
 | # | Guard | File | Test | Mutation | Occurrences | Result |
 |---|---|---|---|---|---|---|
-| 1 | Rust | `rust/src/models.rs` | `manifest_tests::every_huggingface_url_pins_an_immutable_revision` | Revert `FluidInference/kokoro-82m-coreml`'s pin to `main` (all four ANE macros, since they share the literal) | 5 | **PINNED** — `pins mutable ref "main" instead of a 40-hex commit` |
-| 2 | Rust | `rust/src/models.rs` | `manifest_tests::every_huggingface_url_pins_an_immutable_revision` | Revert `drakulavich/vosk-tts-ru-0.9-multi`'s pin to `resolve//` (empty ref / deleted revision) | 1 | **PINNED** — `pins mutable ref "" instead of a 40-hex commit` |
-| 3 | Rust | `rust/src/models.rs` | `manifest_tests::every_huggingface_url_pins_an_immutable_revision` | Revert `drakulavich/vosk-tts-ru-0.9-multi`'s pin to a non-`main`, non-hex ref (`v1.0-legacy`) | 1 | **PINNED** — `pins mutable ref "v1.0-legacy" instead of a 40-hex commit` |
-| 4 | Rust | `rust/src/models.rs` | `manifest_tests::every_huggingface_url_pins_an_immutable_revision` | Delete the `/resolve/<ref>/` segment entirely from `drakulavich/vosk-tts-ru-0.9-multi`'s URL | 1 | **PINNED** — `huggingface.co url has no /resolve/<ref>/ segment` |
+| 1 | Rust | `rust/src/models.rs` | `manifest_tests::every_huggingface_url_pins_an_immutable_revision` | Revert `FluidInference/kokoro-82m-coreml`'s pin to `main` (all four ANE macros, since they share the literal), run via `cargo nextest run --features tts,system_kokoro,system_diarize --no-default-features --features onnx …` — **not** the `--features tts` build `🧪 Rust Tests` runs; required because the ANE macros don't compile without `system_kokoro` | 5 | **PINNED, lane `none`** — `pins mutable ref "main" instead of a 40-hex commit`, on a build no CI job runs as tests |
+| 2 | Rust | `rust/src/models.rs` | `manifest_tests::every_huggingface_url_pins_an_immutable_revision` | Revert `drakulavich/vosk-tts-ru-0.9-multi`'s pin to `resolve//` (empty ref / deleted revision), run via `cargo nextest run --features tts …` — the same default build `🧪 Rust Tests` runs | 1 | **PINNED** — `pins mutable ref "" instead of a 40-hex commit` |
+| 3 | Rust | `rust/src/models.rs` | `manifest_tests::every_huggingface_url_pins_an_immutable_revision` | Revert `drakulavich/vosk-tts-ru-0.9-multi`'s pin to a non-`main`, non-hex ref (`v1.0-legacy`), run via `cargo nextest run --features tts …` — same default build | 1 | **PINNED** — `pins mutable ref "v1.0-legacy" instead of a 40-hex commit` |
+| 4 | Rust | `rust/src/models.rs` | `manifest_tests::every_huggingface_url_pins_an_immutable_revision` | Delete the `/resolve/<ref>/` segment entirely from `drakulavich/vosk-tts-ru-0.9-multi`'s URL, run via `cargo nextest run --features tts …` — same default build | 1 | **PINNED** — `huggingface.co url has no /resolve/<ref>/ segment` |
 | 5 | TS | `tests/unit/check-model-plan-sizes.test.ts` | `parseManifestUrls > no Hugging Face manifest URL resolves through a mutable ref` | Revert `FluidInference/kokoro-82m-coreml`'s pin to `main` (all four ANE macros) | 5 | **PINNED** — fails, naming all 94 affected manifest entries (37 `ANE/` + 12 shared G2P + 43 `ANE-zh/` + 2 pinyin assets) |
 | 6 | TS | `tests/unit/check-model-plan-sizes.test.ts` | `parseManifestUrls > no Hugging Face manifest URL resolves through a mutable ref` | Revert **only** `ane_en_file!`'s pin to `main`, leaving `ane_zh_file!` correctly pinned (the `relPath`-collision case) | 1 | **PINNED** — fails, naming all 37 `ANE_EN_FILES` entries; `ANE_ZH_FILES`'s 43 entries correctly report their still-pinned commit |
 | 7 | TS | `tests/unit/check-model-plan-sizes.test.ts` | `parseManifestUrls > no Hugging Face manifest URL resolves through a mutable ref` | Revert `drakulavich/vosk-tts-ru-0.9-multi`'s pin to `resolve//` (empty ref / deleted revision — the exact hole review round 2 found) | 1 | **PINNED** — fails, naming all 5 `VOSK_RU_FILES` entries; before the ref-parsing fix this mutation **survived** (`NOT PINNED`) |
 | 8 | TS | `tests/unit/check-model-plan-sizes.test.ts` | `parseManifestUrls > no Hugging Face manifest URL resolves through a mutable ref` | Revert `drakulavich/vosk-tts-ru-0.9-multi`'s pin to a non-`main`, non-hex ref (`v1.0-legacy`) | 1 | **PINNED** — fails, naming all 5 `VOSK_RU_FILES` entries |
 | 9 | TS | `tests/unit/check-model-plan-sizes.test.ts` | `parseManifestUrls > no Hugging Face manifest URL resolves through a mutable ref` | Delete the `/resolve/<ref>/` segment entirely from `drakulavich/vosk-tts-ru-0.9-multi`'s URL | 1 | **PINNED** — fails, naming all 5 `VOSK_RU_FILES` entries |
 
-Rows 1 and 5 are the ticket's actual regression, reproduced exactly. Rows 2–4 and 7–9
-prove both guards generalise past a `main`-only denylist: an empty ref, a plausible-looking
-but non-hex ref, and a URL with no `/resolve/` segment at all are all caught, not just the
-literal string `main`. Row 6 proves the `relPath`-collision fix does something — against
-the pre-fix, map-based approach this regression would have been invisible. Row 7 is the
-one review round 2 asked for by name; the pre-fix guard's `NOT PINNED` result for it was
-reproduced and is the reason rows 5–9 exist in their current (post-fix) form.
+Rows 1 and 5 are the ticket's actual regression, reproduced exactly — but only row 5 is a
+CI result; row 1 needed the wider, non-CI `system_kokoro` build to compile at all (review
+round 4), which is the whole reason this PR needed the TS guard in the first place. Rows
+2–4 and 7–9 prove both guards generalise past a `main`-only denylist: an empty ref, a
+plausible-looking but non-hex ref, and a URL with no `/resolve/` segment at all are all
+caught, not just the literal string `main`. Row 6 proves the `relPath`-collision fix does
+something — against the pre-fix, map-based approach this regression would have been
+invisible. Row 7 is the one review round 2 asked for by name; the pre-fix guard's
+`NOT PINNED` result for it was reproduced and is the reason rows 5–9 exist in their
+current (post-fix) form.
 
 **Known drift risk in this table:** the "Test" column repeats each guard's exact function
 or `test(...)` name in prose, and nothing re-checks that string against the source if

--- a/docs/mutation-evidence/issue-1093.md
+++ b/docs/mutation-evidence/issue-1093.md
@@ -1,0 +1,33 @@
+# Mutation evidence — #1093 (Kokoro ANE manifest pinned to a mutable ref)
+
+Guard: `rust/src/models.rs::manifest_tests::every_huggingface_url_pins_an_immutable_revision`
+asserts every `huggingface.co` URL in every model manifest resolves a 40-hex commit,
+never a mutable ref such as `main`.
+
+Command used to prove it (matches `just mutate`'s default `FEATURES`, since the ANE
+manifests are `system_kokoro`-gated and never compile under the default `tts`-only
+feature set):
+
+```
+just mutate rust/src/models.rs \
+  'FluidInference/kokoro-82m-coreml/resolve/c94edcb4b671856795458645cd389c0a9184e8bb/' \
+  'FluidInference/kokoro-82m-coreml/resolve/main/' \
+  cargo nextest run --manifest-path rust/Cargo.toml \
+    --features tts,system_kokoro,system_diarize --no-default-features --features onnx \
+    manifest_tests::every_huggingface_url_pins_an_immutable_revision
+```
+
+| Mutation | Occurrences | Guard result |
+|---|---|---|
+| Revert the `FluidInference/kokoro-82m-coreml` pin from the immutable commit `c94edcb4b6…` back to `main` | 5 | **PINNED** — `every_huggingface_url_pins_an_immutable_revision` fails: `pins mutable ref "main" instead of a 40-hex commit` |
+
+Restore-to-green: `just mutate` restores the file in a `finally` regardless of outcome;
+`cargo nextest run --features tts,system_kokoro,system_diarize --no-default-features --features onnx manifest_tests::every_huggingface_url_pins_an_immutable_revision`
+passes again on the restored file (1 passed, 0 failed).
+
+The same guard also covers the other 6 pinned repos (`istupakov/parakeet-tdt-0.6b-v3-onnx`,
+`FluidInference/diar-streaming-sortformer-coreml`, `drakulavich/SpeechBrain-coreml`,
+`onnx-community/Kokoro-82M-v1.0-ONNX`, `klebster/g2p_multilingual_byT5_tiny_onnx`,
+`drakulavich/vosk-tts-ru-0.9-multi`) under the default `--features tts` build; only the
+`FluidInference/kokoro-82m-coreml` mutation above was exercised end-to-end because it is
+the repo the ticket's regression came from.

--- a/docs/mutation-evidence/issue-1093.md
+++ b/docs/mutation-evidence/issue-1093.md
@@ -1,13 +1,13 @@
 # Mutation evidence — #1093 (Kokoro ANE manifest pinned to a mutable ref)
 
-Two guards assert the same rule — no `huggingface.co` manifest URL may resolve through a
+Two guards assert the same rule — no **Hugging Face manifest URL** may resolve through a
 mutable ref, only a 40-hex commit — from two different angles, because they run in
 different lanes, and each has known reach:
 
-| Guard | File | Where it runs | Reach |
-|---|---|---|---|
-| `every_huggingface_url_pins_an_immutable_revision` | `rust/src/models.rs` (`manifest_tests` mod) | `🧪 Rust Tests` (every PR, default `--features tts` build) | 6 of 7 pinned repos — every manifest **except** the `system_kokoro`-gated ANE ones. Those five macros (`ane_en_file!`, `kokoro_g2p_file!`, `ane_zh_file!`, `ane_zh_asset!`, `ane_kokoro_voice!`) only compile under `--features system_kokoro,target_os=macos,target_arch=aarch64`, and no CI job runs `cargo test`/`nextest` with that combination — the per-PR macos-14 leg only `cargo clippy`s it (`just verify-darwin-full`), which type-checks but never executes `#[test]` bodies. |
-| `no huggingface.co url in the real manifest resolves through a mutable ref` | `tests/unit/check-model-plan-sizes.test.ts` (`parseManifestUrls` describe) | `🧪 CI` (every PR, plain `bun test`, no feature gating at all) | **All 7 repos, including the ANE manifests.** Reads `rust/src/models.rs` as text via `parseManifestEntries` (new export in `.github/scripts/check-model-plan-sizes.ts`), which expands the `ModelFile`-building macros and lists every entry — it isn't compiling Rust, so `#[cfg(...)]` is invisible to it. This is the guard that closes the CI-reach gap Greptile's #1096 review round 1 flagged: it runs on every PR and would have caught #1093 without a macOS `system_kokoro` test lane. |
+| Guard | File | Test | Where it runs | Reach |
+|---|---|---|---|---|
+| Rust | `rust/src/models.rs` | `manifest_tests::every_huggingface_url_pins_an_immutable_revision` | `🧪 Rust Tests` (every PR, default `--features tts` build) | 6 of 7 pinned repos — every manifest **except** the `system_kokoro`-gated ANE ones. Those five macros (`ane_en_file!`, `kokoro_g2p_file!`, `ane_zh_file!`, `ane_zh_asset!`, `ane_kokoro_voice!`) only compile under `--features system_kokoro,target_os=macos,target_arch=aarch64`, and no CI job runs `cargo test`/`nextest` with that combination — the per-PR macos-14 leg only `cargo clippy`s it (`just verify-darwin-full`), which type-checks but never executes `#[test]` bodies. |
+| TS | `tests/unit/check-model-plan-sizes.test.ts` | `parseManifestUrls > no Hugging Face manifest URL resolves through a mutable ref` | `🧪 CI` (every PR, plain `bun test`, no feature gating at all) | **All 7 repos, including the ANE manifests.** Reads `rust/src/models.rs` as text via `parseManifestEntries` (new export in `.github/scripts/check-model-plan-sizes.ts`), which expands the `ModelFile`-building macros and lists every entry — it isn't compiling Rust, so `#[cfg(...)]` is invisible to it. This is the guard that closes the CI-reach gap Greptile's #1096 review round 1 flagged: it runs on every PR and would have caught #1093 without a macOS `system_kokoro` test lane. |
 
 **Reach note on a third, older assertion:** `staged_manifests_are_pinned_and_contained` at
 `rust/src/models.rs:2731` also asserts a URL prefix against the Kokoro ANE manifests, but
@@ -15,6 +15,27 @@ it has the exact same `system_kokoro`-gated compile requirement as the guard abo
 **no CI lane executes it either** — its reach is `none`. It stays in the suite (useful on
 a local `system_kokoro` build) but the TS guard above, not this one, is what actually
 protects `🧪 CI`; do not read the Rust assertion at that line as a live gate.
+
+## Scope: Hugging Face manifest URLs only
+
+Both guards check `startsWith("https://huggingface.co/")` / `strip_prefix("https://huggingface.co/")`
+and skip anything else. Two manifest URLs are GitHub-hosted and neither is immutable
+either, but on purpose neither is in scope here:
+
+- `rust/src/models.rs:72` — `snakers4/silero-vad/raw/v6.2.1/…` resolves through a **git
+  tag**, which can be moved or recreated.
+- `rust/src/models.rs:202` — `thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0/…`
+  is a **GitHub release asset**, which can be deleted and re-uploaded under the same tag.
+
+Either would fail exactly the way #1093 failed: the SHA-256 pin turns the upstream move
+into a hard `E_CACHE_CORRUPT` at install rather than a silent swap, which is the pin
+working as designed — and is also precisely the outage class this ticket is about, so it
+is tempting to fold them in. Deliberately out of scope: the silero-vad tag *could* be
+repinned to a commit SHA (a GitHub tag resolves to one, same as a Hugging Face revision) —
+tracked as a follow-up issue, referenced here once filed. The kokoro-onnx release asset has
+no immutable URL form at all (GitHub release assets are addressed by tag, not commit), so
+for that one file the SHA-256 pin is the only guard there will ever be; widening the "must
+be a 40-hex ref" rule to it would be asserting something that can never hold.
 
 ## Why `parseManifestEntries`, not the existing `parseManifestUrls`
 
@@ -51,17 +72,17 @@ Every row: `just mutate <file> <find> <replace> <test command>`, restored in a `
 regardless of outcome; every restore was confirmed with a clean `git status --short`
 afterward and a green re-run of the named test.
 
-| # | Guard (file, test) | Mutation | File mutated | Occurrences | Result |
-|---|---|---|---|---|---|
-| 1 | Rust — `rust/src/models.rs`, `manifest_tests::every_huggingface_url_pins_an_immutable_revision` | Revert `FluidInference/kokoro-82m-coreml`'s pin to `main` (all four ANE macros, since they share the literal) | `rust/src/models.rs` | 5 | **PINNED** — `pins mutable ref "main" instead of a 40-hex commit` |
-| 2 | Rust — same | Revert `drakulavich/vosk-tts-ru-0.9-multi`'s pin to `resolve//` (empty ref / deleted revision) | `rust/src/models.rs` | 1 | **PINNED** — `pins mutable ref "" instead of a 40-hex commit` |
-| 3 | Rust — same | Revert `drakulavich/vosk-tts-ru-0.9-multi`'s pin to a non-`main`, non-hex ref (`v1.0-legacy`) | `rust/src/models.rs` | 1 | **PINNED** — `pins mutable ref "v1.0-legacy" instead of a 40-hex commit` |
-| 4 | Rust — same | Delete the `/resolve/<ref>/` segment entirely from `drakulavich/vosk-tts-ru-0.9-multi`'s URL | `rust/src/models.rs` | 1 | **PINNED** — `huggingface.co url has no /resolve/<ref>/ segment` |
-| 5 | TS — `tests/unit/check-model-plan-sizes.test.ts`, `parseManifestUrls > no huggingface.co url in the real manifest resolves through a mutable ref` | Revert `FluidInference/kokoro-82m-coreml`'s pin to `main` (all four ANE macros) | `rust/src/models.rs` | 5 | **PINNED** — fails, naming all 94 affected manifest entries (37 `ANE/` + 12 shared G2P + 43 `ANE-zh/` + 2 pinyin assets) |
-| 6 | TS — same | Revert **only** `ane_en_file!`'s pin to `main`, leaving `ane_zh_file!` correctly pinned (the `relPath`-collision case) | `rust/src/models.rs` | 1 | **PINNED** — fails, naming all 37 `ANE_EN_FILES` entries; `ANE_ZH_FILES`'s 43 entries correctly report their still-pinned commit |
-| 7 | TS — same | Revert `drakulavich/vosk-tts-ru-0.9-multi`'s pin to `resolve//` (empty ref / deleted revision — the exact hole review round 2 found) | `rust/src/models.rs` | 1 | **PINNED** — fails, naming all 5 `VOSK_RU_FILES` entries; before the ref-parsing fix this mutation **survived** (`NOT PINNED`) |
-| 8 | TS — same | Revert `drakulavich/vosk-tts-ru-0.9-multi`'s pin to a non-`main`, non-hex ref (`v1.0-legacy`) | `rust/src/models.rs` | 1 | **PINNED** — fails, naming all 5 `VOSK_RU_FILES` entries |
-| 9 | TS — same | Delete the `/resolve/<ref>/` segment entirely from `drakulavich/vosk-tts-ru-0.9-multi`'s URL | `rust/src/models.rs` | 1 | **PINNED** — fails, naming all 5 `VOSK_RU_FILES` entries |
+| # | Guard | File | Test | Mutation | Occurrences | Result |
+|---|---|---|---|---|---|---|
+| 1 | Rust | `rust/src/models.rs` | `manifest_tests::every_huggingface_url_pins_an_immutable_revision` | Revert `FluidInference/kokoro-82m-coreml`'s pin to `main` (all four ANE macros, since they share the literal) | 5 | **PINNED** — `pins mutable ref "main" instead of a 40-hex commit` |
+| 2 | Rust | `rust/src/models.rs` | `manifest_tests::every_huggingface_url_pins_an_immutable_revision` | Revert `drakulavich/vosk-tts-ru-0.9-multi`'s pin to `resolve//` (empty ref / deleted revision) | 1 | **PINNED** — `pins mutable ref "" instead of a 40-hex commit` |
+| 3 | Rust | `rust/src/models.rs` | `manifest_tests::every_huggingface_url_pins_an_immutable_revision` | Revert `drakulavich/vosk-tts-ru-0.9-multi`'s pin to a non-`main`, non-hex ref (`v1.0-legacy`) | 1 | **PINNED** — `pins mutable ref "v1.0-legacy" instead of a 40-hex commit` |
+| 4 | Rust | `rust/src/models.rs` | `manifest_tests::every_huggingface_url_pins_an_immutable_revision` | Delete the `/resolve/<ref>/` segment entirely from `drakulavich/vosk-tts-ru-0.9-multi`'s URL | 1 | **PINNED** — `huggingface.co url has no /resolve/<ref>/ segment` |
+| 5 | TS | `tests/unit/check-model-plan-sizes.test.ts` | `parseManifestUrls > no Hugging Face manifest URL resolves through a mutable ref` | Revert `FluidInference/kokoro-82m-coreml`'s pin to `main` (all four ANE macros) | 5 | **PINNED** — fails, naming all 94 affected manifest entries (37 `ANE/` + 12 shared G2P + 43 `ANE-zh/` + 2 pinyin assets) |
+| 6 | TS | `tests/unit/check-model-plan-sizes.test.ts` | `parseManifestUrls > no Hugging Face manifest URL resolves through a mutable ref` | Revert **only** `ane_en_file!`'s pin to `main`, leaving `ane_zh_file!` correctly pinned (the `relPath`-collision case) | 1 | **PINNED** — fails, naming all 37 `ANE_EN_FILES` entries; `ANE_ZH_FILES`'s 43 entries correctly report their still-pinned commit |
+| 7 | TS | `tests/unit/check-model-plan-sizes.test.ts` | `parseManifestUrls > no Hugging Face manifest URL resolves through a mutable ref` | Revert `drakulavich/vosk-tts-ru-0.9-multi`'s pin to `resolve//` (empty ref / deleted revision — the exact hole review round 2 found) | 1 | **PINNED** — fails, naming all 5 `VOSK_RU_FILES` entries; before the ref-parsing fix this mutation **survived** (`NOT PINNED`) |
+| 8 | TS | `tests/unit/check-model-plan-sizes.test.ts` | `parseManifestUrls > no Hugging Face manifest URL resolves through a mutable ref` | Revert `drakulavich/vosk-tts-ru-0.9-multi`'s pin to a non-`main`, non-hex ref (`v1.0-legacy`) | 1 | **PINNED** — fails, naming all 5 `VOSK_RU_FILES` entries |
+| 9 | TS | `tests/unit/check-model-plan-sizes.test.ts` | `parseManifestUrls > no Hugging Face manifest URL resolves through a mutable ref` | Delete the `/resolve/<ref>/` segment entirely from `drakulavich/vosk-tts-ru-0.9-multi`'s URL | 1 | **PINNED** — fails, naming all 5 `VOSK_RU_FILES` entries |
 
 Rows 1 and 5 are the ticket's actual regression, reproduced exactly. Rows 2–4 and 7–9
 prove both guards generalise past a `main`-only denylist: an empty ref, a plausible-looking
@@ -70,3 +91,9 @@ literal string `main`. Row 6 proves the `relPath`-collision fix does something �
 the pre-fix, map-based approach this regression would have been invisible. Row 7 is the
 one review round 2 asked for by name; the pre-fix guard's `NOT PINNED` result for it was
 reproduced and is the reason rows 5–9 exist in their current (post-fix) form.
+
+**Known drift risk in this table:** the "Test" column repeats each guard's exact function
+or `test(...)` name in prose, and nothing re-checks that string against the source if
+either test is renamed later — a rename would go stale here silently. No automated,
+in-scope way to make that loud was found this round (adding one would be a new test, which
+this round explicitly does not owe); flagging it here rather than adding tooling.

--- a/docs/mutation-evidence/issue-1093.md
+++ b/docs/mutation-evidence/issue-1093.md
@@ -1,17 +1,20 @@
 # Mutation evidence — #1093 (Kokoro ANE manifest pinned to a mutable ref)
 
 Two guards assert the same rule — no `huggingface.co` manifest URL may resolve through a
-mutable ref such as `main`, only a 40-hex commit — from two different angles, because they
-run in different lanes:
+mutable ref, only a 40-hex commit — from two different angles, because they run in
+different lanes, and each has known reach:
 
-| Guard | Where it runs | What it sees |
-|---|---|---|
-| `rust/src/models.rs::manifest_tests::every_huggingface_url_pins_an_immutable_revision` | `🧪 Rust Tests` (every PR, default `--features tts` build) | 6 of 7 pinned repos — every manifest **except** the `system_kokoro`-gated ANE ones. Those five macros (`ane_en_file!`, `kokoro_g2p_file!`, `ane_zh_file!`, `ane_zh_asset!`, `ane_kokoro_voice!`) only compile under `--features system_kokoro,target_os=macos,target_arch=aarch64`, and no CI job runs `cargo test`/`nextest` with that combination — the per-PR macos-14 leg only `cargo clippy`s it (`just verify-darwin-full`), which type-checks but never executes `#[test]` bodies. This is the gap Greptile's #1096 review flagged: the guard for the ANE manifests — where the #1093 regression actually lived — was real but CI-invisible. |
-| `tests/unit/check-model-plan-sizes.test.ts > parseManifestUrls > no huggingface.co url in the real manifest resolves through a mutable ref` | `🧪 CI` (every PR, plain `bun test`, no feature gating at all) | **All 7 repos, including the ANE manifests.** Reads `rust/src/models.rs` as text via `parseManifestEntries` (a new export, alongside the existing `parseManifestUrls`), which expands the `ModelFile`-building macros and lists every entry — it isn't compiling Rust, so `#[cfg(...)]` is invisible to it. This is the guard that closes the CI-reach gap: it runs on every PR and would have caught #1093 without needing a macOS `system_kokoro` test lane. |
+| Guard | File | Where it runs | Reach |
+|---|---|---|---|
+| `every_huggingface_url_pins_an_immutable_revision` | `rust/src/models.rs` (`manifest_tests` mod) | `🧪 Rust Tests` (every PR, default `--features tts` build) | 6 of 7 pinned repos — every manifest **except** the `system_kokoro`-gated ANE ones. Those five macros (`ane_en_file!`, `kokoro_g2p_file!`, `ane_zh_file!`, `ane_zh_asset!`, `ane_kokoro_voice!`) only compile under `--features system_kokoro,target_os=macos,target_arch=aarch64`, and no CI job runs `cargo test`/`nextest` with that combination — the per-PR macos-14 leg only `cargo clippy`s it (`just verify-darwin-full`), which type-checks but never executes `#[test]` bodies. |
+| `no huggingface.co url in the real manifest resolves through a mutable ref` | `tests/unit/check-model-plan-sizes.test.ts` (`parseManifestUrls` describe) | `🧪 CI` (every PR, plain `bun test`, no feature gating at all) | **All 7 repos, including the ANE manifests.** Reads `rust/src/models.rs` as text via `parseManifestEntries` (new export in `.github/scripts/check-model-plan-sizes.ts`), which expands the `ModelFile`-building macros and lists every entry — it isn't compiling Rust, so `#[cfg(...)]` is invisible to it. This is the guard that closes the CI-reach gap Greptile's #1096 review round 1 flagged: it runs on every PR and would have caught #1093 without a macOS `system_kokoro` test lane. |
 
-Keeping both: the Rust guard is the typed one and stays useful wherever it does run
-(local `system_kokoro` builds, `just mutate` locally); the TS guard buys reach without
-adding a new CI lane.
+**Reach note on a third, older assertion:** `staged_manifests_are_pinned_and_contained` at
+`rust/src/models.rs:2731` also asserts a URL prefix against the Kokoro ANE manifests, but
+it has the exact same `system_kokoro`-gated compile requirement as the guard above and
+**no CI lane executes it either** — its reach is `none`. It stays in the suite (useful on
+a local `system_kokoro` build) but the TS guard above, not this one, is what actually
+protects `🧪 CI`; do not read the Rust assertion at that line as a live gate.
 
 ## Why `parseManifestEntries`, not the existing `parseManifestUrls`
 
@@ -22,77 +25,48 @@ time (`stage_into(&fluidaudio_ane_kokoro_dir()?, ANE_EN_FILES, …)` vs
 `stage_into(&zh, ANE_ZH_FILES, …)`), so `relPath` is not a unique key across the whole
 manifest. Building the URL-pin guard on top of the deduping map would let `ANE_ZH_FILES`
 (declared after `ANE_EN_FILES` in `models.rs`) silently shadow the English entry for every
-colliding key — a guard that looked like it covered "all 7 repos" while actually skipping
-half of one of them. `parseManifestEntries` returns every `{relPath, url}` pair in source
-order instead, with no deduping; `parseManifestUrls` is now defined in terms of it
-(behaviour-preserving for existing callers — same "last declaration wins" map).
+colliding key. `parseManifestEntries` returns every `{relPath, url}` pair in source order
+instead, with no deduping; `parseManifestUrls` is now defined in terms of it (same
+last-wins semantics, no behaviour change for existing callers).
 `keeps colliding rel_paths as separate entries rather than letting one shadow the other`
 in `check-model-plan-sizes.test.ts` pins this directly.
 
-## Rust guard — mutation proof
+## Why the ref check is positive, not a denylist
 
-Command (matches `just mutate`'s default `FEATURES`, since the ANE manifests only compile
-under it):
+The TS guard's first version matched `/resolve\/([^/]+)\//` and skipped (`continue`) when
+that failed to match. `[^/]+` requires at least one character, so a botched edit producing
+`resolve//` — a URL that 404s at install time, a *worse* failure than drifting to `main` —
+left an empty ref segment the regex could not capture, and the `undefined` case fell
+through unseen (#1096 review round 2). The fixed version (`tests/unit/check-model-plan-sizes.test.ts:142-151`)
+asserts positively instead: split on `/resolve/`, take the first path segment after it
+(`""` if there is none), and require it to match `^[0-9a-f]{40}$` — nothing short-circuits
+to "skip". The Rust guard (`assert_pins_immutable_revision`,
+`rust/src/models.rs:2217-2230`) was checked for the same shape and was already safe: it
+`panic!`s outright when `/resolve/` is missing, and an empty captured segment already
+fails the `len() == 40` check — proven below rather than assumed.
 
-```
-just mutate rust/src/models.rs \
-  'FluidInference/kokoro-82m-coreml/resolve/c94edcb4b671856795458645cd389c0a9184e8bb/' \
-  'FluidInference/kokoro-82m-coreml/resolve/main/' \
-  cargo nextest run --manifest-path rust/Cargo.toml \
-    --features tts,system_kokoro,system_diarize --no-default-features --features onnx \
-    manifest_tests::every_huggingface_url_pins_an_immutable_revision
-```
+## Mutation proof
 
-| Mutation | Occurrences | Guard result |
-|---|---|---|
-| Revert the `FluidInference/kokoro-82m-coreml` pin from the immutable commit `c94edcb4b6…` back to `main` | 5 | **PINNED** — fails: `pins mutable ref "main" instead of a 40-hex commit` |
+Every row: `just mutate <file> <find> <replace> <test command>`, restored in a `finally`
+regardless of outcome; every restore was confirmed with a clean `git status --short`
+afterward and a green re-run of the named test.
 
-Restore-to-green: `just mutate` restores the file in a `finally` regardless of outcome;
-`cargo nextest run --features tts,system_kokoro,system_diarize --no-default-features --features onnx manifest_tests::every_huggingface_url_pins_an_immutable_revision`
-passes again on the restored file (1 passed, 0 failed).
+| # | Guard (file, test) | Mutation | File mutated | Occurrences | Result |
+|---|---|---|---|---|---|
+| 1 | Rust — `rust/src/models.rs`, `manifest_tests::every_huggingface_url_pins_an_immutable_revision` | Revert `FluidInference/kokoro-82m-coreml`'s pin to `main` (all four ANE macros, since they share the literal) | `rust/src/models.rs` | 5 | **PINNED** — `pins mutable ref "main" instead of a 40-hex commit` |
+| 2 | Rust — same | Revert `drakulavich/vosk-tts-ru-0.9-multi`'s pin to `resolve//` (empty ref / deleted revision) | `rust/src/models.rs` | 1 | **PINNED** — `pins mutable ref "" instead of a 40-hex commit` |
+| 3 | Rust — same | Revert `drakulavich/vosk-tts-ru-0.9-multi`'s pin to a non-`main`, non-hex ref (`v1.0-legacy`) | `rust/src/models.rs` | 1 | **PINNED** — `pins mutable ref "v1.0-legacy" instead of a 40-hex commit` |
+| 4 | Rust — same | Delete the `/resolve/<ref>/` segment entirely from `drakulavich/vosk-tts-ru-0.9-multi`'s URL | `rust/src/models.rs` | 1 | **PINNED** — `huggingface.co url has no /resolve/<ref>/ segment` |
+| 5 | TS — `tests/unit/check-model-plan-sizes.test.ts`, `parseManifestUrls > no huggingface.co url in the real manifest resolves through a mutable ref` | Revert `FluidInference/kokoro-82m-coreml`'s pin to `main` (all four ANE macros) | `rust/src/models.rs` | 5 | **PINNED** — fails, naming all 94 affected manifest entries (37 `ANE/` + 12 shared G2P + 43 `ANE-zh/` + 2 pinyin assets) |
+| 6 | TS — same | Revert **only** `ane_en_file!`'s pin to `main`, leaving `ane_zh_file!` correctly pinned (the `relPath`-collision case) | `rust/src/models.rs` | 1 | **PINNED** — fails, naming all 37 `ANE_EN_FILES` entries; `ANE_ZH_FILES`'s 43 entries correctly report their still-pinned commit |
+| 7 | TS — same | Revert `drakulavich/vosk-tts-ru-0.9-multi`'s pin to `resolve//` (empty ref / deleted revision — the exact hole review round 2 found) | `rust/src/models.rs` | 1 | **PINNED** — fails, naming all 5 `VOSK_RU_FILES` entries; before the ref-parsing fix this mutation **survived** (`NOT PINNED`) |
+| 8 | TS — same | Revert `drakulavich/vosk-tts-ru-0.9-multi`'s pin to a non-`main`, non-hex ref (`v1.0-legacy`) | `rust/src/models.rs` | 1 | **PINNED** — fails, naming all 5 `VOSK_RU_FILES` entries |
+| 9 | TS — same | Delete the `/resolve/<ref>/` segment entirely from `drakulavich/vosk-tts-ru-0.9-multi`'s URL | `rust/src/models.rs` | 1 | **PINNED** — fails, naming all 5 `VOSK_RU_FILES` entries |
 
-The same guard also covers the other 6 pinned repos (`istupakov/parakeet-tdt-0.6b-v3-onnx`,
-`FluidInference/diar-streaming-sortformer-coreml`, `drakulavich/SpeechBrain-coreml`,
-`onnx-community/Kokoro-82M-v1.0-ONNX`, `klebster/g2p_multilingual_byT5_tiny_onnx`,
-`drakulavich/vosk-tts-ru-0.9-multi`) under the default `--features tts` build, which is the
-build `🧪 Rust Tests` actually runs.
-
-## TS guard — mutation proof
-
-Both commands run exactly as `🧪 CI` would — no feature flags, no macOS requirement.
-
-**All four ANE macros reverted at once** (the literal shared verbatim across
-`ane_en_file!`, `kokoro_g2p_file!`, `ane_zh_file!`, `ane_zh_asset!`, plus the
-`staged_manifests_are_pinned_and_contained` Rust test assertion — 5 occurrences):
-
-```
-just mutate rust/src/models.rs \
-  'FluidInference/kokoro-82m-coreml/resolve/c94edcb4b671856795458645cd389c0a9184e8bb/' \
-  'FluidInference/kokoro-82m-coreml/resolve/main/' \
-  bun test tests/unit/check-model-plan-sizes.test.ts -t "mutable ref"
-```
-
-| Mutation | Occurrences | Guard result |
-|---|---|---|
-| Revert all four ANE macros' pin to `main` | 5 | **PINNED** — fails, naming all 94 affected manifest entries (37 `ANE/` + 12 shared G2P + 43 `ANE-zh/` + 2 pinyin assets) |
-
-**English-only regression** — reverts *only* `ane_en_file!`'s pin, leaving `ane_zh_file!`
-correctly pinned. This is the mutation that specifically exercises the `relPath` collision
-fix: against the old `parseManifestUrls`-backed test, the later-declared, still-correctly-pinned
-`ANE_ZH_FILES` entry would have shadowed every colliding `ANE_EN_FILES` key in the map and
-the guard would have missed this regression entirely.
-
-```
-just mutate rust/src/models.rs \
-  $'"https://huggingface.co/FluidInference/kokoro-82m-coreml/resolve/c94edcb4b671856795458645cd389c0a9184e8bb/",\n                "ANE/",' \
-  $'"https://huggingface.co/FluidInference/kokoro-82m-coreml/resolve/main/",\n                "ANE/",' \
-  bun test tests/unit/check-model-plan-sizes.test.ts -t "mutable ref"
-```
-
-| Mutation | Occurrences | Guard result |
-|---|---|---|
-| Revert only `ane_en_file!`'s pin to `main` (`ANE_ZH_FILES` stays correctly pinned) | 1 | **PINNED** — fails, naming all 37 `ANE_EN_FILES` entries; `ANE_ZH_FILES`'s 43 entries correctly report their still-pinned commit |
-
-Restore-to-green after each: `just mutate` restores the file in a `finally`; `bun test
-tests/unit/check-model-plan-sizes.test.ts -t "mutable ref"` passes again on the restored
-file (1 passed, 0 failed).
+Rows 1 and 5 are the ticket's actual regression, reproduced exactly. Rows 2–4 and 7–9
+prove both guards generalise past a `main`-only denylist: an empty ref, a plausible-looking
+but non-hex ref, and a URL with no `/resolve/` segment at all are all caught, not just the
+literal string `main`. Row 6 proves the `relPath`-collision fix does something — against
+the pre-fix, map-based approach this regression would have been invisible. Row 7 is the
+one review round 2 asked for by name; the pre-fix guard's `NOT PINNED` result for it was
+reproduced and is the reason rows 5–9 exist in their current (post-fix) form.

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -33,27 +33,27 @@ pub struct ModelFile {
 const ASR_FILES: &[ModelFile] = &[
     ModelFile {
         rel_path: "models/parakeet-tdt-v3/encoder-model.onnx",
-        url: "https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx/resolve/main/encoder-model.onnx",
+        url: "https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx/resolve/8f23f0c03c8761650bdb5b40aaf3e40d2c15f1ce/encoder-model.onnx",
         sha256: "98a74b21b4cc0017c1e7030319a4a96f4a9506e50f0708f3a516d02a77c96bb1",
     },
     ModelFile {
         rel_path: "models/parakeet-tdt-v3/encoder-model.onnx.data",
-        url: "https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx/resolve/main/encoder-model.onnx.data",
+        url: "https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx/resolve/8f23f0c03c8761650bdb5b40aaf3e40d2c15f1ce/encoder-model.onnx.data",
         sha256: "9a22d372c51455c34f13405da2520baefb7125bd16981397561423ed32d24f36",
     },
     ModelFile {
         rel_path: "models/parakeet-tdt-v3/decoder_joint-model.onnx",
-        url: "https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx/resolve/main/decoder_joint-model.onnx",
+        url: "https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx/resolve/8f23f0c03c8761650bdb5b40aaf3e40d2c15f1ce/decoder_joint-model.onnx",
         sha256: "e978ddf6688527182c10fde2eb4b83068421648985ef23f7a86be732be8706c1",
     },
     ModelFile {
         rel_path: "models/parakeet-tdt-v3/nemo128.onnx",
-        url: "https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx/resolve/main/nemo128.onnx",
+        url: "https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx/resolve/8f23f0c03c8761650bdb5b40aaf3e40d2c15f1ce/nemo128.onnx",
         sha256: "a9fde1486ebfcc08f328d75ad4610c67835fea58c73ba57e3209a6f6cf019e9f",
     },
     ModelFile {
         rel_path: "models/parakeet-tdt-v3/vocab.txt",
-        url: "https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx/resolve/main/vocab.txt",
+        url: "https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx/resolve/8f23f0c03c8761650bdb5b40aaf3e40d2c15f1ce/vocab.txt",
         sha256: "d58544679ea4bc6ac563d1f545eb7d474bd6cfa467f0a6e2c1dc1c7d37e3c35d",
     },
 ];
@@ -88,22 +88,22 @@ const VAD_FILES: &[ModelFile] = &[ModelFile {
 const DIARIZE_FILES: &[ModelFile] = &[
     ModelFile {
         rel_path: "models/diarize/SortformerNvidiaLow_v2.mlpackage/Manifest.json",
-        url: "https://huggingface.co/FluidInference/diar-streaming-sortformer-coreml/resolve/main/SortformerNvidiaLow_v2.mlpackage/Manifest.json",
+        url: "https://huggingface.co/FluidInference/diar-streaming-sortformer-coreml/resolve/ae9a27ab45dc0aa3abede7d2d6bad2b7a69aa6d1/SortformerNvidiaLow_v2.mlpackage/Manifest.json",
         sha256: "48005880c54b1b7f5b0ae81a33fead3a36e3e2a773eb3fbf1f61ebe08515bba6",
     },
     ModelFile {
         rel_path: "models/diarize/SortformerNvidiaLow_v2.mlpackage/Data/com.apple.CoreML/model.mlmodel",
-        url: "https://huggingface.co/FluidInference/diar-streaming-sortformer-coreml/resolve/main/SortformerNvidiaLow_v2.mlpackage/Data/com.apple.CoreML/model.mlmodel",
+        url: "https://huggingface.co/FluidInference/diar-streaming-sortformer-coreml/resolve/ae9a27ab45dc0aa3abede7d2d6bad2b7a69aa6d1/SortformerNvidiaLow_v2.mlpackage/Data/com.apple.CoreML/model.mlmodel",
         sha256: "478267113144c0292a3db41fb22148b6c052d2399ae3dab0ca20cd3687880358",
     },
     ModelFile {
         rel_path: "models/diarize/SortformerNvidiaLow_v2.mlpackage/Data/com.apple.CoreML/weights/0-weight.bin",
-        url: "https://huggingface.co/FluidInference/diar-streaming-sortformer-coreml/resolve/main/SortformerNvidiaLow_v2.mlpackage/Data/com.apple.CoreML/weights/0-weight.bin",
+        url: "https://huggingface.co/FluidInference/diar-streaming-sortformer-coreml/resolve/ae9a27ab45dc0aa3abede7d2d6bad2b7a69aa6d1/SortformerNvidiaLow_v2.mlpackage/Data/com.apple.CoreML/weights/0-weight.bin",
         sha256: "ad40d62ccd7a0943d2cd9cc8eeee7f27116e58cf6532ab43196b34142fc86583",
     },
     ModelFile {
         rel_path: "models/diarize/SortformerNvidiaLow_v2.mlpackage/Data/com.apple.CoreML/weights/1-weight.bin",
-        url: "https://huggingface.co/FluidInference/diar-streaming-sortformer-coreml/resolve/main/SortformerNvidiaLow_v2.mlpackage/Data/com.apple.CoreML/weights/1-weight.bin",
+        url: "https://huggingface.co/FluidInference/diar-streaming-sortformer-coreml/resolve/ae9a27ab45dc0aa3abede7d2d6bad2b7a69aa6d1/SortformerNvidiaLow_v2.mlpackage/Data/com.apple.CoreML/weights/1-weight.bin",
         sha256: "e8ebd6767429fd224671b79ad2a3e3cd8bd34f83373ff84fca2f5387414191a0",
     },
 ];
@@ -113,17 +113,17 @@ const DIARIZE_FILES: &[ModelFile] = &[
 const LANG_ID_FILES: &[ModelFile] = &[
     ModelFile {
         rel_path: "models/lang-id-ecapa/lang-id-ecapa.onnx",
-        url: "https://huggingface.co/drakulavich/SpeechBrain-coreml/resolve/main/lang-id-ecapa.onnx",
+        url: "https://huggingface.co/drakulavich/SpeechBrain-coreml/resolve/41e60dea31b80ea5d4f9d9d9e818501ea184e568/lang-id-ecapa.onnx",
         sha256: "4af3b6a5b4165f78715fe363ed6b7650d5f77ed0a6e2966c500eadc46252a288",
     },
     ModelFile {
         rel_path: "models/lang-id-ecapa/lang-id-ecapa.onnx.data",
-        url: "https://huggingface.co/drakulavich/SpeechBrain-coreml/resolve/main/lang-id-ecapa.onnx.data",
+        url: "https://huggingface.co/drakulavich/SpeechBrain-coreml/resolve/41e60dea31b80ea5d4f9d9d9e818501ea184e568/lang-id-ecapa.onnx.data",
         sha256: "78fefd776536f4a686bcf705dedb8e9a497b924a2107a949b42a24b2b90174a2",
     },
     ModelFile {
         rel_path: "models/lang-id-ecapa/labels.json",
-        url: "https://huggingface.co/drakulavich/SpeechBrain-coreml/resolve/main/labels.json",
+        url: "https://huggingface.co/drakulavich/SpeechBrain-coreml/resolve/41e60dea31b80ea5d4f9d9d9e818501ea184e568/labels.json",
         sha256: "9e515c3c7932659fd1e6c3febc395529d0a8092328adb9f5e75185a04bb523d0",
     },
 ];
@@ -220,7 +220,7 @@ macro_rules! kokoro_voice {
         ModelFile {
             rel_path: concat!("models/kokoro-82m/voices/", $name, ".bin"),
             url: concat!(
-                "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices/",
+                "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/1939ad2a8e416c0acfeecc08a694d14ef25f2231/voices/",
                 $name,
                 ".bin"
             ),
@@ -256,17 +256,17 @@ const KOKORO_EN_VOICE: ModelFile = kokoro_voice!(
 const G2P_CHARSIU_FILES: &[ModelFile] = &[
     ModelFile {
         rel_path: "models/g2p/byt5-tiny/encoder_model.onnx",
-        url: "https://huggingface.co/klebster/g2p_multilingual_byT5_tiny_onnx/resolve/main/encoder_model.onnx",
+        url: "https://huggingface.co/klebster/g2p_multilingual_byT5_tiny_onnx/resolve/0e2cf759874353bcc0cd153d4b6886a27f61e4a7/encoder_model.onnx",
         sha256: "1ac7aca11845527873f9e0e870fbe1e3c3ac2cb009d8852230332d10541aab04",
     },
     ModelFile {
         rel_path: "models/g2p/byt5-tiny/decoder_model.onnx",
-        url: "https://huggingface.co/klebster/g2p_multilingual_byT5_tiny_onnx/resolve/main/decoder_model.onnx",
+        url: "https://huggingface.co/klebster/g2p_multilingual_byT5_tiny_onnx/resolve/0e2cf759874353bcc0cd153d4b6886a27f61e4a7/decoder_model.onnx",
         sha256: "de32477aae14e254d4a7dee4b2c324fb39f93a0dc254181c5bfdd8fc67492919",
     },
     ModelFile {
         rel_path: "models/g2p/byt5-tiny/decoder_with_past_model.onnx",
-        url: "https://huggingface.co/klebster/g2p_multilingual_byT5_tiny_onnx/resolve/main/decoder_with_past_model.onnx",
+        url: "https://huggingface.co/klebster/g2p_multilingual_byT5_tiny_onnx/resolve/0e2cf759874353bcc0cd153d4b6886a27f61e4a7/decoder_with_past_model.onnx",
         sha256: "fae30b9f3a8d935be01b32af851bae6d54f330813167073e84caf6d0a1890fcb",
     },
 ];
@@ -368,7 +368,7 @@ macro_rules! ane_kokoro_voice {
         ModelFile {
             rel_path: concat!($name, ".bin"),
             url: concat!(
-                "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices/",
+                "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/1939ad2a8e416c0acfeecc08a694d14ef25f2231/voices/",
                 $name,
                 ".bin"
             ),
@@ -522,7 +522,7 @@ macro_rules! ane_en_file {
         ModelFile {
             rel_path: $rel,
             url: concat!(
-                "https://huggingface.co/FluidInference/kokoro-82m-coreml/resolve/main/",
+                "https://huggingface.co/FluidInference/kokoro-82m-coreml/resolve/c94edcb4b671856795458645cd389c0a9184e8bb/",
                 "ANE/",
                 $rel
             ),
@@ -704,7 +704,7 @@ macro_rules! kokoro_g2p_file {
         ModelFile {
             rel_path: $rel,
             url: concat!(
-                "https://huggingface.co/FluidInference/kokoro-82m-coreml/resolve/main/",
+                "https://huggingface.co/FluidInference/kokoro-82m-coreml/resolve/c94edcb4b671856795458645cd389c0a9184e8bb/",
                 "",
                 $rel
             ),
@@ -787,7 +787,7 @@ macro_rules! ane_zh_file {
         ModelFile {
             rel_path: $rel,
             url: concat!(
-                "https://huggingface.co/FluidInference/kokoro-82m-coreml/resolve/main/",
+                "https://huggingface.co/FluidInference/kokoro-82m-coreml/resolve/c94edcb4b671856795458645cd389c0a9184e8bb/",
                 "ANE-zh/",
                 $rel
             ),
@@ -1000,7 +1000,7 @@ macro_rules! ane_zh_asset {
         ModelFile {
             rel_path: $rel,
             url: concat!(
-                "https://huggingface.co/FluidInference/kokoro-82m-coreml/resolve/main/",
+                "https://huggingface.co/FluidInference/kokoro-82m-coreml/resolve/c94edcb4b671856795458645cd389c0a9184e8bb/",
                 $remote
             ),
             sha256: $sha,
@@ -1628,28 +1628,28 @@ pub fn incomplete_ane_bundle_names() -> Vec<String> {
 pub const VOSK_RU_FILES: &[ModelFile] = &[
     ModelFile {
         rel_path: "models/vosk-ru/model.onnx",
-        url: "https://huggingface.co/drakulavich/vosk-tts-ru-0.9-multi/resolve/main/model.onnx",
+        url: "https://huggingface.co/drakulavich/vosk-tts-ru-0.9-multi/resolve/37c7b45a32b3fa62f3a2bbce89677080dcd2107f/model.onnx",
         sha256: "0fa5a36b22a8bf7fe7179a3882c6371d2c01e5317019e717516f892d329c24b9",
     },
     ModelFile {
         rel_path: "models/vosk-ru/dictionary",
-        url: "https://huggingface.co/drakulavich/vosk-tts-ru-0.9-multi/resolve/main/dictionary",
+        url: "https://huggingface.co/drakulavich/vosk-tts-ru-0.9-multi/resolve/37c7b45a32b3fa62f3a2bbce89677080dcd2107f/dictionary",
         sha256: "2939e72c170bb41ac8e256828cca1c5fac4db1e36717f9f53fde843b00a220ba",
     },
     ModelFile {
         rel_path: "models/vosk-ru/config.json",
-        url: "https://huggingface.co/drakulavich/vosk-tts-ru-0.9-multi/resolve/main/config.json",
+        url: "https://huggingface.co/drakulavich/vosk-tts-ru-0.9-multi/resolve/37c7b45a32b3fa62f3a2bbce89677080dcd2107f/config.json",
         sha256: "e155fb266a730e1858a2420442b465acf08a3236dffad7d1a507bf155b213d50",
     },
     ModelFile {
         rel_path: "models/vosk-ru/bert/model.onnx",
         url:
-            "https://huggingface.co/drakulavich/vosk-tts-ru-0.9-multi/resolve/main/bert/model.onnx",
+            "https://huggingface.co/drakulavich/vosk-tts-ru-0.9-multi/resolve/37c7b45a32b3fa62f3a2bbce89677080dcd2107f/bert/model.onnx",
         sha256: "2e2f1740eaae5e29c2b4844625cbb01ff644b2b5fb0560bd34374c35d8a092c1",
     },
     ModelFile {
         rel_path: "models/vosk-ru/bert/vocab.txt",
-        url: "https://huggingface.co/drakulavich/vosk-tts-ru-0.9-multi/resolve/main/bert/vocab.txt",
+        url: "https://huggingface.co/drakulavich/vosk-tts-ru-0.9-multi/resolve/37c7b45a32b3fa62f3a2bbce89677080dcd2107f/bert/vocab.txt",
         sha256: "bbe5063cc3d7a314effd90e9c5099cf493b81f2b9552c155264e16eeab074237",
     },
     // removed: README.md (drakulavich/vosk-tts-ru-0.9-multi) — not opened at
@@ -2210,6 +2210,81 @@ mod manifest_tests {
         let _ = fs::remove_file(&target);
         Ok(())
     }
+
+    /// Every `huggingface.co` URL must resolve a 40-hex commit, never a mutable
+    /// ref like `main` — upstream republishing under `main` silently invalidates
+    /// every hash pinned against it in one shot (#1093).
+    fn assert_pins_immutable_revision(f: &ModelFile) {
+        let Some(rest) = f.url.strip_prefix("https://huggingface.co/") else {
+            return;
+        };
+        let Some((_, after_resolve)) = rest.split_once("/resolve/") else {
+            panic!("{f:?} huggingface.co url has no /resolve/<ref>/ segment");
+        };
+        let ref_segment = after_resolve.split('/').next().unwrap_or("");
+        assert!(
+            ref_segment.len() == 40 && ref_segment.chars().all(|c| c.is_ascii_hexdigit()),
+            "{f:?} pins mutable ref {ref_segment:?} instead of a 40-hex commit — an \
+             upstream republish under it breaks every hash already pinned against it (#1093)"
+        );
+    }
+
+    #[test]
+    fn every_huggingface_url_pins_an_immutable_revision() {
+        #[cfg(not(feature = "coreml"))]
+        for f in ASR_FILES {
+            assert_pins_immutable_revision(f);
+        }
+        for f in DIARIZE_FILES {
+            assert_pins_immutable_revision(f);
+        }
+        for f in LANG_ID_FILES {
+            assert_pins_immutable_revision(f);
+        }
+        #[cfg(feature = "tts")]
+        for f in VOSK_RU_FILES {
+            assert_pins_immutable_revision(f);
+        }
+        #[cfg(all(
+            feature = "tts",
+            not(all(
+                feature = "system_kokoro",
+                target_os = "macos",
+                target_arch = "aarch64"
+            ))
+        ))]
+        {
+            for f in G2P_CHARSIU_FILES {
+                assert_pins_immutable_revision(f);
+            }
+            assert_pins_immutable_revision(&KOKORO_EN_VOICE);
+            for lang in ["es", "fr", "it", "pt"] {
+                assert_pins_immutable_revision(
+                    &multilang_voice(lang).expect("known Kokoro language"),
+                );
+            }
+        }
+        #[cfg(all(
+            feature = "system_kokoro",
+            target_os = "macos",
+            target_arch = "aarch64"
+        ))]
+        {
+            for f in ANE_KOKORO_VOICES {
+                assert_pins_immutable_revision(f);
+            }
+            for manifest in [
+                ANE_EN_FILES,
+                ANE_ZH_FILES,
+                ANE_ZH_G2P_ASSETS,
+                KOKORO_G2P_FILES,
+            ] {
+                for f in manifest {
+                    assert_pins_immutable_revision(f);
+                }
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -2512,7 +2587,7 @@ mod tts_tests {
         for f in m {
             assert!(f.sha256.len() == 64, "sha256 must be 64 hex chars");
             assert!(f.url.starts_with(
-                "https://huggingface.co/drakulavich/vosk-tts-ru-0.9-multi/resolve/main/"
+                "https://huggingface.co/drakulavich/vosk-tts-ru-0.9-multi/resolve/37c7b45a32b3fa62f3a2bbce89677080dcd2107f/"
             ));
         }
     }
@@ -2669,7 +2744,7 @@ mod tts_tests {
                 );
                 assert!(
                     f.url.starts_with(
-                        "https://huggingface.co/FluidInference/kokoro-82m-coreml/resolve/main/"
+                        "https://huggingface.co/FluidInference/kokoro-82m-coreml/resolve/c94edcb4b671856795458645cd389c0a9184e8bb/"
                     ),
                     "{f:?} must come from the FluidInference repo FluidAudio itself uses"
                 );

--- a/tests/unit/check-model-plan-sizes.test.ts
+++ b/tests/unit/check-model-plan-sizes.test.ts
@@ -100,15 +100,15 @@ describe("parseManifestUrls", () => {
     const urls = realManifestUrls();
 
     expect(urls.get("models/parakeet-tdt-v3/vocab.txt")).toBe(
-      "https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx/resolve/main/vocab.txt",
+      "https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx/resolve/8f23f0c03c8761650bdb5b40aaf3e40d2c15f1ce/vocab.txt",
     );
     expect(urls.get("models/kokoro-82m/voices/am_michael.bin")).toBe(
-      "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices/am_michael.bin",
+      "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/1939ad2a8e416c0acfeecc08a694d14ef25f2231/voices/am_michael.bin",
     );
     expect(
       urls.get("models/diarize/SortformerNvidiaLow_v2.mlpackage/Data/com.apple.CoreML/weights/0-weight.bin"),
     ).toBe(
-      "https://huggingface.co/FluidInference/diar-streaming-sortformer-coreml/resolve/main/SortformerNvidiaLow_v2.mlpackage/Data/com.apple.CoreML/weights/0-weight.bin",
+      "https://huggingface.co/FluidInference/diar-streaming-sortformer-coreml/resolve/ae9a27ab45dc0aa3abede7d2d6bad2b7a69aa6d1/SortformerNvidiaLow_v2.mlpackage/Data/com.apple.CoreML/weights/0-weight.bin",
     );
   });
 });

--- a/tests/unit/check-model-plan-sizes.test.ts
+++ b/tests/unit/check-model-plan-sizes.test.ts
@@ -6,15 +6,18 @@ import {
   contentLength,
   flattenPlan,
   liveSize,
+  parseManifestEntries,
   parseManifestUrls,
   type FetchLike,
 } from "../../.github/scripts/check-model-plan-sizes";
 import modelPlan from "../../model-plan.json" with { type: "json" };
 
 const repoRoot = join(import.meta.dir, "..", "..");
+const realManifestSource = () =>
+  readFileSync(join(repoRoot, "rust", "src", "models.rs"), "utf8");
 
-const realManifestUrls = () =>
-  parseManifestUrls(readFileSync(join(repoRoot, "rust", "src", "models.rs"), "utf8"));
+const realManifestUrls = () => parseManifestUrls(realManifestSource());
+const realManifestEntries = () => parseManifestEntries(realManifestSource());
 
 describe("flattenPlan", () => {
   test("reads arrays, single files and per-language maps alike", () => {
@@ -110,6 +113,39 @@ describe("parseManifestUrls", () => {
     ).toBe(
       "https://huggingface.co/FluidInference/diar-streaming-sortformer-coreml/resolve/ae9a27ab45dc0aa3abede7d2d6bad2b7a69aa6d1/SortformerNvidiaLow_v2.mlpackage/Data/com.apple.CoreML/weights/0-weight.bin",
     );
+  });
+
+  // The English and Mandarin ANE bundles stage identical basenames (e.g.
+  // `KokoroAlbert.mlmodelc/analytics/coremldata.bin`) into different directories at install
+  // time — `stage_into(&fluidaudio_ane_kokoro_dir()?, ANE_EN_FILES, …)` vs `stage_into(&zh,
+  // ANE_ZH_FILES, …)` — so `relPath` is not unique across the manifest. `parseManifestUrls`'s
+  // map would let the later declaration (`ANE_ZH_FILES`) silently shadow the earlier one
+  // (`ANE_EN_FILES`) for every colliding key; `parseManifestEntries` must keep both.
+  test("keeps colliding rel_paths as separate entries rather than letting one shadow the other", () => {
+    const albertCoremldata = realManifestEntries().filter(
+      (entry) => entry.relPath === "KokoroAlbert.mlmodelc/analytics/coremldata.bin",
+    );
+    expect(albertCoremldata).toHaveLength(2);
+    expect(albertCoremldata.map((entry) => entry.url)).toEqual([
+      expect.stringContaining("/ANE/KokoroAlbert.mlmodelc/analytics/coremldata.bin"),
+      expect.stringContaining("/ANE-zh/KokoroAlbert.mlmodelc/analytics/coremldata.bin"),
+    ]);
+  });
+
+  // `parseManifestEntries` expands the `ModelFile`-building macros in place, so this sees
+  // every manifest models.rs declares regardless of `cfg` — including the `system_kokoro`
+  // ANE ones no CI lane ever compiles as tests (#1093, #1096 review) — and every entry, not
+  // just one per colliding `relPath` (the test above). `manifest_tests::
+  // every_huggingface_url_pins_an_immutable_revision` in models.rs covers the same rule with
+  // real Rust types where it does run; this is the one that runs everywhere.
+  test("no huggingface.co url in the real manifest resolves through a mutable ref", () => {
+    const mutableRefs: string[] = [];
+    for (const { relPath, url } of realManifestEntries()) {
+      const ref = /^https:\/\/huggingface\.co\/[^/]+\/[^/]+\/resolve\/([^/]+)\//.exec(url)?.[1];
+      if (ref === undefined) continue;
+      if (!/^[0-9a-f]{40}$/.test(ref)) mutableRefs.push(`${relPath}: ${url}`);
+    }
+    expect(mutableRefs).toEqual([]);
   });
 });
 

--- a/tests/unit/check-model-plan-sizes.test.ts
+++ b/tests/unit/check-model-plan-sizes.test.ts
@@ -139,7 +139,7 @@ describe("parseManifestUrls", () => {
   // every_huggingface_url_pins_an_immutable_revision` in models.rs covers the same rule with
   // real Rust types where it does run; this is the one that runs everywhere.
   // Asserted positively — a denylist of `main` alone let `resolve//` through unseen.
-  test("no huggingface.co url in the real manifest resolves through a mutable ref", () => {
+  test("no Hugging Face manifest URL resolves through a mutable ref", () => {
     const mutableRefs: string[] = [];
     for (const { relPath, url } of realManifestEntries()) {
       if (!url.startsWith("https://huggingface.co/")) continue;

--- a/tests/unit/check-model-plan-sizes.test.ts
+++ b/tests/unit/check-model-plan-sizes.test.ts
@@ -138,11 +138,13 @@ describe("parseManifestUrls", () => {
   // just one per colliding `relPath` (the test above). `manifest_tests::
   // every_huggingface_url_pins_an_immutable_revision` in models.rs covers the same rule with
   // real Rust types where it does run; this is the one that runs everywhere.
+  // Asserted positively — a denylist of `main` alone let `resolve//` through unseen.
   test("no huggingface.co url in the real manifest resolves through a mutable ref", () => {
     const mutableRefs: string[] = [];
     for (const { relPath, url } of realManifestEntries()) {
-      const ref = /^https:\/\/huggingface\.co\/[^/]+\/[^/]+\/resolve\/([^/]+)\//.exec(url)?.[1];
-      if (ref === undefined) continue;
+      if (!url.startsWith("https://huggingface.co/")) continue;
+      const afterResolve = url.split("/resolve/")[1];
+      const ref = afterResolve?.split("/")[0] ?? "";
       if (!/^[0-9a-f]{40}$/.test(ref)) mutableRefs.push(`${relPath}: ${url}`);
     }
     expect(mutableRefs).toEqual([]);


### PR DESCRIPTION
Closes #1093
Refs #1099

`kesha install --tts` hard-failed for every darwin-arm64 user: the Kokoro ANE
manifest resolved `FluidInference/kokoro-82m-coreml` at `resolve/main`, and
upstream republished the vocoder bundle on 2026-08-19 (commit `cdaea5e293…`),
so four pinned SHA-256s no longer matched what the URL now serves.

## Fix

Pin every third-party `huggingface.co/…/resolve/main/…` URL in
`rust/src/models.rs` to an immutable 40-hex commit instead of `main`:

| Repo | Pinned revision | How verified |
|---|---|---|
| `FluidInference/kokoro-82m-coreml` | `c94edcb4b671856795458645cd389c0a9184e8bb` (last revision before the republish) | all 94 `ANE/`, `ANE-zh/`, G2P files re-hashed against this revision — all 94 match the pins already in `models.rs` |
| `istupakov/parakeet-tdt-0.6b-v3-onnx` | `8f23f0c03c8761650bdb5b40aaf3e40d2c15f1ce` | `main`'s current `x-repo-commit`; representative file hash matches |
| `FluidInference/diar-streaming-sortformer-coreml` | `ae9a27ab45dc0aa3abede7d2d6bad2b7a69aa6d1` | same |
| `drakulavich/SpeechBrain-coreml` | `41e60dea31b80ea5d4f9d9d9e818501ea184e568` | same |
| `onnx-community/Kokoro-82M-v1.0-ONNX` | `1939ad2a8e416c0acfeecc08a694d14ef25f2231` | all 26 voice files used across both macros re-hashed against this revision — all 26 match |
| `klebster/g2p_multilingual_byT5_tiny_onnx` | `0e2cf759874353bcc0cd153d4b6886a27f61e4a7` | representative file hash matches |
| `drakulavich/vosk-tts-ru-0.9-multi` | `37c7b45a32b3fa62f3a2bbce89677080dcd2107f` | representative file hash matches |

The six non-`kokoro-82m-coreml` repos serve today, at `main`, byte-identical
content to the revisions pinned above — this is a no-op for users on those
paths, not a hash bump. No SHA-256 in `models.rs` was changed; `download_verified`
keeps its existing hash gate for every file (CLAUDE.md "MODEL HASHES ARE PINNED",
#174).

Adopting the *newer* vocoder weights upstream now ships (post `cdaea5e293…`)
is out of scope here — that changes synthesized audio and needs a listening
test before it lands. Filed as #1098.

### Scope: Hugging Face manifest URLs only

Two other manifest URLs are GitHub-hosted and equally mutable in principle
(`rust/src/models.rs:72`, `snakers4/silero-vad` pinned to a git *tag*;
`rust/src/models.rs:202`, a `thewh1teagle/kokoro-onnx` *release asset*), but
neither is touched here. Rationale and the guards' explicit scoping are in
`docs/mutation-evidence/issue-1093.md`'s "Scope" section — short version: the
silero-vad tag could be repinned to a commit (tracked as #1099), while a
GitHub release asset has no immutable URL form at all, so the SHA-256 pin is
the only guard that file will ever have.

### Guards added

Two regression guards, covering different lanes:

- `manifest_tests::every_huggingface_url_pins_an_immutable_revision`
  (`rust/src/models.rs`) — runs in `🧪 Rust Tests` on every PR, but only
  compiles the `system_kokoro`-gated ANE manifests (where the #1093
  regression actually lived) under a feature combination no CI job builds as
  tests.
- `parseManifestUrls > no Hugging Face manifest URL resolves through a
  mutable ref` (`tests/unit/check-model-plan-sizes.test.ts`) — runs in
  `🧪 CI` on every PR with no feature gating, reading `models.rs` as text via
  a new `parseManifestEntries` export, so it sees every manifest entry
  (`#[cfg(...)]` is invisible to a text parser) — this is the guard that
  actually closes the CI-reach gap for the ANE manifests.

Building the second guard surfaced (and fixed) a real bug in the parsing
helper it's built on: `parseManifestUrls`'s `Map<relPath, url>` let the
Mandarin ANE bundle silently shadow the English one wherever their
(intentionally identical) basenames collided. `parseManifestEntries` returns
every entry undeduped instead.

Also fixed `tests/unit/check-model-plan-sizes.test.ts`'s existing byte-exact
URL assertions (three of them, pinned against the old `resolve/main` strings).

## Deviations from docs/design.md

none

## Docs updated

none — no docs describe the manifest's URL-pinning scheme beyond the
`rust/src/models.rs` doc comments and the CLAUDE.md "MODEL HASHES ARE PINNED"
rule, neither of which changes: pinning `resolve/<rev>/` instead of
`resolve/main/` is the existing pinned-hash discipline extended to the ref
segment, not a new rule.

## Mutation evidence

`docs/mutation-evidence/issue-1093.md` — 9 rows, each naming its guard, file,
exact test, mutation, and result. Covers the ticket's actual regression (full
manifest and English-ANE-only reverts to `main`) plus three mutation shapes
that generalise past a `main`-only denylist (an empty `resolve//` ref, a
plausible-but-non-hex ref, and a fully deleted `/resolve/` segment) — the
`resolve//` case is the one review round 2 found the first guard version
missed; the table records that it reproducibly returned `NOT PINNED`
pre-fix and `PINNED` post-fix.

