### PR TITLE
leak-guard fixtures outlive the reaper on abnormal exit — self-expiry or a SIGKILL sweep

### DIFF
--- a/rust/src/process_tree.rs
+++ b/rust/src/process_tree.rs
@@ -96,7 +96,8 @@ mod tests {
     fn drop_kills_unreaped_child() {
         let child = Command::new("sh")
             .arg("-c")
-            .arg("trap '' TERM; while :; do sleep 1; done")
+            // Mortal by clock: an interrupted run drops no guard, and a TERM-immune child then parks at PPID=1 (#1131).
+            .arg("trap '' TERM; n=0; while [ $n -lt 300 ]; do sleep 1; n=$((n+1)); done")
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null())

--- a/tests/helpers/process.ts
+++ b/tests/helpers/process.ts
@@ -163,3 +163,10 @@ export function installInterruptReaper(): void {
     });
   }
 }
+
+const STUBBORN_FIXTURE_TTL_S = 300;
+
+/** TERM-immune so the reaper's escalation stays exercised, clock-bounded so an interrupted run cannot strand it at PPID=1 (#1131). */
+export function stubbornShell(traps: string, ttlSeconds = STUBBORN_FIXTURE_TTL_S): string {
+  return `trap '' ${traps}; n=0; while [ $n -lt ${ttlSeconds} ]; do sleep 1; n=$((n+1)); done`;
+}

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -62,3 +62,11 @@ worth catching are the ones that trap SIGTERM.
 Nothing to do at a call site: `waitForPidFile` tracks what it returns. Only descendants and pids a
 test actually saw are ever signalled, so a parallel lane's processes are out of reach by
 construction.
