### PR TITLE
ci: measure the unit-tests macOS row, keep it, and pin it (#1105)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,6 +272,7 @@ jobs:
       id-token: write
     strategy:
       matrix:
+        # 14 unit cases assert only on darwin (#1105) — see docs/decision-log.md before trimming this.
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - name: 📥 Checkout

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -176,16 +176,26 @@ issue/PR that drove it). Newest concerns first within each section.
   ```bash
   gh run download <run-id> -n test-results-ubuntu-latest -n test-results-macos-latest -D junit
   bun -e '
-  const cases = async (os) => new Map([...(await Bun.file(`junit/test-results-${os}/unit-${os}.xml`).text())
-    .matchAll(/<testcase name="([^"]*)" classname="([^"]*)"[^>]*?assertions="([0-9]+)"/g)]
-    .map((m) => [`${m[2]} :: ${m[1]}`, +m[3]]));
+  const attrs = (tag) => Object.fromEntries([...tag.matchAll(/([a-z]+)="([^"]*)"/g)].map((a) => [a[1], a[2]]));
+  const cases = async (os) => {
+    const xml = await Bun.file(`junit/test-results-${os}/unit-${os}.xml`).text();
+    const seen = [...xml.matchAll(/<testcase\b([^>]*)/g)].map((m) => attrs(m[1])).filter((a) => a.name && a.classname);
+    if (seen.length === 0) throw new Error(`parsed no testcases from ${os} — the junit format moved, this answer would be wrong`);
+    return new Map(seen.map((a) => [`${a.classname} :: ${a.name}`, +(a.assertions ?? 0)]));
+  };
   const [ubuntu, macos] = [await cases("ubuntu-latest"), await cases("macos-latest")];
-  for (const [k, n] of [...macos].filter(([k, n]) => (ubuntu.get(k) ?? 0) < n)) console.log(`${ubuntu.get(k) ?? 0}/${n}  ${k}`);
+  const only = [...macos].filter(([k, n]) => (ubuntu.get(k) ?? 0) < n);
+  for (const [k, n] of only) console.log(`${ubuntu.get(k) ?? 0}/${n}  ${k}`);
+  console.log(`${only.length} cases assert on macos and not, or less, on ubuntu`);
   '
   ```
 
