### PR TITLE
chore(release): kesha-engine 1.24.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     }
   },
   "keshaEngine": {
-    "version": "1.24.10"
+    "version": "1.24.11"
   },
   "scripts": {
     "test": "bun test --timeout 30000",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "kesha-engine"
-version = "1.24.10"
+version = "1.24.11"
 dependencies = [
  "anyhow",
  "audioadapter-buffers",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesha-engine"
-version = "1.24.10"
+version = "1.24.11"
 edition = "2021"
 description = "Inference engine for Kesha Voice Kit: ASR + language detection"
 # Not for crates.io. The library target (`src/lib.rs`) exists only for the


### PR DESCRIPTION
Engine-only version bump for the `v1.24.11` release.

Three fields, nothing else: `rust/Cargo.toml`, `rust/Cargo.lock` and
`package.json#keshaEngine.version`. `package.json#version` deliberately stays
on the unreleased CLI line (1.29.0) — dragging it down would publish that as
npm `latest` and downgrade every user (#729). `check:versions` rule 2
(`cli >= engine`) holds: 1.29.0 >= 1.24.11.

## What ships in v1.24.11

- **#1093** — `kesha install --tts` hard-failed for every darwin-arm64 user with
  `E_CACHE_CORRUPT` after `FluidInference/kokoro-82m-coreml` republished its ANE
  vocoder bundle on a `resolve/main` URL. Every Hugging Face manifest URL is now
  pinned to an immutable 40-hex commit, with guards in both CI lanes against a
  return to a mutable ref. No pinned SHA-256 changed (#1096).
- **#1058** — engine: serialize stdout fd ownership.
- **#1059** — record: bound the callback queue's ownership.

## Deviations from docs/design.md

none

## Docs updated

none — version bump only.
