### PR TITLE
models: pin silero-vad manifest URL to an immutable commit (#1099)

### DIFF
--- a/NOTICES.md
+++ b/NOTICES.md
@@ -19,7 +19,7 @@ see [speechbrain/lang-id-voxlingua107-ecapa](https://huggingface.co/speechbrain/
 ### Silero VAD v5 (opt-in: `kesha install --vad`)
 
 Voice activity detection. MIT. Authored by [Silero Team](https://github.com/snakers4/silero-vad).
-Pinned to the `v6.2.1` tag.
+Pinned to a commit (the `v6.2.1` tag's target at the time of pinning).
 
 ## Models downloaded by `kesha install --tts`
 

--- a/docs/mutation-evidence/issue-1093.md
+++ b/docs/mutation-evidence/issue-1093.md
@@ -22,9 +22,9 @@ Both guards check `startsWith("https://huggingface.co/")` / `strip_prefix("https
 and skip anything else. Two manifest URLs are GitHub-hosted and neither is immutable
 either, but on purpose neither is in scope here:
 
-- `rust/src/models.rs:72` — `snakers4/silero-vad/raw/v6.2.1/…` resolves through a **git
+- `rust/src/models.rs:70` — `snakers4/silero-vad/raw/v6.2.1/…` resolves through a **git
   tag**, which can be moved or recreated.
-- `rust/src/models.rs:202` — `thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0/…`
+- `rust/src/models.rs:203` — `thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0/…`
   is a **GitHub release asset**, which can be deleted and re-uploaded under the same tag.
 
 Either would fail exactly the way #1093 failed: the SHA-256 pin turns the upstream move
@@ -36,6 +36,11 @@ tracked as #1099. The kokoro-onnx release asset has no immutable URL form at all
 release assets are addressed by tag, not commit), so for that one file the SHA-256 pin is
 the only guard there will ever be; widening the "must be a 40-hex ref" rule to it would be
 asserting something that can never hold.
+
+**Update (#1099):** the silero-vad line above is now pinned to a commit; see
+`docs/mutation-evidence/issue-1099.md` for the guard and its mutation proof. The kokoro-onnx
+release asset remains permanently unpinnable and carries a one-line note at its declaration
+instead.
 
 ## Why `parseManifestEntries`, not the existing `parseManifestUrls`
 

--- a/docs/mutation-evidence/issue-1099.md
+++ b/docs/mutation-evidence/issue-1099.md
@@ -17,14 +17,22 @@ test("the silero-vad manifest URL pins a 40-hex commit, not the movable v6.2.1 t
 One assertion, scoped to the single `VAD_FILES` entry in `rust/src/models.rs`, read through
 `parseManifestEntries` the same way `no Hugging Face manifest URL resolves through a mutable
 ref` (same describe block) reads every other manifest entry. Runs in the `unit-tests` job of
-the `🧪 CI` workflow on every PR — `rust/src/models.rs` is explicitly in `ci.yml`'s `code`
-path filter, so an edit to it always triggers that job regardless of anything else touched.
+the `🧪 CI` workflow whenever `ci.yml`'s `code` path filter matches — not on every PR
+unconditionally, since `unit-tests` is gated `if: needs.changes.outputs.code == 'true'`. For
+this diff specifically that filter always matches: `rust/src/models.rs` is one of its listed
+paths, so an edit to it always triggers the job.
 
-No matching Rust-side test exists or was added: `VAD_FILES` carries no `#[cfg(...)]` gate, so
-a Rust test would see the exact same one entry over the same always-triggered lane — strictly
-equal reach to the TS test above it, not wider. (Contrast the Hugging-Face guards, which keep
-both a Rust and a TS version because the TS one's reach genuinely exceeds the Rust one — it
-sees `system_kokoro`-gated manifests no CI lane ever compiles as tests.)
+No matching Rust-side test exists or was added, and here the reach comparison runs the other
+way from what an earlier draft of this file claimed: `VAD_FILES` carries no `#[cfg(...)]`
+gate, so a Rust test would see the same one entry, but the TS `code` filter also matches
+`tests/**` and `model-plan.json` changes that touch neither `rust/src/models.rs` nor anything
+the Rust gate's own path filter watches — a test-only edit to this very file, for instance,
+re-runs the TS assertion without ever triggering a Rust nextest run. The TS test's trigger set
+is a superset of what a hypothetical Rust duplicate would add, not merely equal to it, so the
+duplicate would still add no reach the TS test doesn't already have. (Contrast the
+Hugging-Face guards, which keep both a Rust and a TS version because the TS one's reach
+genuinely exceeds the Rust one in a different way — it sees `system_kokoro`-gated manifests no
+CI lane ever compiles as tests.)
 
 ## Observed red before the fix
 
@@ -97,6 +105,7 @@ tests/unit/check-model-plan-sizes.test.ts -t "silero-vad manifest URL"`, restore
 | 1 (delete) | Revert the pinned URL's ref segment from the commit back to `v6.2.1` | The property "resolves through a 40-hex commit" is fully absent, reproducing the real pre-fix red above | 1 | **PINNED** — `ref` is `"v6.2.1"` |
 | 2 (present, not satisfying) | Same 40 characters, same length, uppercased (`7E30209A3E901F9842F81B225F3E93D8199902B1`) | The shape of a commit SHA, wrong case — the regex is lowercase-only | 1 | **PINNED** |
 | 3 (present, not satisfying) | Drop the `raw/` path segment entirely, so `.split("/raw/")[1]` is `undefined` and `ref` falls back to `""` | The empty-segment edge case #1096 review round 2 found missing from the Hugging-Face guard's first draft | 1 | **PINNED** — fails on the empty-string fallback, not a crash |
+| 4 (present, not satisfying — **survives**) | Same 40 characters, same length, all zeroes (`0000…0000`) — a lowercase-hex string that is not a real commit | Nothing: the regex only checks shape, so a lowercase 40-hex string that names no actual commit is indistinguishable from one that does | 1 | **NOT PINNED** — `just mutate` exits 1; the mutated URL 404s at install time but the assertion passes |
 | control | None — the real, correctly-pinned commit SHA, untouched | — | — | **passes** (`1 pass / 0 fail`) |
 
 Row 3 is not a second assertion — it is the same regex-match assertion exercised through the
@@ -109,3 +118,14 @@ moved back, or a future edit to the URL's structure slips past the `/raw/` marke
 assertion depends on. Row 2 is not a defect this ticket names, but the same shape-vs-content
 distinction the sibling Hugging-Face guard's mutation table already tests for its own regex,
 so it was run here rather than assumed to hold by symmetry.
+
+**Row 4 is a stated boundary, not a bug to fix.** The assertion proves the ref is
+lowercase-40-hex-shaped; it does not and cannot prove the ref names a commit that exists,
+because that would require a network call from an offline, deterministic unit-test lane. This
+is not a gap unique to this guard: the sibling Hugging-Face predicate accepted at #1096
+(`assert_pins_immutable_revision`, and its TS twin) carries the identical residual — a
+`/resolve/<40 hex that resolves to nothing>/` URL passes both of them too. A commit-existence
+check was considered and rejected for the reason above; the honest claim for this guard is
+"pins a lowercase-40-hex ref," not "pins a commit that is verified to exist" — the latter is
+established once, by hand, at pin time (§"Verifying the resolved commit before pinning"
+above), not on every CI run.

--- a/docs/mutation-evidence/issue-1099.md
+++ b/docs/mutation-evidence/issue-1099.md
@@ -22,17 +22,33 @@ unconditionally, since `unit-tests` is gated `if: needs.changes.outputs.code == 
 this diff specifically that filter always matches: `rust/src/models.rs` is one of its listed
 paths, so an edit to it always triggers the job.
 
-No matching Rust-side test exists or was added, and here the reach comparison runs the other
-way from what an earlier draft of this file claimed: `VAD_FILES` carries no `#[cfg(...)]`
-gate, so a Rust test would see the same one entry, but the TS `code` filter also matches
-`tests/**` and `model-plan.json` changes that touch neither `rust/src/models.rs` nor anything
-the Rust gate's own path filter watches — a test-only edit to this very file, for instance,
-re-runs the TS assertion without ever triggering a Rust nextest run. The TS test's trigger set
-is a superset of what a hypothetical Rust duplicate would add, not merely equal to it, so the
-duplicate would still add no reach the TS test doesn't already have. (Contrast the
-Hugging-Face guards, which keep both a Rust and a TS version because the TS one's reach
-genuinely exceeds the Rust one in a different way — it sees `system_kokoro`-gated manifests no
-CI lane ever compiles as tests.)
+No matching Rust-side test exists or was added. Checked directly rather than compared by
+trigger-set size, because the two lanes' path filters are not nested either way:
+`rust-test.yml`'s `test` job runs whenever the `changes` job's own path filter matches
+`rust/**` (`.github/workflows/rust-test.yml:46-47`), gating the job itself at `:111-113`,
+while `ci.yml`'s `code` filter takes only three paths out of the Rust tree —
+`rust-toolchain.toml`, `rust/Cargo.toml`, `rust/src/models.rs` — plus `tests/**` and
+`model-plan.json` on the non-Rust side (`.github/workflows/ci.yml:73-96`). A PR that edits
+only, say, `rust/src/vad.rs` runs the Rust lane and skips `unit-tests`; a PR that edits only
+`tests/unit/check-model-plan-sizes.test.ts` runs `unit-tests` and skips the Rust lane. Neither
+trigger set contains the other, so "identical reach" and "a superset" (an earlier draft's
+claim, retracted here) are both false as statements about how often each lane runs.
+
+The comparison that holds is about **signal, not trigger sets**: this assertion reads only
+`rust/src/models.rs`'s text, so its result cannot change on a run where that file didn't
+change — a Rust duplicate reading the same file has the identical property. Both lanes
+already fire on every change to `rust/src/models.rs` (the TS one because that path is
+explicitly in the `code` filter; a hypothetical Rust one because it's under `rust/**`), which
+is the only event either assertion could ever flip on. The extra runs each lane's broader
+filter buys — TS on a `tests/**`-only change, Rust on an unrelated `rust/**`-only change — are
+runs where `rust/src/models.rs` is unchanged, so neither assertion's outcome can differ from
+its last run. A Rust duplicate therefore adds no catching power on the axis that matters, not
+because its trigger set is a subset of the TS one's, but because the two assertions can only
+disagree with each other's last result when the file both of them read has changed, and both
+already run then. (Contrast the Hugging-Face guards, which keep both a Rust and a TS version
+because the TS one covers manifests — the `system_kokoro`-gated ones — that no CI lane ever
+compiles as Rust tests at all, a real difference in what each assertion can see, not in how
+often it runs.)
 
 ## Observed red before the fix
 

--- a/docs/mutation-evidence/issue-1099.md
+++ b/docs/mutation-evidence/issue-1099.md
@@ -1,0 +1,111 @@
+# Mutation evidence — #1099 (silero-vad manifest URL pinned to an immutable commit)
+
+## The guard
+
+`tests/unit/check-model-plan-sizes.test.ts`, inside `describe("parseManifestUrls", …)`:
+
+```ts
+test("the silero-vad manifest URL pins a 40-hex commit, not the movable v6.2.1 tag", () => {
+  const vad = realManifestEntries().find(
+    (entry) => entry.relPath === "models/silero-vad/silero_vad.onnx",
+  );
+  const ref = vad?.url.split("/raw/")[1]?.split("/")[0] ?? "";
+  expect(/^[0-9a-f]{40}$/.test(ref)).toBe(true);
+});
+```
+
+One assertion, scoped to the single `VAD_FILES` entry in `rust/src/models.rs`, read through
+`parseManifestEntries` the same way `no Hugging Face manifest URL resolves through a mutable
+ref` (same describe block) reads every other manifest entry. Runs in the `unit-tests` job of
+the `🧪 CI` workflow on every PR — `rust/src/models.rs` is explicitly in `ci.yml`'s `code`
+path filter, so an edit to it always triggers that job regardless of anything else touched.
+
+No matching Rust-side test exists or was added: `VAD_FILES` carries no `#[cfg(...)]` gate, so
+a Rust test would see the exact same one entry over the same always-triggered lane — strictly
+equal reach to the TS test above it, not wider. (Contrast the Hugging-Face guards, which keep
+both a Rust and a TS version because the TS one's reach genuinely exceeds the Rust one — it
+sees `system_kokoro`-gated manifests no CI lane ever compiles as tests.)
+
+## Observed red before the fix
+
+Captured before `rust/src/models.rs`'s `VAD_FILES` URL was touched, against the tag-pinned
+source (`raw/v6.2.1/…`):
+
+```
+$ bun test tests/unit/check-model-plan-sizes.test.ts -t "silero-vad manifest URL"
+bun test v1.3.13 (bf2e2cec)
+
+tests/unit/check-model-plan-sizes.test.ts:
+153 |   test("the silero-vad manifest URL pins a 40-hex commit, not the movable v6.2.1 tag", () => {
+154 |     const vad = realManifestEntries().find(
+155 |       (entry) => entry.relPath === "models/silero-vad/silero_vad.onnx",
+156 |     );
+157 |     const ref = vad?.url.split("/raw/")[1]?.split("/")[0] ?? "";
+158 |     expect(/^[0-9a-f]{40}$/.test(ref)).toBe(true);
+                                             ^
+error: expect(received).toBe(expected)
+
+Expected: true
+Received: false
+
+      at <anonymous> (tests/unit/check-model-plan-sizes.test.ts:158:40)
+(fail) parseManifestUrls > the silero-vad manifest URL pins a 40-hex commit, not the movable v6.2.1 tag [8.12ms]
+
+ 0 pass
+ 22 filtered out
+ 1 fail
+ 1 expect() calls
+Ran 1 test across 1 file. [52.00ms]
+```
+
+`ref` evaluates to `"v6.2.1"` — a 6-character tag, not 40 hex — so the regex is `false` and
+`expect(false).toBe(true)` fails. Turned green by pinning the URL's `/raw/` segment to
+`7e30209a3e901f9842f81b225f3e93d8199902b1` (the tag's resolved commit, verified below), with
+no other line in the test file changed.
+
+## Verifying the resolved commit before pinning
+
+Per "VERIFY THIRD-PARTY MODEL FORMATS WITH A SPIKE," run in a throwaway `/tmp/` directory,
+deleted after:
+
+```
+$ git ls-remote https://github.com/snakers4/silero-vad.git refs/tags/v6.2.1
+7e30209a3e901f9842f81b225f3e93d8199902b1  refs/tags/v6.2.1
+```
+
+One line, no `^{}` peel entry — a lightweight tag, so that hash is the commit itself.
+
+```
+$ curl -sSL https://github.com/snakers4/silero-vad/raw/7e30209a3e901f9842f81b225f3e93d8199902b1/src/silero_vad/data/silero_vad.onnx | shasum -a 256
+1a153a22f4509e292a94e67d6f9b85e8deb25b4988682b7e174c65279d8788e3  (2327524 bytes)
+```
+
+Matches the pin already in `rust/src/models.rs` (`sha256: "1a153a22f4509e292a94e67d6f9b85e8deb25b4988682b7e174c65279d8788e3"`)
+and the size already recorded in `model-plan.json` (`"vad": [{ "relPath":
+"models/silero-vad/silero_vad.onnx", "sizeBytes": 2327524 }]`) exactly — re-verified at the
+target revision, not assumed, and neither value needed to change.
+
+## Mutation proof
+
+Every row: `just mutate rust/src/models.rs <find> <replace> bun test
+tests/unit/check-model-plan-sizes.test.ts -t "silero-vad manifest URL"`, restored in a
+`finally` regardless of outcome; every restore was confirmed with a clean `git status
+--short` afterward.
+
+| # | Mutation | What it removes | Occurrences | Result |
+|---|---|---|---|---|
+| 1 (delete) | Revert the pinned URL's ref segment from the commit back to `v6.2.1` | The property "resolves through a 40-hex commit" is fully absent, reproducing the real pre-fix red above | 1 | **PINNED** — `ref` is `"v6.2.1"` |
+| 2 (present, not satisfying) | Same 40 characters, same length, uppercased (`7E30209A3E901F9842F81B225F3E93D8199902B1`) | The shape of a commit SHA, wrong case — the regex is lowercase-only | 1 | **PINNED** |
+| 3 (present, not satisfying) | Drop the `raw/` path segment entirely, so `.split("/raw/")[1]` is `undefined` and `ref` falls back to `""` | The empty-segment edge case #1096 review round 2 found missing from the Hugging-Face guard's first draft | 1 | **PINNED** — fails on the empty-string fallback, not a crash |
+| control | None — the real, correctly-pinned commit SHA, untouched | — | — | **passes** (`1 pass / 0 fail`) |
+
+Row 3 is not a second assertion — it is the same regex-match assertion exercised through the
+parser's failure path (`?? ""`), which is the residual the Hugging-Face guard's own history
+(`docs/mutation-evidence/issue-1093.md`, rows 4/7/9) flags as worth checking explicitly
+rather than trusting the optional-chaining fallback not to throw or to silently pass.
+
+Rows 1 and 3 are the two ways the actual defect class in #1099 could resurface — the tag
+moved back, or a future edit to the URL's structure slips past the `/raw/` marker the
+assertion depends on. Row 2 is not a defect this ticket names, but the same shape-vs-content
+distinction the sibling Hugging-Face guard's mutation table already tests for its own regex,
+so it was run here rather than assumed to hold by symmetry.

--- a/rust/src/models.rs
+++ b/rust/src/models.rs
@@ -64,12 +64,10 @@ const ASR_FILES: &[ModelFile] = &[
 /// NOTE: `apply_mirror` only rewrites `huggingface.co` URLs, so this one
 /// passes through unchanged even with `KESHA_MODEL_MIRROR` set. Operators
 /// who need a mirrored VAD can pre-stage the file under the cache dir.
-// Pinned to a release tag (not `master`) so upstream can't break fresh
-// installs with a force-push. Hash verification already guards integrity;
-// the tag pin guards availability.
+// Pinned to a commit, not the `v6.2.1` tag, so upstream can't move it under us (#1099)
 const VAD_FILES: &[ModelFile] = &[ModelFile {
     rel_path: "models/silero-vad/silero_vad.onnx",
-    url: "https://github.com/snakers4/silero-vad/raw/v6.2.1/src/silero_vad/data/silero_vad.onnx",
+    url: "https://github.com/snakers4/silero-vad/raw/7e30209a3e901f9842f81b225f3e93d8199902b1/src/silero_vad/data/silero_vad.onnx",
     sha256: "1a153a22f4509e292a94e67d6f9b85e8deb25b4988682b7e174c65279d8788e3",
 }];
 
@@ -189,6 +187,9 @@ pub fn validate_tts_langs(langs: &[&str]) -> Result<()> {
 /// official kokoro-onnx project release, which uses different IO
 /// tensor names (`tokens`/`audio` vs `input_ids`/`waveform`) but
 /// same dtypes/shapes — handled in `kokoro::Kokoro::infer`.
+///
+/// A GitHub release asset has no immutable URL form to pin, so the sha256 pinned below is
+/// the only guard against a re-upload under the same tag (#1099).
 #[cfg(all(
     feature = "tts",
     not(all(

--- a/tests/unit/check-model-plan-sizes.test.ts
+++ b/tests/unit/check-model-plan-sizes.test.ts
@@ -149,6 +149,14 @@ describe("parseManifestUrls", () => {
     }
     expect(mutableRefs).toEqual([]);
   });
+
+  test("the silero-vad manifest URL pins a 40-hex commit, not the movable v6.2.1 tag", () => {
+    const vad = realManifestEntries().find(
+      (entry) => entry.relPath === "models/silero-vad/silero_vad.onnx",
+    );
+    const ref = vad?.url.split("/raw/")[1]?.split("/")[0] ?? "";
+    expect(/^[0-9a-f]{40}$/.test(ref)).toBe(true);
+  });
 });
 
 describe("compareEntry", () => {


### PR DESCRIPTION
## What

`rust/src/models.rs:70` (silero-vad) pinned its URL through the movable `v6.2.1` git tag —
the same defect class #1093 hit on `huggingface.co`, one host over. Pins it to the tag's
resolved commit instead, with the same SHA-256 (unchanged, re-verified below).

`rust/src/models.rs:203` (the kokoro-onnx `KOKORO_GRAPH` release asset) has no immutable
URL form at all — a GitHub release asset is addressed by tag, not commit — so it gets a
one-line doc comment stating that instead of a guard that could never exist.

Closes #1099
Refs #1093, #1096

## Verified before pinning (spike, deleted after)

```
$ git ls-remote https://github.com/snakers4/silero-vad.git refs/tags/v6.2.1
7e30209a3e901f9842f81b225f3e93d8199902b1  refs/tags/v6.2.1
```

One line, no `^{}` peel entry — a lightweight tag, so that hash is the commit itself.

```
$ curl -sSL https://github.com/snakers4/silero-vad/raw/7e30209a3e901f9842f81b225f3e93d8199902b1/src/silero_vad/data/silero_vad.onnx | shasum -a 256
1a153a22f4509e292a94e67d6f9b85e8deb25b4988682b7e174c65279d8788e3  (2327524 bytes)
```

Matches the pin already in `rust/src/models.rs` and the size already recorded in
`model-plan.json` exactly. The SHA-256 is re-verified at the target revision, not assumed,
and does not change.

## The change

1. `rust/src/models.rs` — pin `VAD_FILES`' URL to the resolved commit; rewrite the now-false
   "pinned to a release tag" comment to state it's a commit now; add a one-line note on
   `KOKORO_GRAPH` explaining why the release asset next to it can never get the same fix.
2. `tests/unit/check-model-plan-sizes.test.ts` — a new, standalone assertion scoped to
   exactly this one manifest entry: its `/raw/<ref>/` segment must be a lowercase 40-hex
   string. Runs in the `unit-tests` job of `🧪 CI` whenever `ci.yml`'s `code` path filter
   matches, which this diff's own edit to `rust/src/models.rs` always does — not "every PR"
   unconditionally, since that job is gated `if: needs.changes.outputs.code == 'true'`.
3. `NOTICES.md` and `docs/mutation-evidence/issue-1093.md` — both described the silero-vad
   URL as tag-pinned; both are now false and updated. `docs/mutation-evidence/issue-1099.md`
   is new: the observed red before the fix, the resolved-commit spike, and the mutation
   table below, in full.

### Why no matching Rust-side test

Checked directly rather than compared by trigger-set size, because the two lanes' path
filters are not nested either way: `rust-test.yml`'s `test` job runs whenever the `changes`
job's filter matches `rust/**`; `ci.yml`'s `code` filter takes only three paths out of the
Rust tree (`rust-toolchain.toml`, `rust/Cargo.toml`, `rust/src/models.rs`) plus `tests/**`
and `model-plan.json`. A PR touching only `rust/src/vad.rs` runs the Rust lane and skips
`unit-tests`; one touching only the TS test file runs `unit-tests` and skips the Rust lane.
Neither trigger set contains the other — "identical reach" and "a superset" (both claimed in
earlier revisions of this section, both wrong) are false as statements about how often each
lane runs.

The comparison that holds is about signal, not trigger sets: this assertion reads only
`rust/src/models.rs`, so its result cannot change on a run where that file didn't change, and
a Rust duplicate reading the same file has the identical property. Both lanes already fire on
every change to `rust/src/models.rs` — the only event either assertion could ever flip on —
so a Rust duplicate adds no catching power there. Full derivation, with exact line citations,
in `docs/mutation-evidence/issue-1099.md`.

### Why not widen the existing Hugging-Face guards instead

Considered accepting `/raw/<ref>/` in addition to `/resolve/<ref>/` in the existing
predicates (`assert_pins_immutable_revision` in Rust, `no Hugging Face manifest URL resolves
through a mutable ref` in TS). That rule is keyed on URL form, not host, and the
release-asset URL contains neither `/resolve/` nor `/raw/`, so it would need no exception.
Rejected anyway: both predicates are explicitly named and documented as Hugging-Face-only,
and widening either costs a rename, a doc-comment rewrite, and a scope-section update — more
than a six-line standalone test, for a URL shape with exactly one live instance today.

## Mutation proof

One assertion, four rows plus a control — full detail, real `just mutate` output, and the
observed red before the fix, in `docs/mutation-evidence/issue-1099.md`.

| # | Mutation | Result |
|---|---|---|
| 1 (delete) | Revert the ref back to `v6.2.1` | **PINNED** |
| 2 (present, not satisfying) | Same 40 chars, uppercased | **PINNED** |
| 3 (present, not satisfying) | Drop the `/raw/` segment entirely (empty-ref fallback) | **PINNED** |
| 4 (present, not satisfying) | Same 40 chars, all zeroes — lowercase-hex-shaped, not a real commit | **NOT PINNED — a stated boundary, not a bug** |
| control | Untouched, correctly-pinned commit | passes |

Row 4 survives on purpose: the assertion proves the ref is lowercase-40-hex-shaped, not that
it names a commit that exists — that would need a network call from an offline,
deterministic unit-test lane. The sibling Hugging-Face guard accepted at #1096 carries the
identical residual. Commit existence is verified once, by hand, at pin time (the spike
above), not by this test on every CI run.

## Gates

`just preflight` — green: TS gate (`bun run test`, lint, `check:recipes`, `check:workflows`,
`check:versions`, `check:specs`, `check:engine-targets`, `check:release-manifest`), `cargo
fmt` + `clippy --all-targets -- -D warnings`, and Rust tests via nextest (612/612 passed).

`just verify-darwin-full` **not run**: the diff touches only `VAD_FILES` (no `#[cfg(...)]`
gate at all — always compiled) and a doc-comment-only change inside a `system_kokoro`-gated
block (the code that block compiles to is unaffected). Neither is under `rust/src/tts/**`
nor toggles `system_kokoro`/`system_diarize`/`system_text_lang`.

## What this deliberately does not do

- Does not touch the Hugging-Face-only predicates (see above).
- Does not add a Rust-side duplicate of the new TS test (see above).
- Does not attempt any URL-shape guard for the kokoro-onnx release asset — none can exist;
  the one-line comment is the whole fix for that half.
- Does not add a commit-existence check for the pinned ref (row 4 above). That would make an
  offline, deterministic unit test network-dependent, for a residual the accepted
  Hugging-Face guard already carries. Named as a boundary instead of hidden.

## Sizing

Standard, uncontested by the implementer.

