### PR TITLE
perf: print a gate's output only when it fails

### DIFF
--- a/.claude/commands/preflight.md
+++ b/.claude/commands/preflight.md
@@ -6,7 +6,7 @@ allowed-tools: Bash(just:*)
 
 Run `just preflight` — or `just ALL=1 preflight` when `$ARGUMENTS` contains `--all` — and report a concise PASS/FAIL summary with the actual command output. Do **not** claim success on any failure: surface the failing output verbatim and stop.
 
-The recipe owns which gates run and with which flags; do not reconstruct the commands here or reach past it to raw `cargo`.
+The recipe owns which gates run and with which flags; do not reconstruct the commands here or reach past it to raw `cargo`. It prints one line per passing gate and the failing gate's log verbatim, so relay what it printed — re-running a gate loudly to see more only reprints what it already gave you.
 
 - If `cargo fmt` reformatted anything, mention the whitespace diff to commit.
 - If clippy fails only because CI's rustc is newer, point at `gh run view <id> --log-failed`.

--- a/justfile
+++ b/justfile
@@ -107,22 +107,26 @@ preflight:
     # A checkout that quietly fell 14 commits behind had an agent reading a stale CLAUDE.md for nine hours (#1070).
     [ "$behind" = "0" ] || echo "==> NOTE: this checkout is $behind commit(s) behind origin/main — read instructions with: git show origin/main:<path>"
 
+    # A green gate's output is never read, and handing it to an agent costs thousands of tokens
+    # per run; quiet-gate buffers it and prints it verbatim only when the gate fails.
+    gate() { bun scripts/quiet-gate.ts "$1" -- "${@:2}"; }
+
     echo "==> TS gate (always)"
-    bun run test
-    bun run lint
+    gate test bun run test
+    gate lint bun run lint
     # tests/unit/preflight-parity.test.ts holds this list equal to what CI runs (#1070).
-    bun run check:recipes
-    bun run check:workflows
-    bun run check:versions
-    bun run check:specs
-    bun run check:engine-targets
-    bun run check:release-manifest
+    gate check:recipes bun run check:recipes
+    gate check:workflows bun run check:workflows
+    gate check:versions bun run check:versions
+    gate check:specs bun run check:specs
+    gate check:engine-targets bun run check:engine-targets
+    gate check:release-manifest bun run check:release-manifest
 
     if [ -n "$rust" ]; then
       echo "==> Rust gate"
       # `cargo fmt` formats in place rather than checking, so this can leave a whitespace diff to commit.
-      (cd rust && cargo fmt && cargo clippy --all-targets -- -D warnings)
-      {{ just_executable() }} rust-test
+      gate clippy bash -c 'cd rust && cargo fmt && cargo clippy --all-targets -- -D warnings'
+      gate rust-test {{ just_executable() }} rust-test
     else
       echo "==> Rust gate skipped: no rust/ changes (force with just ALL=1 preflight)"
     fi
@@ -130,7 +134,7 @@ preflight:
     if [ -n "$backend" ]; then
       echo "==> CoreML build check"
       # --all-targets matches rust-test.yml's check so the #[cfg(feature = "coreml")] tests compile too (#708).
-      (cd rust && cargo check --features coreml --no-default-features --all-targets)
+      gate coreml bash -c 'cd rust && cargo check --features coreml --no-default-features --all-targets'
     else
       echo "==> CoreML check skipped: no rust/src/backend/ changes"
     fi

--- a/scripts/mutate.ts
+++ b/scripts/mutate.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env bun
 import { readFileSync, writeFileSync } from "node:fs";
+import { runQuiet } from "./quiet-gate";
 
 export type MutationResult = { replacements: number; source: string };
 
@@ -9,6 +10,17 @@ export function mutate(source: string, find: string, replace: string): MutationR
   if (find.length === 0) throw new Error("the text to replace must not be empty");
   const replacements = source.split(find).length - 1;
   return { replacements, source: replacements === 0 ? source : source.split(find).join(replace) };
