### PR TITLE
refactor(engine): TranscribeBackend takes &str where it means &Path

### DIFF
--- a/rust/src/audio.rs
+++ b/rust/src/audio.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use anyhow::{Context, Result};
 use audioadapter_buffers::direct::SequentialSliceOfVecs;
 use rubato::{
@@ -34,12 +36,9 @@ fn get_codec_registry() -> CodecRegistry {
 ///
 /// Returns an empty [`Hint`] when the path has no extension or the
 /// extension is non-UTF-8.
-fn build_hint(path: &str) -> Hint {
+fn build_hint(path: &Path) -> Hint {
     let mut hint = Hint::new();
-    if let Some(ext) = std::path::Path::new(path)
-        .extension()
-        .and_then(|e| e.to_str())
-    {
+    if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
         hint.with_extension(&ext.to_ascii_lowercase());
     }
     hint
@@ -48,7 +47,7 @@ fn build_hint(path: &str) -> Hint {
 /// Open `path`, probe format + select the first supported audio track.
 /// Shared by the decode loop and the duration probes so container
 /// detection + error messages live in one place.
-fn open_format(path: &str) -> Result<(Box<dyn FormatReader>, u32, CodecParameters)> {
+fn open_format(path: &Path) -> Result<(Box<dyn FormatReader>, u32, CodecParameters)> {
     let src = std::fs::File::open(path).map_err(|e| {
         let code = if e.kind() == std::io::ErrorKind::NotFound {
             ErrorCode::InputNotFound
@@ -56,9 +55,9 @@ fn open_format(path: &str) -> Result<(Box<dyn FormatReader>, u32, CodecParameter
             ErrorCode::BadAudio
         };
         let message = if code == ErrorCode::InputNotFound {
-            format!("file not found: {path}")
+            format!("file not found: {}", path.display())
         } else {
-            format!("could not open audio file: {path}: {e}")
+            format!("could not open audio file: {}: {e}", path.display())
         };
         anyhow::Error::new(crate::errors::CodedError { code, message })
     })?;
@@ -76,7 +75,7 @@ fn open_format(path: &str) -> Result<(Box<dyn FormatReader>, u32, CodecParameter
             &FormatOptions::default(),
             &MetadataOptions::default(),
         )
-        .with_context(|| format!("unsupported audio format: {path}"))
+        .with_context(|| format!("unsupported audio format: {}", path.display()))
         .coded(ErrorCode::BadAudio)?;
 
     let track = probed
@@ -84,7 +83,7 @@ fn open_format(path: &str) -> Result<(Box<dyn FormatReader>, u32, CodecParameter
         .tracks()
         .iter()
         .find(|t| t.codec_params.codec != CODEC_TYPE_NULL)
-        .with_context(|| format!("no supported audio tracks in: {path}"))
+        .with_context(|| format!("no supported audio tracks in: {}", path.display()))
         .coded(ErrorCode::BadAudio)?;
 
     let track_id = track.id;
@@ -96,12 +95,12 @@ fn open_format(path: &str) -> Result<(Box<dyn FormatReader>, u32, CodecParameter
 /// interleaved samples to `on_samples`. Returns the track's sample rate and
 /// channel count. Consumers that don't need the audio itself must not retain
 /// the slice, so they stay O(1) in memory.
-fn decode_packets<F: FnMut(&[f32])>(path: &str, mut on_samples: F) -> Result<(u32, usize)> {
+fn decode_packets<F: FnMut(&[f32])>(path: &Path, mut on_samples: F) -> Result<(u32, usize)> {
     let (mut format, track_id, codec_params) = open_format(path)?;
 
     let sample_rate = codec_params
         .sample_rate
-        .with_context(|| format!("unknown sample rate in: {path}"))
+        .with_context(|| format!("unknown sample rate in: {}", path.display()))
         .coded(ErrorCode::BadAudio)?;
     let channels = codec_params.channels.map(|c| c.count()).unwrap_or(1);
 
@@ -109,7 +108,7 @@ fn decode_packets<F: FnMut(&[f32])>(path: &str, mut on_samples: F) -> Result<(u3
     let codec_registry = get_codec_registry();
     let mut decoder = codec_registry
         .make(&codec_params, &dec_opts)
-        .with_context(|| format!("unsupported codec in: {path}"))
+        .with_context(|| format!("unsupported codec in: {}", path.display()))
         .coded(ErrorCode::BadAudio)?;
 
     let mut sample_buf: Option<SampleBuffer<f32>> = None;
@@ -120,7 +119,7 @@ fn decode_packets<F: FnMut(&[f32])>(path: &str, mut on_samples: F) -> Result<(u3
             Err(SymphoniaError::IoError(_)) | Err(SymphoniaError::ResetRequired) => break,
             Err(e) => {
                 return Err(e)
-                    .with_context(|| format!("decode error in: {path}"))
+                    .with_context(|| format!("decode error in: {}", path.display()))
                     .coded(ErrorCode::BadAudio)
             }
         };
@@ -138,7 +137,7 @@ fn decode_packets<F: FnMut(&[f32])>(path: &str, mut on_samples: F) -> Result<(u3
             Err(SymphoniaError::IoError(_)) | Err(SymphoniaError::DecodeError(_)) => continue,
             Err(e) => {
                 return Err(e)
-                    .with_context(|| format!("decode error in: {path}"))
+                    .with_context(|| format!("decode error in: {}", path.display()))
                     .coded(ErrorCode::BadAudio)
             }
         };
@@ -154,7 +153,7 @@ fn decode_packets<F: FnMut(&[f32])>(path: &str, mut on_samples: F) -> Result<(u3
     Ok((sample_rate, channels))
 }
 
-fn decode_audio(path: &str) -> Result<(Vec<f32>, u32, usize)> {
+fn decode_audio(path: &Path) -> Result<(Vec<f32>, u32, usize)> {
     let mut all_samples: Vec<f32> = Vec::new();
     let (sample_rate, channels) =
         decode_packets(path, |samples| all_samples.extend_from_slice(samples))?;
@@ -265,14 +264,16 @@ pub(crate) fn resample_mono(samples: &[f32], src_rate: u32, dst_rate: u32) -> Re
     Ok(output_mono)
 }
 
-pub fn load_audio(path: &str) -> Result<Vec<f32>> {
+/// Takes `&Path` rather than `&str`: the sole call site that needed to
+/// express an arbitrary OS path without a lossy round-trip (#958).
+pub fn load_audio(path: &Path) -> Result<Vec<f32>> {
     let (interleaved, sample_rate, channels) = decode_audio(path)?;
     let mono = mix_to_mono(&interleaved, channels);
     resample_mono(&mono, sample_rate, TARGET_SAMPLE_RATE)
 }
 
 pub fn load_audio_truncated(path: &str, max_seconds: f32) -> Result<Vec<f32>> {
-    let samples = load_audio(path)?;
+    let samples = load_audio(Path::new(path))?;
     let max_samples = (max_seconds * TARGET_SAMPLE_RATE as f32) as usize;
     Ok(samples.into_iter().take(max_samples).collect())
 }
@@ -283,7 +284,7 @@ pub fn load_audio_truncated(path: &str, max_seconds: f32) -> Result<Vec<f32>> {
 /// falling back to a decode-and-measure, which would defeat the purpose of a
 /// cheap probe.
 pub fn probe_duration_seconds(path: &str) -> Result<Option<f32>> {
-    let (_format, _track_id, codec_params) = open_format(path)?;
+    let (_format, _track_id, codec_params) = open_format(Path::new(path))?;
     match (codec_params.n_frames, codec_params.sample_rate) {
         (Some(n), Some(sr)) if sr > 0 => Ok(Some(n as f32 / sr as f32)),
         _ => Ok(None),
@@ -298,7 +299,8 @@ pub fn probe_duration_seconds(path: &str) -> Result<Option<f32>> {
 /// advisory routing decisions.
 pub fn measure_duration_seconds(path: &str) -> Result<f32> {
     let mut decoded_samples = 0usize;
-    let (sample_rate, channels) = decode_packets(path, |samples| decoded_samples += samples.len())?;
+    let (sample_rate, channels) =
+        decode_packets(Path::new(path), |samples| decoded_samples += samples.len())?;
     let frames = decoded_samples / channels.max(1);
     if frames == 0 || sample_rate == 0 {
         coded_bail!(
@@ -326,7 +328,7 @@ pub fn measure_duration_seconds(path: &str) -> Result<f32> {
 /// Transcription failed" is the worst offender, since it lands ~25 s into
 /// the ASR cold-load on a file we knew at the top was unusable).
 pub fn ensure_audio_track(path: &str) -> Result<()> {
-    open_format(path).map(|_| ())
+    open_format(Path::new(path)).map(|_| ())
 }
 
 #[cfg(test)]

--- a/rust/src/backend/fluidaudio.rs
+++ b/rust/src/backend/fluidaudio.rs
@@ -50,7 +50,7 @@ impl TranscribeBackend for FluidAudioBackend {
             Ok((result, words)) => Ok(chunk_from(result.text, words)),
             // FluidAudio refuses a file below ~0.25 s; the padding path serves it, and load_audio names a real fault better (#995).
             Err(_) => {
-                let samples = crate::audio::load_audio(&audio_path.to_string_lossy())?;
+                let samples = crate::audio::load_audio(audio_path)?;
                 super::ensure_transcribable(&samples)?;
                 self.transcribe_samples(&samples)
             }
@@ -484,7 +484,7 @@ mod tests {
             !bytes.starts_with(b"version https://git-lfs"),
             "fixture is an unmaterialized Git LFS pointer — run `git lfs pull` before this test"
         );
-        let samples = crate::audio::load_audio(wav).expect("decode sentence fixture");
+        let samples = crate::audio::load_audio(Path::new(wav)).expect("decode sentence fixture");
 
         // Declared first so it drops last — after the backend's CoreML teardown.
         let mut dump = FailureDump { first_call: None };
@@ -536,7 +536,7 @@ mod tests {
             !bytes.starts_with(b"version https://git-lfs"),
             "fixture is an unmaterialized Git LFS pointer — run `git lfs pull` before this test"
         );
-        let samples = crate::audio::load_audio(wav).expect("decode sentence fixture");
+        let samples = crate::audio::load_audio(Path::new(wav)).expect("decode sentence fixture");
 
         let mut be = FluidAudioBackend::new().expect("init FluidAudio CoreML backend");
         let chunk = be

--- a/rust/src/backend/fluidaudio.rs
+++ b/rust/src/backend/fluidaudio.rs
@@ -1,4 +1,5 @@
 use std::os::fd::OwnedFd;
+use std::path::Path;
 
 use anyhow::{Context, Result};
 use fluidaudio_rs::{AsrWordTiming, FluidAudio};
@@ -41,7 +42,7 @@ impl FluidAudioBackend {
 impl TranscribeBackend for FluidAudioBackend {
     /// stdout stays silenced: a file FluidAudio rejects prints there, and the fallback
     /// below can still return a transcript, whose `--json` that chatter would corrupt.
-    fn transcribe(&mut self, audio_path: &str) -> Result<TranscriptionChunk> {
+    fn transcribe(&mut self, audio_path: &Path) -> Result<TranscriptionChunk> {
         let attempt = with_silenced_stdout(self.sink.as_ref(), || {
             self.audio.transcribe_file_with_words(audio_path)
         });
@@ -49,7 +50,7 @@ impl TranscribeBackend for FluidAudioBackend {
             Ok((result, words)) => Ok(chunk_from(result.text, words)),
             // FluidAudio refuses a file below ~0.25 s; the padding path serves it, and load_audio names a real fault better (#995).
             Err(_) => {
-                let samples = crate::audio::load_audio(audio_path)?;
+                let samples = crate::audio::load_audio(&audio_path.to_string_lossy())?;
                 super::ensure_transcribable(&samples)?;
                 self.transcribe_samples(&samples)
             }
@@ -113,7 +114,6 @@ fn pad_to_min(samples: &[f32], min_len: usize) -> std::borrow::Cow<'_, [f32]> {
 mod tests {
     use super::*;
     use std::fmt::Write as _;
-    use std::path::Path;
 
     /// #841: the warm-cache flake fails ~20 s in with a bare "Transcription
     /// failed" on a cleanly restored bundle, and a same-SHA rerun goes green —
@@ -429,7 +429,10 @@ mod tests {
         if skip_without_ane("a_sub_second_file_transcribes_instead_of_erroring") {
             return;
         }
-        let short = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/tone-150ms.wav");
+        let short = Path::new(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/fixtures/tone-150ms.wav"
+        ));
         let mut be = FluidAudioBackend::new().expect("init FluidAudio CoreML backend");
         be.transcribe(short)
             .expect("a 0.15 s file must transcribe, not fail as invalid audio data");
@@ -442,7 +445,10 @@ mod tests {
         if skip_without_ane("an_undecodable_file_is_coded_bad_audio") {
             return;
         }
-        let alac = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/alac.m4a");
+        let alac = Path::new(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/fixtures/alac.m4a"
+        ));
         let mut be = FluidAudioBackend::new().expect("init FluidAudio CoreML backend");
         let err = be
             .transcribe(alac)

--- a/rust/src/backend/mod.rs
+++ b/rust/src/backend/mod.rs
@@ -103,7 +103,7 @@ mod tests {
         }
     }
 
-    // A real `&Path` argument, not a `&str` one, is what proves this boundary takes `&Path` (#958).
+    // Guards a revert to `&str`; a generic `AsRef<Path>` signature would also satisfy this, and that's fine (#958).
     #[test]
     fn transcribe_takes_a_path_argument() {
         let mut be = StubBackend;
@@ -111,10 +111,5 @@ mod tests {
             .transcribe(Path::new("/tmp/958.wav"))
             .expect("stub never fails");
         assert_eq!(chunk.text, "/tmp/958.wav");
-    }
-
-    #[test]
-    fn create_backend_takes_a_path_argument() {
-        let _ = create_backend(Path::new("/nonexistent-958-model-dir"));
     }
 }

--- a/rust/src/backend/mod.rs
+++ b/rust/src/backend/mod.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use anyhow::Result;
 
 use crate::transcribe::WordTiming;
@@ -43,13 +45,13 @@ pub fn ensure_transcribable(samples: &[f32]) -> Result<()> {
 }
 
 pub trait TranscribeBackend {
-    fn transcribe(&mut self, audio_path: &str) -> Result<TranscriptionChunk>;
+    fn transcribe(&mut self, audio_path: &Path) -> Result<TranscriptionChunk>;
     /// Transcribe a pre-decoded 16 kHz mono f32 waveform without re-reading
     /// from disk. Used by the VAD-segmented path to feed per-segment slices.
     fn transcribe_samples(&mut self, samples: &[f32]) -> Result<TranscriptionChunk>;
 }
 
-pub fn create_backend(model_dir: &str) -> Result<Box<dyn TranscribeBackend>> {
+pub fn create_backend(model_dir: &Path) -> Result<Box<dyn TranscribeBackend>> {
     #[cfg(feature = "coreml")]
     {
         let _ = model_dir;
@@ -87,5 +89,32 @@ mod tests {
     #[test]
     fn a_clip_at_the_floor_passes() {
         assert!(ensure_transcribable(&vec![0.0; MIN_TRANSCRIBABLE_SAMPLES]).is_ok());
+    }
+
+    struct StubBackend;
+
+    impl TranscribeBackend for StubBackend {
+        fn transcribe(&mut self, audio_path: &Path) -> Result<TranscriptionChunk> {
+            Ok(audio_path.display().to_string().into())
+        }
+
+        fn transcribe_samples(&mut self, _samples: &[f32]) -> Result<TranscriptionChunk> {
+            unimplemented!("not exercised by this test")
+        }
+    }
+
+    // A real `&Path` argument, not a `&str` one, is what proves this boundary takes `&Path` (#958).
+    #[test]
+    fn transcribe_takes_a_path_argument() {
+        let mut be = StubBackend;
+        let chunk = be
+            .transcribe(Path::new("/tmp/958.wav"))
+            .expect("stub never fails");
+        assert_eq!(chunk.text, "/tmp/958.wav");
+    }
+
+    #[test]
+    fn create_backend_takes_a_path_argument() {
+        let _ = create_backend(Path::new("/nonexistent-958-model-dir"));
     }
 }

--- a/rust/src/backend/onnx.rs
+++ b/rust/src/backend/onnx.rs
@@ -222,7 +222,7 @@ impl OnnxBackend {
 
 impl TranscribeBackend for OnnxBackend {
     fn transcribe(&mut self, audio_path: &Path) -> Result<TranscriptionChunk> {
-        let audio_samples = audio::load_audio(&audio_path.to_string_lossy())?;
+        let audio_samples = audio::load_audio(audio_path)?;
         self.transcribe_samples(&audio_samples)
     }
 

--- a/rust/src/backend/onnx.rs
+++ b/rust/src/backend/onnx.rs
@@ -31,9 +31,7 @@ pub struct OnnxBackend {
 }
 
 impl OnnxBackend {
-    pub fn new(model_dir: &str) -> Result<Self> {
-        let model_path = Path::new(model_dir);
-
+    pub fn new(model_path: &Path) -> Result<Self> {
         let preprocessor = Session::builder()
             .context("Failed to create preprocessor session builder")
             .coded(ErrorCode::ModelLoad)?
@@ -223,8 +221,8 @@ impl OnnxBackend {
 }
 
 impl TranscribeBackend for OnnxBackend {
-    fn transcribe(&mut self, audio_path: &str) -> Result<TranscriptionChunk> {
-        let audio_samples = audio::load_audio(audio_path)?;
+    fn transcribe(&mut self, audio_path: &Path) -> Result<TranscriptionChunk> {
+        let audio_samples = audio::load_audio(&audio_path.to_string_lossy())?;
         self.transcribe_samples(&audio_samples)
     }
 

--- a/rust/src/cli/install.rs
+++ b/rust/src/cli/install.rs
@@ -66,9 +66,7 @@ pub fn run(args: InstallArgs) -> Result<()> {
     // first real `kesha audio.ogg` is fast. CoreML cache is keyed by (model bytes, signing
     // identity) and survives process exit; survives re-runs until next `kesha install` re-signs (#295).
     if !no_warmup {
-        let asr_dir = models::model_dir(models::ModelKind::Asr)?
-            .to_string_lossy()
-            .into_owned();
+        let asr_dir = models::model_dir(models::ModelKind::Asr)?;
         let cost_hint = if cfg!(feature = "coreml") {
             "one-time, ~20-30 s for the ANE compile on first install"
         } else {

--- a/rust/src/streaming_asr.rs
+++ b/rust/src/streaming_asr.rs
@@ -243,7 +243,7 @@ mod tests {
             !bytes.starts_with(b"version https://git-lfs"),
             "fixture is an unmaterialized Git LFS pointer — run `git lfs pull` first"
         );
-        crate::audio::load_audio(&path).expect("decode fixture")
+        crate::audio::load_audio(std::path::Path::new(&path)).expect("decode fixture")
     }
 
     fn transcribe_streaming(samples: &[f32]) -> String {

--- a/rust/src/transcribe/mod.rs
+++ b/rust/src/transcribe/mod.rs
@@ -407,7 +407,7 @@ fn finalize_output(
 }
 
 /// Shared by plain and chunked paths to avoid duplicate timing+logging+create_backend blocks.
-fn create_timed_backend(model_dir: &str) -> Result<Box<dyn backend::TranscribeBackend>> {
+fn create_timed_backend(model_dir: &Path) -> Result<Box<dyn backend::TranscribeBackend>> {
     let t0 = Instant::now();
     let be = backend::create_backend(model_dir)?;
     let dt_ms = t0.elapsed().as_millis() as u64;
@@ -426,13 +426,13 @@ fn join_segment_texts(segments: &[TranscriptionSegment]) -> String {
 
 fn transcribe_plain(
     audio_path: &str,
-    model_dir: &str,
+    model_dir: &Path,
     duration: Option<f32>,
     timestamps_required: bool,
 ) -> Result<TranscriptionOutput> {
     let mut be = create_timed_backend(model_dir)?;
     let t1 = Instant::now();
-    let chunk = be.transcribe(audio_path)?;
+    let chunk = be.transcribe(Path::new(audio_path))?;
     let text = chunk.text;
     dtrace!(
         "asr::transcribe.end dt={}ms chars={}",
@@ -452,7 +452,7 @@ fn transcribe_plain(
 
 fn transcribe_chunked(
     audio_path: &str,
-    model_dir: &str,
+    model_dir: &Path,
     timestamps_required: bool,
 ) -> Result<TranscriptionOutput> {
     let t_audio = Instant::now();
@@ -483,7 +483,7 @@ fn transcribe_chunked(
 /// threshold never silently drops input and never forces unsafe full-file ASR.
 fn transcribe_via_vad(
     audio_path: &str,
-    model_dir: &str,
+    model_dir: &Path,
     vad_dir: &str,
     cfg: VadConfig,
 ) -> Result<TranscriptionOutput> {
@@ -1019,7 +1019,7 @@ fn resolve_diarize_model_path() -> Result<std::path::PathBuf> {
 /// Returns the cached ASR model dir or bails with the install hint. Takes the
 /// cache-root resolution rather than reading it, so a null home surfaces as the
 /// coded `E_INTERNAL` #953 established instead of "no models installed" (#969).
-fn ensure_asr_installed(cache: Result<std::path::PathBuf>) -> Result<String> {
+fn ensure_asr_installed(cache: Result<std::path::PathBuf>) -> Result<std::path::PathBuf> {
     let dir = models::model_dir_at(models::ModelKind::Asr, &cache?);
     if !models::is_cached_in(models::ModelKind::Asr, &dir) {
         anyhow::bail!(
@@ -1027,7 +1027,7 @@ fn ensure_asr_installed(cache: Result<std::path::PathBuf>) -> Result<String> {
              Please run: kesha install"
         );
     }
-    Ok(dir.to_string_lossy().into_owned())
+    Ok(dir)
 }
 
 #[cfg(test)]
@@ -2239,10 +2239,7 @@ mod seam_long_form {
             eprintln!("SKIP seam_long_form: ASR weights not installed (`kesha install`)");
             return None;
         }
-        let dir = models::model_dir(models::ModelKind::Asr)
-            .expect("resolve ASR model dir")
-            .to_string_lossy()
-            .into_owned();
+        let dir = models::model_dir(models::ModelKind::Asr).expect("resolve ASR model dir");
         Some(backend::create_backend(&dir).expect("create ASR backend"))
     }
 

--- a/rust/src/transcribe/mod.rs
+++ b/rust/src/transcribe/mod.rs
@@ -456,7 +456,7 @@ fn transcribe_chunked(
     timestamps_required: bool,
 ) -> Result<TranscriptionOutput> {
     let t_audio = Instant::now();
-    let samples = audio::load_audio(audio_path)?;
+    let samples = audio::load_audio(Path::new(audio_path))?;
     dtrace!(
         "chunked::audio_loaded dt={}ms samples={}",
         t_audio.elapsed().as_millis(),
@@ -495,7 +495,7 @@ fn transcribe_via_vad(
     }
 
     let t_audio = Instant::now();
-    let samples = audio::load_audio(audio_path)?;
+    let samples = audio::load_audio(Path::new(audio_path))?;
     dtrace!(
         "vad::audio_loaded dt={}ms samples={}",
         t_audio.elapsed().as_millis(),
@@ -2247,7 +2247,7 @@ mod seam_long_form {
         let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("../tests/fixtures/benchmark-en")
             .join(name);
-        audio::load_audio(path.to_str().unwrap()).unwrap_or_else(|e| {
+        audio::load_audio(&path).unwrap_or_else(|e| {
             panic!("load {name}: {e} — run `git lfs pull` if fixtures are pointer stubs")
         })
     }

--- a/rust/src/tts/encode.rs
+++ b/rust/src/tts/encode.rs
@@ -720,7 +720,7 @@ mod tests {
         // a non-silent signal of roughly the right duration back.
         let path = std::env::temp_dir().join(format!("kesha-flac-rt-{}.flac", std::process::id()));
         std::fs::write(&path, &bytes).unwrap();
-        let decoded = crate::audio::load_audio(path.to_str().unwrap()).unwrap();
+        let decoded = crate::audio::load_audio(&path).unwrap();
         std::fs::remove_file(&path).ok();
         assert!(!decoded.is_empty(), "decoded FLAC was empty");
         let rms = (decoded.iter().map(|s| s * s).sum::<f32>() / decoded.len() as f32).sqrt();

--- a/rust/src/vad.rs
+++ b/rust/src/vad.rs
@@ -473,7 +473,7 @@ mod tests {
             "{}/../tests/fixtures/benchmark-en/03-review-pull-request.ogg",
             env!("CARGO_MANIFEST_DIR")
         );
-        let mut samples = crate::audio::load_audio(&fixture).expect("decode fixture");
+        let mut samples = crate::audio::load_audio(Path::new(&fixture)).expect("decode fixture");
         let mut endpoint = StreamingVad::load(
             Path::new(&path),
             EndpointConfig {
@@ -491,10 +491,10 @@ mod tests {
             );
         }
 
-        let silence = crate::audio::load_audio(&format!(
+        let silence = crate::audio::load_audio(Path::new(&format!(
             "{}/../tests/fixtures/silence.wav",
             env!("CARGO_MANIFEST_DIR")
-        ))
+        )))
         .expect("decode silence fixture");
         for _ in 0..3 {
             samples.extend_from_slice(&silence);

--- a/rust/tests/audio_format.rs
+++ b/rust/tests/audio_format.rs
@@ -44,7 +44,8 @@ fn unsupported_container_is_coded_bad_audio_not_internal() {
     );
 
     // The same path reached through the decode entry point must agree.
-    let err = audio::load_audio(path).expect_err("decoding a non-container must fail");
+    let err = audio::load_audio(std::path::Path::new(path))
+        .expect_err("decoding a non-container must fail");
     assert_eq!(code_of(&err), ErrorCode::BadAudio, "{err:#}");
 }
 
@@ -72,7 +73,8 @@ fn undecodable_codec_is_coded_bad_audio() {
     let path = fixture("alac.m4a");
     // The container opens (the track is real), so the failure surfaces at decode.
     audio::ensure_audio_track(&path).expect("ALAC container opens; the track is valid");
-    let err = audio::load_audio(&path).expect_err("an undecodable codec must fail");
+    let err =
+        audio::load_audio(std::path::Path::new(&path)).expect_err("an undecodable codec must fail");
     assert_eq!(code_of(&err), ErrorCode::BadAudio, "{err:#}");
     assert!(
         format!("{err:#}").contains("unsupported codec"),


### PR DESCRIPTION
Closes #958

## Claim

`TranscribeBackend::transcribe` and `create_backend` take `&Path`, and the two production implementations no longer re-narrow to `&str` via `to_string_lossy()` — `audio::load_audio` itself now takes `&Path` (with `open_format`/`decode_packets`/`decode_audio`/`build_hint` threading it through), so `onnx.rs`/`fluidaudio.rs` pass `audio_path` straight through with zero conversion. If this is wrong, either `cargo check --features onnx,tts` (or `--features coreml,...` via `just verify-darwin-full`) fails to compile a call site still expecting `&str`, or `grep -n 'to_string_lossy' rust/src/backend/onnx.rs rust/src/backend/fluidaudio.rs` finds a reintroduced lossy conversion between the trait boundary and the actual file read.
