### PR TITLE
ci(build-engine): serialise runs that share a ref, never cancel them

### DIFF
--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -741,15 +741,20 @@ export function requireRustTestCancelsSupersededRuns(path: string, document: unk
   ];
 }
 
+const BUILD_ENGINE_GROUP = "${{ github.workflow }}-${{ github.ref }}";
+
 /**
  * Fails when `build-engine.yml` stops serialising runs that share a ref.
  *
- * A tag ref is not single-use: deleting and re-pushing a failed release tag is how this repo
- * retries one, and `refs/tags/v1.0.1` carried three `push` runs at three different head SHAs
- * that way. Two of them in flight together would put two `release` jobs against one draft
- * release, and a release published short a platform binary needs a whole new patch tag to
- * repair. So the group must vary per ref, and `cancel-in-progress` must stay `false` because
- * cancelling a run mid-upload is itself the partial-draft defect (#1108).
+ * A tag ref is not single-use: `refs/tags/v1.0.1` carried three `push` runs at three different
+ * head SHAs, because delete-and-re-push is how a failed release tag is retried here. Two in
+ * flight together put two `release` jobs against one draft release, and a release published
+ * short a platform binary needs a new patch tag to repair.
+ *
+ * The group is pinned to its exact text rather than checked with `groupVariesPerRef`, whose
+ * stated residual would accept both a boolean that collapses every ref but one into a single
+ * lane and a run-scoped group that serialises nothing — both mention `github.ref`. Changing
+ * the group means changing this constant and saying why (#1108).
  */
 export function requireBuildEngineSerialisesRunsPerRef(path: string, document: unknown): string[] {
   if (!path.endsWith("build-engine.yml")) return [];
@@ -758,9 +763,9 @@ export function requireBuildEngineSerialisesRunsPerRef(path: string, document: u
   const group = typeof concurrency === "string" ? concurrency : (concurrency as { group?: unknown } | undefined)?.group;
   const errors: string[] = [];
 
-  if (typeof group !== "string" || !groupVariesPerRef(group)) {
+  if (group !== BUILD_ENGINE_GROUP) {
     errors.push(
-      `${path}: \`concurrency.group\` must vary per ref — set it to \`\${{ github.workflow }}-\${{ github.ref }}\`; without a group two runs at one tag ref race the same draft release, and a group that does not vary per ref queues every ref into one lane instead (#1108)`,
+      `${path}: \`concurrency.group\` must be exactly \`${BUILD_ENGINE_GROUP}\`, not \`${String(group)}\`; a coarser group queues unrelated refs into one lane and a finer one serialises nothing, and both can still mention \`github.ref\`. Changing it deliberately means changing this rule and saying why (#1108)`,
     );
   }
 

--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -742,6 +742,38 @@ export function requireRustTestCancelsSupersededRuns(path: string, document: unk
 }
 
 /**
+ * Fails when `build-engine.yml` stops serialising runs that share a ref.
+ *
+ * A tag ref is not single-use: deleting and re-pushing a failed release tag is how this repo
+ * retries one, and `refs/tags/v1.0.1` carried three `push` runs at three different head SHAs
+ * that way. Two of them in flight together would put two `release` jobs against one draft
+ * release, and a release published short a platform binary needs a whole new patch tag to
+ * repair. So the group must vary per ref, and `cancel-in-progress` must stay `false` because
+ * cancelling a run mid-upload is itself the partial-draft defect (#1108).
+ */
+export function requireBuildEngineSerialisesRunsPerRef(path: string, document: unknown): string[] {
+  if (!path.endsWith("build-engine.yml")) return [];
+
+  const concurrency = (document as { concurrency?: unknown } | undefined)?.concurrency;
+  const group = typeof concurrency === "string" ? concurrency : (concurrency as { group?: unknown } | undefined)?.group;
+  const errors: string[] = [];
+
+  if (typeof group !== "string" || !groupVariesPerRef(group)) {
+    errors.push(
+      `${path}: \`concurrency.group\` must vary per ref — set it to \`\${{ github.workflow }}-\${{ github.ref }}\`; without a group two runs at one tag ref race the same draft release, and a group that does not vary per ref queues every ref into one lane instead (#1108)`,
+    );
+  }
+
+  if ((concurrency as { "cancel-in-progress"?: unknown } | undefined)?.["cancel-in-progress"] !== false) {
+    errors.push(
+      `${path}: \`concurrency.cancel-in-progress\` must be spelled \`false\`; cancelling a superseded run mid-upload leaves the draft release short an asset, and a release name cannot be reused to repair it (#1108)`,
+    );
+  }
+
+  return errors;
+}
+
+/**
  * Fails when the `ci` aggregator needs `nix-build`.
  *
  * A job in the required `ci` aggregator that cannot run on a pull request reds `main` — on
@@ -783,6 +815,7 @@ export function checkFile(
       ...requireReusableCallPermissions(path, document),
       ...requireConcurrencyOnPullRequestWorkflows(path, document),
       ...requireRustTestCancelsSupersededRuns(path, document),
+      ...requireBuildEngineSerialisesRunsPerRef(path, document),
       ...forbidNixBuildInCiAggregator(path, document),
       ...requireJobTimeouts(path, document),
       ...requireDepsBeforeBunTest(path, document),

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -27,6 +27,11 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  # Never cancel a run mid-upload: the release job would leave the draft short an asset (#1108).
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -11,6 +11,7 @@ import {
   requireJobTimeouts,
   requireBashOnWindowsRunSteps,
   requireConcurrencyOnPullRequestWorkflows,
+  requireBuildEngineSerialisesRunsPerRef,
   requireRustTestCancelsSupersededRuns,
   requirePipefailShell,
   requireReusableCallPermissions,
@@ -857,6 +858,53 @@ describe("requireConcurrencyOnPullRequestWorkflows", () => {
     const path = join(mkdtempSync(join(tmpdir(), "kesha-wf-")), "probe.yml");
     writeFileSync(path, yaml);
     expect(checkFile(path, [], [], undefined).filter((e) => e.includes("#1105"))).toHaveLength(1);
+  });
+});
+
+describe("requireBuildEngineSerialisesRunsPerRef", () => {
+  const ref = { group: "${{ github.workflow }}-${{ github.ref }}", "cancel-in-progress": false };
+
+  test("passes on the real build-engine.yml", () => {
+    expect(requireBuildEngineSerialisesRunsPerRef(PATH, parseRepoYaml(PATH))).toEqual([]);
+  });
+
+  // rust-test.yml sets cancel-in-progress: true deliberately (#1105); this rule must not reach it.
+  test("ignores every other workflow", () => {
+    const RUST_TEST = ".github/workflows/rust-test.yml";
+    expect(requireBuildEngineSerialisesRunsPerRef(RUST_TEST, parseRepoYaml(RUST_TEST))).toEqual([]);
+  });
+
+  test("fails when the group does not vary per ref", () => {
+    const errors = requireBuildEngineSerialisesRunsPerRef(PATH, {
+      concurrency: { group: "build-engine", "cancel-in-progress": false },
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("#1108");
+  });
+
+  test("fails when cancel-in-progress is true", () => {
+    const errors = requireBuildEngineSerialisesRunsPerRef(PATH, {
+      concurrency: { ...ref, "cancel-in-progress": true },
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("mid-upload");
+  });
+
+  test("fails when cancel-in-progress is dropped entirely", () => {
+    expect(
+      requireBuildEngineSerialisesRunsPerRef(PATH, { concurrency: { group: ref.group } }),
+    ).toHaveLength(1);
+  });
+
+  test("fails when the whole concurrency block is gone", () => {
+    expect(requireBuildEngineSerialisesRunsPerRef(PATH, { on: { push: null }, jobs: {} })).toHaveLength(2);
+  });
+
+  test("the file gate actually runs it", () => {
+    const yaml = "on:\n  push:\njobs: {}\n";
+    const path = join(mkdtempSync(join(tmpdir(), "kesha-wf-")), "build-engine.yml");
+    writeFileSync(path, yaml);
+    expect(checkFile(path, [], [], undefined).filter((e) => e.includes("#1108"))).toHaveLength(2);
   });
 });
 

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -874,12 +874,27 @@ describe("requireBuildEngineSerialisesRunsPerRef", () => {
     expect(requireBuildEngineSerialisesRunsPerRef(RUST_TEST, parseRepoYaml(RUST_TEST))).toEqual([]);
   });
 
-  test("fails when the group does not vary per ref", () => {
+  test("fails when the group is constant across refs", () => {
     const errors = requireBuildEngineSerialisesRunsPerRef(PATH, {
       concurrency: { group: "build-engine", "cancel-in-progress": false },
     });
     expect(errors).toHaveLength(1);
     expect(errors[0]).toContain("#1108");
+  });
+
+  // Both of these mention github.ref, so groupVariesPerRef accepts them; only the exact pin rejects them.
+  test("fails when a boolean group collapses every ref but one into a single lane", () => {
+    const errors = requireBuildEngineSerialisesRunsPerRef(PATH, {
+      concurrency: { group: "${{ github.ref == 'refs/tags/v1.0.1' }}", "cancel-in-progress": false },
+    });
+    expect(errors).toHaveLength(1);
+  });
+
+  test("fails when a run-scoped group serialises nothing", () => {
+    const errors = requireBuildEngineSerialisesRunsPerRef(PATH, {
+      concurrency: { group: `${ref.group}-\${{ github.run_id }}`, "cancel-in-progress": false },
+    });
+    expect(errors).toHaveLength(1);
   });
 
   test("fails when cancel-in-progress is true", () => {


### PR DESCRIPTION
`build-engine.yml` gains a top-level `concurrency` group keyed per ref, with `cancel-in-progress: false`.

Closes #1108
Refs #1105

## The ticket's premise does not hold

#1108 argued a ref-keyed group would be a no-op here: `build-engine.yml` fires on `push: tags: [v*, !v*-cli]`, tag names are one-use, so "a tag-push run is the only member its group will ever have."

GitHub reserves *release* names permanently. It does not reserve *tag refs*. `refs/tags/v1.0.1` carried three `push` runs at three different head SHAs:

| run | head SHA | title |
|---|---|---|
| 24456297956 | `cac5dd2` | `chore: release v1.0.1 (#90)` |
| 24456665040 | `156184e` | `fix(ci): build coreml engine on macos-15 for Swift 6 toolchain (#91)` |
| 24458021670 | `ed519ad` | `fix(rust): make CoreML backend actually compile (#92)` |

`refs/tags/v1.0.0-beta.1` has two the same way. Delete-and-re-push is how a failed release tag gets retried here, and it means the group has held three members, not one.

Conversely, the case #1108 called "the only real exposure" — two dispatches sharing `refs/heads/main` — carries none. The `release` job is gated on `startsWith(github.ref, 'refs/tags/v')`, and the single such overlap in the history (`24460021432` / `24460258249`) shows `release: skipped` in both.

## What the guard is for

Two runs at one **tag** ref put two `release` jobs against **one draft release**: two `softprops/action-gh-release` uploads of identically-named assets, and on an alpha a `gh release edit --draft=false` firing from one run while the other is still uploading. A release published short a platform binary makes `kesha install` 404 for that platform, and release names are one-use, so the only repair is a new patch tag.

**This has never happened.** Stated plainly, because the two halves are observed separately and their intersection is not:

- same-ref concurrency in this workflow: **2 of 96 runs**, at two different refs;
- a tag ref receiving more than one run: **5 runs across 2 refs**;
- both at once: **never**.

The mechanism is real rather than hypothetical. Both same-ref overlaps have a *negative* end-to-start gap — the second run began before the first finished:

| ref | first run | second run | gap |
|---|---|---|---|
| `exp/kokoro-macos15` | `30986878593`, cancelled 07:55:43 | `30986909622` started 07:55:29 | −14 s |
| `refs/heads/main` | `24460021432`, failure, ended 14:28:10 | `24460258249` started 14:28:04 | −6 s |

`build-engine.yml`'s `build` job sets `fail-fast: false`, so a red matrix leg does not stop the run — the other legs continue and the run stays in progress for minutes after the failure is visible. The human reacts to a visibly-red run rather than a finished one, which is what produces a negative gap. `v1.0.1`'s first run is exactly that shape: macos-14 red, linux and windows green, run still going.

## Why `cancel-in-progress: false`

The opposite value from `rust-test.yml`'s (#1105). There the line was the whole cost saving; here cancelling a run mid-upload *is* the partial-draft defect the guard exists to prevent.

## Why `queue` is left at its default

`queue` is a real documented key ([control workflow concurrency](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency)): `single` is the default and permits one pending run, cancelling and replacing it when a new one queues; `max` permits up to 100; `max` with `cancel-in-progress: true` is a validation error.

Default kept, deliberately. Runs at one tag ref are **interchangeable** — a pending run can only ever be evicted by a later push of that same tag, so it is superseded by construction and newest-wins is what a retry lane wants. `queue: max` would additionally spend a macOS build for no change in the final draft, since queued runs execute in wait order and the newest uploads last — a property that holds only while the release is still a draft, per the residual below.

`npm-publish.yml` sets `queue: max` for the opposite reason and remains correct: each of its runs publishes a **distinct version**, so no run is ever superseded and a dropped pending run loses that version permanently. That difference is why diverging from it here is a decision rather than drift.

**Named consequence:** an evicted pending run reports nothing (#597). Under this choice a maintainer who pushes a tag three times in quick succession sees the middle push produce no run at all. That is a behaviour change from today, where all three would run. Accepted, because the third push is what evicted it and the third push is what they want built.

## Residual this change introduces

`refs/heads/main` is the one lane where runs are **not** interchangeable: two `tag` dispatches there create two *different* tags. Three dispatches inside the `tag` job's 11–20 s runtime would evict the middle one and silently skip its tag creation. Accepted — observed main-lane dispatch spacing is hours to days apart, with a single 4.62 min pair in 4.5 months and no three-in-a-window instance.

### Old-first ordering can publish a superseded build

Not cancelling fixes the ordering: the run already in flight finishes first, and the queued newer one second. So when a tag is re-pushed *while its first run is still running* — the negative-gap shape above — run A carries the **older** SHA and reaches the release job first.

This repository has GitHub immutable releases enabled (`classify-release-tag.mjs`), so an asset uploaded after publication fails with 422. Two consequences:

- **Alpha** (auto-published by the workflow): A publishes, then B's upload 422s and **B's release job goes red**. The published alpha carries A's artifacts while the tag points at B's commit. Wrong, but loud.
- **Stable / beta** (human un-draft gate): if the maintainer un-drafts A's draft before B finishes, the published release carries A's artifacts against B's tag, and the tap picks that up. Wrong and **silent** — this is the one to know about.

Accepted, because no available value avoids it. `cancel-in-progress: true` reverses the ordering only by cancelling mid-upload, which is the defect this change exists to prevent; `queue: max` preserves the same wait-order; and removing the group restores the concurrent race, whose bad outcome is a *partial* draft — an unusable release rather than a stale-but-working one. The trade is deliberate: a complete release from a superseded commit beats a release missing a platform binary, and the alpha variant fails loudly.

The fix that would close it, considered and rejected: a conditional group giving non-tag refs a unique key. A GitHub expression's evaluation is only observable on a real run, and this workflow's real runs are release cuts. `groupVariesPerRef`'s own doc comment records the predicate as necessary-but-not-sufficient for exactly that class of expression (#1105). Shipping an unexercisable expression onto the release workflow to close a ~20 s window that has never opened is the worse trade.

## Release path

- `homebrew-tap.yml` triggers on `release: [published]`. This workflow's own un-draft runs under `GITHUB_TOKEN`, which does not cascade workflow events, and the tap skips any tag not matching `^v[0-9]+\.[0-9]+\.[0-9]+$`. It fires only on a human un-draft.
- The chosen value never cancels a running run, so it removes the *partial*-draft outcome. It does **not** make the tap immune: it fixes the ordering to old-first, which introduces the stale-publish residual documented below. What the tap can see changes from "possibly incomplete" to "complete, possibly built from a superseded commit".
- The parent-to-child self-dispatch is unaffected: the parent runs at `refs/heads/main`, the child at the tag, so they are in different groups. That handoff occurs on every dispatch-path release cut (5 of the 9 measured overlaps), which is why a workflow-wide constant group was rejected.

## Tests

`requireBuildEngineSerialisesRunsPerRef` in `.github/scripts/check-workflows.ts`, mirroring `requireRustTestCancelsSupersededRuns` — one narrow rule per workflow rather than generalising `requireConcurrencyOnPullRequestWorkflows`, which keys on a `pull_request` trigger this workflow does not have and whose required value is the opposite one.

The test landed red in its own commit (73d9fa9): `build-engine.yml` had no top-level `concurrency`, so `passes on the real build-engine.yml` failed with both errors until 444e402 added the block.

The rule originally reused `groupVariesPerRef`, and review showed that was not a guard. That predicate accepts any expression *mentioning* `github.ref` — its own doc comment states the residual — so two degenerate groups passed the entire suite and `check:workflows` at head `444e402`:

- `${{ github.ref == 'refs/tags/v1.0.1' }}` — collapses every ref but one into a single lane, which is the cross-release eviction the rule exists to prevent;
- `${{ github.workflow }}-${{ github.ref }}-${{ github.run_id }}` — gives every run its own group and serialises nothing at all.

The failure mode runs in **both** directions, too coarse and too fine, and that is what decides the fix. A looser check such as "the group must contain a bare `${{ github.ref }}`" catches the boolean but not the `run_id` shape, because that one does contain it. So the group is pinned to its exact text in a `BUILD_ENGINE_GROUP` constant.

**This deliberately makes any change to the group value fail the lint.** That is the intended cost, argued rather than overlooked: for a release-path value whose failure mode is silent and unrepairable, "you must edit this rule and say why" is the behaviour worth having. A future author with a legitimate reason changes one constant.

Knock-on, recorded rather than quietly kept: the rule no longer reuses `groupVariesPerRef`, so the plan-stage argument that a rule beat a test-only pin *because* it reused that predicate no longer holds, and I withdraw it. The rule still earns its place on placement — it fires under `bun run check:workflows`, where a workflow author is already looking. `groupVariesPerRef` remains in use by `requireConcurrencyOnPullRequestWorkflows`, so nothing is orphaned.

### Mutation results

`just mutate <file> <find> <replace> bun test tests/unit/check-workflows.test.ts` — all five caught.

| # | file | find | replace | result |
|---|---|---|---|---|
| 1 | `build-engine.yml` | `concurrency:` | `x-disabled-concurrency:` | PINNED |
| 2 | `build-engine.yml` | `${{ github.workflow }}-${{ github.ref }}` | `build-engine` | PINNED |
| 3 | `build-engine.yml` | `cancel-in-progress:` | `x-cancel-in-progress:` | PINNED |
| 4 | `build-engine.yml` | `cancel-in-progress: false` | `cancel-in-progress: true` | PINNED |
| 5 | `check-workflows.ts` | the `checkFile` registration line | *(deleted)* | PINNED |
| 6 | `build-engine.yml` | `${{ github.workflow }}-${{ github.ref }}` | `${{ github.ref == 'refs/tags/v1.0.1' }}` | PINNED |
| 7 | `build-engine.yml` | `${{ github.workflow }}-${{ github.ref }}` | `${{ github.workflow }}-${{ github.ref }}-${{ github.run_id }}` | PINNED |

Rows 2, 4, 6 and 7 are the wrong-value mutations: each leaves a valid, non-empty value that a weaker check would accept. Row 4 is the behavioural one for `cancel-in-progress`. **Rows 6 and 7 both survived the first version of this rule** and are why it changed — see below. Row 3 is honestly a documentation pin rather than a behavioural one — `cancel-in-progress` defaults to `false` when absent, so deleting the key changes nothing at GitHub; the assertion pins the value as *written*, because relying on an implicit default is what a future editor misreads.

## Review findings

Adversarial review on head `444e402`. Two findings applied, one rejected.

- **Applied** — the per-ref guard was unpinned. `groupVariesPerRef` accepts any expression that merely mentions `github.ref`, so a boolean group survived the suite. Fixed by pinning the exact group text; see the tests section.
- **Applied** — the release-path claim in this body was false. Corrected above, with the old-first stale-publish residual now disclosed.
- **Rejected** — that the silent eviction of a distinct tag-creating dispatch on `refs/heads/main` was undisclosed. It was already disclosed in the residual section, with the 11-20 s window, the requirement of three dispatches inside it, and the observed main-lane spacing. The finding read the release-path claim without the residual that qualified it — which the corrected wording above should now make unmistakable.

Not covered by the review, and not by me either: no live retag race was run, no repository Actions or tag-protection settings were inspected, and the external tap repository was not exercised.

## Verification

`just preflight` from the worktree, exit 0: 1611 pass / 6 skip / 0 fail across 113 files, `tsc --noEmit` clean, all six `check:*` scripts clean. Rust gate correctly skipped (no `rust/` changes).

`just verify-darwin-full` was not run and is not applicable: nothing here touches `rust/src/tts/**` or the `system_kokoro` / `system_diarize` / `system_text_lang` surface. Nothing in this diff compiles.

## Sizing

Sized **Light** by the team lead (infrastructure only, no `src/**`, no `rust/src/**`), which I do not contest. I contested one clause of the justification — that the run-history measurement had already settled the outcome, leaving at most a decision to record. It reported the cardinality of the repeated tag refs but dismissed them as sequential retries without pulling their head SHAs, and the SHAs are what refute the ticket's premise. The outcome is a change, not a note. The team lead accepts the correction as stated.
