### PR TITLE
fix(homebrew): pin tap formula version from tagged package.json

### DIFF
--- a/.github/scripts/stage-homebrew-worktree-formula.d.mts
+++ b/.github/scripts/stage-homebrew-worktree-formula.d.mts
@@ -1,4 +1,4 @@
 export function rewriteFormula(
   formula: string,
-  fields: { url: string; version: string; sha256: string },
+  fields: { url: string; version: string | null; sha256: string },
 ): string;

--- a/.github/scripts/stage-homebrew-worktree-formula.mjs
+++ b/.github/scripts/stage-homebrew-worktree-formula.mjs
@@ -24,16 +24,12 @@ function replaceOne(source, pattern, replacement, label) {
 }
 
 export function rewriteFormula(formula, { url, version, sha256 }) {
-  // Strip before deciding whether to insert: a caller may pass an already-rewritten formula
-  // (a Homebrew tap's previous release), and re-inserting without stripping first leaves two
-  // `version` lines, of which Homebrew silently keeps the stale one (#1105).
+  // Strip first: re-inserting into an already-rewritten (tap's prior release) formula duplicates `version`, and Homebrew keeps the stale one (#1105).
   const withoutVersion = formula.replace(/^  version ".*"\n/m, "");
   const urlLine = version
-    ? // A file:// url gives Homebrew no version to parse, and the formula's `test do`
-      // asserts `version` matches `kesha --version`, so pin it from package.json.
+    ? // The formula's `test do` compares `version` to `kesha --version`, so pin it from package.json.
       `  url "${url}"\n  version "${version}"`
-    : // Falsy version means the caller's version already equals what Homebrew scans from the
-      // url itself — an explicit line here fails `brew audit --strict` as redundant (#1105).
+    : // Falsy version already equals what Homebrew scans from the url; an explicit line here fails `brew audit --strict` as redundant (#1105).
       `  url "${url}"`;
   const withUrl = replaceOne(withoutVersion, /^  url ".*"$/m, urlLine, "url");
   return replaceOne(withUrl, /^  sha256 "[a-f0-9]{64}"$/m, `  sha256 "${sha256}"`, "sha256");

--- a/.github/scripts/stage-homebrew-worktree-formula.mjs
+++ b/.github/scripts/stage-homebrew-worktree-formula.mjs
@@ -24,14 +24,18 @@ function replaceOne(source, pattern, replacement, label) {
 }
 
 export function rewriteFormula(formula, { url, version, sha256 }) {
-  const withUrl = replaceOne(
-    formula,
-    /^  url ".*"$/m,
-    // A file:// url gives Homebrew no version to parse, and the formula's `test do`
-    // asserts `version` matches `kesha --version`, so pin it from package.json.
-    `  url "${url}"\n  version "${version}"`,
-    "url",
-  );
+  // Strip before deciding whether to insert: a caller may pass an already-rewritten formula
+  // (a Homebrew tap's previous release), and re-inserting without stripping first leaves two
+  // `version` lines, of which Homebrew silently keeps the stale one (#1105).
+  const withoutVersion = formula.replace(/^  version ".*"\n/m, "");
+  const urlLine = version
+    ? // A file:// url gives Homebrew no version to parse, and the formula's `test do`
+      // asserts `version` matches `kesha --version`, so pin it from package.json.
+      `  url "${url}"\n  version "${version}"`
+    : // Falsy version means the caller's version already equals what Homebrew scans from the
+      // url itself — an explicit line here fails `brew audit --strict` as redundant (#1105).
+      `  url "${url}"`;
+  const withUrl = replaceOne(withoutVersion, /^  url ".*"$/m, urlLine, "url");
   return replaceOne(withUrl, /^  sha256 "[a-f0-9]{64}"$/m, `  sha256 "${sha256}"`, "sha256");
 }
 

--- a/.github/scripts/update-homebrew-tap.d.mts
+++ b/.github/scripts/update-homebrew-tap.d.mts
@@ -1,0 +1,9 @@
+type FetchImpl = (url: string, init?: RequestInit) => Promise<Response>;
+
+export function sha256ForUrl(url: string, fetchImpl?: FetchImpl): Promise<string>;
+export function versionForTag(tag: string, fetchImpl?: FetchImpl): Promise<string>;
+export function buildUpdatedFormula(args: {
+  tag: string;
+  formula: string;
+  fetchImpl?: FetchImpl;
+}): Promise<string>;

--- a/.github/scripts/update-homebrew-tap.mjs
+++ b/.github/scripts/update-homebrew-tap.mjs
@@ -41,8 +41,7 @@ export async function buildUpdatedFormula({ tag, formula, fetchImpl = fetch }) {
   ]);
 
   const tagVersion = tag.slice(1);
