### PR TITLE
ci(workflows): give the 26 unbounded jobs a timeout-minutes

### DIFF
--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -296,6 +296,7 @@ export function requirePactVerificationCoversEveryTarget(path: string, document:
 type Job = {
   "runs-on"?: unknown;
   "timeout-minutes"?: number;
+  uses?: unknown;
   steps?: unknown[];
   strategy?: { matrix?: unknown };
   defaults?: { run?: { shell?: unknown } };
@@ -469,35 +470,44 @@ export function requireRestoreOnlyCachesHaveAWriter(
   return errors;
 }
 
-/**
- * Fails when a job on Ubuntu invokes apt-get without a timeout bound strictly below 360 minutes.
- * An apt mirror stall burns GitHub's full 6-hour default if unbounded; 30-60 minutes stops the burn (#1090).
- */
-export function requireAptTimeouts(path: string, document: unknown): string[] {
-  if (!path.endsWith("rust-test.yml")) return [];
+/** The concrete `timeout-minutes` values a job's declaration resolves to, substituting matrix keys. */
+function timeoutCandidates(job: Job): string[] {
+  const raw = String(job["timeout-minutes"]);
+  const references = [...raw.matchAll(/\$\{\{\s*matrix\.([\w.]+)\s*\}\}/g)];
+  if (references.length === 0) return [raw];
+  const matrix = job.strategy?.matrix;
+  return references.flatMap((reference) => {
+    const key = (reference[1] ?? "").split(".");
+    return [...valuesAt(matrix, key), ...valuesAt((matrix as { include?: unknown })?.include, key)];
+  });
+}
 
+/**
+ * Fails when a job with its own steps has no `timeout-minutes`, or resolves to a value ≥360.
+ * Generalises the apt-get-only, rust-test.yml-only rule #1090 added — the risk was never
+ * apt-specific, and a macOS hang costs 10.3x an Ubuntu one (#1105).
+ */
+export function requireJobTimeouts(path: string, document: unknown): string[] {
   const jobs = (document as { jobs?: Record<string, Job> })?.jobs;
   if (!jobs || typeof jobs !== "object") return [];
 
   const errors: string[] = [];
   for (const [name, job] of Object.entries(jobs)) {
-    const labels = runnerLabels(job);
-    if (labels.length === 0 || !labels.some((label) => /ubuntu/i.test(label))) continue;
+    if (typeof job?.uses === "string") continue;
+    if (!Array.isArray(job?.steps)) continue;
 
-    const steps = Array.isArray(job?.steps) ? (job.steps as Step[]) : [];
-    const hasAptGet = steps.some((step) => typeof step?.run === "string" && /apt-get/i.test(step.run));
-    if (!hasAptGet) continue;
-
-    const timeout = job["timeout-minutes"];
-    if (timeout === undefined) {
+    if (job["timeout-minutes"] == null) {
       errors.push(
-        `${path}: \`${name}\` runs on Ubuntu and invokes apt-get, but has no \`timeout-minutes\`; an apt stall burns 360 minutes unattended (#1090)`,
+        `${path}: \`${name}\` has no \`timeout-minutes\`; an unattended stall burns GitHub's 360-minute default (#1105)`,
       );
-    } else {
-      const timeoutNum = Number(timeout);
+      continue;
+    }
+
+    for (const candidate of timeoutCandidates(job)) {
+      const timeoutNum = Number(candidate);
       if (isNaN(timeoutNum) || timeoutNum >= 360) {
         errors.push(
-          `${path}: \`${name}\` runs on Ubuntu and invokes apt-get, but \`timeout-minutes: ${timeout}\` is not strictly below 360; an apt stall exceeds this bound (#1090)`,
+          `${path}: \`${name}\` sets \`timeout-minutes: ${candidate}\`, not strictly below 360; an unattended stall still exceeds this bound (#1105)`,
         );
       }
     }
@@ -752,7 +762,7 @@ export function checkFile(
       ...requireReusableCallPermissions(path, document),
       ...requireConcurrencyOnPullRequestWorkflows(path, document),
       ...requireRustTestCancelsSupersededRuns(path, document),
-      ...requireAptTimeouts(path, document),
+      ...requireJobTimeouts(path, document),
       ...requireDepsBeforeBunTest(path, document),
       ...requireRestoreOnlyCachesHaveAWriter(path, document, cacheWriters),
       ...requireTestedScriptsInCodeFilter(path, document, testedScripts),

--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -296,7 +296,6 @@ export function requirePactVerificationCoversEveryTarget(path: string, document:
 type Job = {
   "runs-on"?: unknown;
   "timeout-minutes"?: number;
-  uses?: unknown;
   steps?: unknown[];
   strategy?: { matrix?: unknown };
   defaults?: { run?: { shell?: unknown } };
@@ -493,7 +492,8 @@ export function requireJobTimeouts(path: string, document: unknown): string[] {
 
   const errors: string[] = [];
   for (const [name, job] of Object.entries(jobs)) {
-    if (typeof job?.uses === "string") continue;
+    // A reusable-workflow-call job (`uses:`) never has `steps` — GitHub's schema is one or
+    // the other — so this already excludes it without a separate `uses` check.
     if (!Array.isArray(job?.steps)) continue;
 
     if (job["timeout-minutes"] == null) {

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -39,6 +39,7 @@ jobs:
   tag:
     if: github.event_name == 'workflow_dispatch' && inputs.tag != ''
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: write
       actions: write # for the self-dispatch below (#651)
@@ -110,6 +111,7 @@ jobs:
             features: onnx,tts
             binary: kesha-engine-windows-x64.exe
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     env:
       # Target macOS 14 so the Swift compiler treats concurrency as
       # OS-provided and does not emit an explicit @rpath dependency on
@@ -445,6 +447,7 @@ jobs:
     needs: [build, darwin-synthesis-smoke]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -34,6 +34,7 @@ defaults:
 jobs:
   reclaim:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       # Deleting cache entries needs write on the Actions scope. Nothing else in
       # this job touches the repository, so every other scope stays unset.

--- a/.github/workflows/cargo-dependency-maintenance.yml
+++ b/.github/workflows/cargo-dependency-maintenance.yml
@@ -23,6 +23,7 @@ concurrency:
 jobs:
   checklist:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: 🧾 Open monthly Cargo checklist
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ defaults:
 jobs:
   changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       code: ${{ steps.filter.outputs.code }}
       integration: ${{ steps.filter.outputs.integration }}
@@ -190,6 +191,7 @@ jobs:
       needs.changes.outputs.workflows == 'true' || needs.changes.outputs.recipes == 'true'
       || github.event_name == 'schedule'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -976,6 +978,7 @@ jobs:
       - openspec-validate
       - nix-build
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Fail if any required job failed
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,6 +22,7 @@ env:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/linux-packages.yml
+++ b/.github/workflows/linux-packages.yml
@@ -43,6 +43,7 @@ jobs:
   # CI only. The packages users install are cut from a `-cli` tag by release-cli.yml (#728).
   linux-packages:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -56,6 +56,7 @@ jobs:
   resolve:
     if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.tag != '')
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
       version: ${{ steps.tag.outputs.version }}

--- a/.github/workflows/post-engine-release.yml
+++ b/.github/workflows/post-engine-release.yml
@@ -20,6 +20,7 @@ defaults:
 jobs:
   follow_up:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/prune-alpha-releases.yml
+++ b/.github/workflows/prune-alpha-releases.yml
@@ -17,6 +17,7 @@ defaults:
 jobs:
   prune:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
     steps:

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -35,6 +35,7 @@ jobs:
   decide:
     name: Decide and derive
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
       pull-requests: read
@@ -99,6 +100,7 @@ jobs:
     needs: decide
     if: needs.decide.outputs.publish == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: write
     steps:

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -31,6 +31,7 @@ jobs:
   plan:
     name: Classify the tag
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     # Not for writing: a draft release is invisible to a read-only token, and a guard that
     # cannot see the drafts it exists to catch would pass the build straight into one.
     permissions:
@@ -68,6 +69,7 @@ jobs:
     needs: plan
     if: needs.plan.outputs.packages == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
     steps:
@@ -104,6 +106,7 @@ jobs:
     name: Publish to npm
     needs: [plan, packages]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       actions: write

--- a/.github/workflows/release-npm-publish.yml
+++ b/.github/workflows/release-npm-publish.yml
@@ -34,6 +34,7 @@ defaults:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout at ref
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -33,6 +33,7 @@ jobs:
   # its required check reports; outputs gate the heavy rust jobs below.
   changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
       coreml: ${{ steps.filter.outputs.coreml }}
@@ -122,6 +123,7 @@ jobs:
       matrix:
         os: [macos-14, windows-latest]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     env:
       KOKORO_CACHE: ${{ github.workspace }}/.kokoro-spike
       MACOSX_DEPLOYMENT_TARGET: "14.0"
@@ -530,6 +532,7 @@ jobs:
     if: always()
     needs: [changes, lint-ubuntu, test, coverage, coreml-regression]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Fail if any required job failed
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -33,6 +33,7 @@ jobs:
   # Always runs so the required checks always report; outputs gate the audits.
   changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       deps: ${{ steps.filter.outputs.deps }}
     steps:
@@ -55,6 +56,7 @@ jobs:
     # PR that doesn't, this skips → reports success → satisfies branch protection.
     if: github.event_name != 'pull_request' || needs.changes.outputs.deps == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       # Only the scheduled run needs to upsert the findings issue.
@@ -91,6 +93,7 @@ jobs:
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.deps == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       # Only the scheduled run needs to upsert the findings issue.
@@ -134,6 +137,7 @@ jobs:
     if: always()
     needs: [changes, cargo-deny, bun-audit]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Fail if any required job failed
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -2,11 +2,12 @@ import { mkdtempSync, readdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
+import { parse } from "yaml";
 import {
   checkFile,
   collectCacheWriters,
   forbidLinuxPackaging,
-  requireAptTimeouts,
+  requireJobTimeouts,
   requireBashOnWindowsRunSteps,
   requireConcurrencyOnPullRequestWorkflows,
   requireRustTestCancelsSupersededRuns,
@@ -566,88 +567,75 @@ describe("Rust toolchain pin", () => {
   });
 });
 
-describe("requireAptTimeouts", () => {
-  const RUST_TEST = ".github/workflows/rust-test.yml";
-
-  test("passes on the real rust-test.yml", () => {
-    expect(requireAptTimeouts(RUST_TEST, parseRepoYaml(RUST_TEST))).toEqual([]);
+describe("requireJobTimeouts", () => {
+  test("passes on every workflow in the repo", () => {
+    for (const file of readdirSync(repoPath(".github/workflows"))) {
+      const path = `.github/workflows/${file}`;
+      expect([path, requireJobTimeouts(path, parseRepoYaml(path))]).toEqual([path, []]);
+    }
   });
 
-  test("ignores non-rust-test workflows", () => {
-    const doc = {
-      jobs: {
-        test: { "runs-on": "ubuntu-latest", steps: [{ run: "sudo apt-get install x" }] },
-      },
-    };
-    expect(requireAptTimeouts(CI, doc)).toEqual([]);
+  test("ignores a job that calls a reusable workflow via `uses:`", () => {
+    const doc = { jobs: { smoke: { uses: "./.github/workflows/release-install-smoke.yml" } } };
+    expect(requireJobTimeouts(CI, doc)).toEqual([]);
   });
 
-  test("ignores jobs that do not run on ubuntu", () => {
-    const doc = {
-      jobs: {
-        test: { "runs-on": "macos-14", steps: [{ run: "sudo apt-get install x" }] },
-      },
-    };
-    expect(requireAptTimeouts(RUST_TEST, doc)).toEqual([]);
+  // toEqual on the exact message, not toHaveLength: a mutant that neutralises the missing-value
+  // check still emits one error (Number(undefined) is NaN), just with different text — only an
+  // exact match tells the two branches apart.
+  test("fails when a job with steps has no timeout-minutes", () => {
+    const doc = { jobs: { lint: { "runs-on": "ubuntu-latest", steps: [{ run: "echo hi" }] } } };
+    expect(requireJobTimeouts(CI, doc)).toEqual([
+      `${CI}: \`lint\` has no \`timeout-minutes\`; an unattended stall burns GitHub's 360-minute default (#1105)`,
+    ]);
   });
 
-  test("ignores jobs that do not invoke apt-get", () => {
-    const doc = {
-      jobs: {
-        test: { "runs-on": "ubuntu-latest", steps: [{ run: "bun test" }] },
-      },
-    };
-    expect(requireAptTimeouts(RUST_TEST, doc)).toEqual([]);
-  });
-
-  test("fails when a job on ubuntu runs apt-get with no timeout-minutes", () => {
-    const doc = {
-      jobs: {
-        lint: { "runs-on": "ubuntu-latest", steps: [{ run: "sudo apt-get install -y libopus-dev" }] },
-      },
-    };
-    const errors = requireAptTimeouts(RUST_TEST, doc);
-    expect(errors).toHaveLength(1);
-    expect(errors[0]).toContain("has no `timeout-minutes`");
+  // A bare `timeout-minutes:` with nothing after the colon parses to null, not undefined;
+  // Number(null) is 0, which used to read as "0 minutes, valid" (#1105 review).
+  test("fails when timeout-minutes is written with no value", () => {
+    const doc = parse("jobs:\n  lint:\n    runs-on: ubuntu-latest\n    timeout-minutes:\n    steps:\n      - run: echo hi\n");
+    expect(requireJobTimeouts(CI, doc)).toEqual([
+      `${CI}: \`lint\` has no \`timeout-minutes\`; an unattended stall burns GitHub's 360-minute default (#1105)`,
+    ]);
   });
 
   test("fails when timeout-minutes is 360 or higher", () => {
-    const doc = {
-      jobs: {
-        lint: { "runs-on": "ubuntu-latest", "timeout-minutes": 360, steps: [{ run: "sudo apt-get install -y libopus-dev" }] },
-      },
-    };
-    const errors = requireAptTimeouts(RUST_TEST, doc);
+    const doc = { jobs: { lint: { "runs-on": "ubuntu-latest", "timeout-minutes": 360, steps: [{ run: "echo hi" }] } } };
+    const errors = requireJobTimeouts(CI, doc);
     expect(errors).toHaveLength(1);
     expect(errors[0]).toContain("not strictly below 360");
   });
 
-  test("passes when timeout-minutes is 10", () => {
-    const doc = {
-      jobs: {
-        lint: { "runs-on": "ubuntu-latest", "timeout-minutes": 10, steps: [{ run: "sudo apt-get install -y libopus-dev" }] },
-      },
-    };
-    expect(requireAptTimeouts(RUST_TEST, doc)).toEqual([]);
+  test("passes when timeout-minutes is under 360", () => {
+    const doc = { jobs: { lint: { "runs-on": "ubuntu-latest", "timeout-minutes": 15, steps: [{ run: "echo hi" }] } } };
+    expect(requireJobTimeouts(CI, doc)).toEqual([]);
   });
 
-  test("passes when timeout-minutes is 15", () => {
+  // release-branch-engine-smoke's real shape: `timeout-minutes: ${{ matrix.timeout }}` with the
+  // value living only in strategy.matrix.include, not a top-level matrix key.
+  test("resolves a matrix-templated timeout-minutes per leg", () => {
     const doc = {
       jobs: {
-        push: { "runs-on": "ubuntu-latest", "timeout-minutes": 15, steps: [{ run: "sudo apt-get install -y libopus-dev" }] },
+        smoke: {
+          "runs-on": "${{ matrix.os }}",
+          "timeout-minutes": "${{ matrix.timeout }}",
+          strategy: { matrix: { include: [{ os: "ubuntu-latest", timeout: 30 }, { os: "windows-latest", timeout: 400 }] } },
+          steps: [{ run: "echo hi" }],
+        },
       },
     };
-    expect(requireAptTimeouts(RUST_TEST, doc)).toEqual([]);
+    const errors = requireJobTimeouts(CI, doc);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("timeout-minutes: 400");
   });
 
   // A gate is only a gate if checkFile still calls it, and the live suite cannot notice a
-  // dropped check because the tree it reads is already clean. This test names a rust-test.yml
-  // file so the endsWith check enables the rule.
+  // dropped check because the tree it reads is already clean.
   test("the file gate actually runs it", () => {
-    const yaml = "on: push\njobs:\n  lint:\n    runs-on: ubuntu-latest\n    steps:\n      - run: sudo apt-get install -y libopus-dev\n";
-    const path = join(mkdtempSync(join(tmpdir(), "kesha-wf-")), "rust-test.yml");
+    const yaml = "on: push\njobs:\n  lint:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n";
+    const path = join(mkdtempSync(join(tmpdir(), "kesha-wf-")), "probe.yml");
     writeFileSync(path, yaml);
-    expect(checkFile(path, [], [], undefined).filter((e) => e.includes("#1090"))).toHaveLength(1);
+    expect(checkFile(path, [], [], undefined).filter((e) => e.includes("#1105"))).toHaveLength(1);
   });
 });
 
@@ -863,7 +851,8 @@ describe("requireConcurrencyOnPullRequestWorkflows", () => {
   });
 
   test("the file gate actually runs it", () => {
-    const yaml = "on:\n  pull_request:\njobs:\n  lint:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n";
+    const yaml =
+      "on:\n  pull_request:\njobs:\n  lint:\n    runs-on: ubuntu-latest\n    timeout-minutes: 10\n    steps:\n      - run: echo hi\n";
     const path = join(mkdtempSync(join(tmpdir(), "kesha-wf-")), "probe.yml");
     writeFileSync(path, yaml);
     expect(checkFile(path, [], [], undefined).filter((e) => e.includes("#1105"))).toHaveLength(1);


### PR DESCRIPTION
## What

26 jobs across 14 workflow files had no `timeout-minutes`, so an unattended stall on any of them burns GitHub's 360-minute default unattended. #1090/#1095 already fixed two Ubuntu+apt-get jobs in `rust-test.yml` via a narrow guard; this generalizes that guard repo-wide and gives every one of the 26 an explicit, evidence-based value.

Refs #1105 (item 2 of the audit; two more items remain — not closing).

## Guard generalization

`requireAptTimeouts` (`.github/scripts/check-workflows.ts`) was scoped to `rust-test.yml` + Ubuntu + apt-get only. The top-ranked case in #1105 — `build-engine.yml :: build` on macOS — has no apt-get in it at all, so it's replaced with `requireJobTimeouts`, which checks every job with `steps` in every workflow file. A reusable-workflow-call job (`uses:`) is excluded by that same `steps` check — GitHub's schema is one or the other, never both — so no separate `uses` branch is needed; an earlier draft had one, but Codex review found it unreachable (deleting or neutralising it left every test green) and it's removed rather than kept unpinned.

It also resolves `${{ matrix.* }}`-templated `timeout-minutes` the same way the existing `runnerLabels` resolves `runs-on` — needed because `ci.yml :: release-branch-engine-smoke` already varies its timeout per matrix leg (`ubuntu-latest: 35`, `windows-latest: 50`), and a naive `Number()` check on the raw `${{ matrix.timeout }}` string would false-positive on it.

**Known limits, stated rather than left implied:**
- The guard checks presence and the 360-minute ceiling only, not whether a chosen value is still the right one, and **no assertion verifies headroom at all** — a later author can widen any of the 26 up to 359 and the suite stays green.
- An unresolvable matrix key (e.g. a typo'd `${{ matrix.tiemout }}`) passes vacuously, mirroring a pre-existing property of `runnerLabels` for `runs-on`; no such typo exists in the repo today, and fixing that shared mechanism is out of scope here.

## Values

One shared `timeout-minutes` per job, sized from real `gh run view --json jobs` durations (not guessed) — full table and reasoning in the plan. Stated precisely rather than as one ratio, since a single figure would be wrong for most of the set:

- 13 of the 26 (aggregator gates and paths-filter jobs — `changes`, `ci`, `rust-tests`, `security-audit`, `resolve`, `decide`, `checklist`, `reclaim`, `plan`, `reserve-tag`, etc.) get a 5-minute floor, ~15-70x the ~4-17s actually observed for those. Tightening it further would buy flakes, not protection.
- `security.yml :: cargo-deny`/`bun-audit`, `release-npm-publish.yml :: publish`, `prune-alpha-releases.yml :: prune`: 10m.
- `docker.yml :: docker`, `linux-packages.yml :: linux-packages`, `post-engine-release.yml :: follow_up`, `release-cli.yml :: packages`: 15m.
- `build-engine.yml :: build` (macos-14/ubuntu-latest/windows-latest matrix): 20m — ~3x headroom over the slowest observed leg (windows, 6:25 across 3 real releases). `rust-test.yml :: test` (macos-14/windows-latest matrix): 15m — ~3.4x over its slowest leg (macOS, 4:21 across 4 rust-touching PRs). These two are the jobs an observation meaningfully constrains.
- `release-cli.yml :: publish-npm`: 20m despite ~48s observed — `dispatch-npm-publish.sh` ends in an unbounded `gh run watch --exit-status` that absorbs the nested `npm-publish.yml` run's queue time, so this is the one ceiling that can cut a *succeeding* release rather than a hang. Accepted because ~25x headroom means tripping it at all is already an anomaly, and the failure mode is "someone has to notice and re-verify the publish," not a silently broken release.

## Three commits (Red → Green → cleanup)

1. Guard + tests (`edd4506`) — `passes on every workflow in the repo` red, listing the 26 real gaps.
2. The 26 `timeout-minutes:` insertions (`ee806c0`) — same test green.
3. Drop the unreachable `uses:` branch (`31dc9d4`) — Codex review finding, see Guard generalization above.

## Verification

- `bun test tests/unit/check-workflows.test.ts`: 140 pass after commit 2 (was 1 fail / 139 pass after commit 1, the expected red); still 140 pass after commit 3.
- Two mutations via `just mutate`, both caught, re-run after commit 3:
  - `job["timeout-minutes"] == null` → `false`: caught by the exact-message tests (a length-only assertion would have missed it — the mutant still emits one error, just with different text, since `Number(undefined)` is `NaN`).
  - `timeoutNum >= 360` → `false`: caught by the ≥360 and matrix-leg tests.
- `just preflight`: green (1592 pass, 0 fail; Rust/CoreML gates correctly skipped, no `rust/**` touched), re-run after commit 3.

## Deliberately not doing

- No `KESHA_REQUIRE_*`-style exemption mechanism — none of the 26 legitimately needs ≥360 or no bound.
- No job deletions — all 26 serve a real, verified purpose.
- No per-matrix-leg `timeout-minutes` for jobs that don't already have one (`build-engine :: build`, `rust-test :: test` keep one shared value, matching `ci.yml :: unit-tests`'s existing pattern).
- No changes to `.github/actions/*.yml` (no `jobs:` key there) or to jobs that already have a timeout.
- No headroom-verifying assertion, and no fix to the unresolvable-matrix-key vacuous pass — both are named as known limits above rather than fixed here.
