### PR TITLE
fix(engine-targets): sync the darwin-arm64 asset size to v1.24.11

### DIFF
--- a/src/engine-targets.ts
+++ b/src/engine-targets.ts
@@ -17,7 +17,7 @@ const ENGINE_TARGETS: Record<string, EngineTarget> = {
   "darwin-arm64": {
     assetName: "kesha-engine-darwin-arm64",
     backend: "coreml",
-    sizeBytes: 64_514_624,
+    sizeBytes: 64_514_608,
   },
   "linux-x64": {
     assetName: "kesha-engine-linux-x64",


### PR DESCRIPTION
`check:engine-targets` went red on `main` the moment `v1.24.11` published.

`ENGINE_TARGETS` still carried v1.24.10's darwin-arm64 asset size:

```
darwin-arm64: kesha-engine-darwin-arm64 is 64514608 bytes in v1.24.11,
              but ENGINE_TARGETS says 64514624
```

`linux-x64` and `win32-x64` were byte-identical in size across the two
releases and already matched, so only the one field moved.

## Impact

`sizeBytes` feeds `kesha install --plan`, so the user-visible effect was a
wrong figure in the plan, not a broken install — the download itself is
guarded by the asset name and the release's own checksums. What made it
urgent is the gate: `check-engine-targets` runs in `workflow-lint` and fails
**every** PR that reaches it, and `src/engine-targets.ts` ships inside the CLI
package, so it must be right before the `v1.29.0-cli` tag.

## Verification

`bun run check:engine-targets` was red before this change and is green after,
on all three targets:

```
ok: darwin-arm64 → kesha-engine-darwin-arm64 (64514608 bytes)
ok: linux-x64    → kesha-engine-linux-x64 (66375432 bytes)
ok: win32-x64    → kesha-engine-windows-x64.exe (65355264 bytes)
```

That script is itself the regression guard — it compares the constant against
the published release, so it cannot go stale silently again.

## Deviations from docs/design.md

none

## Docs updated

none — one constant.
