### PR TITLE
docs(ticket-team): carry the per-assertion mutation bar into SKILL.md

### DIFF
--- a/.claude/skills/ticket-team/SKILL.md
+++ b/.claude/skills/ticket-team/SKILL.md
@@ -220,9 +220,10 @@ You may give the implementer facts. **You may not give it the remedy** — not w
 not the shape of the test, not which of two options you would accept. Facts are free; a design you
 supplied is a design you cannot judge.
 
-**At verdict time, hold the plan's mutation table to the review round's first sweep item**: for
-each guard, both mutations — deleted, and neutralised with its shape left in place — plus one row
-per residual any delegated predicate names in its own doc comment. Your charter carries the
+**At verdict time, hold the plan's mutation table to the review round's first sweep item**: one
+row per **assertion**, not per guard — a guard with six assertions has six ways to be neutralised
+— with both mutations each, deleted and neutralised-in-shape, plus one row per residual any
+delegated predicate names in its own doc comment. Your charter carries the
 reasoning; what belongs here is that the check runs at the moment of judging, because on #1108
 the reviewer was asked for it, the planner was not, and the guard shipped past an approval with
 every gate green.


### PR DESCRIPTION
#1117 amended implementer.md and the ledger to one-row-per-assertion; SKILL.md's verdict-time check still said per-guard, so on merge the planner and the judge were held to different bars — the inverse of fd03896's defect and the fourth instance of the grep-the-other-files class in two days. Found by the cross-audit retro before the merge, applied after. Wording is teamlead-1105-unittests's from #1117, carried into the third file.

Refs #1105