-  // Homebrew scans this exact string out of the archive/refs/tags url itself; an explicit
-  // version equal to it fails `brew audit --strict` as redundant (#1105).
+  // Homebrew scans this exact string from the url; an explicit version equal to it fails `brew audit --strict` as redundant (#1105).
   const version = cliVersion === tagVersion ? null : cliVersion;
 
   return rewriteFormula(formula, { url: tarballUrl, version, sha256 });

--- a/.github/scripts/update-homebrew-tap.mjs
+++ b/.github/scripts/update-homebrew-tap.mjs
@@ -3,27 +3,14 @@ import { createHash } from "node:crypto";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { isStableTag } from "./release-tags.mjs";
+import { rewriteFormula } from "./stage-homebrew-worktree-formula.mjs";
+import { isEntry } from "./script-entry.mjs";
 
 const REPOSITORY = "drakulavich/kesha-voice-kit";
 const FORMULA_REL = "Formula/kesha-voice-kit.rb";
 
-function usage() {
-  console.error(
-    "usage: node .github/scripts/update-homebrew-tap.mjs --tag vX.Y.Z --tap-dir path",
-  );
-  process.exit(2);
-}
-
-function getArg(name) {
-  const i = process.argv.indexOf(name);
-  if (i === -1) return undefined;
-  const value = process.argv[i + 1];
-  if (!value || value.startsWith("--")) usage();
-  return value;
-}
-
-async function sha256ForUrl(url) {
-  const res = await fetch(url, { redirect: "follow" });
+export async function sha256ForUrl(url, fetchImpl = fetch) {
+  const res = await fetchImpl(url, { redirect: "follow" });
   if (!res.ok) {
     throw new Error(`could not fetch ${url}: HTTP ${res.status}`);
   }
@@ -31,38 +18,67 @@ async function sha256ForUrl(url) {
   return createHash("sha256").update(bytes).digest("hex");
 }
 
-function replaceOne(source, pattern, replacement, label) {
-  if (!pattern.test(source)) throw new Error(`formula is missing ${label}`);
-  return source.replace(pattern, replacement);
+export async function versionForTag(tag, fetchImpl = fetch) {
+  const url = `https://raw.githubusercontent.com/${REPOSITORY}/${tag}/package.json`;
+  const res = await fetchImpl(url);
+  if (!res.ok) {
+    throw new Error(`could not fetch ${url}: HTTP ${res.status}`);
+  }
+  const pkg = await res.json();
+  if (!pkg.version) throw new Error(`package.json at ${tag} is missing a version`);
+  return pkg.version;
 }
 
-const tag = getArg("--tag");
-const tapDir = getArg("--tap-dir");
-if (!tag || !tapDir) usage();
-if (!isStableTag(tag)) {
-  throw new Error(`Homebrew tap updates only support stable vX.Y.Z tags, got: ${tag}`);
+export async function buildUpdatedFormula({ tag, formula, fetchImpl = fetch }) {
+  if (!isStableTag(tag)) {
+    throw new Error(`Homebrew tap updates only support stable vX.Y.Z tags, got: ${tag}`);
+  }
+
+  const tarballUrl = `https://github.com/${REPOSITORY}/archive/refs/tags/${tag}.tar.gz`;
+  const [sha256, cliVersion] = await Promise.all([
+    sha256ForUrl(tarballUrl, fetchImpl),
+    versionForTag(tag, fetchImpl),
+  ]);
+
+  const tagVersion = tag.slice(1);
+  // Homebrew scans this exact string out of the archive/refs/tags url itself; an explicit
+  // version equal to it fails `brew audit --strict` as redundant (#1105).
+  const version = cliVersion === tagVersion ? null : cliVersion;
+
+  return rewriteFormula(formula, { url: tarballUrl, version, sha256 });
 }
 
-const tarballUrl = `https://github.com/${REPOSITORY}/archive/refs/tags/${tag}.tar.gz`;
-const sha256 = await sha256ForUrl(tarballUrl);
-const formulaPath = join(tapDir, FORMULA_REL);
-let formula = readFileSync(formulaPath, "utf8");
+if (isEntry(import.meta.url)) {
+  const usage = () => {
+    console.error(
+      "usage: node .github/scripts/update-homebrew-tap.mjs --tag vX.Y.Z --tap-dir path",
+    );
+    process.exit(2);
+  };
 
-formula = replaceOne(
-  formula,
-  /^  url ".*"$/m,
-  `  url "${tarballUrl}"`,
-  "url",
-);
-formula = replaceOne(
-  formula,
-  /^  sha256 "[a-f0-9]{64}"$/m,
-  `  sha256 "${sha256}"`,
-  "sha256",
-);
+  const getArg = (name) => {
+    const i = process.argv.indexOf(name);
+    if (i === -1) return undefined;
+    const value = process.argv[i + 1];
+    if (!value || value.startsWith("--")) usage();
+    return value;
+  };
 
-mkdirSync(dirname(formulaPath), { recursive: true });
-writeFileSync(formulaPath, formula);
-console.log(`Updated ${FORMULA_REL} for ${tag}`);
-console.log(`url: ${tarballUrl}`);
-console.log(`sha256: ${sha256}`);
+  const tag = getArg("--tag");
+  const tapDir = getArg("--tap-dir");
+  if (!tag || !tapDir) usage();
+
+  const formulaPath = join(tapDir, FORMULA_REL);
+  const formula = await buildUpdatedFormula({ tag, formula: readFileSync(formulaPath, "utf8") });
+
+  mkdirSync(dirname(formulaPath), { recursive: true });
+  writeFileSync(formulaPath, formula);
+
+  const url = formula.match(/^  url "(.*)"$/m)?.[1];
+  const sha256 = formula.match(/^  sha256 "([a-f0-9]{64})"$/m)?.[1];
+  const version = formula.match(/^  version "(.*)"$/m)?.[1];
+  console.log(`Updated ${FORMULA_REL} for ${tag}`);
+  console.log(`url: ${url}`);
+  console.log(`sha256: ${sha256}`);
+  console.log(version ? `version: ${version}` : "version: left to Homebrew's URL inference (matches the tag)");
+}

--- a/tests/unit/stage-homebrew-worktree-formula.test.ts
+++ b/tests/unit/stage-homebrew-worktree-formula.test.ts
@@ -30,6 +30,22 @@ describe("rewriteFormula", () => {
     expect(out).toContain(`version "${VERSION}"`);
   });
 
+  test("replaces an existing version line rather than duplicating it", () => {
+    const withVersion = rewriteFormula(FORMULA, { url: URL, version: "1.29.1", sha256: SHA256 });
+    const out = rewriteFormula(withVersion, { url: URL, version: "1.30.0", sha256: SHA256 });
+
+    expect(out.match(/^  version /gm)).toHaveLength(1);
+    expect(out).toContain('version "1.30.0"');
+    expect(out).not.toContain('version "1.29.1"');
+  });
+
+  test("omits the version line, and strips any existing one, when version is falsy", () => {
+    const withVersion = rewriteFormula(FORMULA, { url: URL, version: "1.24.7", sha256: SHA256 });
+    const out = rewriteFormula(withVersion, { url: URL, version: null, sha256: SHA256 });
+
+    expect(out).not.toMatch(/^  version /m);
+  });
+
   // The CLI writes the tap formula only with rewriteFormula's return value, so a
   // formula it rejects can never leave a partial file behind.
   test("refuses a formula with no url before returning a rewrite", () => {

--- a/tests/unit/update-homebrew-tap.test.ts
+++ b/tests/unit/update-homebrew-tap.test.ts
@@ -79,6 +79,8 @@ describe("buildUpdatedFormula", () => {
         ? new Response("not found", { status: 404 })
         : new Response(Buffer.from("fake tarball"));
 
-    await expect(buildUpdatedFormula({ tag: "v1.24.12", formula: FORMULA, fetchImpl })).rejects.toThrow();
+    await expect(buildUpdatedFormula({ tag: "v1.24.12", formula: FORMULA, fetchImpl })).rejects.toThrow(
+      /HTTP 404/,
+    );
   });
 });

--- a/tests/unit/update-homebrew-tap.test.ts
+++ b/tests/unit/update-homebrew-tap.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import { buildUpdatedFormula } from "../../.github/scripts/update-homebrew-tap.mjs";
+import { readRepoFile } from "../helpers/repo";
+
+const FORMULA = readRepoFile("packaging/homebrew/Formula/kesha-voice-kit.rb");
+
+function fetchReturning(version: string) {
+  return async (url: string) =>
+    url.endsWith("package.json")
+      ? new Response(JSON.stringify({ version }))
+      : new Response(Buffer.from("fake tarball"));
+}
+
+describe("buildUpdatedFormula", () => {
+  test("shape (i): pins version from the tagged package.json, not the tag string", async () => {
+    const out = await buildUpdatedFormula({
+      tag: "v1.24.9",
+      formula: FORMULA,
+      fetchImpl: fetchReturning("1.27.0"),
+    });
+
+    expect(out).toContain('version "1.27.0"');
+    expect(out).not.toContain('version "1.24.9"');
+  });
+
+  test("shape (ii): a second release replaces the prior release's version line, not duplicates it", async () => {
+    const first = await buildUpdatedFormula({
+      tag: "v1.24.9",
+      formula: FORMULA,
+      fetchImpl: fetchReturning("1.27.0"),
+    });
+    const second = await buildUpdatedFormula({
+      tag: "v1.24.10",
+      formula: first,
+      fetchImpl: fetchReturning("1.28.0"),
+    });
+
+    expect(second.match(/^  version /gm)).toHaveLength(1);
+    expect(second).toContain('version "1.28.0"');
+    expect(second).not.toContain('version "1.27.0"');
+  });
+
+  test("shape (iii): omits the version line when the tag and the CLI version happen to match", async () => {
+    const out = await buildUpdatedFormula({
+      tag: "v1.24.7",
+      formula: FORMULA,
+      fetchImpl: fetchReturning("1.24.7"),
+    });
+
+    expect(out).not.toMatch(/^  version /m);
+  });
+
+  test("rejects a non-stable tag before fetching anything", async () => {
+    await expect(
+      buildUpdatedFormula({
+        tag: "v1.24.9-cli",
+        formula: FORMULA,
+        fetchImpl: () => {
+          throw new Error("must not fetch for a rejected tag");
+        },
+      }),
+    ).rejects.toThrow(/stable/i);
+  });
+});

--- a/tests/unit/update-homebrew-tap.test.ts
+++ b/tests/unit/update-homebrew-tap.test.ts
@@ -61,4 +61,24 @@ describe("buildUpdatedFormula", () => {
       }),
     ).rejects.toThrow(/stable/i);
   });
+
+  test("rejects when the tagged package.json has no version, rather than falling back to the tag", async () => {
+    const fetchImpl = async (url: string) =>
+      url.endsWith("package.json")
+        ? new Response(JSON.stringify({}))
+        : new Response(Buffer.from("fake tarball"));
+
+    await expect(
+      buildUpdatedFormula({ tag: "v1.24.12", formula: FORMULA, fetchImpl }),
+    ).rejects.toThrow(/version/i);
+  });
+
+  test("rejects when the package.json fetch itself fails", async () => {
+    const fetchImpl = async (url: string) =>
+      url.endsWith("package.json")
+        ? new Response("not found", { status: 404 })
+        : new Response(Buffer.from("fake tarball"));
+
+    await expect(buildUpdatedFormula({ tag: "v1.24.12", formula: FORMULA, fetchImpl })).rejects.toThrow();
+  });
 });


