### PR TITLE
Test releaseIsPublished's HTTP contract, not just the boolean it yields

### DIFF
--- a/.github/scripts/post-engine-release.ts
+++ b/.github/scripts/post-engine-release.ts
@@ -223,8 +223,12 @@ async function fetchJson(url: string, token: string): Promise<unknown> {
   return response.json();
 }
 
-async function releaseIsPublished(token: string, tag: string): Promise<boolean> {
-  const response = await fetch(`https://api.github.com/repos/${REPO}/releases/tags/${encodeURIComponent(tag)}`, {
+export async function releaseIsPublished(
+  token: string,
+  tag: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<boolean> {
+  const response = await fetchImpl(`https://api.github.com/repos/${REPO}/releases/tags/${encodeURIComponent(tag)}`, {
     headers: { accept: "application/vnd.github+json", authorization: `Bearer ${token}` },
   });
   if (response.status === 404) return false;

--- a/tests/unit/post-engine-release.test.ts
+++ b/tests/unit/post-engine-release.test.ts
@@ -178,9 +178,29 @@ describe("releaseIsPublished", () => {
     expect(await releaseIsPublished("token", "v1.29.0-cli", fetchImpl)).toBe(true);
   });
 
+  test("a prerelease is not published even with a published_at timestamp", async () => {
+    const body = JSON.stringify({ draft: false, prerelease: true, published_at: "2026-01-01T00:00:00Z" });
+    const fetchImpl = fakeFetch(new Response(body, { status: 200 }));
+    expect(await releaseIsPublished("token", "v1.29.0-cli", fetchImpl)).toBe(false);
+  });
+
   test("a non-404 error status throws instead of silently reading as not published", async () => {
     const fetchImpl = fakeFetch(new Response(null, { status: 500 }));
-    expect(releaseIsPublished("token", "v1.29.0-cli", fetchImpl)).rejects.toThrow(/GitHub API request failed \(500\)/);
+    await expect(releaseIsPublished("token", "v1.29.0-cli", fetchImpl)).rejects.toThrow(/GitHub API request failed \(500\)/);
+  });
+
+  test("a non-boolean draft field is refused instead of read as not-a-draft", async () => {
+    const body = JSON.stringify({ draft: "true", prerelease: false, published_at: "2026-01-01T00:00:00Z" });
+    const fetchImpl = fakeFetch(new Response(body, { status: 200 }));
+    await expect(releaseIsPublished("token", "v1.29.0-cli", fetchImpl)).rejects.toThrow(/CLI marker release draft must be a boolean/);
+  });
+
+  test("a non-boolean prerelease field is refused instead of read as not-a-prerelease", async () => {
+    const body = JSON.stringify({ draft: false, prerelease: "false", published_at: "2026-01-01T00:00:00Z" });
+    const fetchImpl = fakeFetch(new Response(body, { status: 200 }));
+    await expect(releaseIsPublished("token", "v1.29.0-cli", fetchImpl)).rejects.toThrow(
+      /CLI marker release prerelease must be a boolean/,
+    );
   });
 });
 

--- a/tests/unit/post-engine-release.test.ts
+++ b/tests/unit/post-engine-release.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { buildPostEngineReleaseFollowup } from "../../.github/scripts/post-engine-release";
+import { buildPostEngineReleaseFollowup, releaseIsPublished } from "../../.github/scripts/post-engine-release";
 import { decideFollowup, ownsTag, refuseConcurrentFollowup } from "../../.github/scripts/post-release-guard";
 import { parseRepoYaml } from "../helpers/repo";
 
@@ -144,6 +144,43 @@ describe("buildPostEngineReleaseFollowup", () => {
         serverSource,
       }),
     ).toThrow(/CLI marker release.*not published/i);
+  });
+});
+
+describe("releaseIsPublished", () => {
+  function fakeFetch(response: Response): typeof fetch {
+    return (async (input: RequestInfo | URL) => {
+      expect(String(input)).toBe("https://api.github.com/repos/drakulavich/kesha-voice-kit/releases/tags/v1.29.0-cli");
+      return response;
+    }) as typeof fetch;
+  }
+
+  test("a 404 for the tag means not published", async () => {
+    const fetchImpl = fakeFetch(new Response(null, { status: 404 }));
+    expect(await releaseIsPublished("token", "v1.29.0-cli", fetchImpl)).toBe(false);
+  });
+
+  test("a draft release is not published even with a published_at timestamp", async () => {
+    const body = JSON.stringify({ draft: true, prerelease: false, published_at: "2026-01-01T00:00:00Z" });
+    const fetchImpl = fakeFetch(new Response(body, { status: 200 }));
+    expect(await releaseIsPublished("token", "v1.29.0-cli", fetchImpl)).toBe(false);
+  });
+
+  test("a null published_at means not published", async () => {
+    const body = JSON.stringify({ draft: false, prerelease: false, published_at: null });
+    const fetchImpl = fakeFetch(new Response(body, { status: 200 }));
+    expect(await releaseIsPublished("token", "v1.29.0-cli", fetchImpl)).toBe(false);
+  });
+
+  test("a non-draft, non-prerelease release with a published_at timestamp is published", async () => {
+    const body = JSON.stringify({ draft: false, prerelease: false, published_at: "2026-01-01T00:00:00Z" });
+    const fetchImpl = fakeFetch(new Response(body, { status: 200 }));
+    expect(await releaseIsPublished("token", "v1.29.0-cli", fetchImpl)).toBe(true);
+  });
+
+  test("a non-404 error status throws instead of silently reading as not published", async () => {
+    const fetchImpl = fakeFetch(new Response(null, { status: 500 }));
+    expect(releaseIsPublished("token", "v1.29.0-cli", fetchImpl)).rejects.toThrow(/GitHub API request failed \(500\)/);
   });
 });
 


### PR DESCRIPTION
Closes #1069

## Claim

`releaseIsPublished`'s eight tests each pin a distinct HTTP-contract branch — 404, draft, prerelease, null published_at, published:true, HTTP 500 (awaited), and malformed non-boolean draft/prerelease fields; deleting any one of the draft/prerelease/booleanAt-validation checks in `.github/scripts/post-engine-release.ts` turns exactly the matching test red (verified for all three review-flagged mutations via `just mutate`, each reporting "PINNED: the mutation was caught").
