### PR TITLE
fix(release): read whole npm metadata, and lead the base to 1.30.0

### DIFF
--- a/.github/scripts/release-install-smoke.sh
+++ b/.github/scripts/release-install-smoke.sh
@@ -80,9 +80,7 @@ run_npm() {
   export npm_config_cache="$scratch/npm-cache"
   export NPM_CONFIG_PREFIX="$prefix"
 
-  # Ask for the whole document, never a field list. `--json a,b,c` answers with an empty
-  # document at exit 0, and `jq -e` on no input exits 4; the space-separated form flattens to
-  # keys named literally "dist.integrity". Both defeat a nested filter, for different reasons.
+  # Never a field list: `--json a,b,c` yields an empty document at exit 0, and the space-separated form flattens `dist.integrity` into a literal key.
   npm view "$package@$VERSION" --json > "$metadata"
   jq -e --arg version "$VERSION" '
     .version == $version

--- a/.github/scripts/release-install-smoke.sh
+++ b/.github/scripts/release-install-smoke.sh
@@ -80,7 +80,7 @@ run_npm() {
   export npm_config_cache="$scratch/npm-cache"
   export NPM_CONFIG_PREFIX="$prefix"
 
-  # Never a field list: `--json a,b,c` yields an empty document at exit 0, and the space-separated form flattens `dist.integrity` into a literal key.
+  # Never a field list: `--json a,b,c` returns zero bytes at exit 0, and the space-separated form flattens `dist.integrity` into a literal key.
   npm view "$package@$VERSION" --json > "$metadata"
   jq -e --arg version "$VERSION" '
     .version == $version

--- a/.github/scripts/release-install-smoke.sh
+++ b/.github/scripts/release-install-smoke.sh
@@ -80,8 +80,9 @@ run_npm() {
   export npm_config_cache="$scratch/npm-cache"
   export NPM_CONFIG_PREFIX="$prefix"
 
-  # Ask for the whole document, not a field list: `npm view --json a b c` answers with keys
-  # named literally "dist.integrity" and "dist.attestations", so a nested filter reads null.
+  # Ask for the whole document, never a field list. `--json a,b,c` answers with an empty
+  # document at exit 0, and `jq -e` on no input exits 4; the space-separated form flattens to
+  # keys named literally "dist.integrity". Both defeat a nested filter, for different reasons.
   npm view "$package@$VERSION" --json > "$metadata"
   jq -e --arg version "$VERSION" '
     .version == $version

--- a/.github/scripts/release-install-smoke.sh
+++ b/.github/scripts/release-install-smoke.sh
@@ -80,7 +80,9 @@ run_npm() {
   export npm_config_cache="$scratch/npm-cache"
   export NPM_CONFIG_PREFIX="$prefix"
 
-  npm view "$package@$VERSION" --json version,dist.integrity,dist.attestations > "$metadata"
+  # Ask for the whole document, not a field list: `npm view --json a b c` answers with keys
+  # named literally "dist.integrity" and "dist.attestations", so a nested filter reads null.
+  npm view "$package@$VERSION" --json > "$metadata"
   jq -e --arg version "$VERSION" '
     .version == $version
     and (.dist.integrity | type == "string" and startswith("sha512-"))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakulavich/kesha-voice-kit",
-  "version": "1.29.1",
+  "version": "1.30.0",
   "description": "Give your tools a voice — speech to text and back, 25 languages, up to ~19× faster than Whisper. On your machine.",
   "type": "module",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/drakulavich/kesha-voice-kit",
     "source": "github"
   },
-  "version": "1.29.1",
+  "version": "1.30.0",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@drakulavich/kesha-voice-kit",
-      "version": "1.29.1",
+      "version": "1.30.0",
       "transport": {
         "type": "stdio"
       },

--- a/tests/unit/release-install-smoke.test.ts
+++ b/tests/unit/release-install-smoke.test.ts
@@ -7,8 +7,9 @@ const SCRIPT = ".github/scripts/release-install-smoke.sh";
 function metadataFilter(): string {
   const source = readFileSync(SCRIPT, "utf8");
   const match = source.match(/jq -e --arg version "\$VERSION" '\n([\s\S]*?)\n\s*' "\$metadata"/);
-  if (!match) throw new Error(`${SCRIPT}: could not find the npm metadata jq filter`);
-  return match[1];
+  const filter = match?.[1];
+  if (!filter) throw new Error(`${SCRIPT}: could not find the npm metadata jq filter`);
+  return filter;
 }
 
 async function runFilter(document: unknown): Promise<boolean> {

--- a/tests/unit/release-install-smoke.test.ts
+++ b/tests/unit/release-install-smoke.test.ts
@@ -3,14 +3,12 @@ import { readFileSync } from "node:fs";
 
 const SCRIPT = ".github/scripts/release-install-smoke.sh";
 
-// These cases execute the script's real jq rather than a reimplementation, so they need it
-// on PATH. GitHub runners all ship it; a contributor machine may not.
+// These cases run the script's real jq, which a contributor machine may not have.
 const JQ = Bun.which("jq");
 
 /** The jq the script actually runs, lifted from the script so the test cannot drift from it. */
 function metadataFilter(): string {
-  // Windows CI checks the tree out with CRLF, and the pattern below anchors on newlines:
-  // without this the filter is simply not found and every case fails on that runner alone.
+  // Windows CI checks out CRLF and the pattern anchors on newlines.
   const source = readFileSync(SCRIPT, "utf8").replace(/\r\n/g, "\n");
   const match = source.match(/jq -e --arg version "\$VERSION" '\n([\s\S]*?)\n\s*' "\$metadata"/);
   const filter = match?.[1];
@@ -44,8 +42,6 @@ const PUBLISHED = {
 };
 
 describe("release-install-smoke npm metadata gate", () => {
-  // The skip is an escape hatch for contributor machines, not for CI. Without this a future
-  // image change could silently skip every predicate case and leave the suite green.
   test("jq is present in CI, so none of the cases below are silently skipped", () => {
     if (process.env.CI) expect(JQ).toBeTruthy();
   });
@@ -54,16 +50,12 @@ describe("release-install-smoke npm metadata gate", () => {
     expect(await runFilter(PUBLISHED)).toBe(true);
   });
 
-  // THE regression. The replaced command was `--json version,dist.integrity,dist.attestations`
-  // — one comma-joined argument, not three. npm answers that with an empty document at exit 0,
-  // and `jq -e` on no input exits 4, so the gate failed every release whatever was published.
+  // The regression: `--json version,dist.integrity,dist.attestations` is one comma-joined argument, and npm answers it with nothing.
   test.skipIf(!JQ)("fails on the empty document the comma-joined field list produced", async () => {
     expect(await runFilterRaw("")).toBe(4);
   });
 
-  // Not the regression: the space-separated form flattens instead of emptying. Kept because it
-  // is the other way a field list breaks this filter, and the difference is easy to misread —
-  // the first analysis of this bug reproduced this shape and described it as the cause.
+  // The other way a field list breaks this filter, and the one easily mistaken for the regression above.
   test.skipIf(!JQ)("rejects the flattened shape a space-separated field list returns", async () => {
     const flattened = {
       version: "1.29.1",

--- a/tests/unit/release-install-smoke.test.ts
+++ b/tests/unit/release-install-smoke.test.ts
@@ -1,53 +1,78 @@
 import { describe, expect, test } from "bun:test";
-import { parseRepoYaml, readRepoFile } from "../helpers/repo";
+import { readFileSync } from "node:fs";
 
-const WORKFLOW = ".github/workflows/release-install-smoke.yml";
 const SCRIPT = ".github/scripts/release-install-smoke.sh";
 
-describe("release install smoke", () => {
-  test("keeps the draft gate manual and makes the post-npm path reusable", () => {
-    const workflow = parseRepoYaml(WORKFLOW);
+/** The jq the script actually runs, lifted from the script so the test cannot drift from it. */
+function metadataFilter(): string {
+  const source = readFileSync(SCRIPT, "utf8");
+  const match = source.match(/jq -e --arg version "\$VERSION" '\n([\s\S]*?)\n\s*' "\$metadata"/);
+  if (!match) throw new Error(`${SCRIPT}: could not find the npm metadata jq filter`);
+  return match[1];
+}
 
-    expect(workflow.on.workflow_dispatch.inputs.mode.default).toBe("draft-engine");
-    expect(workflow.on.workflow_call.inputs.version.required).toBe(true);
-    expect(workflow.on.workflow_call.inputs.mode.default).toBe("npm");
-    expect(workflow.jobs["draft-engine"].permissions).toEqual({ contents: "write" });
-    expect(workflow.jobs.npm.permissions).toEqual({ contents: "read" });
+async function runFilter(document: unknown): Promise<boolean> {
+  const proc = Bun.spawn(["jq", "-e", "--arg", "version", "1.29.1", metadataFilter()], {
+    stdin: new TextEncoder().encode(JSON.stringify(document)),
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  return (await proc.exited) === 0;
+}
+
+/** What `npm view <pkg> --json` returns, trimmed to the keys the filter reads. */
+const PUBLISHED = {
+  version: "1.29.1",
+  dist: {
+    integrity: "sha512-avT1buNeu0R2AsD0eaN1FCs5wlerjWET7jAlmBcGhnksILSmDOWjKJkAQe1wvkEkGkn/rhGop3ieB9QuCPRmPA==",
+    attestations: {
+      url: "https://registry.npmjs.org/-/npm/v1/attestations/@drakulavich%2fkesha-voice-kit@1.29.1",
+      provenance: { predicateType: "https://slsa.dev/provenance/v1" },
+    },
+  },
+};
+
+describe("release-install-smoke npm metadata gate", () => {
+  test("accepts a genuinely published, provenance-carrying version", async () => {
+    expect(await runFilter(PUBLISHED)).toBe(true);
   });
 
-  test("downloads the authenticated draft artifact into a disposable private cache", () => {
-    const script = readRepoFile(SCRIPT);
-    const synthesisSmoke = readRepoFile(".github/scripts/smoke-synthesis.ts");
-
-    expect(script).toContain('gh release download "$TAG"');
-    expect(script).toContain('[ "$(gh release view "$TAG" --json isDraft --jq .isDraft)" = "true" ]');
-    expect(script).toContain('KESHA_ENGINE_BIN="$assets/$asset"');
-    expect(script).toContain('KESHA_CACHE_DIR="$scratch/cache"');
-    expect(script).toContain('bun "$repo_root/.github/scripts/assert-install-warmup.ts"');
-    expect(script).toContain('bun "$repo_root/.github/scripts/smoke-synthesis.ts"');
-    expect(script).toContain('trap cleanup EXIT');
-    expect(synthesisSmoke).toContain('process.env.KESHA_COMMAND || "kesha"');
+  test("rejects the flattened shape `npm view --json <fields>` returns", async () => {
+    // Asking for a field list answers with keys named
+    // literally "dist.integrity" / "dist.attestations", so the nested filter reads null
+    // and the gate fails every release regardless of what was published.
+    const flattened = {
+      version: "1.29.1",
+      "dist.integrity": PUBLISHED.dist.integrity,
+      "dist.attestations": PUBLISHED.dist.attestations,
+    };
+    expect(await runFilter(flattened)).toBe(false);
   });
 
-  test("installs an exact npm package and requires provenance metadata", () => {
-    const script = readRepoFile(SCRIPT);
-
-    expect(script).toContain('npm view "$package@$VERSION" --json version,dist.integrity,dist.attestations');
-    expect(script).toContain('https://slsa.dev/provenance/v1');
-    expect(script).toContain('npm install --global "$package@$VERSION"');
-    expect(script).toContain('NPM_CONFIG_PREFIX="$prefix"');
-    expect(script).toContain('installed npm package version was $installed_version, expected $VERSION');
+  test("the script therefore requests the whole document, not a field list", () => {
+    const source = readFileSync(SCRIPT, "utf8");
+    expect(source).toContain(`npm view "$package@$VERSION" --json > "$metadata"`);
   });
 
-  test("runs the npm smoke only after the release lane has observed the published version", () => {
-    const cliRelease = parseRepoYaml(".github/workflows/release-cli.yml");
-    const job = cliRelease.jobs["published-install-smoke"];
+  test("rejects a version published without provenance", async () => {
+    const noProvenance = { ...PUBLISHED, dist: { ...PUBLISHED.dist, attestations: undefined } };
+    expect(await runFilter(noProvenance)).toBe(false);
+  });
 
-    expect(job.needs).toEqual(["plan", "publish-npm"]);
-    expect(job.uses).toBe("./.github/workflows/release-install-smoke.yml");
-    expect(job.with).toEqual({
-      tag: "${{ needs.plan.outputs.tag }}",
-      version: "${{ needs.plan.outputs.version }}",
-    });
+  test("rejects a provenance predicate that is not SLSA v1", async () => {
+    const wrongPredicate = {
+      ...PUBLISHED,
+      dist: { ...PUBLISHED.dist, attestations: { provenance: { predicateType: "https://slsa.dev/provenance/v0.2" } } },
+    };
+    expect(await runFilter(wrongPredicate)).toBe(false);
+  });
+
+  test("rejects a mismatched version even when everything else is present", async () => {
+    expect(await runFilter({ ...PUBLISHED, version: "1.29.0" })).toBe(false);
+  });
+
+  test("rejects an integrity digest that is not sha512", async () => {
+    const weakDigest = { ...PUBLISHED, dist: { ...PUBLISHED.dist, integrity: "sha1-deadbeef" } };
+    expect(await runFilter(weakDigest)).toBe(false);
   });
 });

--- a/tests/unit/release-install-smoke.test.ts
+++ b/tests/unit/release-install-smoke.test.ts
@@ -1,16 +1,21 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
+import { parseRepoYaml, readRepoFile } from "../helpers/repo";
 
+const WORKFLOW = ".github/workflows/release-install-smoke.yml";
 const SCRIPT = ".github/scripts/release-install-smoke.sh";
 
 // These cases run the script's real jq, which a contributor machine may not have.
 const JQ = Bun.which("jq");
 
-/** The jq the script actually runs, lifted from the script so the test cannot drift from it. */
+/** Windows checks the tree out with CRLF and the pattern below anchors on newlines. */
+function readScript(): string {
+  return readFileSync(SCRIPT, "utf8").replace(/\r\n/g, "\n");
+}
+
+/** The jq the script actually runs, lifted from it so the test cannot drift from the lane. */
 function metadataFilter(): string {
-  // Windows CI checks out CRLF and the pattern anchors on newlines.
-  const source = readFileSync(SCRIPT, "utf8").replace(/\r\n/g, "\n");
-  const match = source.match(/jq -e --arg version "\$VERSION" '\n([\s\S]*?)\n\s*' "\$metadata"/);
+  const match = readScript().match(/jq -e --arg version "\$VERSION" '\n([\s\S]*?)\n\s*' "\$metadata"/);
   const filter = match?.[1];
   if (!filter) throw new Error(`${SCRIPT}: could not find the npm metadata jq filter`);
   return filter;
@@ -41,6 +46,54 @@ const PUBLISHED = {
   },
 };
 
+describe("release install smoke", () => {
+  test("keeps the draft gate manual and makes the post-npm path reusable", () => {
+    const workflow = parseRepoYaml(WORKFLOW);
+
+    expect(workflow.on.workflow_dispatch.inputs.mode.default).toBe("draft-engine");
+    expect(workflow.on.workflow_call.inputs.version.required).toBe(true);
+    expect(workflow.on.workflow_call.inputs.mode.default).toBe("npm");
+    expect(workflow.jobs["draft-engine"].permissions).toEqual({ contents: "write" });
+    expect(workflow.jobs.npm.permissions).toEqual({ contents: "read" });
+  });
+
+  test("downloads the authenticated draft artifact into a disposable private cache", () => {
+    const script = readRepoFile(SCRIPT);
+    const synthesisSmoke = readRepoFile(".github/scripts/smoke-synthesis.ts");
+
+    expect(script).toContain('gh release download "$TAG"');
+    expect(script).toContain('[ "$(gh release view "$TAG" --json isDraft --jq .isDraft)" = "true" ]');
+    expect(script).toContain('KESHA_ENGINE_BIN="$assets/$asset"');
+    expect(script).toContain('KESHA_CACHE_DIR="$scratch/cache"');
+    expect(script).toContain('bun "$repo_root/.github/scripts/assert-install-warmup.ts"');
+    expect(script).toContain('bun "$repo_root/.github/scripts/smoke-synthesis.ts"');
+    expect(script).toContain('trap cleanup EXIT');
+    expect(synthesisSmoke).toContain('process.env.KESHA_COMMAND || "kesha"');
+  });
+
+  test("installs an exact npm package and requires provenance metadata", () => {
+    const script = readRepoFile(SCRIPT);
+
+    expect(script).toContain('npm view "$package@$VERSION" --json > "$metadata"');
+    expect(script).toContain('https://slsa.dev/provenance/v1');
+    expect(script).toContain('npm install --global "$package@$VERSION"');
+    expect(script).toContain('NPM_CONFIG_PREFIX="$prefix"');
+    expect(script).toContain('installed npm package version was $installed_version, expected $VERSION');
+  });
+
+  test("runs the npm smoke only after the release lane has observed the published version", () => {
+    const cliRelease = parseRepoYaml(".github/workflows/release-cli.yml");
+    const job = cliRelease.jobs["published-install-smoke"];
+
+    expect(job.needs).toEqual(["plan", "publish-npm"]);
+    expect(job.uses).toBe("./.github/workflows/release-install-smoke.yml");
+    expect(job.with).toEqual({
+      tag: "${{ needs.plan.outputs.tag }}",
+      version: "${{ needs.plan.outputs.version }}",
+    });
+  });
+});
+
 describe("release-install-smoke npm metadata gate", () => {
   test("jq is present in CI, so none of the cases below are silently skipped", () => {
     if (process.env.CI) expect(JQ).toBeTruthy();
@@ -50,8 +103,10 @@ describe("release-install-smoke npm metadata gate", () => {
     expect(await runFilter(PUBLISHED)).toBe(true);
   });
 
-  // The regression: `--json version,dist.integrity,dist.attestations` is one comma-joined argument, and npm answers it with nothing.
-  test.skipIf(!JQ)("fails on the empty document the comma-joined field list produced", async () => {
+  // The regression: `--json version,dist.integrity,dist.attestations` is one comma-joined
+  // argument, and npm answers it with zero bytes at exit 0 — not an empty object, which
+  // would exit 1 rather than 4.
+  test.skipIf(!JQ)("fails on the nothing-at-all the comma-joined field list returns", async () => {
     expect(await runFilterRaw("")).toBe(4);
   });
 
@@ -66,8 +121,7 @@ describe("release-install-smoke npm metadata gate", () => {
   });
 
   test("the script therefore requests the whole document, not a field list", () => {
-    const source = readFileSync(SCRIPT, "utf8").replace(/\r\n/g, "\n");
-    expect(source).toContain(`npm view "$package@$VERSION" --json > "$metadata"`);
+    expect(readScript()).toContain(`npm view "$package@$VERSION" --json > "$metadata"`);
   });
 
   test.skipIf(!JQ)("rejects a version published without provenance", async () => {

--- a/tests/unit/release-install-smoke.test.ts
+++ b/tests/unit/release-install-smoke.test.ts
@@ -3,6 +3,12 @@ import { readFileSync } from "node:fs";
 
 const SCRIPT = ".github/scripts/release-install-smoke.sh";
 
+// The gate under test is a bash script that only ever runs on the Ubuntu release runner,
+// and these cases execute its real jq rather than a reimplementation. Windows runners ship
+// no jq, so there the filter cases have nothing to run — the structural assertion below
+// still runs everywhere and is the one that catches the regression this file exists for.
+const JQ = Bun.which("jq");
+
 /** The jq the script actually runs, lifted from the script so the test cannot drift from it. */
 function metadataFilter(): string {
   const source = readFileSync(SCRIPT, "utf8");
@@ -34,11 +40,11 @@ const PUBLISHED = {
 };
 
 describe("release-install-smoke npm metadata gate", () => {
-  test("accepts a genuinely published, provenance-carrying version", async () => {
+  test.skipIf(!JQ)("accepts a genuinely published, provenance-carrying version", async () => {
     expect(await runFilter(PUBLISHED)).toBe(true);
   });
 
-  test("rejects the flattened shape `npm view --json <fields>` returns", async () => {
+  test.skipIf(!JQ)("rejects the flattened shape `npm view --json <fields>` returns", async () => {
     // Asking for a field list answers with keys named
     // literally "dist.integrity" / "dist.attestations", so the nested filter reads null
     // and the gate fails every release regardless of what was published.
@@ -55,12 +61,12 @@ describe("release-install-smoke npm metadata gate", () => {
     expect(source).toContain(`npm view "$package@$VERSION" --json > "$metadata"`);
   });
 
-  test("rejects a version published without provenance", async () => {
+  test.skipIf(!JQ)("rejects a version published without provenance", async () => {
     const noProvenance = { ...PUBLISHED, dist: { ...PUBLISHED.dist, attestations: undefined } };
     expect(await runFilter(noProvenance)).toBe(false);
   });
 
-  test("rejects a provenance predicate that is not SLSA v1", async () => {
+  test.skipIf(!JQ)("rejects a provenance predicate that is not SLSA v1", async () => {
     const wrongPredicate = {
       ...PUBLISHED,
       dist: { ...PUBLISHED.dist, attestations: { provenance: { predicateType: "https://slsa.dev/provenance/v0.2" } } },
@@ -68,11 +74,11 @@ describe("release-install-smoke npm metadata gate", () => {
     expect(await runFilter(wrongPredicate)).toBe(false);
   });
 
-  test("rejects a mismatched version even when everything else is present", async () => {
+  test.skipIf(!JQ)("rejects a mismatched version even when everything else is present", async () => {
     expect(await runFilter({ ...PUBLISHED, version: "1.29.0" })).toBe(false);
   });
 
-  test("rejects an integrity digest that is not sha512", async () => {
+  test.skipIf(!JQ)("rejects an integrity digest that is not sha512", async () => {
     const weakDigest = { ...PUBLISHED, dist: { ...PUBLISHED.dist, integrity: "sha1-deadbeef" } };
     expect(await runFilter(weakDigest)).toBe(false);
   });

--- a/tests/unit/release-install-smoke.test.ts
+++ b/tests/unit/release-install-smoke.test.ts
@@ -18,13 +18,17 @@ function metadataFilter(): string {
   return filter;
 }
 
-async function runFilter(document: unknown): Promise<boolean> {
+async function runFilterRaw(input: string): Promise<number> {
   const proc = Bun.spawn(["jq", "-e", "--arg", "version", "1.29.1", metadataFilter()], {
-    stdin: new TextEncoder().encode(JSON.stringify(document)),
+    stdin: new TextEncoder().encode(input),
     stdout: "ignore",
     stderr: "ignore",
   });
-  return (await proc.exited) === 0;
+  return await proc.exited;
+}
+
+async function runFilter(document: unknown): Promise<boolean> {
+  return (await runFilterRaw(JSON.stringify(document))) === 0;
 }
 
 /** What `npm view <pkg> --json` returns, trimmed to the keys the filter reads. */
@@ -40,14 +44,27 @@ const PUBLISHED = {
 };
 
 describe("release-install-smoke npm metadata gate", () => {
+  // The skip is an escape hatch for contributor machines, not for CI. Without this a future
+  // image change could silently skip every predicate case and leave the suite green.
+  test("jq is present in CI, so none of the cases below are silently skipped", () => {
+    if (process.env.CI) expect(JQ).toBeTruthy();
+  });
+
   test.skipIf(!JQ)("accepts a genuinely published, provenance-carrying version", async () => {
     expect(await runFilter(PUBLISHED)).toBe(true);
   });
 
-  test.skipIf(!JQ)("rejects the flattened shape `npm view --json <fields>` returns", async () => {
-    // Asking for a field list answers with keys named
-    // literally "dist.integrity" / "dist.attestations", so the nested filter reads null
-    // and the gate fails every release regardless of what was published.
+  // THE regression. The replaced command was `--json version,dist.integrity,dist.attestations`
+  // — one comma-joined argument, not three. npm answers that with an empty document at exit 0,
+  // and `jq -e` on no input exits 4, so the gate failed every release whatever was published.
+  test.skipIf(!JQ)("fails on the empty document the comma-joined field list produced", async () => {
+    expect(await runFilterRaw("")).toBe(4);
+  });
+
+  // Not the regression: the space-separated form flattens instead of emptying. Kept because it
+  // is the other way a field list breaks this filter, and the difference is easy to misread —
+  // the first analysis of this bug reproduced this shape and described it as the cause.
+  test.skipIf(!JQ)("rejects the flattened shape a space-separated field list returns", async () => {
     const flattened = {
       version: "1.29.1",
       "dist.integrity": PUBLISHED.dist.integrity,

--- a/tests/unit/release-install-smoke.test.ts
+++ b/tests/unit/release-install-smoke.test.ts
@@ -3,15 +3,15 @@ import { readFileSync } from "node:fs";
 
 const SCRIPT = ".github/scripts/release-install-smoke.sh";
 
-// The gate under test is a bash script that only ever runs on the Ubuntu release runner,
-// and these cases execute its real jq rather than a reimplementation. Windows runners ship
-// no jq, so there the filter cases have nothing to run — the structural assertion below
-// still runs everywhere and is the one that catches the regression this file exists for.
+// These cases execute the script's real jq rather than a reimplementation, so they need it
+// on PATH. GitHub runners all ship it; a contributor machine may not.
 const JQ = Bun.which("jq");
 
 /** The jq the script actually runs, lifted from the script so the test cannot drift from it. */
 function metadataFilter(): string {
-  const source = readFileSync(SCRIPT, "utf8");
+  // Windows CI checks the tree out with CRLF, and the pattern below anchors on newlines:
+  // without this the filter is simply not found and every case fails on that runner alone.
+  const source = readFileSync(SCRIPT, "utf8").replace(/\r\n/g, "\n");
   const match = source.match(/jq -e --arg version "\$VERSION" '\n([\s\S]*?)\n\s*' "\$metadata"/);
   const filter = match?.[1];
   if (!filter) throw new Error(`${SCRIPT}: could not find the npm metadata jq filter`);
@@ -57,7 +57,7 @@ describe("release-install-smoke npm metadata gate", () => {
   });
 
   test("the script therefore requests the whole document, not a field list", () => {
-    const source = readFileSync(SCRIPT, "utf8");
+    const source = readFileSync(SCRIPT, "utf8").replace(/\r\n/g, "\n");
     expect(source).toContain(`npm view "$package@$VERSION" --json > "$metadata"`);
   });
 


### PR DESCRIPTION
The `v1.29.1-cli` lane published correctly and then failed its own post-publish gate:

```
##[error]npm metadata for @drakulavich/kesha-voice-kit@1.29.1 lacks the expected
version, integrity, or provenance
```

The package is fine. npm serves 1.29.1 as `latest` with a sha512 integrity digest, one
signature, and `dist.attestations.provenance.predicateType` = `https://slsa.dev/provenance/v1`.

## Cause

```bash
npm view "$package@$VERSION" --json version,dist.integrity,dist.attestations
```

That is **one comma-joined argument**, and npm 11.19.0 answers it with an **empty document
at exit 0**. `jq -e` on no input exits 4, so the gate failed for every release whatever was
published. Measured against the live registry:

| form | stdout | unchanged filter |
|---|---|---|
| `--json version,dist.integrity,dist.attestations` (what the script had) | 0 bytes, exit 0 | `jq` exit **4** |
| `--json version dist.integrity dist.attestations` (space-separated) | keys named literally `dist.integrity` | reads null → false |
| `--json` (this PR) | nested document | passes |

This was the gate's first execution — the job arrived in #1055, which landed after
`v1.28.0-cli`, so `v1.29.1` is the first release to reach it. It has never passed.

**Correction, recorded rather than quietly fixed:** this PR originally said the cause was the
flattened `dist.integrity` keys. That is what the *space-separated* form does, and this script
never used it — the first analysis reproduced a similar-looking command rather than the one in
the file. The fix was right; the stated reason was not. Codex review refuted the claim, and it
was confirmed here against the live registry before being accepted.

## Fix

Request the whole document. The filter is unchanged, so the properties it asserts — exact
version, sha512 integrity, SLSA v1 provenance — are identical to before.

## Guard

`tests/unit/release-install-smoke.test.ts` lifts the jq filter **out of the script** by regex,
so the test cannot drift from what the lane runs. Nine cases:

- the empty document at exit 4 — **the regression the old command actually produced**;
- the flattened shape, relabelled as the other way a field list defeats this filter, with a
  note that the two are easy to confuse, since that confusion produced the wrong explanation;
- the published shape passes, and it rejects missing provenance, a non-SLSA-v1 predicate, a
  mismatched version, and a non-sha512 digest;
- one structural assertion pinning the query form, which goes red when the comma form is
  restored — verified by mutation, then restored;
- one CI-only assertion that `jq` is present. The `skipIf` is an escape hatch for contributor
  machines; deleting all six skips passed green, so the escape hatch is now pinned to local.

The regex normalises CRLF: Windows CI checks the tree out with `\r\n` and the pattern anchors
on newlines, so without it `metadataFilter()` throws and every case fails on that runner alone.
Demonstrated against a real CRLF copy rather than reasoned about.

## Also: leads the CLI base to 1.30.0

`#802` requires `main` to carry the next *unreleased* CLI version once a release consumes the
current one. Without it the alpha derivation keeps emitting `1.29.1-alpha.N` for an
already-released 1.29.1, pointing `@alpha` at something older than `@latest`.

## Deviations from docs/design.md

none

## Docs updated

none — the reason lives in a comment beside the query it explains.