### PR DESCRIPTION
## Claim

`🍺 Homebrew Tap` fails on every stable engine tag this workflow processes, from v1.24.9 onward (`-alpha`/`-beta` engine tags never reach this path — `homebrew-tap.yml` gates on `^v[0-9]+\.[0-9]+\.[0-9]+$`). `update-homebrew-tap.mjs` rewrote only `url` and `sha256`, leaving Homebrew to infer `version` from the engine tag string in the URL. The formula's `test do` asserts that inferred version against `kesha --version`, which reports the CLI's own, independently-versioned `package.json#version` — the two diverged after #691 put the next unreleased CLI version on `main`.

Confirmed against real run history: v1.24.9/.10/.11 all failed on exactly this assertion (`Minitest::Assertion: Expected /1\.24\.11/ to match "1.29.0\n"`, run `33173980346`); v1.24.7 (last success, 2026-07-27) passed only by coincidence — the CLI version happened to equal the engine tag at the time. No engine tag has updated the tap since.

Refs #1105 (item 4 of the CI-minutes audit; items 1-3 shipped separately as #1109/#1110/#1111, one more item split to #1108 — not closing).

## Fix

Two defects had to be fixed together, both found and reproduced against a real Homebrew binary during planning review before this PR existed:

1. **Version now pinned from the tagged commit's real `package.json`.** `update-homebrew-tap.mjs` restructured into testable exports (`buildUpdatedFormula`, `versionForTag`, `sha256ForUrl`) behind the repo's `isEntry()` convention. `buildUpdatedFormula` fetches `https://raw.githubusercontent.com/.../<tag>/package.json` and pins that version into the formula via the shared `rewriteFormula`.
2. **`rewriteFormula` made idempotent.** It previously only inserted a `version` line; called against a Homebrew tap's own previous-release output (which already carries a version line), it left two lines, and Homebrew silently kept the stale one — the fix would have passed exactly one release and then quietly broken again. It now strips any existing line before deciding whether to insert a new one.
3. **Redundant-version omission.** `brew audit --strict` flags an explicit `version` that equals what Homebrew scans from the `url` itself as `redundant with version scanned from URL` — a real, recurring shape (v1.24.4/.6/.7 all had tag == CLI version). `buildUpdatedFormula` now omits the explicit line when `tag.slice(1) === cliVersion`, letting Homebrew's own URL inference stand (which is correct precisely because the two values are equal in that case).

