### PR TITLE
check-workflows: requirePipefailShell skips composite actions' runs.steps

### DIFF
--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -368,7 +368,13 @@ export function requireBashOnWindowsRunSteps(path: string, document: unknown): s
  */
 const PIPEFAIL_SHELLS = new Set(["bash", "pwsh", "powershell", "python"]);
 
-function pipefailErrorsForSteps(path: string, name: string, steps: Step[], defaultShell: unknown): string[] {
+function pipefailErrorsForSteps(
+  path: string,
+  name: string,
+  steps: Step[],
+  defaultShell: unknown,
+  remedy: string,
+): string[] {
   const errors: string[] = [];
   for (const [at, step] of steps.entries()) {
     if (typeof step?.run !== "string") continue;
@@ -381,12 +387,15 @@ function pipefailErrorsForSteps(path: string, name: string, steps: Step[], defau
         : `sets \`shell: ${String(shell)}\``;
     errors.push(
       `${path}: \`${name}\` step ${label} ${found} — no pipefail there, so a pipeline reports ` +
-        `only its last stage and a failed command inside one passes silently. Name \`shell: bash\`, ` +
-        `or set \`defaults.run.shell: bash\` once for the workflow (#1084, #1089)`,
+        `only its last stage and a failed command inside one passes silently. ${remedy} (#1084, #1089)`,
     );
   }
   return errors;
 }
+
+// A composite step can't inherit `defaults.run.shell` — GitHub requires it be explicit (#1089 review).
+const JOB_REMEDY = "Name `shell: bash`, or set `defaults.run.shell: bash` once for the workflow";
+const COMPOSITE_REMEDY = "Name `shell: bash` on the step";
 
 export function requirePipefailShell(path: string, document: unknown): string[] {
   const jobs = (document as { jobs?: Record<string, Job> })?.jobs;
@@ -398,14 +407,16 @@ export function requirePipefailShell(path: string, document: unknown): string[] 
       if (!Array.isArray(job?.steps)) continue;
       const labels = runnerLabels(job);
       if (labels.length > 0 && labels.every((label) => /windows/i.test(label))) continue;
-      errors.push(...pipefailErrorsForSteps(path, name, job.steps as Step[], job.defaults?.run?.shell ?? workflowShell));
+      errors.push(
+        ...pipefailErrorsForSteps(path, name, job.steps as Step[], job.defaults?.run?.shell ?? workflowShell, JOB_REMEDY),
+      );
     }
     return errors;
   }
 
   const compositeSteps = (document as { runs?: { steps?: unknown[] } })?.runs?.steps;
   if (!Array.isArray(compositeSteps)) return [];
-  return pipefailErrorsForSteps(path, "runs", compositeSteps as Step[], undefined);
+  return pipefailErrorsForSteps(path, "runs", compositeSteps as Step[], undefined, COMPOSITE_REMEDY);
 }
 
 /**

--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -359,39 +359,53 @@ export function requireBashOnWindowsRunSteps(path: string, document: unknown): s
  * output and went green (#1083). `shell: sh` is the same trap spelled out, and so is `cmd`, which
  * exits with the last program's error level. An explicit non-POSIX shell has no pipelines to get
  * wrong and passes. Windows defaults to pwsh, which is `requireBashOnWindowsRunSteps`'s lane (#850).
+ *
+ * Composite actions (`.github/actions/**`) have no `jobs`; their steps live under `runs.steps`
+ * instead, and GitHub requires `shell:` on every composite `run:` step — so the unspecified
+ * default can't occur there, but an explicit `shell: sh` is the same trap and went unchecked
+ * (#1089). They also have no `runs-on` to apply the Windows skip to: a composite can be consumed
+ * by a Windows job, so it is always checked.
  */
 const PIPEFAIL_SHELLS = new Set(["bash", "pwsh", "powershell", "python"]);
 