+}
+
+export type MutationRun = { exitCode: number; log: string; discard?: () => void };
+export type MutationVerdict = { pinned: boolean; report: string };
+
+/// A caught mutation's output is the failure the run asked for, and nobody reads it — but a test
+/// command that never ran a test (a build error, a filterset matching nothing) also exits non-zero
+/// and reads identically, so the tail stays. A survivor is the surprising outcome: print it all.
+export function verdict(run: MutationRun, tailLines = 5): MutationVerdict {
+  if (run.exitCode === 0) return { pinned: false, report: run.log };
+  return { pinned: true, report: run.log.replace(/\n$/, "").split("\n").slice(-tailLines).join("\n") };
 }
 
 function usage(message: string): never {
@@ -27,17 +39,20 @@ async function main(): Promise<void> {
     process.exit(2);
   }
 
-  let survived = false;
+  let run: MutationRun = { exitCode: 0, log: "" };
   try {
     writeFileSync(file, source);
     console.error(`==> mutated ${file} (${replacements} occurrence${replacements === 1 ? "" : "s"}); running: ${command.join(" ")}`);
-    survived = (await Bun.spawn(command, { stdout: "inherit", stderr: "inherit" }).exited) === 0;
+    run = await runQuiet(command);
   } finally {
     writeFileSync(file, original);
     console.error(`==> restored ${file}`);
   }
 
-  if (survived) {
+  const result = verdict(run);
+  run.discard?.();
+  console.error(result.report);
+  if (!result.pinned) {
     console.error(`NOT PINNED: the mutation survived — nothing failed when '${find}' was replaced`);
     process.exit(1);
   }

--- a/scripts/quiet-gate.ts
+++ b/scripts/quiet-gate.ts
@@ -1,0 +1,65 @@
+#!/usr/bin/env bun
+import { closeSync, mkdtempSync, openSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/// `discard` removes the kept log; a caller that prints the log keeps the file so a large failure
+/// can be grepped instead of re-run.
+export type QuietResult = { exitCode: number; log: string; logPath: string; durationMs: number; discard: () => void };
+
+/// Both streams share one file descriptor so the log reads in the order the command wrote it:
+/// separate pipes reorder a failure's error relative to the output that followed it.
+export async function runQuiet(argv: string[], directory = mkdtempSync(join(tmpdir(), "kesha-gate-"))): Promise<QuietResult> {
+  const logPath = join(directory, "gate.log");
+  const started = Date.now();
+  const discard = () => rmSync(directory, { recursive: true, force: true });
+  const fd = openSync(logPath, "w");
+  let log: string;
+  let exitCode: number;
+  try {
+    exitCode = await Bun.spawn(argv, { stdout: fd, stderr: fd }).exited;
+  } catch (error) {
+    exitCode = 127;
+    log = `could not start ${argv[0]}: ${error instanceof Error ? error.message : String(error)}\n`;
+    closeSync(fd);
+    writeFileSync(logPath, log);
+    return { exitCode, log, logPath, durationMs: Date.now() - started, discard };
+  }
+  closeSync(fd);
+  log = readFileSync(logPath, "utf8");
+  return { exitCode, log, logPath, durationMs: Date.now() - started, discard };
+}
+
+function usage(message: string): never {
+  console.error(`${message}\nusage: bun scripts/quiet-gate.ts <label> -- <command> [args...]`);
+  process.exit(2);
+}
+
+function seconds(durationMs: number): string {
+  return `${(durationMs / 1000).toFixed(1)}s`;
+}
+
+async function main(): Promise<void> {
+  const [label, separator, ...command] = process.argv.slice(2);
+  if (!label) usage("a label is required");
+  if (separator !== "--" || command.length === 0) usage("the command must follow a literal --");
+
+  // A buffered gate shows nothing while it runs, which matters only to someone watching it.
+  if (process.stderr.isTTY) process.stderr.write(`… ${label}\n`);
+  const result = await runQuiet(command);
+  if (result.exitCode === 0) {
+    result.discard();
+    console.log(`✓ ${label} ${seconds(result.durationMs)}`);
+    return;
+  }
+  process.stderr.write(result.log);
+  process.stderr.write(`✗ ${label} failed (exit ${result.exitCode}) after ${seconds(result.durationMs)}; log kept at ${result.logPath}\n`);
+  process.exit(result.exitCode);
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error(`quiet-gate: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(2);
+  });
+}

--- a/tests/unit/mutate.test.ts
+++ b/tests/unit/mutate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mutate } from "../../scripts/mutate";
+import { mutate, verdict } from "../../scripts/mutate";
 
 describe("mutate", () => {
   // A perl one-liner whose pattern misses exits 0 and changes nothing, so the test passes and the
@@ -22,5 +22,32 @@ describe("mutate", () => {
 
   test("refuses an empty needle instead of splitting every character", () => {
     expect(() => mutate("abc", "", "x")).toThrow("must not be empty");
+  });
+});
+
+describe("verdict", () => {
+  const log = ["compiling", "running", "(fail) it refuses", "1 fail", "Ran 3 tests"].join("\n");
+
+  test("a caught mutation reports the run's last lines, not the failure it was asking for", () => {
+    const result = verdict({ exitCode: 1, log }, 2);
+
+    expect(result.pinned).toBe(true);
+    expect(result.report).toBe("1 fail\nRan 3 tests");
+    expect(result.report).not.toContain("compiling");
+  });
+
+  // A test command that never ran a test — a build error, a filter matching nothing — exits
+  // non-zero and would otherwise read exactly like a caught assertion.
+  test("keeps enough of a caught run to tell an assertion from a command that never ran", () => {
+    const result = verdict({ exitCode: 101, log: "error: could not compile `kesha-engine`" }, 2);
+
+    expect(result.report).toContain("could not compile");
+  });
+
+  test("a surviving mutation reports the whole run, because nothing failed to point at", () => {
+    const result = verdict({ exitCode: 0, log }, 2);
+
+    expect(result.pinned).toBe(false);
+    expect(result.report).toBe(log);
   });
 });

--- a/tests/unit/preflight-parity.test.ts
+++ b/tests/unit/preflight-parity.test.ts
@@ -43,6 +43,16 @@ describe("preflight is the gate CLAUDE.md claims it is", () => {
     expect(missing).toEqual([]);
   });
 
+  // A green gate's output is never read, and every line of it is context an agent pays for.
+  test("it runs every gate through the quiet wrapper", () => {
+    const loud = preflightBody()
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => /^(bun run |cargo |\{\{ just_executable\(\) \}\})/.test(line));
+
+    expect(loud).toEqual([]);
+  });
+
   test("it reports a stale checkout rather than staying silent about it", () => {
     // The number is already computed for the gate selection; a checkout 14 commits behind had an
     // agent reading a stale CLAUDE.md for nine hours before anyone noticed (#1070).

--- a/tests/unit/quiet-gate.test.ts
+++ b/tests/unit/quiet-gate.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import { runQuiet } from "../../scripts/quiet-gate";
+
+// process.execPath, not "bun": a bare name fails uv_spawn on Windows. import.meta.dir is
+// Bun-native and absolute, where a file URL's pathname keeps the leading slash Windows rejects.
+const SCRIPT = join(import.meta.dir, "..", "..", "scripts", "quiet-gate.ts");
+
+async function cli(argv: string[]): Promise<{ code: number; stdout: string; stderr: string }> {
+  const proc = Bun.spawn([process.execPath, SCRIPT, ...argv], { stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr, code] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text(), proc.exited]);
+  return { code, stdout, stderr };
+}
+
+describe("runQuiet", () => {
+  test("keeps the two streams in the order the command wrote them", async () => {
+    // Separate pipes would report both streams whole, and a failing gate's error would read as
+    // if it happened after output that actually followed it.
+    const result = await runQuiet(["bash", "-c", "echo one; echo two >&2; echo three"]);
+
+    expect(result.log).toBe("one\ntwo\nthree\n");
+  });
+
+  test("propagates the command's exit code", async () => {
+    expect((await runQuiet(["bash", "-c", "exit 7"])).exitCode).toBe(7);
+  });
+
+  test("reports a command that could not start rather than calling it a pass", async () => {
+    const result = await runQuiet(["kesha-no-such-binary"]);
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.log).toContain("kesha-no-such-binary");
+  });
+});
+
+describe("quiet-gate cli", () => {
+  test("a passing gate reports one line and not the output it swallowed", async () => {
+    const result = await cli(["unit", "--", "bash", "-c", "echo 1339 pass; echo 9 skip"]);
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("unit");
+    expect(result.stdout).not.toContain("1339 pass");
+    expect(result.stderr).not.toContain("1339 pass");
+  });
+
+  test("a failing gate prints what it ran verbatim, so the failure is never swallowed", async () => {
+    const result = await cli(["unit", "--", "bash", "-c", "echo 1 fail; echo boom >&2; exit 3"]);
+
+    expect(result.code).toBe(3);
+    expect(`${result.stdout}${result.stderr}`).toContain("1 fail");
+    expect(`${result.stdout}${result.stderr}`).toContain("boom");
+  });
+
+  test("refuses a call with no command instead of reporting an empty gate as green", async () => {
+    const result = await cli(["unit"]);
+
+    expect(result.code).toBe(2);
+    expect(result.stderr).toContain("usage");
+  });
+});


### PR DESCRIPTION
## What

The two pieces of #1087 that survive the conveyor migration, re-cut against today's `main`.
Every file touched here is still on `main`; nothing in this PR concerns the retired conveyor.

- **`scripts/quiet-gate.ts` + a quiet `preflight`.** A labelled command runs with **one shared
  file descriptor for stdout and stderr**, so the buffered log keeps the order the command wrote
  it — separate pipes reorder a failure's error against the output that followed it. A pass
  prints `✓ label 54.4s`; a failure prints the log **verbatim**, the kept log path, and the
  child's exit code, and `preflight` stops there as it always did. A new
  `tests/unit/preflight-parity.test.ts` case fails if any gate goes loud again.
- **`just mutate` reports a caught mutation by its tail.** Not by zero lines: a build error or a
  filterset matching nothing also exits non-zero and would read exactly like a caught assertion,
  so the tail is what tells them apart. A survivor still prints whole, being the surprising
  outcome.

## Why

Measured on `main`: `bun run test` alone is 197 lines / 9.4 KB, and `preflight` runs 8 TS gates
plus up to 3 Rust ones, handing every line of all of them to whoever ran it. On a green run none
of it is read. `just mutate` had the same shape inverted — a *caught* mutation, the outcome the
command exists to produce, printed an entire failing suite.

Both measurements are independent of #1094: the gates and the mutation harness are unchanged by
the conveyor's move to a standalone tool.

Refs #1087.

## Testing

- `just preflight` on this branch: the test gate printed its log verbatim and stopped, on
  `tests/unit/doctor.test.ts:342` — which `chmod 000`s a directory and asserts the read fails,
  so it fails on any checkout run **as root** and not in CI. Untouched by this diff, and
  reproduced on unmodified `main` in the same container. The remaining gates were then run
  individually and are all green: `lint`, `check:recipes`, `check:workflows`, `check:versions`,
  `check:specs`, `check:engine-targets`, `check:release-manifest`. No `rust/` changes, so the
  Rust and CoreML gates are correctly skipped.
- `bun test tests/unit/{quiet-gate,mutate,preflight-parity}.test.ts` — 16 pass.
- Both new guards proved with the harness they guard:
  `bun scripts/mutate.ts justfile 'gate lint bun run lint' 'bun run lint' bun test tests/unit/preflight-parity.test.ts`
  reports `PINNED`, and the same for the `gate test` line.
- The three `quiet-gate cli` cases resolve the script through `import.meta.dir` and spawn
  `process.execPath`, the idiom `tests/unit/mcp-stdout-discipline.test.ts` documents — a file
  URL's pathname and a bare `bun` both fail on Windows, which is how they failed in #1087 before
  the fix carried here.

## Checklist

- [x] `bun run check` passes (lint + version drift + fast tests)
- [x] Tests added/updated for the change
- [ ] Rust changes — none in this PR
- [x] Docs updated: `.claude/commands/preflight.md` notes that the recipe already prints the
      failing gate's log verbatim

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DiFrNwMupZF4oxxkkLkaRX

---
_Generated by [Claude Code](https://claude.ai/code/session_01DiFrNwMupZF4oxxkkLkaRX)_