-  On run `33244355718` (`d738b0b`) it prints 14 lines. Row totals there were 3021 / 3052 /
-  2664 assertions and 9 / 0 / 186 skipped for ubuntu / macos / windows, over 1399 cases each.
+  Attributes are read by name rather than by position, and a file that yields no testcases
+  throws instead of reporting zero — a silent `0` here would tell a future audit there are no
+  darwin-specific assertions, which is the exact false conclusion this entry exists to prevent.
+  On run `33244355718` (`d738b0b`) it prints the 14 and their per-row counts. Row totals there
+  were 3021 / 3052 / 2664 assertions and 9 / 0 / 186 skipped for ubuntu / macos / windows, over
+  1399 cases each.
 - **Status:** active ([#1105]).
 
 ---

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -149,6 +149,38 @@ issue/PR that drove it). Newest concerns first within each section.
   publish + the `make` flow remain authoritative.
 - **Status:** active, secondary ([#242], [#264]).
 
+## Continuous integration
+
+### `unit-tests` keeps its macOS row
+- **Decision:** the `unit-tests` matrix in `.github/workflows/ci.yml` stays at three
+  runners. The #1105 minutes audit proposed dropping `macos-latest` as "the cheapest 10x
+  saving available"; measuring it refused the proposal.
+- **Context:** 14 unit cases assert on `macos-latest` and assert nothing, or less, on
+  `ubuntu-latest` — 9 skipped outright via `isDarwinArm64() ? test : test.skip`, 5 more
+  cut short by an in-body early return. They cover the darwin sidecars, Gatekeeper
+  unblocking, the Kokoro ANE staging and the warm-up, all of which production code reaches
+  through `isDarwinArm64` in `src/engine-targets.ts`. `unit-tests` is the only CI job that
+  runs the unit suite, so removing the leg would run those cases in no lane at all.
+- **Rationale:** the saving is $0 — the repository is public — and 0 s of latency, since
+  `windows-latest` is the slowest row and gates the same downstream jobs. Neither ubuntu
+  nor macOS is a subset of the other: one case runs on ubuntu and windows and not on macOS.
+  `tests/unit/lane-exclusive-tests.test.ts` pins the leg so a future audit fails loudly
+  instead of deleting the coverage silently.
+- **Reproduce** against any `ci.yml` run that executed `unit-tests`. Each row uploads a
+  junit artifact, and bun's reporter records an `assertions` count on every `<testcase>` —
+  comparing those counts row by row catches both a `test.skip` and an in-body early return,
+  where comparing test names alone would miss the second:
+
+  ```bash
+  gh run download <run-id> -n test-results-ubuntu-latest -n test-results-macos-latest \
+    -n test-results-windows-latest -D junit
+  grep -o 'assertions="[0-9]*"' junit/test-results-*/unit-*.xml | head   # totals are on <testsuites>
+  ```
+
+  On run `33244355718` (`d738b0b`): 3021 / 3052 / 2664 assertions and 9 / 0 / 186 skipped
+  for ubuntu / macos / windows, over 1399 cases each.
+- **Status:** active ([#1105]).
+
 ---
 
 [#123]: https://github.com/drakulavich/kesha-voice-kit/issues/123
@@ -166,3 +198,4 @@ issue/PR that drove it). Newest concerns first within each section.
 [#291]: https://github.com/drakulavich/kesha-voice-kit/issues/291
 [#473]: https://github.com/drakulavich/kesha-voice-kit/issues/473
 [#509]: https://github.com/drakulavich/kesha-voice-kit/pull/509
+[#1105]: https://github.com/drakulavich/kesha-voice-kit/issues/1105

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -153,32 +153,39 @@ issue/PR that drove it). Newest concerns first within each section.
 
 ### `unit-tests` keeps its macOS row
 - **Decision:** the `unit-tests` matrix in `.github/workflows/ci.yml` stays at three
-  runners. The #1105 minutes audit proposed dropping `macos-latest` as "the cheapest 10x
-  saving available"; measuring it refused the proposal.
+  runners. The #1105 minutes audit ranked dropping `macos-latest` as the cheapest 10x
+  saving available *if* the unit suite had no darwin-specific assertions, and asked for that
+  to be checked rather than assumed. It was checked; it has them.
 - **Context:** 14 unit cases assert on `macos-latest` and assert nothing, or less, on
   `ubuntu-latest` — 9 skipped outright via `isDarwinArm64() ? test : test.skip`, 5 more
   cut short by an in-body early return. They cover the darwin sidecars, Gatekeeper
   unblocking, the Kokoro ANE staging and the warm-up, all of which production code reaches
-  through `isDarwinArm64` in `src/engine-targets.ts`. `unit-tests` is the only CI job that
-  runs the unit suite, so removing the leg would run those cases in no lane at all.
+  through `isDarwinArm64` in `src/engine-targets.ts`. Two CI jobs run the unit suite —
+  `unit-tests`, and `ts-coverage` through `coverage:ts` → `test:cli-fast` — and `ts-coverage`
+  is `ubuntu-latest` only, so this matrix row is the sole place those 14 cases assert.
 - **Rationale:** the saving is $0 — the repository is public — and 0 s of latency, since
   `windows-latest` is the slowest row and gates the same downstream jobs. Neither ubuntu
   nor macOS is a subset of the other: one case runs on ubuntu and windows and not on macOS.
   `tests/unit/lane-exclusive-tests.test.ts` pins the leg so a future audit fails loudly
   instead of deleting the coverage silently.
-- **Reproduce** against any `ci.yml` run that executed `unit-tests`. Each row uploads a
+- **Re-derive the 14** from any `ci.yml` run that executed `unit-tests`. Each row uploads a
   junit artifact, and bun's reporter records an `assertions` count on every `<testcase>` —
-  comparing those counts row by row catches both a `test.skip` and an in-body early return,
-  where comparing test names alone would miss the second:
+  comparing per-case counts catches both a `test.skip` and an in-body early return, where
+  comparing test names alone would miss the second:
 
   ```bash
-  gh run download <run-id> -n test-results-ubuntu-latest -n test-results-macos-latest \
-    -n test-results-windows-latest -D junit
-  grep -o 'assertions="[0-9]*"' junit/test-results-*/unit-*.xml | head   # totals are on <testsuites>
+  gh run download <run-id> -n test-results-ubuntu-latest -n test-results-macos-latest -D junit
+  bun -e '
+  const cases = async (os) => new Map([...(await Bun.file(`junit/test-results-${os}/unit-${os}.xml`).text())
+    .matchAll(/<testcase name="([^"]*)" classname="([^"]*)"[^>]*?assertions="([0-9]+)"/g)]
+    .map((m) => [`${m[2]} :: ${m[1]}`, +m[3]]));
+  const [ubuntu, macos] = [await cases("ubuntu-latest"), await cases("macos-latest")];
+  for (const [k, n] of [...macos].filter(([k, n]) => (ubuntu.get(k) ?? 0) < n)) console.log(`${ubuntu.get(k) ?? 0}/${n}  ${k}`);
+  '
   ```
 
-  On run `33244355718` (`d738b0b`): 3021 / 3052 / 2664 assertions and 9 / 0 / 186 skipped
-  for ubuntu / macos / windows, over 1399 cases each.
+  On run `33244355718` (`d738b0b`) it prints 14 lines. Row totals there were 3021 / 3052 /
+  2664 assertions and 9 / 0 / 186 skipped for ubuntu / macos / windows, over 1399 cases each.
 - **Status:** active ([#1105]).
 
 ---

--- a/tests/unit/lane-exclusive-tests.test.ts
+++ b/tests/unit/lane-exclusive-tests.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { parseRepoYaml } from "../helpers/repo";
 
 const ROOT = join(import.meta.dir, "..", "..");
 const WORKFLOW = ".github/workflows/rust-test.yml";
@@ -54,5 +55,26 @@ describe("a lane-exclusive test cannot run nowhere", () => {
     const sources = ["rust/src/backend/fluidaudio.rs", ...LANE_EXCLUSIVE].map((relative) => read(relative)).join("\n");
     // A rename that empties the lane must fail here rather than quietly select nothing.
     for (const name of named) expect(sources).toContain(`fn ${name}`);
+  });
+});
+
+describe("the darwin-only unit tests have a lane", () => {
+  // 14 unit cases assert only on darwin (#1105); without a macOS leg they would run in no lane.
+  const unitTests = () => parseRepoYaml(".github/workflows/ci.yml").jobs["unit-tests"];
+
+  test("the matrix keeps a macOS runner it does not exclude", () => {
+    const job = unitTests();
+    expect(job["runs-on"]).toBe("${{ matrix.os }}");
+    const runners: string[] = job.strategy.matrix.os;
+    expect(runners.filter((r) => r.startsWith("macos"))).not.toEqual([]);
+    expect(job.strategy.matrix.exclude).toBeUndefined();
+  });
+
+  test("the step that runs the unit suite is not conditioned off a row", () => {
+    const steps = unitTests().steps.filter(
+      (s: { run?: string }) => typeof s.run === "string" && s.run.includes("test:unit"),
+    );
+    expect(steps).toHaveLength(1);
+    expect(steps[0].if).toBeUndefined();
   });
 });

--- a/tests/unit/lane-exclusive-tests.test.ts
+++ b/tests/unit/lane-exclusive-tests.test.ts
@@ -66,8 +66,9 @@ describe("the darwin-only unit tests have a lane", () => {
     const job = unitTests();
     expect(job["runs-on"]).toBe("${{ matrix.os }}");
     const runners: string[] = job.strategy.matrix.os;
-    // Intel macOS carries `-large` or `-intel`; bare and `-xlarge` labels are arm64, which is what the gated cases need.
-    const arm64Macos = (r: string) => r.startsWith("macos") && !r.endsWith("-large") && !r.endsWith("-intel");
+    // Positively arm64 per actions/runner-images; an unrecognised macOS label fails here rather than passing (#1105).
+    const ARM64_MACOS = ["macos-latest", "macos-14", "macos-15", "macos-26"];
+    const arm64Macos = (r: string) => ARM64_MACOS.includes(r.replace(/-xlarge$/, ""));
     expect(runners.filter(arm64Macos)).not.toEqual([]);
     expect(job.strategy.matrix.exclude).toBeUndefined();
   });

--- a/tests/unit/lane-exclusive-tests.test.ts
+++ b/tests/unit/lane-exclusive-tests.test.ts
@@ -59,14 +59,16 @@ describe("a lane-exclusive test cannot run nowhere", () => {
 });
 
 describe("the darwin-only unit tests have a lane", () => {
-  // 14 unit cases assert only on darwin (#1105); without a macOS leg they would run in no lane.
+  // 14 unit cases assert only on darwin (#1105); the other unit lane is ubuntu-only, so this leg is where they assert.
   const unitTests = () => parseRepoYaml(".github/workflows/ci.yml").jobs["unit-tests"];
 
   test("the matrix keeps a macOS runner it does not exclude", () => {
     const job = unitTests();
     expect(job["runs-on"]).toBe("${{ matrix.os }}");
     const runners: string[] = job.strategy.matrix.os;
-    expect(runners.filter((r) => r.startsWith("macos"))).not.toEqual([]);
+    // Intel macOS carries `-large` or `-intel`; bare and `-xlarge` labels are arm64, which is what the gated cases need.
+    const arm64Macos = (r: string) => r.startsWith("macos") && !r.endsWith("-large") && !r.endsWith("-intel");
+    expect(runners.filter(arm64Macos)).not.toEqual([]);
     expect(job.strategy.matrix.exclude).toBeUndefined();
   });
 


### PR DESCRIPTION
The last open item of #1105 is a **measurement**, not a change:

> `unit-tests (macos-latest)` runs 46 times in ten days at ~1 minute each. If the TypeScript unit suite has no darwin-specific assertions, this is the cheapest 10× saving available. It needs checking rather than assuming — this repo is darwin-centric and some suites legitimately gate on the platform.

**Measured. It does have darwin-specific assertions, so the row stays.** This PR lands the decision, not the deletion.

## The claim this PR makes

**14 unit cases assert on `macos-latest` and assert nothing, or less, on `ubuntu-latest`, and every other lane that runs the unit suite is `ubuntu-latest` — so dropping the macOS leg would leave those cases asserting in no lane at all.**

## Method, re-runnable from the artifacts alone

Each matrix row uploads a junit artifact, and bun's reporter records an `assertions` count on **every** `<testcase>`. Comparing those counts row by row catches both gating mechanisms the suite actually uses — a `test.skip` on the wrong host, and an in-body `if (!(darwin && arm64)) return;` early return that a test-name diff cannot see.

```bash
gh run download 33244355718 -n test-results-ubuntu-latest -n test-results-macos-latest \
  -n test-results-windows-latest -D junit
```

`docs/decision-log.md` carries a snippet that keys testcases by `classname :: name` and prints the 14 with their per-row assertion counts. It reads attributes by name rather than by position, and throws when a file yields no testcases — a silent `0` would tell a future audit there are no darwin-specific assertions, which is the exact false conclusion the entry exists to prevent, and the same class as `npm view --json a,b,c` returning zero bytes at exit 0.

Checked by extracting the snippet **from the committed file** and running it verbatim in three conditions:

| condition | result |
|---|---|
| the real artifacts | 14, exit 0 |
| every `<testcase>` attribute order reversed | 14, exit 0 — the previous revision printed 0 lines at exit 0 here |
| `<testcase>` renamed, so the format genuinely moved | throws, exit 1, 0 stdout lines |

Run `33244355718` is the `push` run on `d738b0b` — this branch's base.

| row | cases | assertions | skipped |
|---|---|---|---|
| ubuntu-latest | 1399 | 3021 | 9 |
| macos-latest | 1399 | **3052** | **0** |
| windows-latest | 1399 | 2664 | 186 |

Pairwise "asserts more than", in cases:

| | vs ubuntu | vs macos | vs windows |
|---|---|---|---|
| **ubuntu** | — | 1 | 178 |
| **macos** | **14** | — | 190 |
| **windows** | **0** | 1 | — |

9 of the 14 are `<skipped/>` on ubuntu via `isDarwinArm64() ? test : test.skip` in `doctor.test.ts`, `engine-install-decisions.test.ts`, `engine-repair.test.ts` and `kokoro-ane.test.ts`. The other 5 execute everywhere but assert fewer times, via the in-body early return in `engine-version-override.test.ts` and `install-plan.test.ts`. They cover the darwin sidecars, Gatekeeper unblocking, the Kokoro ANE staging and the warm-up — all reached in production through `isDarwinArm64` in `src/engine-targets.ts`. The tests are gated because the code is.

Two CI jobs run the unit suite, not one: `unit-tests`, and `ts-coverage` through `coverage:ts` → `test:cli-fast`. `ts-coverage` is `ubuntu-latest` only, so the 9 skip and the 5 truncate there too — this matrix row is the sole place the 14 assert. (An earlier revision of this PR said `unit-tests` was the only such job; that was wrong, and the harm claim is unaffected.)

Neither row is a subset of the other: one case (`--tts plan on non-darwin`) asserts on ubuntu and windows and not on macOS.

## What the saving would have been

- **Cash: $0.** Public repository; `$0.062/min` is a ranking lens, ~$2.7 per ten days notional.
- **Latency: 0 s.** `windows-latest` is the slowest row and gates the same downstream jobs — on that run ubuntu 28 s, macos 38 s, windows 59 s, and both `ts-coverage` and `integration-tests` `needs: unit-tests`, i.e. the whole matrix.

## The diff

| file | why |
|---|---|
| `tests/unit/lane-exclusive-tests.test.ts` | the guard — this file already owns "a lane-exclusive test cannot run nowhere" for the Rust side (#951/#1072) |
| `docs/decision-log.md` | the durable decision, with the method so a future audit re-measures instead of re-assuming |
| `.github/workflows/ci.yml` | one line, where someone trimming CI cost is already looking |

The guard asserts over two removal surfaces: the **matrix entry** (an **arm64** macOS runner is present, not excluded, and `runs-on` actually interpolates the matrix) and the **leg running the suite** (exactly one step invokes `test:unit`, and it carries no `if:`). Arm64 matters because the coverage premise is `isDarwinArm64()`. The predicate accepts **only** the labels `actions/runner-images` documents as arm64 — `macos-latest`, `macos-14`, `macos-15`, `macos-26`, and their `-xlarge` forms — and fails on anything else. An earlier revision used the inverse, rejecting the `-large` and `-intel` suffixes that mark Intel; Greptile flagged it as a P2 and was right. That form rested on GitHub continuing to mark Intel by suffix, which is a convention rather than a guarantee, and it would have failed **silently**: a bare Intel label would leave the guard green while all 14 cases skipped. The allowlist inverts the default, so an image GitHub has not shipped yet makes this stale in the loud direction — one red test, one line to fix. The second surface exists because `if: matrix.os == 'ubuntu-latest'` is already the idiom on the two steps immediately above it, so a one-line `if:` is the cheapest way to stop running the suite on macOS — and an earlier version of this guard stayed green against exactly that.

The `if:` assertion asserts **absence** rather than matching condition spellings. That is deliberate: matching spellings is the chase #1109 paid three rounds for, and rows X2/X2b/X2c below show one absence assertion catching three spellings.

## Mutation evidence

Every row run through the real `just mutate` recipe against this branch, one invocation per row, test command passed as trailing positional arguments:

```bash
just mutate .github/workflows/ci.yml \
  'os: [ubuntu-latest, windows-latest, macos-latest]' \
  'os: [ubuntu-latest, windows-latest]' \
  bun test tests/unit/lane-exclusive-tests.test.ts
```

| # | mutation | want | got |
|---|---|---|---|
| M1 | **deleted** — macOS off the matrix | caught | caught |
| M2 | **neutralised, shape intact** — three runners, none macOS | caught | caught |
| M3 | control — `macos-14`, a legitimately pinned image | survived | survived |
| I1 | Intel label — `macos-15-intel` | caught | caught |
| I2 | Intel label — `macos-15-large` | caught | caught |
| B1 | bare Intel label — `macos-13` | caught | caught — **survived under the earlier denylist; this is Greptile's P2** |
| B2 | unrecognised future image — `macos-27` | caught | caught — the declared maintenance cost |
| I3 | control — `macos-15-xlarge` is arm64 | survived | survived |
| C1 | control — `macos-26` | survived | survived |
| C2 | control — `macos-latest-xlarge` | survived | survived |
| M4 | `runs-on` hardcoded, matrix ignored | caught | caught |
| X1 | `strategy.matrix.exclude: [{ os: macos-latest }]` | caught | caught |
| X2 | `if: matrix.os != 'macos-latest'` on the unit step | caught | caught |
| X2b | same, `if: startsWith(matrix.os, 'ubuntu')` | caught | caught |
| X2c | same, `if: runner.os != 'macOS'` | caught | caught |
| X4 | the step stops invoking the suite | caught | caught |
| X3 | matrix key renamed `os` → `platform` | caught | caught |
| X5 | `continue-on-error: true` on the job | survived | survived |

Two green rows, both named rather than left silent:

- **X5 survives by design.** `continue-on-error` leaves the 14 cases *running*, so the harm above does not occur; it weakens the gate equally on all three rows, which is a different property and out of scope. The same is true of `|| true` on the run line, `continue-on-error` on the step, and `if: false` on the job.
- **The run body can still be neutralised in shell** — wrapping it in `if [[ "$RUNNER_OS" != "macOS" ]]; then … fi` leaves `test:unit` in the step and no YAML `if:` on it, and the harm does occur. Deliberately not guarded: catching it needs either an exact match on the `run:` string, which is structure-sensitive and breaks on any legitimate flag change, or a shell parser. The YAML `if:` idiom that *is* used twice in this job is caught; this spelling appears nowhere in the repository. Named here rather than dropped, because a residual nobody wrote down reads identically to one nobody found.
- **The runner allowlist goes stale when GitHub ships a new macOS image.** B2 is that case: `macos-27` is rejected today. The dependency an earlier revision carried — that GitHub keeps bare Intel labels retired and marks Intel by suffix — is what this change removes; what replaces it is a maintenance cost that announces itself. Both directions were weighed and the loud one was chosen deliberately.
- **X3 is a false positive in the cheap direction**, and so is a legitimate `exclude:` that drops some unrelated combination: both turn the guard red while macOS coverage is untouched. Each fails loudly with an accurate message and costs one line to fix. Reading the matrix key out of `runs-on` instead would be three more lines of machinery to make a rename nobody has proposed cheaper, and it would weaken M4.

## Gate

`just preflight`, exit 0. TS gate only — no `rust/**` in the diff, so the Rust gate and the CoreML check correctly skipped, and `just verify-darwin-full` is not owed (nothing under `rust/src/tts/**`, no `system_kokoro` / `system_diarize` / `system_text_lang` surface).

```
==> TS gate (always)
$ bun test --timeout 30000
 1615 pass
 6 skip
 0 fail
Ran 1621 tests across 113 files. [158.77s]
$ bunx tsc --noEmit
$ bun .github/scripts/check-recipes.ts
$ bun .github/scripts/check-workflows.ts
$ bun .github/scripts/check-versions.ts
$ bunx @fission-ai/openspec@1.4.1 validate --specs --strict
$ bun .github/scripts/check-engine-targets.ts
$ bun .github/scripts/release-manifest.mjs --check
==> Rust gate skipped: no rust/ changes (force with just ALL=1 preflight)
==> CoreML check skipped: no rust/src/backend/ changes
```

## Deliberately not done

- **Not touching `windows-latest`**, though it contributes **0** unique assertions over ubuntu and is the slowest row. Unique-assertion count is the wrong metric for a row whose value is running the *same* assertions on another OS, and the audit window carries 8 windows failures against 0 macOS. Recorded so these numbers are not reused for that.
- **Not trimming the macOS row to the darwin-relevant files.** The 14 cases span 6 files; a hand-maintained list saves ~20 s of a $0 job and goes stale silently — the same runs-nowhere class the guard exists to prevent.
- **Not parameterising the 14 cases so ubuntu could run them.** Several exercise real sidecar downloads, `codesign`/`xattr` and warm-up subprocesses; porting them trades real-OS signal for a simulation and saves $0.
- **Not writing a class rule** that scans `tests/unit/**` for darwin gates and requires a lane conditionally. It needs a source-scanning predicate for "gates on darwin" — the class-parser that produced all nine defects on the first item of this audit. This guard is the instance: one job, one file.

## Red → Green, honestly

Inverted, and stated rather than implied: there is no defect here, so nothing was red first. The guard pins behaviour that already holds, and its red is the mutation table above rather than a temporarily-failing assertion.

Closes #1105