## Verification

**Real `brew audit --strict` / `brew info --json=v2`, run against the actual implemented code (Homebrew 6.0.17, disposable scratch tap, created and removed):**

| shape | transition | audit | `brew info` stable version |
|---|---|---|---|
| (i) | base → v1.24.9 / cli 1.27.0 | exit 0 | 1.27.0 |
| (ii) | (i) → v1.24.10 / cli 1.28.0 | exit 0 | 1.28.0 (single `version` line, not stale) |
| (iii) | base → v1.24.7 / cli 1.24.7 (redundant) | exit 0 | 1.24.7 (from URL inference alone) |
| (iv) | (ii) → v1.24.7 / cli 1.24.7 (divergent → redundant) | exit 0 | 1.24.7 (prior line stripped) |
| (v) | (iii) → v1.24.12 / cli 1.29.1 (redundant → divergent again) | exit 0 | 1.29.1 |

**Unit tests** (`bun test tests/unit/update-homebrew-tap.test.ts tests/unit/stage-homebrew-worktree-formula.test.ts`): 13 pass, 0 fail — covers shapes (i)/(ii)/(iii), the non-stable-tag rejection, and (added in a fix pass after review) rejection when the tagged `package.json` has no version or its fetch fails, so those two guards can't silently fall back to reproducing #1105.

