### PR TITLE
build-engine: `find … | head -1` is a SIGPIPE landmine under the pipefail it already runs with

### DIFF
--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -18,6 +18,7 @@ import { engineTargetEntries, targetKey } from "../../src/engine-targets";
 
 const dirs = [".github/workflows", ".github/actions"];
 const RUST_TOOLCHAIN_FILE = "rust-toolchain.toml";
+const FLAKE_NIX = "flake.nix";
 
 export type RustToolchainPin = {
   channel: string;
@@ -592,6 +593,21 @@ export function requireTestedScriptsInCodeFilter(
     .map((file) => `${path}: ${file} has a unit test but no matching path in the \`code\` filter, so edits to it skip that test`);
 }
 
+/** Fails when ci.yml stops routing flake.nix changes to workflow-lint, the only lane that runs checkFlakeNix (#1088). */
+export function requireFlakeNixInWorkflowsFilter(path: string, document: unknown): string[] {
+  if (!path.endsWith("ci.yml")) return [];
+
+  const raw = jobSteps(document, "changes")?.find((step) => typeof step?.with?.filters === "string")?.with?.filters;
+  if (typeof raw !== "string") return [`${path}: expected a \`changes\` job with inline paths-filter filters`];
+
+  const workflows = (parse(raw) as Record<string, string[]>)?.workflows;
+  if (!Array.isArray(workflows)) return [`${path}: paths-filter is missing a \`workflows\` list`];
+
+  return workflows.includes(FLAKE_NIX)
+    ? []
+    : [`${path}: \`workflows\` filter must include \`${FLAKE_NIX}\`, or checkFlakeNix's guard never runs in CI (#1088)`];
+}
+
 function collectTestedScripts(): string[] {
   const tests = readdirSync("tests/unit", { recursive: true })
     .filter((entry): entry is string => typeof entry === "string" && entry.endsWith(".test.ts"))
@@ -849,6 +865,7 @@ export function checkFile(
       ...requireDepsBeforeBunTest(path, document),
       ...requireRestoreOnlyCachesHaveAWriter(path, document, cacheWriters),
       ...requireTestedScriptsInCodeFilter(path, document, testedScripts),
+      ...requireFlakeNixInWorkflowsFilter(path, document),
       ...(rustToolchain ? requirePinnedRustToolchain(path, document, rustToolchain) : []),
     ];
   } catch (err) {
@@ -857,7 +874,6 @@ export function checkFile(
 }
 
 const SEED_WORKFLOW = ".github/workflows/cache-seed.yml";
-const FLAKE_NIX = "flake.nix";
 
 /**
  * flake.nix stages the same `say-avspeech` sidecar as build-engine.yml's steps, under the same

--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -857,6 +857,17 @@ export function checkFile(
 }
 
 const SEED_WORKFLOW = ".github/workflows/cache-seed.yml";
+const FLAKE_NIX = "flake.nix";
+
+/**
+ * flake.nix stages the same `say-avspeech` sidecar as build-engine.yml's steps, under the same
+ * `find | head` SIGPIPE race (#1088) — but it isn't YAML, so it can't go through `checkFile`'s
+ * `parse(contents)`. `forbidFindPipedToHead` is plain-text already; run it here directly instead.
+ */
+export function checkFlakeNix(path: string): string[] {
+  if (!existsSync(path)) return [];
+  return forbidFindPipedToHead(path, readFileSync(path, "utf8"));
+}
 
 function main(): void {
   const files = dirs.flatMap((dir) => collectYamlFiles(dir)).sort();
@@ -874,6 +885,7 @@ function main(): void {
   const errors = [
     ...rustToolchainErrors,
     ...files.flatMap((path) => checkFile(path, testedScripts, cacheWriters, rustToolchain)),
+    ...checkFlakeNix(FLAKE_NIX),
   ];
   for (const error of errors) console.error(error);
 

--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -395,6 +395,28 @@ export function requirePipefailShell(path: string, document: unknown): string[] 
 }
 
 /**
+ * Fails when a `run:` step pipes `find` into `head`. Both of these steps carry `shell: bash`,
+ * which GitHub runs as `bash --noprofile --norc -eo pipefail {0}` — under pipefail, if `find` is
+ * still writing when `head` has read enough lines and exits, `find` takes SIGPIPE and exits 141,
+ * and `-e` fails the step on a traversal that actually succeeded. Whether it fires depends on how
+ * many matches the tree produces and when, so it is a race that has simply not lost yet, not a
+ * safe pattern (#1088). `find ... -print -quit` returns the same first match with no second
+ * process and nothing to signal.
+ */
+export function forbidFindPipedToHead(path: string, contents: string): string[] {
+  const errors: string[] = [];
+  contents.split("\n").forEach((line, at) => {
+    if (/^\s*#/.test(line)) return;
+    if (!/\bfind\b/.test(line) || !/\|\s*head\b/.test(line)) return;
+    errors.push(
+      `${path}:${at + 1}: pipes \`find\` into \`head\` — under pipefail that is a SIGPIPE race (\`find\` can exit ` +
+        `141 while still traversing), not a guaranteed success; use \`find ... -print -quit\` instead (#1088)`,
+    );
+  });
+  return errors;
+}
+
+/**
  * Fails when a restore-only model cache has no writer, or has one that disagrees about the entry.
  *
  * `cache-write: "false"` hands the whole responsibility for an entry to cache-seed.yml (#661). Nothing
@@ -813,6 +835,7 @@ export function checkFile(
       ...requirePreUploadSynthesisSmoke(path, document),
       ...requireDarwinSmokeCoversBothEngines(path, document),
       ...forbidLinuxPackaging(path, contents),
+      ...forbidFindPipedToHead(path, contents),
       ...requireNpmPublishAfterPackaging(path, document),
       ...requirePactVerificationCoversEveryTarget(path, document),
       ...requireBashOnWindowsRunSteps(path, document),

--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -406,14 +406,29 @@ export function requirePipefailShell(path: string, document: unknown): string[] 
  */
 export function forbidFindPipedToHead(path: string, contents: string): string[] {
   const errors: string[] = [];
-  contents.split("\n").forEach((line, at) => {
-    if (/^\s*#/.test(line)) return;
-    if (!/\bfind\b/.test(line) || !/\|\s*head\b/.test(line)) return;
+  let logical = "";
+  let startAt = 0;
+
+  const check = () => {
+    if (/^\s*#/.test(logical)) return;
+    if (!/\bfind\b/.test(logical) || !/\|\s*head\b/.test(logical)) return;
     errors.push(
-      `${path}:${at + 1}: pipes \`find\` into \`head\` — under pipefail that is a SIGPIPE race (\`find\` can exit ` +
+      `${path}:${startAt + 1}: pipes \`find\` into \`head\` — under pipefail that is a SIGPIPE race (\`find\` can exit ` +
         `141 while still traversing), not a guaranteed success; use \`find ... -print -quit\` instead (#1088)`,
     );
+  };
+
+  // A trailing `\` continues a shell command onto the next physical line; join before matching, or the two halves of a wrapped find|head never meet.
+  contents.split("\n").forEach((line, at) => {
+    if (logical === "") startAt = at;
+    const continued = /\\\s*$/.test(line);
+    logical += continued ? `${line.replace(/\\\s*$/, "")} ` : line;
+    if (continued) return;
+    check();
+    logical = "";
   });
+  if (logical !== "") check();
+
   return errors;
 }
 

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -213,7 +213,7 @@ jobs:
         if: matrix.os == 'macos-14'
         shell: bash
         run: |
-          sidecar=$(find "rust/target/${{ matrix.target }}/release/build" -name say-avspeech -type f | head -1)
+          sidecar=$(find "rust/target/${{ matrix.target }}/release/build" -name say-avspeech -type f -print -quit)
           if [ -z "$sidecar" ]; then
             echo "say-avspeech sidecar not found — system_tts feature may not have compiled" >&2
             exit 1
@@ -235,7 +235,7 @@ jobs:
         if: matrix.os == 'macos-14'
         shell: bash
         run: |
-          sidecar=$(find "rust/target/${{ matrix.target }}/release/build" -name kesha-textlang -type f | head -1)
+          sidecar=$(find "rust/target/${{ matrix.target }}/release/build" -name kesha-textlang -type f -print -quit)
           if [ -z "$sidecar" ]; then
             echo "kesha-textlang sidecar not found — build.rs::build_text_lang_helper may have failed" >&2
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,8 @@ jobs:
               - 'bun.lock'
               # The file check:engine-targets guards; without it a size edit never runs the check.
               - 'src/engine-targets.ts'
+              # checkFlakeNix (#1088) scans this file; without it here workflow-lint never runs on a flake.nix-only change.
+              - 'flake.nix'
             # check:recipes reads the justfile on one side and the prose on the other, so either
             # side moving has to re-run it — renaming a recipe and citing a recipe are the same bug.
             recipes:

--- a/docs/mutation-evidence/issue-1088.md
+++ b/docs/mutation-evidence/issue-1088.md
@@ -1,0 +1,46 @@
+# Mutation evidence — #1088 (`find | head` SIGPIPE race under pipefail)
+
+Three guards in `.github/scripts/check-workflows.ts`, all pinned by `just mutate <file> <find>
+<replace> <test…>`, which restores the mutated file in a `finally` and exits 0 only when the
+mutation was **caught**. `git status --short` was clean after every row below.
+
+| Guard | Asserts | Where it runs |
+|---|---|---|
+| `forbidFindPipedToHead` | No `run:` line in a workflow/action YAML pipes `find` into `head`, skipping genuine comment lines | `checkFile`, every `.github/workflows/**` and `.github/actions/**` file |
+| `checkFlakeNix` | Same pattern, in `flake.nix`'s `postInstall` — plain text, not YAML, so it runs outside `checkFile` | `main()`, directly against `flake.nix` |
+| `requireFlakeNixInWorkflowsFilter` | `ci.yml`'s `workflows` path filter still lists `flake.nix`, or `checkFlakeNix` never runs in CI | `checkFile`, `ci.yml` only |
+
+Three guards because review round 2 found the first two were each real but incompletely wired:
+`checkFlakeNix` existed and was correct, but nothing pinned its registration in `main()`: deleting
+`...checkFlakeNix(FLAKE_NIX)` or renaming the `FLAKE_NIX` constant both left every test in this
+file green, because none of the five direct `checkFlakeNix` tests drives the script through its
+own entry point. Separately, `checkFlakeNix` firing at all in CI depends on `ci.yml`'s `workflows`
+path filter naming `flake.nix` — with a `find|head` reintroduced, a PR touching only `flake.nix`
+ran neither `unit-tests` nor `workflow-lint`, so the guard the ticket's own PR added never fired
+on the class of change it exists to police.
+
+## Mutation proof
+
+| # | File | Mutation | Test | Result |
+|---|---|---|---|---|
+| 1 | `.github/scripts/check-workflows.ts` | `forbidFindPipedToHead`'s `if (/^\s*#/.test(line)) return;` → `if (false) return;` — the comment-skip branch deleted | `bun test tests/unit/check-workflows.test.ts` | **PINNED** — 175 pass, 1 fail (`a commented-out find\|head line is not flagged`) |
+| 2 | `.github/scripts/check-workflows.ts` | Same branch → `if (/#/.test(line)) return;` — neutralised to match a trailing comment anywhere on the line, not just a comment-only line | `bun test tests/unit/check-workflows.test.ts` | **PINNED** — 175 pass, 1 fail (`a trailing comment after a real find\|head command does not hide it`) |
+| 3 | `.github/scripts/check-workflows.ts` | `main()`'s `...checkFlakeNix(FLAKE_NIX),` spread → deleted | `bun test tests/unit/check-workflows.test.ts` | **PINNED** — 175 pass, 1 fail (`check:workflows fails end-to-end when flake.nix reintroduces find\|head`) |
+| 4 | `.github/scripts/check-workflows.ts` | `const FLAKE_NIX = "flake.nix";` → `"flake.nix.disabled"` — `checkFlakeNix`'s `existsSync` guard then fails open | `bun test tests/unit/check-workflows.test.ts` | **PINNED** — 172 pass, 4 fail (the end-to-end test plus three `requireFlakeNixInWorkflowsFilter` tests, which also reference the constant) |
+| 5 | `.github/scripts/check-workflows.ts` | `checkFile`'s `...requireFlakeNixInWorkflowsFilter(path, document),` → deleted | `bun test tests/unit/check-workflows.test.ts` | **PINNED** — 175 pass, 1 fail (`the file gate actually runs it`) |
+| 6 | `.github/scripts/check-workflows.ts` | `requireFlakeNixInWorkflowsFilter`'s `workflows.includes(FLAKE_NIX)` → `true` — the membership check itself neutralised | `bun test tests/unit/check-workflows.test.ts` | **PINNED** — 174 pass, 2 fail |
+| 7 | `flake.nix` | `-print -quit` reverted to `\| head -1` | `bun run check:workflows` | **PINNED** — exit 1, `flake.nix:175: pipes find into head … (#1088)` |
+| 8 | `.github/workflows/ci.yml` | `'flake.nix'` entry removed from the `workflows` path filter | `bun run check:workflows` | **PINNED** — exit 1, `` ci.yml: `workflows` filter must include `flake.nix` … (#1088) `` |
+
+Rows 3–5 are the load-bearing ones for review round 2: each mirrors row 2 of `issue-1105.md`'s
+table — a guard whose *definition* is correct and directly tested, but whose *registration* in
+`main()` or `checkFile` had no test driving it. Rows 3 and 5 both use an
+`the file gate actually runs it`-style probe — row 3 spawns the script as a subprocess
+(`Bun.spawn(["bun", ...])` against a temp fixture directory, since `checkFlakeNix`'s registration
+lives in `main()` rather than `checkFile`) rather than calling the guard directly, and fail
+precisely when the registration line is gone or the constant no longer matches a real path.
+
+Rows 7 and 8 reproduce the actual defect class end to end, independent of the unit-test suite:
+row 7 is the SIGPIPE race #1088 opened on, still live in `flake.nix` until this PR; row 8 is
+review round 2's second finding, that the guard existed but never ran on the change it was meant
+to catch.

--- a/docs/mutation-evidence/issue-1088.md
+++ b/docs/mutation-evidence/issue-1088.md
@@ -19,6 +19,12 @@ path filter naming `flake.nix` — with a `find|head` reintroduced, a PR touchin
 ran neither `unit-tests` nor `workflow-lint`, so the guard the ticket's own PR added never fired
 on the class of change it exists to police.
 
+Greptile's PR review then found a fourth gap in `forbidFindPipedToHead` itself: it matched each
+physical line independently, so a shell command wrapped across two lines with a trailing `\` —
+`find ... \` on one line, `| head -1)` on the next — matched neither line's regex and passed clean.
+Fixed by joining backslash-continued physical lines into one logical line before matching, keeping
+the first physical line's number for the error.
+
 ## Mutation proof
 
 | # | File | Mutation | Test | Result |
@@ -31,6 +37,7 @@ on the class of change it exists to police.
 | 6 | `.github/scripts/check-workflows.ts` | `requireFlakeNixInWorkflowsFilter`'s `workflows.includes(FLAKE_NIX)` → `true` — the membership check itself neutralised | `bun test tests/unit/check-workflows.test.ts` | **PINNED** — 174 pass, 2 fail |
 | 7 | `flake.nix` | `-print -quit` reverted to `\| head -1` | `bun run check:workflows` | **PINNED** — exit 1, `flake.nix:175: pipes find into head … (#1088)` |
 | 8 | `.github/workflows/ci.yml` | `'flake.nix'` entry removed from the `workflows` path filter | `bun run check:workflows` | **PINNED** — exit 1, `` ci.yml: `workflows` filter must include `flake.nix` … (#1088) `` |
+| 9 | `.github/scripts/check-workflows.ts` | `forbidFindPipedToHead`'s `const continued = /\\\s*$/.test(line);` → `const continued = false;` — line-joining disabled, restoring the per-line-only match | `bun test tests/unit/check-workflows.test.ts` | **PINNED** — 177 pass, 1 fail (`catches a backslash-continued pipeline split across two lines`) |
 
 Rows 3–5 are the load-bearing ones for review round 2: each mirrors row 2 of `issue-1105.md`'s
 table — a guard whose *definition* is correct and directly tested, but whose *registration* in
@@ -43,4 +50,5 @@ precisely when the registration line is gone or the constant no longer matches a
 Rows 7 and 8 reproduce the actual defect class end to end, independent of the unit-test suite:
 row 7 is the SIGPIPE race #1088 opened on, still live in `flake.nix` until this PR; row 8 is
 review round 2's second finding, that the guard existed but never ran on the change it was meant
-to catch.
+to catch. Row 9 is Greptile's finding on round 2: the matcher itself was structure-insensitive to
+line wrapping, not just unwired.

--- a/flake.nix
+++ b/flake.nix
@@ -172,7 +172,7 @@
           postInstall = ''
             echo "${cliPkg.keshaEngine.version}" > $out/bin/kesha-engine.version
           '' + lib.optionalString (isDarwin && isAarch64) ''
-            sidecar=$(find . -path '*/build/*/out/say-avspeech' -type f 2>/dev/null | head -1)
+            sidecar=$(find . -path '*/build/*/out/say-avspeech' -type f -print -quit 2>/dev/null)
             if [ -z "$sidecar" ]; then
               echo "error: say-avspeech sidecar not found — system_tts may not have compiled" >&2
               exit 1

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -6,6 +6,7 @@ import { parse } from "yaml";
 import {
   checkFile,
   collectCacheWriters,
+  forbidFindPipedToHead,
   forbidLinuxPackaging,
   forbidNixBuildInCiAggregator,
   requireJobTimeouts,
@@ -174,6 +175,55 @@ describe("forbidLinuxPackaging", () => {
   test("prose about the policy is not packaging", () => {
     const comment = "      # packages (.deb/.rpm) moved off engine tags; see nfpm notes in #728";
     expect(forbidLinuxPackaging(PATH, comment)).toEqual([]);
+  });
+});
+
+describe("forbidFindPipedToHead", () => {
+  test("passes on every workflow in the repo", () => {
+    for (const file of readdirSync(repoPath(".github/workflows"))) {
+      const path = `.github/workflows/${file}`;
+      expect([path, forbidFindPipedToHead(path, readRepoFile(path))]).toEqual([path, []]);
+    }
+  });
+
+  test("ignores every other file", () => {
+    expect(forbidFindPipedToHead(CI, 'run: echo "no find here"')).toEqual([]);
+  });
+
+  test.each([
+    'sidecar=$(find "rust/target/x/release/build" -name say-avspeech -type f | head -1)',
+    "path=$(find . -name '*.so' | head -n1)",
+    "path=$(find . -name '*.so' | head -n 1)",
+  ])("catches %s", (line) => {
+    const errors = forbidFindPipedToHead(PATH, `          ${line}`);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("SIGPIPE");
+    expect(errors[0]).toContain("#1088");
+  });
+
+  test("names the 1-indexed line number", () => {
+    const contents = "line one\nline two\nsidecar=$(find . -name x | head -1)\n";
+    const errors = forbidFindPipedToHead(PATH, contents);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain(`${PATH}:3:`);
+  });
+
+  test("accepts the -print -quit replacement", () => {
+    const line = '          sidecar=$(find "rust/target/x/release/build" -name say-avspeech -type f -print -quit)';
+    expect(forbidFindPipedToHead(PATH, line)).toEqual([]);
+  });
+
+  test("prose about the pattern in a comment is not a pipeline", () => {
+    const comment = "      # avoid piping find into head, see #1088";
+    expect(forbidFindPipedToHead(PATH, comment)).toEqual([]);
+  });
+
+  // A dropped check wouldn't show up against the clean repo tree, only against a probe (see above).
+  test("the file gate actually runs it", () => {
+    const yaml = "on: push\njobs:\n  smoke:\n    runs-on: macos-14\n    steps:\n      - run: find . -name x | head -1\n";
+    const path = join(mkdtempSync(join(tmpdir(), "kesha-wf-")), "probe.yml");
+    writeFileSync(path, yaml);
+    expect(checkFile(path, [], [], undefined).filter((e) => e.includes("#1088"))).toHaveLength(1);
   });
 });
 

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, test } from "bun:test";
 import { parse } from "yaml";
 import {
   checkFile,
+  checkFlakeNix,
   collectCacheWriters,
   forbidFindPipedToHead,
   forbidLinuxPackaging,
@@ -218,12 +219,46 @@ describe("forbidFindPipedToHead", () => {
     expect(forbidFindPipedToHead(PATH, comment)).toEqual([]);
   });
 
+  test("a commented-out find|head line is not flagged", () => {
+    const line = "      # sidecar=$(find . -name x | head -1)";
+    expect(forbidFindPipedToHead(PATH, line)).toEqual([]);
+  });
+
+  test("a trailing comment after a real find|head command does not hide it", () => {
+    const line = "      sidecar=$(find . -name x | head -1)  # stage it";
+    expect(forbidFindPipedToHead(PATH, line)).toHaveLength(1);
+  });
+
   // A dropped check wouldn't show up against the clean repo tree, only against a probe (see above).
   test("the file gate actually runs it", () => {
     const yaml = "on: push\njobs:\n  smoke:\n    runs-on: macos-14\n    steps:\n      - run: find . -name x | head -1\n";
     const path = join(mkdtempSync(join(tmpdir(), "kesha-wf-")), "probe.yml");
     writeFileSync(path, yaml);
     expect(checkFile(path, [], [], undefined).filter((e) => e.includes("#1088"))).toHaveLength(1);
+  });
+});
+
+describe("checkFlakeNix", () => {
+  const dir = () => mkdtempSync(join(tmpdir(), "kesha-flake-"));
+
+  test("catches find piped to head", () => {
+    const path = join(dir(), "flake.nix");
+    writeFileSync(path, "sidecar=$(find . -path '*/out/say-avspeech' -type f | head -1)\n");
+    expect(checkFlakeNix(path)).toHaveLength(1);
+  });
+
+  test("accepts the -print -quit replacement", () => {
+    const path = join(dir(), "flake.nix");
+    writeFileSync(path, "sidecar=$(find . -path '*/out/say-avspeech' -type f -print -quit)\n");
+    expect(checkFlakeNix(path)).toEqual([]);
+  });
+
+  test("a missing file is not an error", () => {
+    expect(checkFlakeNix(join(dir(), "does-not-exist.nix"))).toEqual([]);
+  });
+
+  test("the repo's own flake.nix is clean", () => {
+    expect(checkFlakeNix(repoPath("flake.nix"))).toEqual([]);
   });
 });
 

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -210,6 +210,18 @@ describe("forbidFindPipedToHead", () => {
     expect(errors[0]).toContain(`${PATH}:3:`);
   });
 
+  test("catches a backslash-continued pipeline split across two lines", () => {
+    const contents = "sidecar=$(find . -name x \\\n  | head -1)\n";
+    const errors = forbidFindPipedToHead(PATH, contents);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain(`${PATH}:1:`);
+  });
+
+  test("a continuation that never resolves to find|head is not flagged", () => {
+    const contents = "sidecar=$(find . -name x \\\n  -type f)\n";
+    expect(forbidFindPipedToHead(PATH, contents)).toEqual([]);
+  });
+
   test("accepts the -print -quit replacement", () => {
     const line = '          sidecar=$(find "rust/target/x/release/build" -name say-avspeech -type f -print -quit)';
     expect(forbidFindPipedToHead(PATH, line)).toEqual([]);

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
@@ -20,6 +20,7 @@ import {
   requireRestoreOnlyCachesHaveAWriter,
   requireDarwinSmokeCoversBothEngines,
   requireDepsBeforeBunTest,
+  requireFlakeNixInWorkflowsFilter,
   requireNpmPublishAfterPackaging,
   requirePactVerificationCoversEveryTarget,
   requirePinnedRustToolchain,
@@ -27,7 +28,7 @@ import {
   readRustToolchainPin,
   requireTestedScriptsInCodeFilter,
 } from "../../.github/scripts/check-workflows";
-import { parseRepoYaml, readRepoFile, repoPath } from "../helpers/repo";
+import { parseRepoYaml, readRepoFile, repoPath, REPO_ROOT } from "../helpers/repo";
 
 const PATH = ".github/workflows/build-engine.yml";
 const CI = ".github/workflows/ci.yml";
@@ -260,6 +261,34 @@ describe("checkFlakeNix", () => {
   test("the repo's own flake.nix is clean", () => {
     expect(checkFlakeNix(repoPath("flake.nix"))).toEqual([]);
   });
+
+  // Drives the real entry point, unlike every other test here — pins main()'s wiring, not just checkFlakeNix itself.
+  test("check:workflows fails end-to-end when flake.nix reintroduces find|head", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-main-"));
+    try {
+      mkdirSync(join(dir, ".github/workflows"), { recursive: true });
+      mkdirSync(join(dir, ".github/actions"), { recursive: true });
+      mkdirSync(join(dir, "tests/unit"), { recursive: true });
+      writeFileSync(
+        join(dir, ".github/workflows/probe.yml"),
+        "on: push\njobs:\n  probe:\n    runs-on: ubuntu-latest\n    timeout-minutes: 5\n    steps: []\n",
+      );
+      writeFileSync(join(dir, "flake.nix"), "sidecar=$(find . -name x | head -1)\n");
+
+      const proc = Bun.spawn(["bun", join(REPO_ROOT, ".github/scripts/check-workflows.ts")], {
+        cwd: dir,
+        stdout: "ignore",
+        stderr: "pipe",
+      });
+      const stderr = await new Response(proc.stderr).text();
+
+      expect(await proc.exited).toBe(1);
+      expect(stderr).toContain("flake.nix:1:");
+      expect(stderr).toContain("#1088");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("requireNpmPublishAfterPackaging", () => {
@@ -347,6 +376,45 @@ describe("requireTestedScriptsInCodeFilter", () => {
 
   test("fails when the changes job has no inline filters", () => {
     expect(requireTestedScriptsInCodeFilter(CI, { jobs: { changes: {} } }, [])[0]).toContain("expected a `changes` job");
+  });
+});
+
+const workflowsFilter = (paths: string[]) =>
+  job("changes", [{ with: { filters: `workflows:\n${paths.map((p) => `  - '${p}'`).join("\n")}\n` } }]);
+
+describe("requireFlakeNixInWorkflowsFilter", () => {
+  test("passes on the real ci.yml", () => {
+    expect(requireFlakeNixInWorkflowsFilter(CI, parseRepoYaml(CI))).toEqual([]);
+  });
+
+  test("ignores every other workflow", () => {
+    expect(requireFlakeNixInWorkflowsFilter(PATH, workflowsFilter([]))).toEqual([]);
+  });
+
+  test("fails when flake.nix is missing from the workflows filter", () => {
+    const errors = requireFlakeNixInWorkflowsFilter(CI, workflowsFilter([".github/workflows/**"]));
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("must include `flake.nix`");
+  });
+
+  test("accepts flake.nix in the workflows filter", () => {
+    expect(requireFlakeNixInWorkflowsFilter(CI, workflowsFilter(["flake.nix"]))).toEqual([]);
+  });
+
+  test("fails when the workflows list is gone", () => {
+    const document = job("changes", [{ with: { filters: "code:\n  - 'src/**'\n" } }]);
+    expect(requireFlakeNixInWorkflowsFilter(CI, document)[0]).toContain("missing a `workflows` list");
+  });
+
+  test("fails when the changes job has no inline filters", () => {
+    expect(requireFlakeNixInWorkflowsFilter(CI, { jobs: { changes: {} } })[0]).toContain("expected a `changes` job");
+  });
+
+  test("the file gate actually runs it", () => {
+    const yaml = "jobs:\n  changes:\n    steps:\n      - with:\n          filters: |\n            workflows:\n              - '.github/workflows/**'\n";
+    const path = join(mkdtempSync(join(tmpdir(), "kesha-wf-")), "ci.yml");
+    writeFileSync(path, yaml);
+    expect(checkFile(path, [], [], undefined).filter((e) => e.includes("#1088"))).toHaveLength(1);
   });
 });
 


### PR DESCRIPTION
Closes #1088

## Claim

Both `build-engine.yml` sidecar-staging steps (`say-avspeech`, `kesha-textlang`) now resolve the sidecar path with `find ... -print -quit` instead of `find ... | head -1`; if this is wrong, `tests/unit/check-workflows.test.ts`'s `forbidFindPipedToHead > passes on every workflow in the repo` fails by finding a `find | head` pipeline still present in `.github/workflows/build-engine.yml`.
