### PR TITLE
ci(rust-test): cancel superseded runs with a concurrency group

### DIFF
--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -661,13 +661,36 @@ function triggerNames(on: unknown): string[] {
 }
 
 /**
+ * Contexts that take a distinct value per ref. `github.head_ref` is deliberately absent: it is
+ * empty on push events, so a group keyed on it alone collapses every push into one lane.
+ */
+const PER_REF_CONTEXT = /github\.ref(?!\w)/;
+const EXPRESSION = /\$\{\{(.*?)\}\}/gs;
+/** Single quotes with `''` escaping are GitHub's only string literal; `"…"` is invalid syntax, stripped so a typo cannot satisfy the check either. */
+const STRING_LITERAL = /'(?:[^']|'')*'|"[^"]*"/g;
+
+/**
+ * Whether the group takes a distinct value per ref, which is the property that makes
+ * cancellation safe. Necessary, not sufficient: it proves an expression *consumes* a per-ref
+ * context as data, not that the result is injective over refs — `${{ github.ref == 'x' }}`
+ * satisfies it and yields two groups. Deciding that needs an expression evaluator, so the
+ * residual is stated rather than chased (#1105).
+ */
+function groupVariesPerRef(group: string): boolean {
+  for (const [, expression] of group.matchAll(EXPRESSION)) {
+    if (PER_REF_CONTEXT.test((expression ?? "").replace(STRING_LITERAL, ""))) return true;
+  }
+  return false;
+}
+
+/**
  * Fails when a workflow that runs on pull requests declares no top-level `concurrency` group.
  *
  * Without one every superseded push runs to completion: `rust-test.yml` carried two macOS
  * jobs that way, and macOS is 80% of this repo's CI cost at 10.3x Linux per minute (#1105).
- * The group must interpolate `github.ref` — a workflow-wide group serialises every PR into
- * one queue, and GitHub evicts the pending run when a third arrives, so the evicted run
- * reports nothing and the required check never lands, blocking the PR forever (#597).
+ * The group must additionally vary per ref — any group shared across pull requests serialises
+ * them into one queue, and GitHub evicts the pending run when a third arrives, so the evicted
+ * run reports nothing and the required check never lands, blocking the PR forever (#597).
  */
 export function requireConcurrencyOnPullRequestWorkflows(path: string, document: unknown): string[] {
   const doc = document as { on?: unknown; concurrency?: unknown } | undefined;
@@ -681,12 +704,9 @@ export function requireConcurrencyOnPullRequestWorkflows(path: string, document:
   }
 
   const group = typeof concurrency === "string" ? concurrency : (concurrency as { group?: unknown })?.group;
-  // Inside `${{ … }}`, not merely present: a literal `github.ref` is one repository-wide
-  // group, which makes unrelated PRs evict each other rather than none at all. `github.ref`
-  // exactly, so the boolean `github.ref_protected` — and any other `ref_*` — is rejected.
-  if (typeof group !== "string" || !/\$\{\{[^}]*github\.ref(?!\w)[^}]*\}\}/.test(group)) {
+  if (typeof group !== "string" || !groupVariesPerRef(group)) {
     return [
-      `${path}: \`concurrency.group\` must interpolate \`github.ref\` inside a \`\${{ }}\` expression; any group shared across pull requests queues them into one lane and GitHub evicts the pending run, so the required check never lands (#597)`,
+      `${path}: \`concurrency.group\` must vary per ref — some \`\${{ }}\` expression has to use \`github.ref\` as an operand, not as quoted text; a group shared across pull requests queues them into one lane and GitHub evicts the pending run, so the required check never lands (#597)`,
     ];
   }
   return [];

--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -672,12 +672,33 @@ export function requireConcurrencyOnPullRequestWorkflows(path: string, document:
   }
 
   const group = typeof concurrency === "string" ? concurrency : (concurrency as { group?: unknown })?.group;
-  if (typeof group !== "string" || !group.includes("github.ref")) {
+  // Inside `${{ … }}`, not merely present: a literal `github.ref` is one repository-wide
+  // group, which makes unrelated PRs evict each other rather than none at all.
+  if (typeof group !== "string" || !/\$\{\{[^}]*github\.ref[^}]*\}\}/.test(group)) {
     return [
-      `${path}: \`concurrency.group\` must interpolate \`github.ref\`; a ref-less group queues every PR into one lane and GitHub evicts the pending run, so the required check never lands (#597)`,
+      `${path}: \`concurrency.group\` must interpolate \`github.ref\` inside a \`\${{ }}\` expression; any group shared across pull requests queues them into one lane and GitHub evicts the pending run, so the required check never lands (#597)`,
     ];
   }
   return [];