**Mutation proofs** (`just mutate`), one per defect:
- Revert `versionForTag` to the tag string → PINNED, caught by shape (i).
- Revert the idempotency strip → PINNED, caught by "replaces an existing version line" + shape (ii).
- Revert the redundant-version omission → PINNED, caught by shape (iii).
- Remove `versionForTag`'s missing-version guard → PINNED: with an empty `package.json` response, the mutated code silently emits a formula with no `version` line at all — the original #1105 defect verbatim — and the new test catches it.
- Remove `versionForTag`'s non-OK-response guard → PINNED: baseline throws `could not fetch ... HTTP 404`; removing the guard changes the message to `Failed to parse JSON` (still a rejection, but no longer names the url or status). The test asserts `.rejects.toThrow(/HTTP 404/)`, which is the operator-facing contract this repo's ERROR HANDLING rule asks for — the URL and status a release-log reader needs, not an implementation detail. (`if (!res.ok)` occurs twice in this file — `sha256ForUrl` and `versionForTag` — so the mutation's find-string includes the preceding line to target only the latter.)

**`just preflight`**: 1604 pass, 6 skip, 0 fail across 113 files; all `check:*` scripts green; Rust/CoreML gates correctly skipped (no `rust/**` touched).

## What this deliberately does not do

- Does not change `homebrew-tap.yml`'s trigger — `-cli` tags still don't update the tap, and that gap (the public tap tracking engine-release cadence for an artifact that's only the CLI) predates this ticket and isn't closed by it. Worth a follow-up issue, not scope for this PR.
- Does not touch the formula's `test do` block — a formula-only fix was considered and rejected: it would silence the CI failure while leaving `brew info`/`Cellar/<version>` permanently reporting the wrong (engine-tag) version to users.
- Does not touch #1105 items 1-3 (shipped) or the item split to #1108.