+function pipefailErrorsForSteps(path: string, name: string, steps: Step[], defaultShell: unknown): string[] {
+  const errors: string[] = [];
+  for (const [at, step] of steps.entries()) {
+    if (typeof step?.run !== "string") continue;
+    const shell = step.shell ?? defaultShell;
+    if (typeof shell === "string" && PIPEFAIL_SHELLS.has(shell)) continue;
+    const label = typeof step.name === "string" ? `\`${step.name}\`` : `${at + 1}`;
+    const found =
+      shell === undefined
+        ? "has no `shell:`, so it runs under the unspecified default `bash -e {0}`"
+        : `sets \`shell: ${String(shell)}\``;
+    errors.push(
+      `${path}: \`${name}\` step ${label} ${found} — no pipefail there, so a pipeline reports ` +
+        `only its last stage and a failed command inside one passes silently. Name \`shell: bash\`, ` +
+        `or set \`defaults.run.shell: bash\` once for the workflow (#1084, #1089)`,
+    );
+  }
+  return errors;
+}
+
 export function requirePipefailShell(path: string, document: unknown): string[] {
   const jobs = (document as { jobs?: Record<string, Job> })?.jobs;
-  if (!jobs || typeof jobs !== "object") return [];
 
-  const workflowShell = (document as { defaults?: { run?: { shell?: unknown } } })?.defaults?.run?.shell;
-  const errors: string[] = [];
-
-  for (const [name, job] of Object.entries(jobs)) {
-    if (!Array.isArray(job?.steps)) continue;
-    const labels = runnerLabels(job);
-    if (labels.length > 0 && labels.every((label) => /windows/i.test(label))) continue;
-
-    for (const [at, step] of (job.steps as Step[]).entries()) {
-      if (typeof step?.run !== "string") continue;
-      const shell = step.shell ?? job.defaults?.run?.shell ?? workflowShell;
-      if (typeof shell === "string" && PIPEFAIL_SHELLS.has(shell)) continue;
-      const label = typeof step.name === "string" ? `\`${step.name}\`` : `${at + 1}`;
-      const found =
-        shell === undefined
-          ? "has no `shell:`, so it runs under the unspecified default `bash -e {0}`"
-          : `sets \`shell: ${String(shell)}\``;
-      errors.push(
-        `${path}: \`${name}\` step ${label} ${found} — no pipefail there, so a pipeline reports ` +
-          `only its last stage and a failed command inside one passes silently. Name \`shell: bash\`, ` +
-          `or set \`defaults.run.shell: bash\` once for the workflow (#1084)`,
-      );
+  if (jobs && typeof jobs === "object") {
+    const workflowShell = (document as { defaults?: { run?: { shell?: unknown } } })?.defaults?.run?.shell;
+    const errors: string[] = [];
+    for (const [name, job] of Object.entries(jobs)) {
+      if (!Array.isArray(job?.steps)) continue;
+      const labels = runnerLabels(job);
+      if (labels.length > 0 && labels.every((label) => /windows/i.test(label))) continue;
+      errors.push(...pipefailErrorsForSteps(path, name, job.steps as Step[], job.defaults?.run?.shell ?? workflowShell));
     }
+    return errors;
   }
 
-  return errors;
+  const compositeSteps = (document as { runs?: { steps?: unknown[] } })?.runs?.steps;
+  if (!Array.isArray(compositeSteps)) return [];
+  return pipefailErrorsForSteps(path, "runs", compositeSteps as Step[], undefined);
 }
 
 /**

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -465,6 +465,12 @@ describe("requirePipefailShell", () => {
     expect(errors[0]).toContain("sets `shell: sh`");
   });
 
+  // Composite steps can't set defaults.run.shell — pointing authors at it would be a dead end.
+  test("does not suggest defaults.run.shell for a composite action", () => {
+    const errors = requirePipefailShell(".github/actions/example/action.yml", compositeAction([{ ...PIPED, shell: "sh" }]));
+    expect(errors[0]).not.toContain("defaults.run.shell");
+  });
+
   test("passes when a composite action's run step names bash", () => {
     expect(
       requirePipefailShell(".github/actions/example/action.yml", compositeAction([{ ...PIPED, shell: "bash" }])),

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -448,6 +448,48 @@ describe("requirePipefailShell", () => {
     writeFileSync(path, yaml);
     expect(checkFile(path, [], [], undefined).filter((e) => e.includes("#1084"))).toHaveLength(1);
   });
+
+  // Composite steps live under `runs.steps`, not `jobs`; an explicit `shell: sh` there is the same trap (#1089).
+  const compositeAction = (steps: unknown[]) => ({ runs: { using: "composite", steps } });
+
+  test("passes on every composite action in the repo", () => {
+    for (const dir of readdirSync(repoPath(".github/actions"))) {
+      const path = `.github/actions/${dir}/action.yml`;
+      expect([path, requirePipefailShell(path, parseRepoYaml(path))]).toEqual([path, []]);
+    }
+  });
+
+  test("fails on an explicit shell: sh inside a composite action's runs.steps", () => {
+    const errors = requirePipefailShell(".github/actions/example/action.yml", compositeAction([{ ...PIPED, shell: "sh" }]));
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("sets `shell: sh`");
+  });
+
+  test("passes when a composite action's run step names bash", () => {
+    expect(
+      requirePipefailShell(".github/actions/example/action.yml", compositeAction([{ ...PIPED, shell: "bash" }])),
+    ).toEqual([]);
+  });
+
+  // A composite can be consumed by a Windows job, so there is no runner to skip on (#1089).
+  test("checks a composite action even though it has no runs-on to skip on", () => {
+    expect(
+      requirePipefailShell(".github/actions/example/action.yml", compositeAction([{ ...PIPED, shell: "sh" }])),
+    ).toHaveLength(1);
+  });
+
+  test("ignores steps in a composite action that only `uses` another action", () => {
+    expect(
+      requirePipefailShell(".github/actions/example/action.yml", compositeAction([{ uses: "actions/checkout@v5" }])),
+    ).toEqual([]);
+  });
+
+  test("the file gate actually runs it on a composite action", () => {
+    const yaml = "name: Example\nruns:\n  using: composite\n  steps:\n    - run: a | b\n      shell: sh\n";
+    const path = join(mkdtempSync(join(tmpdir(), "kesha-wf-")), "action.yml");
+    writeFileSync(path, yaml);
+    expect(checkFile(path, [], [], undefined).filter((e) => e.includes("#1089"))).toHaveLength(1);
+  });
 });
 
 describe("requireRestoreOnlyCachesHaveAWriter", () => {


### PR DESCRIPTION
Closes #1089

## Claim

`requirePipefailShell` now also walks a composite action's `runs.steps` (files under `.github/actions/**`, which have no `jobs:`), applying the same pipefail-shell check with no Windows skip. If this is wrong, `bun test tests/unit/check-workflows.test.ts -t requirePipefailShell` fails on the test `"fails on an explicit shell: sh inside a composite action's runs.steps"`, which asserts `requirePipefailShell` reports an error for a composite step with `shell: sh` — the same trap the job-level gate already rejects.