+}
+
+/**
+ * Fails when `rust-test.yml` stops cancelling superseded runs.
+ *
+ * Scoped to this one workflow rather than every pull-request workflow: `security.yml` sets
+ * `cancel-in-progress: false` deliberately, and auditing that choice is outside #1105. Here
+ * the line is the entire saving — two macOS jobs at 10.3x Linux per minute.
+ */
+export function requireRustTestCancelsSupersededRuns(path: string, document: unknown): string[] {
+  if (!path.endsWith("rust-test.yml")) return [];
+
+  const concurrency = (document as { concurrency?: unknown } | undefined)?.concurrency;
+  const cancel = (concurrency as { "cancel-in-progress"?: unknown } | undefined)?.["cancel-in-progress"];
+  if (cancel === true) return [];
+
+  return [
+    `${path}: \`concurrency.cancel-in-progress\` must be \`true\`; without it superseded pushes run both macOS jobs to completion, which is the entire cost saving (#1105)`,
+  ];
 }
 
 export function checkFile(
@@ -700,6 +721,7 @@ export function checkFile(
       ...requirePipefailShell(path, document),
       ...requireReusableCallPermissions(path, document),
       ...requireConcurrencyOnPullRequestWorkflows(path, document),
+      ...requireRustTestCancelsSupersededRuns(path, document),
       ...requireAptTimeouts(path, document),
       ...requireDepsBeforeBunTest(path, document),
       ...requireRestoreOnlyCachesHaveAWriter(path, document, cacheWriters),

--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -648,6 +648,38 @@ export function requireReusableCallPermissions(path: string, document: unknown):
   return errors;
 }
 
+/**
+ * Fails when a workflow that runs on pull requests declares no top-level `concurrency` group.
+ *
+ * Without one every superseded push runs to completion: `rust-test.yml` carried two macOS
+ * jobs that way, and macOS is 80% of this repo's CI cost at 10.3x Linux per minute (#1105).
+ * The group must interpolate `github.ref` — a workflow-wide group serialises every PR into
+ * one queue, and GitHub evicts the pending run when a third arrives, so the evicted run
+ * reports nothing and the required check never lands, blocking the PR forever (#597).
+ */
+export function requireConcurrencyOnPullRequestWorkflows(path: string, document: unknown): string[] {
+  const doc = document as { on?: unknown; concurrency?: unknown } | undefined;
+  const triggers = doc?.on;
+  // `on` parses as the string key (YAML 1.2, not the 1.1 boolean) and `pull_request:` with no
+  // body is null, so membership is the only safe test — and it must not match pull_request_target.
+  if (typeof triggers !== "object" || triggers === null || !("pull_request" in triggers)) return [];
+
+  const concurrency = doc?.concurrency;
+  if (concurrency === undefined || concurrency === null) {
+    return [
+      `${path}: runs on pull requests but declares no top-level \`concurrency\`; every superseded push runs the whole workflow to completion (#1105)`,
+    ];
+  }
+
+  const group = typeof concurrency === "string" ? concurrency : (concurrency as { group?: unknown })?.group;
+  if (typeof group !== "string" || !group.includes("github.ref")) {
+    return [
+      `${path}: \`concurrency.group\` must interpolate \`github.ref\`; a ref-less group queues every PR into one lane and GitHub evicts the pending run, so the required check never lands (#597)`,
+    ];
+  }
+  return [];
+}
+
 export function checkFile(
   path: string,
   testedScripts: string[],
@@ -667,6 +699,7 @@ export function checkFile(
       ...requireBashOnWindowsRunSteps(path, document),
       ...requirePipefailShell(path, document),
       ...requireReusableCallPermissions(path, document),
+      ...requireConcurrencyOnPullRequestWorkflows(path, document),
       ...requireAptTimeouts(path, document),
       ...requireDepsBeforeBunTest(path, document),
       ...requireRestoreOnlyCachesHaveAWriter(path, document, cacheWriters),

--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -649,6 +649,18 @@ export function requireReusableCallPermissions(path: string, document: unknown):
 }
 
 /**
+ * The trigger names an `on:` declares, across all three forms GitHub accepts: `on: push`,
+ * `on: [push, pull_request]`, and the mapping. `on` itself parses as the string key rather
+ * than the YAML 1.1 boolean, and a mapping's `pull_request:` may carry a null body.
+ */
+function triggerNames(on: unknown): string[] {
+  if (typeof on === "string") return [on];
+  if (Array.isArray(on)) return on.filter((entry): entry is string => typeof entry === "string");
+  if (typeof on === "object" && on !== null) return Object.keys(on);
+  return [];
+}
+
+/**
  * Fails when a workflow that runs on pull requests declares no top-level `concurrency` group.
  *
  * Without one every superseded push runs to completion: `rust-test.yml` carried two macOS
@@ -659,10 +671,7 @@ export function requireReusableCallPermissions(path: string, document: unknown):
  */
 export function requireConcurrencyOnPullRequestWorkflows(path: string, document: unknown): string[] {
   const doc = document as { on?: unknown; concurrency?: unknown } | undefined;
-  const triggers = doc?.on;
-  // `on` parses as the string key (YAML 1.2, not the 1.1 boolean) and `pull_request:` with no
-  // body is null, so membership is the only safe test — and it must not match pull_request_target.
-  if (typeof triggers !== "object" || triggers === null || !("pull_request" in triggers)) return [];
+  if (!triggerNames(doc?.on).includes("pull_request")) return [];
 
   const concurrency = doc?.concurrency;
   if (concurrency === undefined || concurrency === null) {
@@ -673,8 +682,9 @@ export function requireConcurrencyOnPullRequestWorkflows(path: string, document:
 
   const group = typeof concurrency === "string" ? concurrency : (concurrency as { group?: unknown })?.group;
   // Inside `${{ … }}`, not merely present: a literal `github.ref` is one repository-wide
-  // group, which makes unrelated PRs evict each other rather than none at all.
-  if (typeof group !== "string" || !/\$\{\{[^}]*github\.ref[^}]*\}\}/.test(group)) {
+  // group, which makes unrelated PRs evict each other rather than none at all. `github.ref`
+  // exactly, so the boolean `github.ref_protected` — and any other `ref_*` — is rejected.
+  if (typeof group !== "string" || !/\$\{\{[^}]*github\.ref(?!\w)[^}]*\}\}/.test(group)) {
     return [
       `${path}: \`concurrency.group\` must interpolate \`github.ref\` inside a \`\${{ }}\` expression; any group shared across pull requests queues them into one lane and GitHub evicts the pending run, so the required check never lands (#597)`,
     ];

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -17,6 +17,13 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # Must include the ref: a workflow-wide group serialises every PR into one queue, and
+  # GitHub evicts the pending run when a third arrives — the evicted run reports nothing, so
+  # the required "🧪 Rust Tests" check never lands and the PR is BLOCKED forever (#597).
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -9,6 +9,7 @@ import {
   requireAptTimeouts,
   requireBashOnWindowsRunSteps,
   requireConcurrencyOnPullRequestWorkflows,
+  requireRustTestCancelsSupersededRuns,
   requirePipefailShell,
   requireReusableCallPermissions,
   requireRestoreOnlyCachesHaveAWriter,
@@ -728,6 +729,28 @@ describe("requireConcurrencyOnPullRequestWorkflows", () => {
     expect(errors[0]).toContain("#597");
   });
 
+  // A bare literal is one repository-wide group, so unrelated PRs would evict each other —
+  // worse than no group at all, and `includes("github.ref")` alone accepts it.
+  test("fails a literal github.ref that is not an expression", () => {
+    const errors = requireConcurrencyOnPullRequestWorkflows(SYNTHETIC, {
+      on: { pull_request: null },
+      concurrency: { group: "github.ref", "cancel-in-progress": true },
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("#597");
+  });
+
+  test("accepts github.ref composed with other expressions", () => {
+    for (const group of [GROUP, "${{ github.ref }}", "rust-${{ github.ref }}-${{ github.event_name }}"]) {
+      expect(
+        requireConcurrencyOnPullRequestWorkflows(SYNTHETIC, {
+          on: { pull_request: null },
+          concurrency: { group, "cancel-in-progress": true },
+        }),
+      ).toEqual([]);
+    }
+  });
+
   test("fails the string shorthand when it omits the ref", () => {
     expect(
       requireConcurrencyOnPullRequestWorkflows(SYNTHETIC, { on: { pull_request: null }, concurrency: "one-lane" }),
@@ -766,6 +789,45 @@ describe("requireConcurrencyOnPullRequestWorkflows", () => {
   test("the file gate actually runs it", () => {
     const yaml = "on:\n  pull_request:\njobs:\n  lint:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n";
     const path = join(mkdtempSync(join(tmpdir(), "kesha-wf-")), "probe.yml");
+    writeFileSync(path, yaml);
+    expect(checkFile(path, [], [], undefined).filter((e) => e.includes("#1105"))).toHaveLength(1);
+  });
+});
+
+describe("requireRustTestCancelsSupersededRuns", () => {
+  const RUST_TEST = ".github/workflows/rust-test.yml";
+  const ref = { group: "${{ github.workflow }}-${{ github.ref }}" };
+
+  test("passes on the real rust-test.yml", () => {
+    expect(requireRustTestCancelsSupersededRuns(RUST_TEST, parseRepoYaml(RUST_TEST))).toEqual([]);
+  });
+
+  // security.yml sets `false` deliberately; auditing that is outside #1105, so this rule
+  // must not reach it.
+  test("ignores every other workflow", () => {
+    const SECURITY = ".github/workflows/security.yml";
+    expect(requireRustTestCancelsSupersededRuns(SECURITY, parseRepoYaml(SECURITY))).toEqual([]);
+  });
+
+  test("fails when cancel-in-progress is false", () => {
+    const errors = requireRustTestCancelsSupersededRuns(RUST_TEST, {
+      concurrency: { ...ref, "cancel-in-progress": false },
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("#1105");
+  });
+
+  test("fails when cancel-in-progress is dropped entirely", () => {
+    expect(requireRustTestCancelsSupersededRuns(RUST_TEST, { concurrency: ref })).toHaveLength(1);
+  });
+
+  test("fails when the whole concurrency block is gone", () => {
+    expect(requireRustTestCancelsSupersededRuns(RUST_TEST, { on: { pull_request: null } })).toHaveLength(1);
+  });
+
+  test("the file gate actually runs it", () => {
+    const yaml = "on:\n  pull_request:\nconcurrency:\n  group: ${{ github.ref }}\n  cancel-in-progress: false\njobs: {}\n";
+    const path = join(mkdtempSync(join(tmpdir(), "kesha-wf-")), "rust-test.yml");
     writeFileSync(path, yaml);
     expect(checkFile(path, [], [], undefined).filter((e) => e.includes("#1105"))).toHaveLength(1);
   });

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -8,6 +8,7 @@ import {
   forbidLinuxPackaging,
   requireAptTimeouts,
   requireBashOnWindowsRunSteps,
+  requireConcurrencyOnPullRequestWorkflows,
   requirePipefailShell,
   requireReusableCallPermissions,
   requireRestoreOnlyCachesHaveAWriter,
@@ -696,5 +697,76 @@ describe("requireReusableCallPermissions", () => {
     });
     expect(errors).toHaveLength(1);
     expect(errors[0]).toContain("does not exist");
+  });
+});
+
+describe("requireConcurrencyOnPullRequestWorkflows", () => {
+  const RUST_TEST = ".github/workflows/rust-test.yml";
+  const SYNTHETIC = ".github/workflows/synthetic.yml";
+  const GROUP = "${{ github.workflow }}-${{ github.ref }}";
+
+  test("passes on the real rust-test.yml", () => {
+    expect(requireConcurrencyOnPullRequestWorkflows(RUST_TEST, parseRepoYaml(RUST_TEST))).toEqual([]);
+  });
+
+  test("passes on the real ci.yml", () => {
+    expect(requireConcurrencyOnPullRequestWorkflows(CI, parseRepoYaml(CI))).toEqual([]);
+  });
+
+  test("fails a pull_request workflow with no concurrency at all", () => {
+    const errors = requireConcurrencyOnPullRequestWorkflows(SYNTHETIC, { on: { pull_request: null }, jobs: {} });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("#1105");
+  });
+
+  test("fails a group that does not interpolate github.ref", () => {
+    const errors = requireConcurrencyOnPullRequestWorkflows(SYNTHETIC, {
+      on: { pull_request: null },
+      concurrency: { group: "${{ github.workflow }}", "cancel-in-progress": true },
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("#597");
+  });
+
+  test("fails the string shorthand when it omits the ref", () => {
+    expect(
+      requireConcurrencyOnPullRequestWorkflows(SYNTHETIC, { on: { pull_request: null }, concurrency: "one-lane" }),
+    ).toHaveLength(1);
+  });
+
+  // pull_request_target is a different trigger with a different token; cache-cleanup.yml uses
+  // it, and a prefix match would drag it in.
+  test("ignores pull_request_target", () => {
+    expect(
+      requireConcurrencyOnPullRequestWorkflows(SYNTHETIC, { on: { pull_request_target: { types: ["closed"] } } }),
+    ).toEqual([]);
+  });
+
+  test("ignores a workflow that never runs on pull requests", () => {
+    expect(
+      requireConcurrencyOnPullRequestWorkflows(SYNTHETIC, { on: { schedule: [{ cron: "0 4 * * *" }] }, jobs: {} }),
+    ).toEqual([]);
+  });
+
+  // `pull_request:` with no body parses to null, so a truthiness test would skip the very
+  // workflows this rule exists for.
+  test("checks a pull_request trigger declared with no body", () => {
+    expect(requireConcurrencyOnPullRequestWorkflows(SYNTHETIC, { on: { pull_request: null } })).toHaveLength(1);
+  });
+
+  test("accepts a compliant pull_request workflow", () => {
+    expect(
+      requireConcurrencyOnPullRequestWorkflows(SYNTHETIC, {
+        on: { pull_request: { branches: ["main"] } },
+        concurrency: { group: GROUP, "cancel-in-progress": true },
+      }),
+    ).toEqual([]);
+  });
+
+  test("the file gate actually runs it", () => {
+    const yaml = "on:\n  pull_request:\njobs:\n  lint:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n";
+    const path = join(mkdtempSync(join(tmpdir(), "kesha-wf-")), "probe.yml");
+    writeFileSync(path, yaml);
+    expect(checkFile(path, [], [], undefined).filter((e) => e.includes("#1105"))).toHaveLength(1);
   });
 });

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -751,10 +751,58 @@ describe("requireConcurrencyOnPullRequestWorkflows", () => {
     }
   });
 
-  test("fails the string shorthand when it omits the ref", () => {
+  test("fails the concurrency string shorthand when it omits the ref", () => {
     expect(
       requireConcurrencyOnPullRequestWorkflows(SYNTHETIC, { on: { pull_request: null }, concurrency: "one-lane" }),
     ).toHaveLength(1);
+  });
+
+  // `github.ref_protected` is a boolean, so it collapses every protected-branch run into one
+  // group — the repository-wide failure the expression check exists to stop, respelled.
+  test.each(["${{ github.ref_protected }}", "${{ github.ref_name }}", "${{ github.ref_type }}"])(
+    "fails the ref-adjacent context %s",
+    (group) => {
+      const errors = requireConcurrencyOnPullRequestWorkflows(SYNTHETIC, {
+        on: { pull_request: null },
+        concurrency: { group, "cancel-in-progress": true },
+      });
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain("#597");
+    },
+  );
+
+  test("still accepts github.ref alongside a rejected sibling context", () => {
+    expect(
+      requireConcurrencyOnPullRequestWorkflows(SYNTHETIC, {
+        on: { pull_request: null },
+        concurrency: { group: "${{ github.ref_protected }}-${{ github.ref }}", "cancel-in-progress": true },
+      }),
+    ).toEqual([]);
+  });
+
+  test.each([
+    ["string", "pull_request"],
+    ["array", ["push", "pull_request"]],
+  ])("catches the %s trigger shorthand with no concurrency", (_form, on) => {
+    const errors = requireConcurrencyOnPullRequestWorkflows(SYNTHETIC, { on, jobs: {} });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("#1105");
+  });
+
+  test.each([
+    ["string", "pull_request_target"],
+    ["array", ["push", "pull_request_target"]],
+  ])("ignores pull_request_target in the %s shorthand", (_form, on) => {
+    expect(requireConcurrencyOnPullRequestWorkflows(SYNTHETIC, { on, jobs: {} })).toEqual([]);
+  });
+
+  test("accepts a compliant workflow declared with the array shorthand", () => {
+    expect(
+      requireConcurrencyOnPullRequestWorkflows(SYNTHETIC, {
+        on: ["push", "pull_request"],
+        concurrency: { group: GROUP, "cancel-in-progress": true },
+      }),
+    ).toEqual([]);
   });
 
   // pull_request_target is a different trigger with a different token; cache-cleanup.yml uses

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -757,19 +757,47 @@ describe("requireConcurrencyOnPullRequestWorkflows", () => {
     ).toHaveLength(1);
   });
 
-  // `github.ref_protected` is a boolean, so it collapses every protected-branch run into one
-  // group — the repository-wide failure the expression check exists to stop, respelled.
-  test.each(["${{ github.ref_protected }}", "${{ github.ref_name }}", "${{ github.ref_type }}"])(
-    "fails the ref-adjacent context %s",
-    (group) => {
-      const errors = requireConcurrencyOnPullRequestWorkflows(SYNTHETIC, {
+  // Every spelling of one defect; review rounds 1-3 each closed one of these alone (#1105).
+  test.each([
+    ["bare literal", "github.ref"],
+    ["single-quoted literal", "${{ 'github.ref' }}"],
+    ["double-quoted literal", '${{ "github.ref" }}'],
+    ["literal inside a call", "${{ format('github.ref') }}"],
+    ["boolean sibling context", "${{ github.ref_protected }}"],
+    ["short-name sibling context", "${{ github.ref_name }}"],
+    ["type sibling context", "${{ github.ref_type }}"],
+    ["no per-ref context at all", "${{ github.workflow }}"],
+  ])("fails a group that does not vary per ref: %s", (_form, group) => {
+    const errors = requireConcurrencyOnPullRequestWorkflows(SYNTHETIC, {
+      on: { pull_request: null },
+      concurrency: { group, "cancel-in-progress": true },
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("#597");
+  });
+
+  // A `}` inside a string literal used to truncate the scan and reject these wrongly.
+  test.each([
+    ["composed via format", "${{ format('{0}', github.ref) }}"],
+    ["brace inside a sibling literal", "${{ format('a}b') }}-${{ github.ref }}"],
+  ])("accepts a group that varies per ref: %s", (_form, group) => {
+    expect(
+      requireConcurrencyOnPullRequestWorkflows(SYNTHETIC, {
         on: { pull_request: null },
         concurrency: { group, "cancel-in-progress": true },
-      });
-      expect(errors).toHaveLength(1);
-      expect(errors[0]).toContain("#597");
-    },
-  );
+      }),
+    ).toEqual([]);
+  });
+
+  // Yields two groups repo-wide; rejecting it needs an evaluator, not a longer pattern.
+  test("accepts a boolean comparison over github.ref — the known residual", () => {
+    expect(
+      requireConcurrencyOnPullRequestWorkflows(SYNTHETIC, {
+        on: { pull_request: null },
+        concurrency: { group: "${{ github.ref == 'refs/heads/main' }}", "cancel-in-progress": true },
+      }),
+    ).toEqual([]);
+  });
 
   test("still accepts github.ref alongside a rejected sibling context", () => {
     expect(


### PR DESCRIPTION
## Claim

`rust-test.yml` ran every superseded push to completion because it declared no
`concurrency` group. It now uses the same group `ci.yml` has always had, and a new
`check-workflows.ts` rule keeps the next `pull_request`-triggered workflow from being added
without one.

Closes #1105

## Why

Over 200 runs in 10 days: macOS was 30% of minutes but **80% of cost** (10.3x Linux per
minute). `Rust Tests` was 26.5% of total CI cost, with `test (macos-14)` alone at 84 macOS
minutes over 19 runs. The workflow carries two macOS jobs (`test (macos-14)` and
`coreml-regression`), so three pushes to a PR in five minutes ran all of that three times.

## What changed

**`.github/workflows/rust-test.yml`** — top-level group copied from `ci.yml:28-30`, with
`security.yml`'s #597 reason carried across for why the ref must be in it.

**`.github/scripts/check-workflows.ts`** — `requireConcurrencyOnPullRequestWorkflows`:
for any workflow with an exact `pull_request` trigger, a top-level `concurrency` must exist
and its `group` must interpolate `github.ref`.

Two parser details that were verified rather than assumed, because either would silently
neuter the rule: `on` parses as the **string key** `"on"` (YAML 1.2, not the 1.1 boolean —
`requireNpmPublishAfterPackaging` already relies on this), and `pull_request:` with no body
parses to `null`, so membership is the only safe test. It must also match the exact key —
`cache-cleanup.yml` triggers on `pull_request_target` and a prefix match would drag it in.
Both are pinned by tests.

Of the five workflows with an exact `pull_request` trigger (`ci`, `cross-os-cache-probe`,
`linux-packages`, `security`, `rust-test`), only `rust-test.yml` failed the new rule.

## Behaviour change reviewers should expect

**A superseded SHA's `🧪 Rust Tests` now goes red, not `cancelled`.** `rust-tests`
(`rust-test.yml:521-529`) is `if: always()` with a step gated on
`contains(needs.*.result, 'cancelled')` → `exit 1`; `always()` carries the job through a
run-level cancellation, so the step fires. Measured on cancelled `ci.yml` runs
**32155614107** (`4b7a73da`) and **32167866160** (`4ef15406`): run conclusion `cancelled`,
`🧪 CI` check-run and job both `failure`. On `e2b9a246` the run was cancelled ~14s after
creation before any job started, so no aggregator check-run was created at all — the check
is `failure` or absent, never `cancelled`.

This is not new behaviour for the repo: `🧪 CI` has done exactly this all along. Branch
protection evaluates the head SHA, so a cancelled superseded run cannot block a PR.

## Verification

- **Red before green, observed rather than reasoned.** Commit 942c369 (rule + tests) alone:
  `115 pass, 1 fail`, the failure being `passes on the real rust-test.yml` with
  `` `rust-test.yml`: runs on pull requests but declares no top-level `concurrency` ``.
  Commit b5bf9b7 (the block): `116 pass, 0 fail`.
- **Seven mutation proofs caught** — see the Mutation proofs section below.
- **`just preflight` exit 0**: 1568 pass / 6 skip / 0 fail across 112 files, `tsc --noEmit`
  clean, `check-recipes` / `check-workflows` / `check-versions` / `check-engine-targets` /
  `release-manifest --check` clean, openspec 17 passed / 0 failed.
- Not run, and correctly out of scope: the Rust and CoreML gates (no `rust/**` in the diff)
  and `verify-darwin-full` (nothing in `rust/src/tts/**` or fluidaudio-adjacent).

## Scope: `build-engine.yml` is deliberately excluded

#1105 names it, so the narrowing has an owner: **#1108**.

A ref-keyed group there is a literal no-op — it fires on `push: tags: [v*, !v*-cli]`, tag
names are one-use and permanently reserved, so a tag-push run is the only member its group
will ever have. The only real exposure is two `workflow_dispatch` runs sharing
`refs/heads/main`, and the value that needs is `cancel-in-progress: **false**` (cancelling
mid-upload can leave a partially populated draft release), validated against
build-engine → draft release → `🍺 Homebrew Tap`. That is a different change with a
different justification, so it is not bundled behind a cost-optimisation claim. The new lint
rule keys on `pull_request`, so it does not force a choice there.

## Review round (codex): two findings, both applied

Both were reproduced by mutation before being fixed.

1. **`includes("github.ref")` accepted the bare literal `group: github.ref`** — a hard-coded
   repository-wide group, so unrelated PRs would evict each other. That is worse than having
   no group at all. Now requires the `${{ }}` expression form, matched by pattern rather than
   exact string so composed groups (`rust-${{ github.ref }}-${{ github.event_name }}`) stay
   valid; the four already-compliant workflows are unaffected.
2. **`cancel-in-progress: true` had no guard** — deleting it or setting it `false` left both
   the suite and `check:workflows` green, while that line is the entire cost saving. Now
   asserted by `requireRustTestCancelsSupersededRuns`, scoped to `rust-test.yml` via
   `endsWith` rather than added to the generic rule, because `security.yml` sets `false`
   deliberately and auditing that is outside #1105.

This closes the gap earlier drafts of this PR recorded as known and accepted.

## Review round (Greptile): two gaps in the guard, both applied

Both reproduced against the checker before being fixed.

3. **Only one of the three valid `on:` shorthands was detected.** `on: pull_request` (string)
   and `on: [pull_request]` (array) are both valid GitHub syntax and neither was checked —
   only the mapping form was. A future workflow written either way would have slipped the
   rule entirely, which is the rule's own claim not holding. `triggerNames` now reads all
   three shapes; string and array entries are exact, so `pull_request_target` still does not
   match.
4. **`${{ github.ref_protected }}` was accepted, and it is a boolean** — so every
   protected-branch run would collapse into one group, reintroducing the repository-wide
   failure finding 1 closed, respelled. The pattern now requires `github.ref` with no
   trailing word character, rejecting `ref_protected`, `ref_name` and `ref_type`.
   `github.ref_name` would in fact be unique per PR, but no workflow here uses it and
   admitting only the canonical spelling keeps the rule one thing rather than a list.

Also renamed a test: `fails the string shorthand …` asserts the **`concurrency:`** string
form, not the `on:` one. The assertion was correct; the name read as the other thing.

## Review round (Greptile P1): the guard was chasing spellings

`${{ 'github.ref' }}` and `${{ "github.ref" }}` were accepted. Both evaluate to a constant
string — one repository-wide group, the same defect as the bare literal (finding 1) and
`ref_protected` (finding 4), at a third and fourth spelling.

Three rounds had each closed one spelling of one defect, so this round replaces the pattern
with the property it was approximating: **the group must vary per ref**. Every `${{ … }}`
expression has its string literals stripped, then must still contain a per-ref context.
Quoted text cannot satisfy it at any nesting depth, including inside a call.

The old pattern was also **too tight**, which no round had caught: `[^}]*` could not cross
the `}` in `${{ format('{0}', github.ref) }}`, so a legitimately varying group was rejected.
Both directions are fixed.

| group | before | now |
| --- | --- | --- |
| `${{ github.workflow }}-${{ github.ref }}` | accepted | accepted |
| `${{ format('{0}', github.ref) }}` | **rejected** | accepted |
| `github.ref` | rejected | rejected |
| `${{ 'github.ref' }}` | **accepted** | rejected |
| `${{ "github.ref" }}` | **accepted** | rejected |
| `${{ format('github.ref') }}` | **accepted** | rejected |
| `${{ github.ref_protected }}` | rejected | rejected |

**Accepted contexts are a stated list of one: `github.ref`.** `github.head_ref` is
deliberately excluded — it is empty on push events, so a group keyed on it alone collapses
every push into one lane.

**What it still does not catch, stated rather than chased:** the check is necessary, not
sufficient. It proves an expression *consumes* a per-ref context as data, not that the result
is injective over refs — `${{ github.ref == 'refs/heads/main' }}` satisfies it and yields two
groups. Deciding that needs an expression evaluator, and adding another operator pattern would
repeat the mistake this round ends. That boundary is now a named test rather than a silence.

## Mutation proofs

Every guard in this PR is proven by mutation — `just mutate`, each exit 0 with `PINNED`.

Five spellings of a non-varying group written into the real `rust-test.yml`, all caught by
`passes on the real rust-test.yml`: bare literal, single-quoted, double-quoted,
`format('github.ref')`, and `${{ github.ref_protected }}`. The last two of those were invented
for this round rather than reported, to check the invariant generalises past what review found.

Mutating the checker itself, each caught by the specific table row that covers it: deleting
the string-literal strip (caught by the quoted-literal rows), dropping the `(?!\w)` boundary
(the sibling-context rows), removing string-shape and array-shape trigger handling (the
shorthand rows).

Mutating `rust-test.yml`'s own block: `concurrency:` renamed, `-${{ github.ref }}` dropped,
`cancel-in-progress: true` → `false`.

## Not demonstrated live

The superseding-run demonstration has not happened, across three pushes. Each earlier head's
runs had **already completed green** before the next commit was ready, so no push ever had
anything in flight to cancel:

| head | `🧪 Rust Tests` | `🧪 CI` | `🛡️ Security Audit` |
| --- | --- | --- | --- |
| `b5bf9b7` | 33183064420 ✅ | 33183064563 ✅ | 33183064552 ✅ |
| `6d2cc85` | 33184658437 ✅ | 33184658431 ✅ | 33184658418 ✅ |

Which is itself worth noting: on this branch a full run finishes faster than a review round,
so the cancellation path is real but rarely exercised here. A busier PR — the three-pushes-in-
five-minutes case that motivated the ticket — is where it pays. The assertion when it does
happen is `gh run view <id> --json conclusion` → `cancelled` on the superseded run, never the
check-run, which reports `failure` or nothing at all.
