### PR TITLE
ci: unbreak the Nix flake and move nix-build off the CI aggregator

### DIFF
--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -741,6 +741,27 @@ export function requireRustTestCancelsSupersededRuns(path: string, document: unk
   ];
 }
 
+/**
+ * Fails when the `ci` aggregator needs `nix-build`.
+ *
+ * A job in the required `ci` aggregator that cannot run on a pull request reds `main` — on
+ * `cancelled` as well as `failure` (`ci.yml:984`) — with nothing a PR could have prevented.
+ * Asserted as this one instance because a general matcher's own failure mode is an over-fire
+ * and `check:workflows` is in `preflight`, so over-firing blocks every push; it therefore
+ * misses the same job under another name. Widen on the second instance (#1105).
+ */
+export function forbidNixBuildInCiAggregator(path: string, document: unknown): string[] {
+  if (!path.endsWith("ci.yml")) return [];
+
+  const needs = (document as { jobs?: { ci?: { needs?: unknown } } } | undefined)?.jobs?.ci?.needs;
+  if (!Array.isArray(needs) || !needs.includes("nix-build")) return [];
+
+  return [
+    `${path}: \`ci\` needs \`nix-build\`, which runs only on push — it cannot report on a pull request, ` +
+      `yet a failed or cancelled run reds the required check on \`main\` (#1105)`,
+  ];
+}
+
 export function checkFile(
   path: string,
   testedScripts: string[],
@@ -762,6 +783,7 @@ export function checkFile(
       ...requireReusableCallPermissions(path, document),
       ...requireConcurrencyOnPullRequestWorkflows(path, document),
       ...requireRustTestCancelsSupersededRuns(path, document),
+      ...forbidNixBuildInCiAggregator(path, document),
       ...requireJobTimeouts(path, document),
       ...requireDepsBeforeBunTest(path, document),
       ...requireRestoreOnlyCachesHaveAWriter(path, document, cacheWriters),

--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -745,7 +745,7 @@ export function requireRustTestCancelsSupersededRuns(path: string, document: unk
  * Fails when the `ci` aggregator needs `nix-build`.
  *
  * A job in the required `ci` aggregator that cannot run on a pull request reds `main` — on
- * `cancelled` as well as `failure` (`ci.yml:984`) — with nothing a PR could have prevented.
+ * `cancelled` as well as `failure` (the `ci` aggregator's fail step) — with nothing a PR could have prevented.
  * Asserted as this one instance because a general matcher's own failure mode is an over-fire
  * and `check:workflows` is in `preflight`, so over-firing blocks every push; it therefore
  * misses the same job under another name. Widen on the second instance (#1105).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ permissions:
   contents: read
   # `id-token: write` is NOT granted at workflow scope — it's elevated
   # only on the three test jobs that actually upload to Flakiness.io
-  # (Greptile #301 P1 security finding). `changes`, `raycast-lint`, and
-  # `nix-build` run third-party actions and don't need OIDC capability.
+  # (Greptile #301 P1 security finding). `changes` and `raycast-lint` run
+  # third-party actions and don't need OIDC capability.
   # `pull-requests: write` was previously needed for a sticky test-results
   # comment; removed alongside #303 when Flakiness.io took over the
   # "where did the tests land" surface.
@@ -44,7 +44,6 @@ jobs:
       tts_e2e: ${{ steps.filter.outputs.tts_e2e }}
       raycast: ${{ steps.filter.outputs.raycast }}
       openspec: ${{ steps.filter.outputs.openspec }}
-      nix: ${{ steps.filter.outputs.nix }}
       workflows: ${{ steps.filter.outputs.workflows }}
       recipes: ${{ steps.filter.outputs.recipes }}
       homebrew: ${{ steps.filter.outputs.homebrew }}
@@ -149,12 +148,6 @@ jobs:
               - '.github/workflows/ci.yml'
             openspec:
               - 'openspec/**'
-              - 'package.json'
-              - '.github/workflows/ci.yml'
-            nix:
-              - 'flake.nix'
-              - 'flake.lock'
-              - 'rust/**'
               - 'package.json'
               - '.github/workflows/ci.yml'
             workflows:
@@ -907,55 +900,6 @@ jobs:
           OPENSPEC_TELEMETRY: '0'
         run: bun run check:specs
 
-  # Supplementary post-merge check: verify the Nix flake still evaluates and
-  # the engine derivation builds after relevant changes land on main. Does NOT
-  # replace `build-engine.yml` — distributable release artifacts
-  # continue to go through Github-runner cargo + Swift toolchain pins.
-  #
-  # Currently builds only `.#kesha-engine`. The Bun wrapper package
-  # `.#kesha` uses a fixed-output derivation whose `outputHash` requires
-  # a nix-equipped developer to populate (see flake.nix `keshaNodeModules`
-  # block + #264 plan T5); CI without that hash can't build it.
-  #
-  # macos-14 is Apple Silicon (aarch64-darwin). It exercises the Darwin-
-  # only flake paths: Swift toolchain via nixpkgs, the Apple SDK
-  # frameworks input, and the `say-avspeech` Swift sidecar stage-in
-  # inside the engine derivation's postInstall. The lane uses the
-  # `onnx,tts,system_tts` feature set — not `coreml,tts,system_tts` —
-  # because `fluidaudio-rs`'s build.rs invokes `swift build`, which
-  # tries to clone FluidAudio.git inside the offline Nix sandbox.
-  # The canonical darwin release (build-engine.yml, pinned Xcode 16.2)
-  # still ships the CoreML backend.
-  nix-build:
-    needs: changes
-    if: github.event_name == 'push' && needs.changes.outputs.nix == 'true'
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-14]
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 35
-    steps:
-      - name: 📥 Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: ❄️  Install Nix
-        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
-
-      # No remote Nix cache: DeterminateSystems retired the free
-      # `magic-nix-cache-action` backend (the macos-14 row of this job hung
-      # in `Setup Nix cache` for the full 35-min timeout). FlakeHub Cache
-      # works but requires auth; revisit if cold builds become painful.
-
-      - name: 🔍 Validate flake metadata
-        run: nix flake metadata --no-update-lock-file
-
-      - name: 🦀 Build kesha-engine
-        run: nix build .#kesha-engine --no-update-lock-file -L
-
-      - name: 🚬 Smoke
-        run: ./result/bin/kesha-engine --version
-
   # Aggregator gate = the single required status check for branch protection.
   # Always runs so 🧪 CI reports on every PR; the path-gated jobs above skip on
   # unrelated PRs (→ success). The step fails the gate only if a real job failed.
@@ -976,7 +920,6 @@ jobs:
       - tts-e2e
       - raycast-lint
       - openspec-validate
-      - nix-build
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -26,7 +26,7 @@ name: ❄️ Nix Build
 # still ships the CoreML backend.
 
 on:
-  # `rust/**` and `package.json` feed the derivation too; the weekly run covers them, because an advisory two-OS build on every Rust PR is the cost #1105 removed.
+  # `rust/**` and `package.json` feed this derivation too, so a new crate needing a system library or a `build.rs` change is caught only by the weekly cron below — accepted, because a two-OS build on every Rust push is the cost #1105 removed; widen on the first real instance.
   pull_request:
     paths:
       - 'flake.nix'

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -1,0 +1,80 @@
+name: ❄️ Nix Build
+
+# Advisory, not a gate: this reports on the PR and on a weekly schedule but is
+# deliberately absent from `🧪 CI`'s aggregator, so a Beta install path cannot
+# veto every merge. It moved out of ci.yml because it only ran on push, which
+# meant no PR could report on it while a failed or cancelled run still redded
+# the required check on `main` (#1105).
+#
+# Verify the Nix flake still evaluates and the engine derivation builds. Does
+# NOT replace `build-engine.yml` — distributable release artifacts continue to
+# go through Github-runner cargo + Swift toolchain pins.
+#
+# Currently builds only `.#kesha-engine`. The Bun wrapper package
+# `.#kesha` uses a fixed-output derivation whose `outputHash` requires
+# a nix-equipped developer to populate (see flake.nix `keshaNodeModules`
+# block + #264 plan T5); CI without that hash can't build it.
+#
+# macos-14 is Apple Silicon (aarch64-darwin). It exercises the Darwin-
+# only flake paths: Swift toolchain via nixpkgs, the Apple SDK
+# frameworks input, and the `say-avspeech` Swift sidecar stage-in
+# inside the engine derivation's postInstall. The lane uses the
+# `onnx,tts,system_tts` feature set — not `coreml,tts,system_tts` —
+# because `fluidaudio-rs`'s build.rs invokes `swift build`, which
+# tries to clone FluidAudio.git inside the offline Nix sandbox.
+# The canonical darwin release (build-engine.yml, pinned Xcode 16.2)
+# still ships the CoreML backend.
+
+on:
+  # Only the paths that can actually break the flake — ~7 commits in this
+  # repo's history — rather than every `rust/**` push as before.
+  pull_request:
+    paths:
+      - 'flake.nix'
+      - 'flake.lock'
+      - '.github/workflows/nix-build.yml'
+  # Catches drift no PR would: nixpkgs-unstable moving, or another upstream
+  # policy change like the crates.io User-Agent block this job found (#1105).
+  schedule:
+    - cron: '17 5 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  nix-build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-14]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 35
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: ❄️  Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+
+      # No remote Nix cache: DeterminateSystems retired the free
+      # `magic-nix-cache-action` backend (the macos-14 row of this job hung
+      # in `Setup Nix cache` for the full 35-min timeout). FlakeHub Cache
+      # works but requires auth; revisit if cold builds become painful.
+
+      - name: 🔍 Validate flake metadata
+        run: nix flake metadata --no-update-lock-file
+
+      - name: 🦀 Build kesha-engine
+        run: nix build .#kesha-engine --no-update-lock-file -L
+
+      - name: 🚬 Smoke
+        run: ./result/bin/kesha-engine --version

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -26,8 +26,7 @@ name: ❄️ Nix Build
 # still ships the CoreML backend.
 
 on:
-  # Only the paths that can actually break the flake — ~7 commits in this
-  # repo's history — rather than every `rust/**` push as before.
+  # `rust/**` and `package.json` feed the derivation too; the weekly run covers them, because an advisory two-OS build on every Rust PR is the cost #1105 removed.
   pull_request:
     paths:
       - 'flake.nix'

--- a/docs/mutation-evidence/issue-1105.md
+++ b/docs/mutation-evidence/issue-1105.md
@@ -3,7 +3,7 @@
 One guard, `forbidNixBuildInCiAggregator` in `.github/scripts/check-workflows.ts`. It asserts
 that `jobs.ci.needs` in `ci.yml` does not contain `nix-build` — a job gated on
 `github.event_name == 'push'` cannot report on a pull request, yet a failed **or cancelled**
-run reds the required `🧪 CI` check on `main` (`ci.yml:984`), which is what happened at
+run reds the required `🧪 CI` check on `main` (the `ci` aggregator's fail step), which is what happened at
 `394e013a`.
 
 | Guard | File | Test | Where it runs | Reach |

--- a/docs/mutation-evidence/issue-1105.md
+++ b/docs/mutation-evidence/issue-1105.md
@@ -1,0 +1,61 @@
+# Mutation evidence — #1105 item 3 (`nix-build` redding `main` from inside the CI aggregator)
+
+One guard, `forbidNixBuildInCiAggregator` in `.github/scripts/check-workflows.ts`. It asserts
+that `jobs.ci.needs` in `ci.yml` does not contain `nix-build` — a job gated on
+`github.event_name == 'push'` cannot report on a pull request, yet a failed **or cancelled**
+run reds the required `🧪 CI` check on `main` (`ci.yml:984`), which is what happened at
+`394e013a`.
+
+| Guard | File | Test | Where it runs | Reach |
+|---|---|---|---|---|
+| TS | `.github/scripts/check-workflows.ts` | `forbidNixBuildInCiAggregator > passes on the real ci.yml` (+3 siblings) | `🧪 CI` → `unit-tests` (every PR, plain `bun test` over `tests/unit/`), and `bun run check:workflows` inside `just preflight` | The one instance. It pins `nix-build` returning to the aggregator; it does **not** catch the nix job returning under a different name, nor any other push-only job being added. |
+
+That reach limit is deliberate, not an oversight — see the doc comment on the function and the
+PR body. A general "no push-only job in the aggregator" matcher's own failure mode is an
+over-fire, and `check:workflows` runs inside `preflight`, so over-firing would block every push
+until someone deleted the guard.
+
+## Mutation proof
+
+Both rows: `just mutate <file> <find> <replace> <test…>`, which restores the file in a `finally`
+and exits 0 only when the mutation was **caught**. `git status --short` was clean after each.
+
+Two rows rather than one because there are two ways to lose this guard — breaking what it
+matches, and unwiring it from `checkFile` so it never runs at all. The second is the one every
+directly-called test survives.
+
+| # | File | Mutation | Test | Result |
+|---|---|---|---|---|
+| 1 | `.github/scripts/check-workflows.ts` | `"nix-build"` → `"nix-buildx"` — the job-name comparison matches nothing | `bun test tests/unit/check-workflows.test.ts` | **PINNED** — 142 pass, 2 fail |
+| 2 | `.github/scripts/check-workflows.ts` | `"...forbidNixBuildInCiAggregator(path, document),"` → `""` — the guard is deleted from `checkFile`'s list while its definition and every direct test stay intact | `bun test tests/unit/check-workflows.test.ts` | **PINNED** — 143 pass, 1 fail, and the single failure is `forbidNixBuildInCiAggregator > the file gate actually runs it` |
+
+Row 2 is the load-bearing one. Without `test("the file gate actually runs it")` — which asserts
+through `checkFile(path, [], [], undefined)` rather than calling the guard directly — deleting
+the registration line leaves every other test green while `bun run check:workflows` silently
+stops checking. That test exists because of this mutation, not the other way round.
+
+**Why that test filters on `"nix-build"` and not on `#1105`.** Three of the four existing
+`the file gate actually runs it` tests (`check-workflows.test.ts:638`, `:858`, `:897`) already
+filter on `#1105`, and `requireJobTimeouts` — which cites `#1105` — has no path guard and
+interpolates the job name into its message (`check-workflows.ts:499-501`). A fourth `#1105`
+filter would have counted unrelated errors. For the same reason the probe's jobs carry **no
+`steps:` array**: `check-workflows.ts:497` skips jobs without one, which keeps
+`requireJobTimeouts` (and `requirePipefailShell`, `requireBashOnWindowsRunSteps`,
+`requireDepsBeforeBunTest`, `requireReusableCallPermissions` — the rest of the checks that
+interpolate a job name) silent, so `toHaveLength(1)` counts only this guard's error. The probe
+also uses `on: push` rather than `on: pull_request`, which keeps
+`requireConcurrencyOnPullRequestWorkflows` quiet.
+
+## The flake fix has no mutation row, deliberately
+
+`flake.nix`'s `fetchurl` override is the other half of this PR and it is **not** in the table
+above. A check asserting that `flake.nix` contains a `--user-agent` string would pin the
+implementation rather than a contract a user can observe — the class retired by the #161 audit
+in #163.
+
+Its guard is the `❄️ Nix Build` job itself: remove the override and the next run goes red on
+the same crates.io 403. That is slow, but it is a real guard rather than a restatement of the
+diff, and it fired correctly on this PR — red on the 403 before the override, green after, on
+both `ubuntu-latest` and `macos-14` (run
+[`33198751156`](https://github.com/drakulavich/kesha-voice-kit/actions/runs/33198751156):
+0 occurrences of `error: 403`, 244 successful `crates.io` fetches, smoke `kesha-engine 1.24.11`).

--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,13 @@
         naersk' = pkgs.callPackage naersk {
           cargo = rustToolchain;
           rustc = rustToolchain;
+          # crates.io 403s the `curl/*` User-Agent nixpkgs fetchurl sends, and naersk calls it directly (#1105).
+          fetchurl = args: pkgs.fetchurl (args // {
+            curlOptsList = (args.curlOptsList or [ ]) ++ [
+              "--user-agent"
+              "kesha-voice-kit (+https://github.com/drakulavich/kesha-voice-kit)"
+            ];
+          });
         };
 
         # Platform detection

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -7,6 +7,7 @@ import {
   checkFile,
   collectCacheWriters,
   forbidLinuxPackaging,
+  forbidNixBuildInCiAggregator,
   requireJobTimeouts,
   requireBashOnWindowsRunSteps,
   requireConcurrencyOnPullRequestWorkflows,
@@ -895,5 +896,33 @@ describe("requireRustTestCancelsSupersededRuns", () => {
     const path = join(mkdtempSync(join(tmpdir(), "kesha-wf-")), "rust-test.yml");
     writeFileSync(path, yaml);
     expect(checkFile(path, [], [], undefined).filter((e) => e.includes("#1105"))).toHaveLength(1);
+  });
+});
+
+describe("forbidNixBuildInCiAggregator", () => {
+  test("passes on the real ci.yml", () => {
+    expect(forbidNixBuildInCiAggregator(CI, parseRepoYaml(CI))).toEqual([]);
+  });
+
+  test("fails when the aggregator needs nix-build", () => {
+    const errors = forbidNixBuildInCiAggregator(CI, { jobs: { ci: { needs: ["unit-tests", "nix-build"] } } });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("nix-build");
+  });
+
+  test("ignores workflows other than ci.yml", () => {
+    const doc = { jobs: { ci: { needs: ["nix-build"] } } };
+    expect(forbidNixBuildInCiAggregator(".github/workflows/rust-test.yml", doc)).toEqual([]);
+  });
+
+  // A gate is only a gate if checkFile still calls it, and the live suite cannot notice a gate
+  // that was quietly unwired. The probe's jobs carry no `steps:` because `requireJobTimeouts`
+  // has no path guard and interpolates the job name, so a `steps`-bearing `nix-build` would emit
+  // a second error containing "nix-build" and this would pass asserting nothing (#1105).
+  test("the file gate actually runs it", () => {
+    const yaml = "on: push\njobs:\n  nix-build:\n    if: github.event_name == 'push'\n  ci:\n    needs: [nix-build]\n";
+    const path = join(mkdtempSync(join(tmpdir(), "kesha-wf-")), "ci.yml");
+    writeFileSync(path, yaml);
+    expect(checkFile(path, [], [], undefined).filter((e) => e.includes("nix-build"))).toHaveLength(1);
   });
 });


### PR DESCRIPTION
Item 3 of the #1105 CI-minutes audit. The audit's diagnosis was wrong on two counts, and both change which fix is correct.

## What was actually broken

`nix-build` has failed **100% of the time since 2026-08-27** — 8 job failures, 0 passes, across 4 push runs.

**Not throttling.** crates.io returns a deterministic 403 to any `curl/*` User-Agent on `/api/v1/crates/<name>/<version>/download`, at 0 bytes received. Reproduced directly:

| User-Agent | result |
|---|---|
| `curl/8.7.1 Nixpkgs/25.11` | **403** |
| `Nix/2.28`, `Mozilla/5.0`, `cargo 1.90.0` | 200 |
| `kesha-voice-kit (+https://github.com/…)` | 200 |

**Not macOS-specific.** Both legs failed identically — 4 Ubuntu, 4 macOS. Dropping the macOS row would have left a job that was still 100% red.

**Retry cannot help.** nixpkgs `fetchurl` already backs off 1s/2s/4s; the log shows all four attempts 403.

**And `nix flake update` does not fix it.** nixpkgs patched this class in its Rust fetchers one at a time (fetchCrate, importCargoLock, fetchCargoVendor) but left the generic `fetchurl` User-Agent alone — [NixOS/nixpkgs#513006](https://github.com/NixOS/nixpkgs/issues/513006) is still open, and `builder.sh:29` on master still sends `curl/…`. naersk calls plain `fetchurl` (`build.nix:435-438`), so it never received any of those fixes.

## The fact the audit missed

**`🧪 CI` is red on `main` at `394e013a` right now**, with `nix-build (ubuntu-latest)` and `nix-build (macos-14)` the only failures among 18 jobs. `nix-build` was in the `ci` aggregator's `needs` while gated on `github.event_name == 'push'` — skipped on PRs, so no PR could report on it, but a failed *or cancelled* run redded the required check on `main` (`ci.yml:984` fails on both). CLAUDE.md's "It is not a CI gate" was true for pull requests only.

That is what makes this a fix rather than a cost optimisation, and it stops being demonstrable once this merges.

## What this does

1. **A guard**, `forbidNixBuildInCiAggregator` in `check-workflows.ts`, red before the move and green after.
2. **`nix-build` moves to its own `nix-build.yml`** — `pull_request` restricted to `flake.nix`, `flake.lock` and the workflow itself; a weekly schedule for upstream drift; `workflow_dispatch`. **Advisory, not blocking**: it is deliberately absent from the aggregator and is not a required check, so a Beta install path cannot veto every merge. Adding it to branch protection is a separate maintainer decision.
3. **`flake.nix` overrides `fetchurl` for naersk only**, adding a crates.io-accepted User-Agent. Pure and in-flake, so `nix build .#kesha-engine` works for users too, not only in CI. `nix run .#kesha` stays blocked on #946, untouched.

Cost: from ~4 firings/week on every `rust/**` push to ~1 scheduled run plus flake-touching PRs (~7 commits in this repo's history). macOS is 10.3× Linux per minute.

## Why the guard is narrow

It asserts one instance — `nix-build` must not be in `jobs.ci.needs` — rather than the class. A general "no push-only job in the aggregator" rule was drafted and does work; an independent implementation of its four-step parse was run over all fourteen aggregator conditions plus `!(github.event_name == 'push')` and `github.event_name != 'push'`, and over-fires on none. But not over-firing shows the parser is *correct*, not that it is *warranted*.

The failure costs are lopsided. `check:workflows` runs inside `preflight`, so a **false positive blocks every push in the repository** until someone deletes the guard — and a guard that blocks work gets deleted. A **false negative costs one red `main`**, once, caught by inspection the way this one was. `workflow-lint` (`ci.yml:190-192`) ends `|| github.event_name == 'schedule'` and *does* run on pull requests, so the shape that would trip a careless matcher is one word from being written.

What a general rule would have had to recognise, and where it would still have failed:

| shape | a general rule would | why |
|---|---|---|
| `github.event_name == 'push'` as a whole top-level `&&` term, single disjunct | flag | provably cannot run on a pull request |
| ≥2 top-level disjuncts, e.g. `… == 'push' \|\| needs.x == 'true'` | stay silent | satisfiable by a PR |
| `github.event_name != 'push'`, `!(github.event_name == 'push')` | stay silent | run on pull requests |
| `(… == 'push' \|\| … == 'schedule')` as a parenthesised term | **miss** | cannot run on a PR — and this is how the four `always()` jobs are written |
| `github.event_name != 'pull_request'` as a term | **miss** | a live *spelling* (`security.yml:57`) but not a live instance in the aggregator |

**What the narrow guard does not catch**, stated rather than omitted: the nix job returning under a different name, or any other push-only job being added. That is the price of a rule that cannot obstruct every push. Widen on the second instance.

## Verification

- `just preflight` — **green**: `1596 pass, 0 fail` across 112 files, plus `check:recipes`, `check:workflows`, `check:versions`, OpenSpec (17/17), `check-engine-targets`, `release-manifest --check`. Rust and CoreML gates correctly skipped (no `rust/**` changes).
- `just verify-darwin-full` **not required** — no `rust/src/tts/**`, nothing on the `system_kokoro` / `system_diarize` / `system_text_lang` surface.
- **Both mutations caught.** Breaking the job-name comparison → `PINNED`. Deleting the `checkFile` registration → `PINNED`, red on exactly `test("the file gate actually runs it")`, which exists because every directly-called test survives an unwiring.

### What I could not verify

- **`nix` is not installed on this machine.** No local build was run and none is claimed. The `❄️ Nix Build` run on this PR is the proof — it fires because this PR touches `flake.nix` and `nix-build.yml`, and should be red on the 403 at `160ab09` and green at `1dfbf3f`. (`workflow_dispatch` could not have been used instead: it only triggers when the workflow file is already on the default branch.)
- **The flake fix has no local mutation proof, deliberately.** Asserting `flake.nix` contains a `--user-agent` string would pin the implementation rather than an observable contract — the class retired in #161/#163. Its guard is the weekly job going red on the same 403.

## Cost on the record

Across the sampled window `nix-build` has **zero** observed catches of a regression in this repository's own code: the 4 runs where it passed found nothing, and the 4 where it failed failed on upstream infrastructure. Its one real catch is the present breakage — the flake unbuildable for every Nix user, on a path README.md:144 and `docs/nix-install.md` advertise. That is the honest rate, and it is why the schedule is weekly rather than per-push; dialing it to monthly is a one-line cron change that needs no re-litigation of this ticket.

Refs #1105


## Deviations from the plan

One. The plan specified a three-line `flake.nix` comment carrying the crates.io rationale; `.claude/hooks/check-new-comments.ts` blocks any added multi-line `//` or `#` comment and rejected the edit outright, so it was condensed to one line and the rationale moved to the commit message. Nothing else deviates — the guard, both mutations, the workflow move and the commit order are as approved.

## Docs updated

- `docs/mutation-evidence/issue-1105.md` — new, following the `issue-NNNN.md` convention from #1093.

No other docs needed changing. `CLAUDE.md:195` ("A Nix flake … is not a CI gate") becomes unambiguously *more* true once the job leaves the aggregator, so it is deliberately untouched. `README.md:144` and `docs/nix-install.md` describe the flake as an install path, which this fixes rather than changes.

## Mutation table

Committed at [`docs/mutation-evidence/issue-1105.md`](docs/mutation-evidence/issue-1105.md). Summary — both `PINNED`:

| # | File | Mutation | Test that went red | Result |
|---|---|---|---|---|
| 1 | `.github/scripts/check-workflows.ts` | `"nix-build"` → `"nix-buildx"` | `forbidNixBuildInCiAggregator` cases (2 fail) | **PINNED** |
| 2 | `.github/scripts/check-workflows.ts` | delete `...forbidNixBuildInCiAggregator(path, document),` from `checkFile` | `forbidNixBuildInCiAggregator > the file gate actually runs it` (1 fail) | **PINNED** |

The repository ships no runner for these tables; both rows were produced by `just mutate`, which restores in a `finally` and exits 0 only when the mutation was caught.

The `flake.nix` fix has **no row, deliberately** — asserting it contains a `--user-agent` string would pin the implementation rather than an observable contract (the class retired in #161/#163). Its guard is `❄️ Nix Build`, which fired correctly here: red on the 403 before the override, green on both legs after.