+
+A run killed outright — Ctrl+C on the harness, a timed-out CI step, an interrupted agent session —
+reaches neither hook, so a fixture that traps SIGTERM outlives every reaper there is; fifteen of
+them accumulated at `PPID=1` over two days, the oldest at 45 hours, and only `kill -9` cleared them
+(#1131). Signal-immune fixtures therefore have to end themselves: build the command with
+`stubbornShell()` from `tests/helpers/process.ts`, which keeps the immunity the escalation is tested
+against and adds a five-minute clock. `tests/unit/process-leak-guard.test.ts` scans `tests/` and
+`rust/src/` for the unbounded shape and fails naming the file and line.

--- a/tests/integration/cli-contracts.test.ts
+++ b/tests/integration/cli-contracts.test.ts
@@ -14,7 +14,7 @@ import { tmpdir } from "os";
 import { delimiter, dirname, join } from "path";
 import { engineVersion } from "../../src/package-info";
 import { SUBCOMMAND_NAMES } from "../../src/cli/dispatch";
-import { pidIsAlive, waitForPidExit, waitForPidFile } from "../helpers/process";
+import { pidIsAlive, stubbornShell, waitForPidExit, waitForPidFile } from "../helpers/process";
 import {
   DEFAULT_TIMEOUT_MS,
   installFakeDiarizeModel,
@@ -188,7 +188,7 @@ function createSignalAwareEngine(dir: string, helperPidPath: string): string {
     `#!${process.execPath}
 const args = Bun.argv.slice(2);
 if (args[0] === "transcribe") {
-  const child = Bun.spawn(["sh", "-c", "trap '' TERM; while :; do sleep 1; done"], {
+  const child = Bun.spawn(["sh", "-c", ${JSON.stringify(stubbornShell("TERM"))}], {
     stdout: "ignore",
     stderr: "ignore",
   });

--- a/tests/unit/engine.test.ts
+++ b/tests/unit/engine.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { chmodSync, mkdtempSync, mkdirSync, utimesSync, writeFileSync } from "fs";
 import { homedir, tmpdir } from "os";
 import { join } from "path";
-import { waitForPidExit, waitForPidFile } from "../helpers/process";
+import { stubbornShell, waitForPidExit, waitForPidFile } from "../helpers/process";
 import { readRepoFile } from "../helpers/repo";
 import { envEchoEngine, saveEngineEnv, writeTranscribingEngine } from "../helpers/fake-engine";
 import { applyColorEnv } from "../../src/cli/context";
@@ -62,7 +62,7 @@ function fakeLongRunningEngine(dir: string, helperPidFile: string): string {
     `#!${process.execPath}
 const args = Bun.argv.slice(2);
 if (args[0] === "transcribe") {
-  const child = Bun.spawn(["sh", "-c", "trap '' TERM INT; while :; do sleep 1; done"], {
+  const child = Bun.spawn(["sh", "-c", ${JSON.stringify(stubbornShell("TERM INT"))}], {
     stdout: "ignore",
     stderr: "ignore",
   });

--- a/tests/unit/process-leak-guard.test.ts
+++ b/tests/unit/process-leak-guard.test.ts
@@ -1,11 +1,19 @@
 import { describe, expect, test } from "bun:test";
-import { pidIsAlive, reapLeakedProcesses, trackPid, waitForPidExit } from "../helpers/process";
+import { readdirSync } from "node:fs";
+import {
+  pidIsAlive,
+  reapLeakedProcesses,
+  stubbornShell,
+  trackPid,
+  waitForPidExit,
+} from "../helpers/process";
+import { readRepoFile, repoPath } from "../helpers/repo";
 
 const posix = process.platform === "win32" ? test.skip : test;
 
 /** `label` lands in argv as `$0`, which is what makes the fixture recognisable in `ps`. */
-function spawnStubborn(label: string): number {
-  const proc = Bun.spawn(["sh", "-c", "trap '' TERM INT; while :; do sleep 1; done", label], {
+function spawnStubborn(label: string, ttlSeconds?: number): number {
+  const proc = Bun.spawn(["sh", "-c", stubbornShell("TERM INT", ttlSeconds), label], {
     stdout: "ignore",
     stderr: "ignore",
   });
@@ -60,5 +68,54 @@ describe("process leak guard", () => {
 
     expect(leaked.some((entry) => entry.includes(String(pid)))).toBe(true);
     expect(await waitForPidExit(pid)).toBe(true);
+  });
+
+  /** #1131: an interrupted run reaches no hook at all, so the fixture has to end itself. */
+  posix("expires on its own clock when no reaper ever signals it", async () => {
+    const pid = spawnStubborn("kesha-engine-leak-guard-fixture", 2);
+
+    expect(await waitForPidExit(pid)).toBe(true);
+  });
+});
+
+const SCAN_ROOTS = [
+  { dir: "tests", ext: ".ts" },
+  { dir: "rust/src", ext: ".rs" },
+];
+
+const IMMORTAL_FIXTURE = /trap ''.*while\s+(?::|true)/;
+
+function immortalFixtures(): string[] {
+  return SCAN_ROOTS.flatMap(({ dir, ext }) =>
+    readdirSync(repoPath(dir), { recursive: true, encoding: "utf8" })
+      .filter((name) => name.endsWith(ext))
+      .sort()
+      .flatMap((name) =>
+        readRepoFile(`${dir}/${name}`)
+          .split("\n")
+          .flatMap((line, i) => (IMMORTAL_FIXTURE.test(line) ? [`${dir}/${name}:${i + 1}`] : [])),
+      ),
+  );
+}
+
+/** The shape #1131 forbids, rebuilt from its replacement so this file is not its own offender. */
+const UNBOUNDED = stubbornShell("TERM INT", 1).replace(/n=0;.*/, "while :; do sleep 1; done");
+
+describe("signal-immune fixtures", () => {
+  test("are told apart from bounded ones, or the scan below passes by seeing nothing", () => {
+    expect(IMMORTAL_FIXTURE.test(UNBOUNDED)).toBe(true);
+    expect(IMMORTAL_FIXTURE.test(stubbornShell("TERM INT", 1))).toBe(false);
+  });
+
+  test("all carry a clock, so an interrupted run cannot strand one at PPID=1", () => {
+    const offenders = immortalFixtures();
+    if (offenders.length === 0) return;
+
+    throw new Error(
+      `these fixtures block a signal and then loop forever, so a run killed mid-test leaves them ` +
+        `at PPID=1 until someone finds them in \`ps\` (#1131):\n  ${offenders.join("\n  ")}\n` +
+        `Build the command with stubbornShell() from tests/helpers/process.ts, or bound the loop by ` +
+        `hand where that helper cannot reach. Convention: tests/integration/README.md.`,
+    );
   });
 });


### PR DESCRIPTION
Closes #1131

## Claim

Every signal-immune test fixture in this tree now ends itself on a clock, with no reaper involved: if a spawn site goes back to an unbounded trapped loop, `signal-immune fixtures > all carry a clock, so an interrupted run cannot strand one at PPID=1` fails naming the file and line; if `stubbornShell()` stops bounding the loop, `process leak guard > expires on its own clock when no reaper ever signals it` fails on a `waitForPidExit` timeout.

## What changed

`tests/helpers/process.ts` gains `stubbornShell(traps, ttlSeconds = 300)` — the same TERM/INT immunity the reaper's escalation is tested against, wrapped in a counted loop instead of `while :`. Every fixture of that shape now builds its command through it:

- `tests/unit/process-leak-guard.test.ts` (`spawnStubborn`)
- `tests/unit/engine.test.ts:65`
- `tests/integration/cli-contracts.test.ts:191` — the ticket names the first two; this one is the identical shape and the identical failure mode
- `rust/src/process_tree.rs:99` — same, bounded by hand since the TS helper cannot reach it

Every existing assertion still holds: the guard's escalation is measured in seconds, so a five-minute clock never interferes with it.

## Guards

Two, both proven with `just mutate`:

- behavioural — a fixture spawned with a 2 s clock exits with nothing ever signalling it. Mutating `stubbornShell`'s bound back to `while :` turns it red.
- a scan of `tests/` and `rust/src/` for a trapped signal followed by an unbounded loop, failing with the file, the line and the fix. Reverting one call site to the old literal turns it red.

The scan's own positive sample is built by rewriting `stubbornShell`'s output rather than by quoting the forbidden shape, so the guard file is not its own offender and `spawnStubborn` stays covered by it.

## What I left out

The ticket's optional belt-and-braces — teaching the per-file sweep to SIGKILL labelled fixtures older than one test-file lifetime. With self-expiry in place, any age threshold long enough to be safe (≥5 min) can no longer match anything this repo spawns, and a shorter one would kill a live fixture belonging to a concurrent lane — this repo routinely runs suites in parallel worktrees. Pre-#1131 strays from an older checkout are the only thing it would catch, and they age out too.

## Verification

- `just preflight` (TS + Rust gates; `rust/**` changed)
- `just mutate` on both guards
