### PR TITLE
ci(build-engine): the per-ref group trades a loud failure for a silent one

### DIFF
--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -790,6 +790,13 @@ export function requireBuildEngineSerialisesRunsPerRef(path: string, document: u
  * even finishes. A step comparing the tag's live target against `github.sha` (fixed at trigger)
  * before the draft is created converts that into a failed job (#1115).
  */
+// Strips one `${{ }}` wrapper before comparing — `if: ${{ false }}` disables a step exactly like `if: false` but the bare-string check alone missed it (#1115 review round 3, Greptile P2).
+function isDisabled(step: Step): boolean {
+  const raw = condition(step).trim();
+  const inner = /^\$\{\{([\s\S]*)\}\}$/.exec(raw)?.[1]?.trim() ?? raw;
+  return inner === "false";
+}
+
 export function requireReleaseVerifiesTagIsCurrent(path: string, document: unknown): string[] {
   if (!path.endsWith("build-engine.yml")) return [];
 
@@ -801,23 +808,29 @@ export function requireReleaseVerifiesTagIsCurrent(path: string, document: unkno
     typeof step?.run === "string" &&
     /refs\/tags/.test(step.run) &&
     /GITHUB_SHA/.test(step.run) &&
-    condition(step).trim() !== "false";
-  const guard = steps.findIndex(isGuard);
+    !isDisabled(step);
+
   const publish = steps.findIndex(
     (step) => typeof step?.uses === "string" && step.uses.startsWith("softprops/action-gh-release"),
   );
+  if (publish === -1) {
+    return [`${path}: expected the release job to create the draft release via softprops/action-gh-release`];
+  }
 
+  const guard = steps.findIndex(isGuard);
   if (guard === -1) {
     return [
       `${path}: the release job must verify the tag still points at github.sha before creating the draft — ` +
         `a re-pointed tag builds a complete-looking release from a superseded commit with nothing red (#1115)`,
     ];
   }
-  if (publish === -1) {
-    return [`${path}: expected the release job to create the draft release via softprops/action-gh-release`];
-  }
-  if (guard > publish) {
-    return [`${path}: the tag-currency guard runs after the draft release is created; move it before (#1115)`];
+
+  // Must sit immediately before the draft is created — SBOM/download/sign cost real wall-clock, and an earlier check leaves that whole window unrevalidated (#1115 review round 3, Greptile P1).
+  if (guard !== publish - 1) {
+    return [
+      `${path}: the tag-currency guard must be the step immediately before the draft release is created, not merely somewhere before it — ` +
+        `GitHub resolves the tag to whatever it names by the time that step runs (#1115)`,
+    ];
   }
   return [];
 }

--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -779,6 +779,50 @@ export function requireBuildEngineSerialisesRunsPerRef(path: string, document: u
 }
 
 /**
+ * Fails when the `release` job could publish a draft without first checking that the tag it is
+ * building still points at the commit this run was triggered for.
+ *
+ * `requireBuildEngineSerialisesRunsPerRef` (#1108) makes two runs racing one draft release
+ * loud — the second queues instead of colliding mid-upload. It does not make a re-pointed tag
+ * loud: if the tag moves while run A is still building, A's `release` job checks out whatever
+ * the tag names by the time it runs and creates a complete-looking draft from the superseded
+ * commit — nothing reds, and for stable/beta a human can un-draft it before the correct run
+ * even finishes. A step comparing the tag's live target against `github.sha` (fixed at trigger)
+ * before the draft is created converts that into a failed job (#1115).
+ */
+export function requireReleaseVerifiesTagIsCurrent(path: string, document: unknown): string[] {
+  if (!path.endsWith("build-engine.yml")) return [];
+
+  const steps = jobSteps(document, "release");
+  if (!steps) return [`${path}: expected a \`release\` job with steps`];
+
+  const isGuard = (step: Step) =>
+    typeof step?.run === "string" &&
+    /\bgit rev-parse\b/.test(step.run) &&
+    /refs\/tags/.test(step.run) &&
+    /GITHUB_SHA/.test(step.run) &&
+    condition(step).trim() !== "false";
+  const guard = steps.findIndex(isGuard);
+  const publish = steps.findIndex(
+    (step) => typeof step?.uses === "string" && step.uses.startsWith("softprops/action-gh-release"),
+  );
+
+  if (guard === -1) {
+    return [
+      `${path}: the release job must verify the tag still points at github.sha before creating the draft — ` +
+        `a re-pointed tag builds a complete-looking release from a superseded commit with nothing red (#1115)`,
+    ];
+  }
+  if (publish === -1) {
+    return [`${path}: expected the release job to create the draft release via softprops/action-gh-release`];
+  }
+  if (guard > publish) {
+    return [`${path}: the tag-currency guard runs after the draft release is created; move it before (#1115)`];
+  }
+  return [];
+}
+
+/**
  * Fails when the `ci` aggregator needs `nix-build`.
  *
  * A job in the required `ci` aggregator that cannot run on a pull request reds `main` — on
@@ -821,6 +865,7 @@ export function checkFile(
       ...requireConcurrencyOnPullRequestWorkflows(path, document),
       ...requireRustTestCancelsSupersededRuns(path, document),
       ...requireBuildEngineSerialisesRunsPerRef(path, document),
+      ...requireReleaseVerifiesTagIsCurrent(path, document),
       ...forbidNixBuildInCiAggregator(path, document),
       ...requireJobTimeouts(path, document),
       ...requireDepsBeforeBunTest(path, document),

--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -796,9 +796,9 @@ export function requireReleaseVerifiesTagIsCurrent(path: string, document: unkno
   const steps = jobSteps(document, "release");
   if (!steps) return [`${path}: expected a \`release\` job with steps`];
 
+  // Checks the contract (tag ref resolved, compared to GITHUB_SHA), not the resolving command — pinning `git rev-parse` rejected the `git ls-remote ...^{}` fix for its own tag-object-vs-commit bug (#1115 review).
   const isGuard = (step: Step) =>
     typeof step?.run === "string" &&
-    /\bgit rev-parse\b/.test(step.run) &&
     /refs\/tags/.test(step.run) &&
     /GITHUB_SHA/.test(step.run) &&
     condition(step).trim() !== "false";

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -472,6 +472,17 @@ jobs:
           fetch-tags: true
           fetch-depth: 0
 
+      # #1108 serialises runs per ref but not against a re-pointed tag — the backstop for a local `git push --force`, which meets no uniqueness check (#1115).
+      - name: Verify tag has not been superseded
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          current="$(git rev-parse "refs/tags/$TAG_NAME")"
+          if [ "$current" != "$GITHUB_SHA" ]; then
+            echo "::error::tag $TAG_NAME now points at $current, but this run was triggered for $GITHUB_SHA — the tag was re-pointed mid-build. Refusing to publish a release built from a superseded commit."
+            exit 1
+          fi
+
       - name: Prepare release notes from tag annotation
         env:
           TAG_NAME: ${{ github.ref_name }}

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -472,18 +472,6 @@ jobs:
           fetch-tags: true
           fetch-depth: 0
 
-      # #1108 serialises runs per ref but not against a re-pointed tag — the backstop for a local `git push --force`, which meets no uniqueness check (#1115).
-      # Queries origin live rather than the local ref this job's checkout snapshotted, and the trailing `^{}` line peels an annotated tag to its commit — `git rev-parse refs/tags/<annotated>` alone returns the *tag object* SHA, which never equals `GITHUB_SHA`. A re-annotation that leaves the commit unchanged still passes; that residual is untouched here.
-      - name: Verify tag has not been superseded
-        env:
-          TAG_NAME: ${{ github.ref_name }}
-        run: |
-          current="$(git ls-remote origin "refs/tags/$TAG_NAME" "refs/tags/$TAG_NAME^{}" | tail -1 | cut -f1)"
-          if [ "$current" != "$GITHUB_SHA" ]; then
-            echo "::error::tag $TAG_NAME now points at $current, but this run was triggered for $GITHUB_SHA — the tag was re-pointed mid-build. Refusing to publish a release built from a superseded commit."
-            exit 1
-          fi
-
       - name: Prepare release notes from tag annotation
         env:
           TAG_NAME: ${{ github.ref_name }}
@@ -544,6 +532,17 @@ jobs:
             name="${asset#./}"
             cosign sign-blob --yes --bundle "${name}.sigstore.json" "$name"
           done < <(find . -maxdepth 1 -type f ! -name '*.sigstore.json' -print0 | sort -z)
+
+      # Runs last, right before GitHub resolves the tag to whatever commit it names now — a re-point during the SBOM/download/sign window above is the same #1108/#1115 bug moved later (review round 3, Greptile P1); querying origin live and peeling `^{}` avoids both the stale-local-ref and tag-object-vs-commit traps (round 2 P1/P2), though a same-commit re-annotation still passes.
+      - name: Verify tag has not been superseded
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          current="$(git ls-remote origin "refs/tags/$TAG_NAME" "refs/tags/$TAG_NAME^{}" | tail -1 | cut -f1)"
+          if [ "$current" != "$GITHUB_SHA" ]; then
+            echo "::error::tag $TAG_NAME now points at $current, but this run was triggered for $GITHUB_SHA — the tag was re-pointed mid-build. Refusing to publish a release built from a superseded commit."
+            exit 1
+          fi
 
       # Always a draft: releases here are immutable, and an asset uploaded after publication 422s.
       - name: Create draft release with binaries

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -473,11 +473,12 @@ jobs:
           fetch-depth: 0
 
       # #1108 serialises runs per ref but not against a re-pointed tag — the backstop for a local `git push --force`, which meets no uniqueness check (#1115).
+      # Queries origin live rather than the local ref this job's checkout snapshotted, and the trailing `^{}` line peels an annotated tag to its commit — `git rev-parse refs/tags/<annotated>` alone returns the *tag object* SHA, which never equals `GITHUB_SHA`. A re-annotation that leaves the commit unchanged still passes; that residual is untouched here.
       - name: Verify tag has not been superseded
         env:
           TAG_NAME: ${{ github.ref_name }}
         run: |
-          current="$(git rev-parse "refs/tags/$TAG_NAME")"
+          current="$(git ls-remote origin "refs/tags/$TAG_NAME" "refs/tags/$TAG_NAME^{}" | tail -1 | cut -f1)"
           if [ "$current" != "$GITHUB_SHA" ]; then
             echo "::error::tag $TAG_NAME now points at $current, but this run was triggered for $GITHUB_SHA — the tag was re-pointed mid-build. Refusing to publish a release built from a superseded commit."
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,8 @@ jobs:
               - 'server.json'
               - '.github/workflows/ci.yml'
               - '.github/actions/**'
+              # workflow-lint's static check can't catch a semantic regression in the guard tests/integration/build-engine-tag-guard.test.ts pins (#1115 review round 2).
+              - '.github/workflows/build-engine.yml'
               # Most of these scripts have unit tests; without this a script-only edit skips the tests that cover it (check-workflows.ts enforces it). Deliberately no count — the one that lived here read 16 against an actual 25.
               - '.github/scripts/**'
               # The two halves of the install-plan join (#920): the size canary's unit test
@@ -102,6 +104,7 @@ jobs:
               - 'bun.lock'
               - '.github/workflows/ci.yml'
               - '.github/actions/**'
+              - '.github/workflows/build-engine.yml'
             real_engine_e2e:
               - 'rust/**'
               - 'package.json'

--- a/tests/helpers/git-repo.ts
+++ b/tests/helpers/git-repo.ts
@@ -35,6 +35,18 @@ export async function commit(work: string, subject: string): Promise<void> {
   await git(work, "commit", "-qam", subject);
 }
 
+/** An independent clone of `work`'s remote — pushing from here leaves `work`'s local refs stale. */
+export async function cloneFrom(work: string): Promise<string> {
+  const dir = mkdtempSync(join(tmpdir(), "kesha-git-"));
+  created.push(dir);
+  const clone = join(dir, "clone");
+  const remoteUrl = await git(work, "remote", "get-url", "origin");
+  await git(dir, "clone", "-q", remoteUrl, clone);
+  await git(clone, "config", "user.email", "test@example.com");
+  await git(clone, "config", "user.name", "test");
+  return clone;
+}
+
 export function cleanupGitRepos(): void {
   for (const dir of created.splice(0)) rmSync(dir, { recursive: true, force: true });
 }

--- a/tests/integration/build-engine-tag-guard.test.ts
+++ b/tests/integration/build-engine-tag-guard.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { cleanupGitRepos, commit, git, gitRepoWithRemote } from "../helpers/git-repo";
+import { cleanupGitRepos, cloneFrom, commit, git, gitRepoWithRemote } from "../helpers/git-repo";
 import { parseRepoYaml } from "../helpers/repo";
 
 afterEach(cleanupGitRepos);
@@ -20,8 +20,9 @@ function guardScript(): string {
   return guard.run;
 }
 
+// Mirrors GHA's real `bash --noprofile --norc -eo pipefail {0}` — plain `bash -c` masks a failed `git ls-remote` as an empty `current` instead of aborting (#1115 review round 2).
 async function runGuard(work: string, tagName: string, sha: string): Promise<{ code: number; stdout: string }> {
-  const proc = Bun.spawn(["bash", "-c", guardScript()], {
+  const proc = Bun.spawn(["bash", "--noprofile", "--norc", "-eo", "pipefail", "-c", guardScript()], {
     cwd: work,
     env: { ...process.env, TAG_NAME: tagName, GITHUB_SHA: sha },
     stdout: "pipe",
@@ -68,6 +69,39 @@ describe("build-engine.yml release job: tag-currency guard", () => {
 
     const { code, stdout } = await runGuard(work, "v1.0.0", sha);
     expect({ code, stdout }).toEqual({ code: 0, stdout: "" });
+  });
+
+  // Re-points via a second clone so `work`'s local ref stays stale — a guard reading it instead of querying origin wrongly passes.
+  test("fails an annotated tag re-pointed on the remote only, with the local checkout untouched", async () => {
+    const work = await gitRepoWithRemote();
+    const original = await git(work, "rev-parse", "HEAD");
+    await git(work, "tag", "-a", "v1.0.0", "-m", "notes");
+    await git(work, "push", "-q", "origin", "refs/tags/v1.0.0");
+
+    const other = await cloneFrom(work);
+    await git(other, "checkout", "-q", "v1.0.0");
+    await commit(other, "later work");
+    await git(other, "tag", "-f", "-a", "v1.0.0", "-m", "notes2");
+    await git(other, "push", "-qf", "origin", "refs/tags/v1.0.0");
+
+    expect(await git(work, "rev-parse", "refs/tags/v1.0.0^{commit}")).toBe(original);
+    expect((await runGuard(work, "v1.0.0", original)).code).toBe(1);
+  });
+
+  test("fails a lightweight tag re-pointed on the remote only, with the local checkout untouched", async () => {
+    const work = await gitRepoWithRemote();
+    const original = await git(work, "rev-parse", "HEAD");
+    await git(work, "tag", "v2.0.0");
+    await git(work, "push", "-q", "origin", "refs/tags/v2.0.0");
+
+    const other = await cloneFrom(work);
+    await git(other, "checkout", "-q", "v2.0.0");
+    await commit(other, "later work");
+    await git(other, "tag", "-f", "v2.0.0");
+    await git(other, "push", "-qf", "origin", "refs/tags/v2.0.0");
+
+    expect(await git(work, "rev-parse", "refs/tags/v2.0.0")).toBe(original);
+    expect((await runGuard(work, "v2.0.0", original)).code).toBe(1);
   });
 
   test("passes a lightweight tag that has not moved", async () => {

--- a/tests/integration/build-engine-tag-guard.test.ts
+++ b/tests/integration/build-engine-tag-guard.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanupGitRepos, commit, git, gitRepoWithRemote } from "../helpers/git-repo";
+import { parseRepoYaml } from "../helpers/repo";
+
+afterEach(cleanupGitRepos);
+
+type Step = { run?: unknown };
+
+// Executes the real step's shell, not a hand-copied stand-in — a copy can drift from what ships
+// and still read as coverage, which is what shipped the tag-object-vs-commit bug (#1115 review).
+function guardScript(): string {
+  const document = parseRepoYaml(".github/workflows/build-engine.yml") as {
+    jobs?: { release?: { steps?: Step[] } };
+  };
+  const steps = document.jobs?.release?.steps ?? [];
+  const guard = steps.find(
+    (step) => typeof step.run === "string" && step.run.includes("refs/tags") && step.run.includes("GITHUB_SHA"),
+  );
+  if (!guard || typeof guard.run !== "string") throw new Error("release job has no tag-currency guard step");
+  return guard.run;
+}
+
+async function runGuard(work: string, tagName: string, sha: string): Promise<{ code: number; stdout: string }> {
+  const proc = Bun.spawn(["bash", "-c", guardScript()], {
+    cwd: work,
+    env: { ...process.env, TAG_NAME: tagName, GITHUB_SHA: sha },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const stdout = await new Response(proc.stdout).text();
+  const code = await proc.exited;
+  return { code, stdout };
+}
+
+describe("build-engine.yml release job: tag-currency guard", () => {
+  test("passes an annotated tag that has not moved", async () => {
+    const work = await gitRepoWithRemote();
+    const sha = await git(work, "rev-parse", "HEAD");
+    await git(work, "tag", "-a", "v1.0.0", "-m", "notes");
+    await git(work, "push", "-q", "origin", "refs/tags/v1.0.0");
+
+    expect((await runGuard(work, "v1.0.0", sha)).code).toBe(0);
+  });
+
+  // The bug this whole guard exists to catch: a re-point between trigger and the release job.
+  test("fails an annotated tag re-pointed after the recorded SHA", async () => {
+    const work = await gitRepoWithRemote();
+    const original = await git(work, "rev-parse", "HEAD");
+    await git(work, "tag", "-a", "v1.0.0", "-m", "notes");
+    await git(work, "push", "-q", "origin", "refs/tags/v1.0.0");
+
+    await commit(work, "later work");
+    await git(work, "tag", "-f", "-a", "v1.0.0", "-m", "notes2");
+    await git(work, "push", "-qf", "origin", "refs/tags/v1.0.0");
+
+    const { code, stdout } = await runGuard(work, "v1.0.0", original);
+    expect(code).toBe(1);
+    expect(stdout).toContain("re-pointed mid-build");
+  });
+
+  // `git rev-parse refs/tags/<annotated>` alone returns the tag object, never GITHUB_SHA — this
+  // case is what shipped a guard that reds every annotated release (#1115 review, P1).
+  test("does not fail an annotated tag just because it carries an annotation", async () => {
+    const work = await gitRepoWithRemote();
+    const sha = await git(work, "rev-parse", "HEAD");
+    await git(work, "tag", "-a", "v1.0.0", "-m", "notes");
+    await git(work, "push", "-q", "origin", "refs/tags/v1.0.0");
+
+    const { code, stdout } = await runGuard(work, "v1.0.0", sha);
+    expect({ code, stdout }).toEqual({ code: 0, stdout: "" });
+  });
+
+  test("passes a lightweight tag that has not moved", async () => {
+    const work = await gitRepoWithRemote();
+    const sha = await git(work, "rev-parse", "HEAD");
+    await git(work, "tag", "v2.0.0");
+    await git(work, "push", "-q", "origin", "refs/tags/v2.0.0");
+
+    expect((await runGuard(work, "v2.0.0", sha)).code).toBe(0);
+  });
+
+  test("fails a lightweight tag re-pointed after the recorded SHA", async () => {
+    const work = await gitRepoWithRemote();
+    const original = await git(work, "rev-parse", "HEAD");
+    await git(work, "tag", "v2.0.0");
+    await git(work, "push", "-q", "origin", "refs/tags/v2.0.0");
+
+    await commit(work, "later work");
+    await git(work, "tag", "-f", "v2.0.0");
+    await git(work, "push", "-qf", "origin", "refs/tags/v2.0.0");
+
+    expect((await runGuard(work, "v2.0.0", original)).code).toBe(1);
+  });
+});

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -12,6 +12,7 @@ import {
   requireBashOnWindowsRunSteps,
   requireConcurrencyOnPullRequestWorkflows,
   requireBuildEngineSerialisesRunsPerRef,
+  requireReleaseVerifiesTagIsCurrent,
   requireRustTestCancelsSupersededRuns,
   requirePipefailShell,
   requireReusableCallPermissions,
@@ -920,6 +921,54 @@ describe("requireBuildEngineSerialisesRunsPerRef", () => {
     const path = join(mkdtempSync(join(tmpdir(), "kesha-wf-")), "build-engine.yml");
     writeFileSync(path, yaml);
     expect(checkFile(path, [], [], undefined).filter((e) => e.includes("#1108"))).toHaveLength(2);
+  });
+});
+
+describe("requireReleaseVerifiesTagIsCurrent", () => {
+  const GUARD = {
+    name: "Verify tag has not been superseded",
+    env: { TAG_NAME: "${{ github.ref_name }}" },
+    run: 'current="$(git rev-parse "refs/tags/$TAG_NAME")"\nif [ "$current" != "$GITHUB_SHA" ]; then exit 1; fi\n',
+  };
+  const PUBLISH = { name: "Create draft release with binaries", uses: "softprops/action-gh-release@3d0d9888c" };
+
+  test("passes on the real build-engine.yml", () => {
+    expect(requireReleaseVerifiesTagIsCurrent(PATH, parseRepoYaml(PATH))).toEqual([]);
+  });
+
+  test("ignores every other workflow", () => {
+    expect(requireReleaseVerifiesTagIsCurrent(CI, job("release", [PUBLISH]))).toEqual([]);
+  });
+
+  test("fails when the guard step is missing", () => {
+    const errors = requireReleaseVerifiesTagIsCurrent(PATH, job("release", [PUBLISH]));
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("#1115");
+  });
+
+  test("fails when the guard runs after the draft release is created", () => {
+    const errors = requireReleaseVerifiesTagIsCurrent(PATH, job("release", [PUBLISH, GUARD]));
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("runs after");
+  });
+
+  test("passes when the guard precedes the draft release", () => {
+    expect(requireReleaseVerifiesTagIsCurrent(PATH, job("release", [GUARD, PUBLISH]))).toEqual([]);
+  });
+
+  test("fails when the guard step is disabled", () => {
+    const errors = requireReleaseVerifiesTagIsCurrent(PATH, job("release", [{ ...GUARD, if: "false" }, PUBLISH]));
+    expect(errors[0]).toContain("#1115");
+  });
+
+  test("fails when only half the check is present", () => {
+    const noShaCheck = { ...GUARD, run: 'current="$(git rev-parse "refs/tags/$TAG_NAME")"\necho "$current"\n' };
+    expect(requireReleaseVerifiesTagIsCurrent(PATH, job("release", [noShaCheck, PUBLISH]))[0]).toContain("#1115");
+  });
+
+  test("fails when the release job is gone", () => {
+    const errors = requireReleaseVerifiesTagIsCurrent(PATH, { jobs: { build: {} } });
+    expect(errors[0]).toContain("expected a `release` job");
   });
 });
 

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -951,15 +951,29 @@ describe("requireReleaseVerifiesTagIsCurrent", () => {
   test("fails when the guard runs after the draft release is created", () => {
     const errors = requireReleaseVerifiesTagIsCurrent(PATH, job("release", [PUBLISH, GUARD]));
     expect(errors).toHaveLength(1);
-    expect(errors[0]).toContain("runs after");
+    expect(errors[0]).toContain("immediately before");
   });
 
-  test("passes when the guard precedes the draft release", () => {
+  test("passes when the guard immediately precedes the draft release", () => {
     expect(requireReleaseVerifiesTagIsCurrent(PATH, job("release", [GUARD, PUBLISH]))).toEqual([]);
+  });
+
+  // An early-only check leaves the SBOM/download/sign window unrevalidated — the tag can still move before GitHub resolves it at publish time (#1115 review round 3, Greptile P1).
+  test("fails when the guard runs early but not immediately before the draft release", () => {
+    const OTHER = { name: "Generate source SBOM", uses: "anchore/sbom-action@e22c389" };
+    const errors = requireReleaseVerifiesTagIsCurrent(PATH, job("release", [GUARD, OTHER, PUBLISH]));
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("immediately before");
   });
 
   test("fails when the guard step is disabled", () => {
     const errors = requireReleaseVerifiesTagIsCurrent(PATH, job("release", [{ ...GUARD, if: "false" }, PUBLISH]));
+    expect(errors[0]).toContain("#1115");
+  });
+
+  // `${{ false }}` disables the step exactly like bare `false`, but a naive string-equality check misses it (#1115 review round 3, Greptile P2).
+  test("fails when the guard step is disabled via a wrapped expression", () => {
+    const errors = requireReleaseVerifiesTagIsCurrent(PATH, job("release", [{ ...GUARD, if: "${{ false }}" }, PUBLISH]));
     expect(errors[0]).toContain("#1115");
   });
 

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -928,7 +928,9 @@ describe("requireReleaseVerifiesTagIsCurrent", () => {
   const GUARD = {
     name: "Verify tag has not been superseded",
     env: { TAG_NAME: "${{ github.ref_name }}" },
-    run: 'current="$(git rev-parse "refs/tags/$TAG_NAME")"\nif [ "$current" != "$GITHUB_SHA" ]; then exit 1; fi\n',
+    run:
+      'current="$(git ls-remote origin "refs/tags/$TAG_NAME" "refs/tags/$TAG_NAME^{}" | tail -1 | cut -f1)"\n' +
+      'if [ "$current" != "$GITHUB_SHA" ]; then exit 1; fi\n',
   };
   const PUBLISH = { name: "Create draft release with binaries", uses: "softprops/action-gh-release@3d0d9888c" };
 
@@ -961,9 +963,14 @@ describe("requireReleaseVerifiesTagIsCurrent", () => {
     expect(errors[0]).toContain("#1115");
   });
 
-  test("fails when only half the check is present", () => {
-    const noShaCheck = { ...GUARD, run: 'current="$(git rev-parse "refs/tags/$TAG_NAME")"\necho "$current"\n' };
+  test("fails when the step never compares against GITHUB_SHA", () => {
+    const noShaCheck = { ...GUARD, run: 'current="$(git ls-remote origin "refs/tags/$TAG_NAME^{}")"\necho "$current"\n' };
     expect(requireReleaseVerifiesTagIsCurrent(PATH, job("release", [noShaCheck, PUBLISH]))[0]).toContain("#1115");
+  });
+
+  test("fails when the step never mentions refs/tags", () => {
+    const noTagRef = { ...GUARD, run: 'current="$GITHUB_SHA"\nif [ "$current" != "$GITHUB_SHA" ]; then exit 1; fi\n' };
+    expect(requireReleaseVerifiesTagIsCurrent(PATH, job("release", [noTagRef, PUBLISH]))[0]).toContain("#1115");
   });
 
   test("fails when the release job is gone", () => {

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -970,6 +970,15 @@ describe("requireReleaseVerifiesTagIsCurrent", () => {
     const errors = requireReleaseVerifiesTagIsCurrent(PATH, { jobs: { build: {} } });
     expect(errors[0]).toContain("expected a `release` job");
   });
+
+  // `jobs: {}` alone reports "expected a `release` job", not #1115 — the probe needs a real job.
+  test("the file gate actually runs it", () => {
+    const yaml =
+      "on:\n  push:\njobs:\n  release:\n    steps:\n      - uses: softprops/action-gh-release@3d0d9888c\n";
+    const path = join(mkdtempSync(join(tmpdir(), "kesha-wf-")), "build-engine.yml");
+    writeFileSync(path, yaml);
+    expect(checkFile(path, [], [], undefined).filter((e) => e.includes("#1115"))).toHaveLength(1);
+  });
 });
 
 describe("requireRustTestCancelsSupersededRuns", () => {


### PR DESCRIPTION
## Summary

- #1114's per-ref `concurrency` group removed one silent failure (two runs racing one draft release) but introduced another: if a tag is re-pointed while a run is in flight, the run's `release` job checks out whatever the tag names by the time it runs and creates a complete-looking draft built from a commit the tag no longer names. For an alpha this collides loudly (422 on the immutable published release); for stable/beta a human can un-draft the superseded build before the correct run finishes, and nothing ever reports it.
- Adds a `Verify tag has not been superseded` step to the `release` job, positioned as the last step before `Create draft release with binaries` — GitHub resolves a release's tag to whatever commit it names *when that step runs*, so a check placed earlier (e.g. right after checkout) would leave the SBOM/download/manifest/sign window unrevalidated. The step resolves the tag's live remote target (`git ls-remote origin "refs/tags/$TAG_NAME" "refs/tags/$TAG_NAME^{}" | tail -1 | cut -f1` — the `^{}` line peels an annotated tag to its commit, and querying `origin` live rather than a local snapshot closes the staleness window) against `github.sha` (fixed at trigger time), failing the job on a mismatch.
- Adds a static `requireReleaseVerifiesTagIsCurrent` check in `check-workflows.ts` requiring the guard be the step *immediately* before the draft is created (not merely somewhere before it), so it can't be silently deleted, reordered, or left stranded early — wired into `checkFile` with its own file-gate pin. The disabled-step check strips one `${{ }}` wrapper before comparing, since `if: ${{ false }}` disables a step exactly like bare `if: false`.
- Adds `.github/workflows/build-engine.yml` to `ci.yml`'s `code` and `integration` filters so `tests/integration/build-engine-tag-guard.test.ts` — which executes the guard's real extracted shell against a live git remote — actually runs on a PR that only touches that workflow; before this it ran on neither lane.
- Scope note from the ticket: rate under the live regime is 0/55 non-cli tags, because re-pointing a tag is already forbidden by CLAUDE.md ("TAG NAMES ARE ONE-USE") and blocked on the `workflow_dispatch` path by #651. The gap this closes is a local `git push --force` of a tag, which fires `on.push.tags` and meets no uniqueness check today.
- Known residual, documented inline: a tag re-annotated over the same commit still passes silently — closing that needs threading the original tag object SHA from trigger time into the release job, out of scope for this round.

## Claim

If a tag `vX.Y.Z` is re-pointed to a different commit — on the remote, whether or not a local checkout has fetched it — at any point from run start up until the `release` job's "Verify tag has not been superseded" step executes (which now runs last, immediately before the draft is created), the job fails with a red `::error::` instead of publishing a draft release built from the superseded commit.

## Test plan

- [x] `bun test tests/unit/check-workflows.test.ts` — `requireReleaseVerifiesTagIsCurrent` suite (guard existence, adjacency to the publish step, `false`/`${{ false }}` disabling, missing tag-ref/GITHUB_SHA halves) plus its `checkFile` wiring pin
- [x] `bun test tests/integration/build-engine-tag-guard.test.ts` — executes the guard's real extracted shell (under GHA's actual `bash --noprofile --norc -eo pipefail`) against a live local git remote: annotated and lightweight tags, moved and unmoved, including a remote-only re-point via a second clone so a local-ref read can't pass by accident
- [x] `just mutate` — verified by hand against every mutation raised across all three review rounds (guard deletion, `checkFile` wiring deletion, opt-in env-var condition, `exit 1`→`exit 0`, local-read instead of live `ls-remote`, `isGuard`'s `refs/tags`/`GITHUB_SHA` conjuncts, guard present-but-not-adjacent, `${{ false }}` disabling) — each is now caught
- [x] `just preflight` — full TS suite, `check:workflows`, `check:recipes`, `check:versions`, OpenSpec validation, engine-targets check all green (Rust gate self-skipped, no `rust/**` changes)

Closes #1115
Refs #1108, refs #1114
