### PR TITLE
fix(release-cli): grant the smoke call the permission its callee requests

### DIFF
--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -588,6 +588,66 @@ function describeUnreadable(path: string, err: unknown): string {
   return `${path}: ${err instanceof Error ? err.message : String(err)}`;
 }
 
+const PERMISSION_RANK: Record<string, number> = { none: 0, read: 1, write: 2 };
+const LEVEL_NAME = ["none", "read", "write"] as const;
+
+/** GitHub grants a called workflow only what the calling job holds; a job-level block replaces the workflow-level one. */
+function permissionGrants(node: unknown): Record<string, number> | undefined {
+  if (node === undefined || node === null) return undefined;
+  if (typeof node === "string") return { "*": node === "write-all" ? 2 : node === "read-all" ? 1 : 0 };
+  if (typeof node !== "object") return undefined;
+  const out: Record<string, number> = {};
+  for (const [scope, value] of Object.entries(node as Record<string, unknown>)) {
+    out[scope] = PERMISSION_RANK[String(value)] ?? 0;
+  }
+  return out;
+}
+
+function grantedTo(scope: string, grants: Record<string, number> | undefined): number {
+  if (!grants) return 0;
+  return grants[scope] ?? grants["*"] ?? 0;
+}
+
+export function requireReusableCallPermissions(path: string, document: unknown): string[] {
+  const doc = document as { jobs?: Record<string, Job>; permissions?: unknown } | undefined;
+  const jobs = doc?.jobs;
+  if (!jobs || typeof jobs !== "object") return [];
+
+  const workflowGrants = permissionGrants(doc?.permissions);
+  const errors: string[] = [];
+
+  for (const [name, job] of Object.entries(jobs)) {
+    const uses = (job as { uses?: unknown })?.uses;
+    if (typeof uses !== "string" || !uses.startsWith("./.github/workflows/")) continue;
+
+    const calleePath = uses.slice(2);
+    if (!existsSync(calleePath)) {
+      errors.push(`${path}: \`${name}\` calls ${uses}, which does not exist`);
+      continue;
+    }
+
+    const callee = parse(readFileSync(calleePath, "utf8")) as
+      | { jobs?: Record<string, Job>; permissions?: unknown }
+      | undefined;
+    const calleeDefaults = permissionGrants(callee?.permissions);
+    const granted = permissionGrants((job as { permissions?: unknown })?.permissions) ?? workflowGrants;
+
+    for (const [calleeJob, nested] of Object.entries(callee?.jobs ?? {})) {
+      const wanted = permissionGrants((nested as { permissions?: unknown })?.permissions) ?? calleeDefaults;
+      if (!wanted) continue;
+      for (const [scope, level] of Object.entries(wanted)) {
+        if (scope === "*" || level <= grantedTo(scope, granted)) continue;
+        errors.push(
+          `${path}: \`${name}\` calls ${uses} whose job \`${calleeJob}\` requests \`${scope}: ${LEVEL_NAME[level]}\`, ` +
+            `but the calling job only grants \`${scope}: ${LEVEL_NAME[grantedTo(scope, granted)]}\`. ` +
+            `GitHub validates this before any \`if:\` runs, so the whole workflow fails to start`,
+        );
+      }
+    }
+  }
+  return errors;
+}
+
 export function checkFile(
   path: string,
   testedScripts: string[],
@@ -606,6 +666,7 @@ export function checkFile(
       ...requirePactVerificationCoversEveryTarget(path, document),
       ...requireBashOnWindowsRunSteps(path, document),
       ...requirePipefailShell(path, document),
+      ...requireReusableCallPermissions(path, document),
       ...requireAptTimeouts(path, document),
       ...requireDepsBeforeBunTest(path, document),
       ...requireRestoreOnlyCachesHaveAWriter(path, document, cacheWriters),

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -132,6 +132,10 @@ jobs:
     name: Smoke the published npm install
     needs: [plan, publish-npm]
     uses: ./.github/workflows/release-install-smoke.yml
+    # Static validation: the callee's draft-engine job asks for contents: write, and GitHub
+    # checks that before any `if:` runs — the workflow-level read would refuse to start.
+    permissions:
+      contents: write
     with:
       tag: ${{ needs.plan.outputs.tag }}
       version: ${{ needs.plan.outputs.version }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.29.0",
+  "version": "1.29.1",
   "description": "Give your tools a voice — speech to text and back, 25 languages, up to ~19× faster than Whisper. On your machine.",
   "type": "module",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/drakulavich/kesha-voice-kit",
     "source": "github"
   },
-  "version": "1.29.0",
+  "version": "1.29.1",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@drakulavich/kesha-voice-kit",
-      "version": "1.29.0",
+      "version": "1.29.1",
       "transport": {
         "type": "stdio"
       },

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -9,6 +9,7 @@ import {
   requireAptTimeouts,
   requireBashOnWindowsRunSteps,
   requirePipefailShell,
+  requireReusableCallPermissions,
   requireRestoreOnlyCachesHaveAWriter,
   requireDarwinSmokeCoversBothEngines,
   requireDepsBeforeBunTest,
@@ -645,5 +646,55 @@ describe("requireAptTimeouts", () => {
     const path = join(mkdtempSync(join(tmpdir(), "kesha-wf-")), "rust-test.yml");
     writeFileSync(path, yaml);
     expect(checkFile(path, [], [], undefined).filter((e) => e.includes("#1090"))).toHaveLength(1);
+  });
+});
+
+describe("requireReusableCallPermissions", () => {
+  const SMOKE = "./.github/workflows/release-install-smoke.yml";
+
+  test("passes on the real release-cli.yml", () => {
+    expect(requireReusableCallPermissions(RELEASE_CLI, parseRepoYaml(RELEASE_CLI))).toEqual([]);
+  });
+
+  test("ignores a job that runs steps rather than calling a workflow", () => {
+    expect(requireReusableCallPermissions(RELEASE_CLI, job("build", [UPLOAD]))).toEqual([]);
+  });
+
+  test("fails when the caller grants read and the callee asks for write", () => {
+    const errors = requireReusableCallPermissions(RELEASE_CLI, {
+      permissions: { contents: "read" },
+      jobs: { smoke: { uses: SMOKE } },
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("draft-engine");
+    expect(errors[0]).toContain("fails to start");
+  });
+
+  test("passes once the calling job raises the scope itself", () => {
+    expect(
+      requireReusableCallPermissions(RELEASE_CLI, {
+        permissions: { contents: "read" },
+        jobs: { smoke: { uses: SMOKE, permissions: { contents: "write" } } },
+      }),
+    ).toEqual([]);
+  });
+
+  test("a job-level block replaces the workflow-level one rather than merging", () => {
+    // The job grants only `actions`, so `contents` drops to none for the call — both callee jobs go unmet.
+    const errors = requireReusableCallPermissions(RELEASE_CLI, {
+      permissions: { contents: "write" },
+      jobs: { smoke: { uses: SMOKE, permissions: { actions: "read" } } },
+    });
+    expect(errors).toHaveLength(2);
+    expect(errors.join("\n")).toContain("requests \`contents: read\`");
+    expect(errors.join("\n")).toContain("only grants \`contents: none\`");
+  });
+
+  test("reports a called workflow that does not exist", () => {
+    const errors = requireReusableCallPermissions(RELEASE_CLI, {
+      jobs: { smoke: { uses: "./.github/workflows/does-not-exist.yml" } },
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("does not exist");
   });
 });


### PR DESCRIPTION
`v1.29.0-cli` was pushed and the lane died at startup, creating no release:

```
.github/workflows/release-cli.yml (Line: 131, Col: 3): Error calling workflow
'.../release-install-smoke.yml@3123c5d'. The nested job 'draft-engine' is
requesting 'contents: write', but is only allowed 'contents: read'.
```

## Cause

`release-cli.yml` declares `contents: read` at workflow level. `published-install-smoke`
does not raise it, so the reusable workflow is called with read — while that workflow's
`draft-engine` job asks for `contents: write`.

`draft-engine` never runs from this caller: it is gated on `inputs.mode == 'draft-engine'`
and the caller passes no `mode`, so it defaults to `npm`. **GitHub validates the permission
contract statically, before any `if:` is evaluated**, so the presence of the job is enough
to refuse the entire workflow.

The bug entered in #1055, which landed after `v1.28.0-cli`. This lane only runs on a `-cli`
tag push, so there was no earlier occasion for it to fail — it detonated on the first CLI
release since.

## Fix

`published-install-smoke` raises `contents: write` for itself, which is what `plan` and
`packages` already do in this same file — the workflow-level `read` stays the default for
everything else.

## Guard

`requireReusableCallPermissions` (`.github/scripts/check-workflows.ts`, wired into
`check:workflows` and therefore `workflow-lint`) resolves every
`uses: ./.github/workflows/*.yml` call, computes what each callee job requests against what
the calling job grants — modelling job-level `permissions` as *replacing* the workflow-level
block, which is what GitHub does — and fails on any shortfall.

Removing the fix and re-running the gate reproduces GitHub's own wording:

```
release-cli.yml: `published-install-smoke` calls ./.github/workflows/release-install-smoke.yml
whose job `draft-engine` requests `contents: write`, but the calling job only grants
`contents: read`. GitHub validates this before any `if:` runs, so the whole workflow fails to start
```

Restoring it goes green. `actionlint` does not model cross-workflow permission contracts, which
is why `workflow-lint` was green on the commit that shipped this.

Six tests cover it: the real file, a steps-only job, the shortfall, the fix, job-level
replacement semantics, and a call to a workflow that does not exist.

## Version

Leads the CLI base to **1.29.1** — `package.json#version`, `server.json#version` and
`server.json#packages[0].version`. `v1.29.0-cli` is spent: GitHub reserves tag names, so the
release ships under the next patch. `keshaEngine.version` stays at the published `1.24.11`.

## Deviations from docs/design.md

none

## Docs updated

none — the rule documents itself in its failure message.
