### PR TITLE
sweep the residual models.rs strings the #950 split left in TS sources

### DIFF
--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -671,8 +671,7 @@ export function collectRustSources(root = "rust/src"): string[] {
     .sort();
 }
 
-/** The pair main() feeds the two #950 rules. Exported so the pairing itself is pinnable: handing the
- * models-tree rule the manifest set is silent inside main(), and the sets overlap enough to look right. */
+/** The pair main() feeds the two #950 rules — exported so the pairing is pinnable: handing the all-rust/src rule the manifest set is silent inside main(), and the sets overlap enough to look right. */
 export interface RuleSources {
   manifestSources: string[];
   rustSources: string[];
@@ -685,7 +684,7 @@ export function collectRuleSources(rustRoot?: string, rustSourcesRoot?: string):
   };
 }
 
-/** Fails when a models-tree source falls out of ci.yml's `code` filter: the TS pact suites read it, so an edit to it must fire unit-tests (#950 round 2). */
+/** Fails when any rust/src source falls out of ci.yml's `code` filter: a TS suite reads it, so an edit to it must fire unit-tests (#950 round 2; widened to all of rust/src in #1132). */
 export function requireRustSourcesInCodeFilter(
   path: string,
   document: unknown,

--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -649,9 +649,9 @@ export function requireTestedScriptsInCodeFilter(
  * Deliberately narrower than `tests/helpers/rust-models-source.ts`'s `rustModelsSourcePaths`,
  * which returns every `.rs` file under the models tree (paths.rs and staging.rs included) for
  * the TS suites that read them as plain text. That wider dependency set gets its own enforcement:
- * `collectModelsTreeSources` + `requireModelsTreeInCodeFilter` fail ci.yml when its `code`
- * filter stops covering any models-tree file, so the narrowing hazard is a red check rather than
- * a docstring (#950 round 2).
+ * `collectRustSources` + `requireRustSourcesInCodeFilter` fail ci.yml when its `code`
+ * filter stops covering any Rust source, so the narrowing hazard is a red check rather than
+ * a docstring (#950 round 2, widened from the models tree to all of rust/src in #1132).
  */
 export function collectManifestSources(root = "rust/src"): string[] {
   if (!existsSync(root)) return [];
@@ -662,8 +662,8 @@ export function collectManifestSources(root = "rust/src"): string[] {
     .sort();
 }
 
-/** Every .rs under the models tree — the files the TS pact suites read as plain text, a strict superset of the ModelFile-literal set (#950 round 2). */
-export function collectModelsTreeSources(root = "rust/src/models"): string[] {
+/** Every .rs under rust/src — the TS pact suites read the models tree, tests/unit/rust-cross-references.test.ts reads all of it (#1132). */
+export function collectRustSources(root = "rust/src"): string[] {
   if (!existsSync(root)) return [];
   return readdirSync(root, { recursive: true })
     .filter((entry): entry is string => typeof entry === "string" && entry.endsWith(".rs"))
@@ -675,21 +675,21 @@ export function collectModelsTreeSources(root = "rust/src/models"): string[] {
  * models-tree rule the manifest set is silent inside main(), and the sets overlap enough to look right. */
 export interface RuleSources {
   manifestSources: string[];
-  modelsTreeSources: string[];
+  rustSources: string[];
 }
 
-export function collectRuleSources(rustRoot?: string, modelsRoot?: string): RuleSources {
+export function collectRuleSources(rustRoot?: string, rustSourcesRoot?: string): RuleSources {
   return {
     manifestSources: collectManifestSources(rustRoot),
-    modelsTreeSources: collectModelsTreeSources(modelsRoot),
+    rustSources: collectRustSources(rustSourcesRoot),
   };
 }
 
 /** Fails when a models-tree source falls out of ci.yml's `code` filter: the TS pact suites read it, so an edit to it must fire unit-tests (#950 round 2). */
-export function requireModelsTreeInCodeFilter(
+export function requireRustSourcesInCodeFilter(
   path: string,
   document: unknown,
-  modelsTreeSources: string[],
+  rustSources: string[],
 ): string[] {
   if (!path.endsWith("ci.yml")) return [];
 
@@ -699,17 +699,17 @@ export function requireModelsTreeInCodeFilter(
   const code = (parse(raw) as Record<string, string[]>)?.code;
   if (!Array.isArray(code)) return [`${path}: paths-filter is missing a \`code\` list`];
 
-  if (modelsTreeSources.length === 0) {
+  if (rustSources.length === 0) {
     return [
-      `${path}: collectModelsTreeSources() returned no files — it ran against the wrong cwd or the models tree moved, either way the guard cannot pass vacuously (#950)`,
+      `${path}: collectRustSources() returned no files — it ran against the wrong cwd or rust/src moved, either way the guard cannot pass vacuously (#950)`,
     ];
   }
 
-  return modelsTreeSources
+  return rustSources
     .filter((file) => !coveredBy(code, file))
     .map(
       (file) =>
-        `${path}: ${file} is read by the TS pact suites but no path in the \`code\` filter matches it, so an edit to it skips unit-tests (#950)`,
+        `${path}: ${file} is read by a TS suite but no path in the \`code\` filter matches it, so an edit to it skips unit-tests (#950, #1132)`,
     );
 }
 
@@ -1099,7 +1099,7 @@ export function checkFile(
       ...requireRestoreOnlyCachesHaveAWriter(path, document, cacheWriters),
       ...requireTestedScriptsInCodeFilter(path, document, testedScripts),
       ...requireManifestSourcesInCodeFilter(path, document, sources.manifestSources),
-      ...requireModelsTreeInCodeFilter(path, document, sources.modelsTreeSources),
+      ...requireRustSourcesInCodeFilter(path, document, sources.rustSources),
       ...requireManifestSourcesInSeedFilter(path, document, sources.manifestSources),
       ...requireFlakeNixInWorkflowsFilter(path, document),
       ...(rustToolchain ? requirePinnedRustToolchain(path, document, rustToolchain) : []),

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,8 @@ jobs:
               # asserts every plan entry still resolves to a URL in the manifest, and a change
               # to either file alone would otherwise never run it.
               - 'model-plan.json'
-              - 'rust/src/models/**'
+              # Widened from `rust/src/models/**` in #1132: rust-cross-references.test.ts reads all of rust/src.
+              - 'rust/src/**'
             integration:
               - 'src/**'
               - 'tests/integration/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,9 @@ jobs:
               - 'model-plan.json'
               # Widened from `rust/src/models/**` in #1132: rust-cross-references.test.ts reads all of rust/src.
               - 'rust/src/**'
+              # resolveFile also accepts rust/build.rs and rust/tests/*.rs as reference targets, so a rename there must fire the cross-reference test too (#1132).
+              - 'rust/build.rs'
+              - 'rust/tests/**'
             integration:
               - 'src/**'
               - 'tests/integration/**'

--- a/openspec/changes/darwin-skips-onnx-asr/proposal.md
+++ b/openspec/changes/darwin-skips-onnx-asr/proposal.md
@@ -61,7 +61,8 @@ None.
 
 ## Impact
 
-- `rust/src/models.rs` (`ASR_FILES` gating, `is_cached_in`, `install`), `rust/src/transcribe/mod.rs`
+- `rust/src/models/manifest.rs` (`ASR_FILES` gating), `rust/src/models/paths.rs` (`is_cached_in`),
+  `rust/src/models/mod.rs` (`install`), `rust/src/transcribe/mod.rs`
   (`ensure_asr_installed`), `rust/src/cli/install.rs` (warm-up path).
 - `src/install-plan.ts`, `src/status.ts`, `src/doctor.ts` — the user-facing half.
 - macOS users: ~2.43 GB less downloaded and stored per install.

--- a/openspec/changes/darwin-skips-onnx-asr/specs/installation/spec.md
+++ b/openspec/changes/darwin-skips-onnx-asr/specs/installation/spec.md
@@ -56,5 +56,5 @@ weights fetched by the Backend outside the Model cache rather than omitting them
 - AND nothing is downloaded
 
 > *Technical Note — sources: `src/install-plan.ts` (`asr: ASR_FILES`, `modelBundle("ASR Parakeet
-> TDT v3", …)`), `rust/src/models.rs::install` (no backend branch today),
+> TDT v3", …)`), `rust/src/models/mod.rs::install` (no backend branch today),
 > `rust/src/backend/mod.rs::create_backend` (`let _ = model_dir` on the coreml arm).*

--- a/openspec/specs/GLOSSARY.md
+++ b/openspec/specs/GLOSSARY.md
@@ -9,7 +9,7 @@ verbatim; if you need a new term, add it here first.
 | **Engine** | The `kesha-engine` Rust binary, downloaded from GitHub Releases by `kesha install` and invoked by the CLI as a subprocess. Never linked in-process. |
 | **Backend** | The compile-time ASR implementation inside the Engine: **CoreML** (Apple Silicon, FluidAudio/ANE) or **ONNX** (Linux/Windows/fallback, `ort`). Exactly one per Engine binary; no runtime fallback. |
 | **Model cache** | `~/.cache/kesha/` (override: `KESHA_CACHE_DIR`) where the Engine binary and all models live. |
-| **Pinned hash** | The SHA-256 recorded for every model file in `rust/src/models.rs`; downloads that don't match are rejected, never cached. |
+| **Pinned hash** | The SHA-256 recorded for every model file in `rust/src/models/manifest.rs`; downloads that don't match are rejected, never cached. |
 | **Channel** | How a published artifact is selected: **stable**, what an install resolves when nothing is named, and **alpha**, reached only by naming it (`@alpha` on npm). npm dist-tags are the mechanism; a `beta` dist-tag also exists for release candidates. |
 | **Alpha** | An unblessed build published on the alpha channel so a change can be run before it is released. Version `<next-version>-alpha.N`, derived from existing tags at publish time and never committed. No stability promise. |
 | **Prerelease** | A GitHub Release marked as not "Latest". Engine alphas are published Prereleases; beta Engine releases stay drafts until validated by hand. |

--- a/openspec/specs/engine-contract/spec.md
+++ b/openspec/specs/engine-contract/spec.md
@@ -259,8 +259,8 @@ spawn time (inheriting `process.env` from the CLI).
 > | Variable | Read by | Effect |
 > |---|---|---|
 > | `KESHA_ENGINE_BIN` | CLI | Override Engine binary path (`src/engine.ts:47`). |
-> | `KESHA_CACHE_DIR` | CLI + Engine | Override Model cache root (default `~/.cache/kesha/`). CLI: `src/paths.ts:5`. Engine: `rust/src/models.rs:614`. |
-> | `KESHA_MODEL_MIRROR` | Engine | Rewrite HuggingFace download base URLs; GitHub release URLs are never rewritten. Safe because of Pinned hashes (`rust/src/models.rs:628`). |
+> | `KESHA_CACHE_DIR` | CLI + Engine | Override Model cache root (default `~/.cache/kesha/`). CLI: `src/paths.ts:5`. Engine: `rust/src/models/paths.rs::cache_dir`. |
+> | `KESHA_MODEL_MIRROR` | Engine | Rewrite HuggingFace download base URLs; GitHub release URLs are never rewritten. Safe because of Pinned hashes (`rust/src/models/download.rs::model_mirror`). |
 > | `KESHA_DEBUG` | CLI + Engine | Enable debug trace output. Falsey values: `""`, `"0"`, `"false"`, `"no"`, `"off"` (case-insensitive). Truthy: any other non-empty value. CLI: `src/log.ts:30`. Engine: `rust/src/debug.rs:57`. |
 > | `KESHA_DEBUG_FD` | CLI + Engine | Forward a file descriptor number to the Engine for NDJSON debug event output. Values 0/1/2 are rejected (covered by stdin/stdout/stderr). Values above 1024 (`MAX_FORWARDED_FD`) are rejected. Must be a non-negative integer ≥ 3. CLI: `src/engine.ts:92`. Engine: `rust/src/debug.rs:159`. |
 > | `KESHA_DIARIZE_TIMEOUT_SECS` | Engine | Cap total diarization wall time (seconds). It can only cut a run short — the phase budgets still apply, so it never widens one. Unset or empty means no overall cap; any other non-positive or unparseable value fails with `E_INVALID_ARG` rather than silently removing the cap. Engine: `rust/src/transcribe/diarize.rs`. |

--- a/openspec/specs/installation/spec.md
+++ b/openspec/specs/installation/spec.md
@@ -354,7 +354,7 @@ asset check SHALL NOT require them.
 - THEN the Vosk-TTS files land in the Model cache
 - AND no FluidAudio Kokoro asset is downloaded or staged
 
-> *Technical Note — sources: `rust/src/models.rs::download_tts` calls
+> *Technical Note — sources: `rust/src/models/download.rs::download_tts` calls
 > `stage_fluidaudio_kokoro_assets` (manifests `ANE_EN_FILES`,
 > `KOKORO_G2P_FILES`, `ANE_ZH_FILES`, `ANE_ZH_G2P_ASSETS`; the English variant
 > serves `ANE_ENGLISH_VARIANT_LANGS` = en/es/fr/hi/it/ja/pt) and
@@ -405,7 +405,7 @@ The CLI SHALL install the Sortformer diarization model only when `--diarize` is 
 ### Requirement: Every model file has a Pinned hash; mismatches are rejected, not cached
 
 The Engine SHALL verify the SHA-256 hash of every downloaded model file against the
-Pinned hash recorded in `rust/src/models.rs`. A file whose hash does not match SHALL
+Pinned hash recorded in `rust/src/models/manifest.rs`. A file whose hash does not match SHALL
 be deleted and the install SHALL fail with an error. The file SHALL NOT be left in the
 Model cache.
 
@@ -430,7 +430,7 @@ begin.
 - AND all HuggingFace model URLs are rewritten to use the mirror base
 - AND the Engine binary URL is not rewritten
 
-> *Technical Note — sources: `rust/src/models.rs` (SHA-256 per `ModelFile` entry,
+> *Technical Note — sources: `rust/src/models/manifest.rs` (SHA-256 per `ModelFile` entry,
 > `download_verified` function, `init_mirror_logging`, `model_mirror()`).
 > Error code `E_CACHE_CORRUPT` is used when a cached file fails hash verification.*
 
@@ -480,7 +480,7 @@ the first one is still streaming into.
 > (health-gated cache validity; skipped on a read-only engine directory, where nothing
 > could be repaired anyway), `src/engine-install.ts::sidecarNeedsDownload`,
 > `src/cli/install.ts::probeCapabilitiesForInstall`. Mirrors the staging and the
-> age-gated, Unix-only orphan sweep of `rust/src/models.rs` (`write_verified`,
+> age-gated, Unix-only orphan sweep of `rust/src/models/download.rs` (`write_verified`,
 > `cleanup_orphan_staging`): Windows keeps last-write time stale while a handle is open,
 > so an in-flight download there cannot be told apart from an orphan.*
 

--- a/openspec/specs/tts-synthesis/spec.md
+++ b/openspec/specs/tts-synthesis/spec.md
@@ -230,7 +230,7 @@ the first few missing paths so the gap is identifiable, and the refusal exits 4
 > *Technical Note — model presence gates:
 > `rust/src/tts/voices.rs::build_kokoro_voice` (ONNX Kokoro) and
 > `::resolve_vosk_ru` (Vosk). `macos-*` voices need no model download.
-> The darwin-arm64 pre-check is `rust/src/models.rs::missing_kokoro_assets`,
+> The darwin-arm64 pre-check is `rust/src/models/staging.rs::missing_kokoro_assets`,
 > called from `tts/fluid_kokoro.rs::with_kokoro` alongside
 > `fluidaudio_rs::set_offline_mode(true)` — two defences because neither covers
 > the other: the flag stops upstream's repo downloads but not its
@@ -530,7 +530,7 @@ stderr note, because the upstream CharsiuG2P export has no Castilian θ tag.
 > by `is_castilian_region` while `es`/`es-419`/`es-MX` use the LatAm tag
 > directly. zh runs off FluidAudio's separate Mandarin (`ANE-zh/`) bundle,
 > which `kesha install --tts zh` stages like every other model — voice packs
-> and pinyin dictionaries included (`rust/src/models.rs::ANE_ZH_FILES`,
+> and pinyin dictionaries included (`rust/src/models/manifest.rs::ANE_ZH_FILES`,
 > `ANE_ZH_G2P_ASSETS`, #823).*
 
 ### Requirement: List installed voices

--- a/rust/src/models/download.rs
+++ b/rust/src/models/download.rs
@@ -1229,8 +1229,24 @@ mod characterization_tests {
         fs::create_dir_all(dir.join("bert")).unwrap();
         fs::write(dir.join("model.onnx"), b"dummy").unwrap();
         fs::write(dir.join("dictionary"), b"dummy").unwrap();
+        fs::write(dir.join("config.json"), b"{}").unwrap();
         fs::write(dir.join("bert/model.onnx"), b"dummy").unwrap();
+        fs::write(dir.join("bert/vocab.txt"), b"v").unwrap();
         assert!(is_cached_in(ModelKind::VoskRu, &dir));
+    }
+
+    /// `Vosk::load` reads `model.config.audio.sample_rate`, so a bundle without
+    /// `config.json` is not loadable however cached it looks (#1132).
+    #[cfg(feature = "tts")]
+    #[test]
+    fn is_cached_in_vosk_ru_false_without_config_and_vocab() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("models/vosk-ru");
+        fs::create_dir_all(dir.join("bert")).unwrap();
+        fs::write(dir.join("model.onnx"), b"dummy").unwrap();
+        fs::write(dir.join("dictionary"), b"dummy").unwrap();
+        fs::write(dir.join("bert/model.onnx"), b"dummy").unwrap();
+        assert!(!is_cached_in(ModelKind::VoskRu, &dir));
     }
 
     #[cfg(feature = "tts")]

--- a/rust/src/models/download.rs
+++ b/rust/src/models/download.rs
@@ -1226,38 +1226,41 @@ mod characterization_tests {
     fn is_cached_in_vosk_ru_true_when_layout_present() {
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path().join("models/vosk-ru");
-        fs::create_dir_all(dir.join("bert")).unwrap();
-        fs::write(dir.join("model.onnx"), b"dummy").unwrap();
-        fs::write(dir.join("dictionary"), b"dummy").unwrap();
-        fs::write(dir.join("config.json"), b"{}").unwrap();
-        fs::write(dir.join("bert/model.onnx"), b"dummy").unwrap();
-        fs::write(dir.join("bert/vocab.txt"), b"v").unwrap();
+        for f in VOSK_RU_FILES {
+            let rel = f.rel_path.strip_prefix("models/vosk-ru/").unwrap();
+            let path = dir.join(rel);
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(path, b"dummy").unwrap();
+        }
         assert!(is_cached_in(ModelKind::VoskRu, &dir));
     }
 
-    /// `Vosk::load` reads `model.config.audio.sample_rate`, so a bundle without
-    /// `config.json` is not loadable however cached it looks (#1132).
+    /// One negative case per manifest file: `Vosk::load` opens every entry, so a
+    /// bundle missing any single one is not loadable however cached it looks.
+    /// Omitting exactly one file per iteration keeps each existence check
+    /// individually pinned (#1132).
     #[cfg(feature = "tts")]
     #[test]
-    fn is_cached_in_vosk_ru_false_without_config_and_vocab() {
-        let tmp = tempfile::tempdir().unwrap();
-        let dir = tmp.path().join("models/vosk-ru");
-        fs::create_dir_all(dir.join("bert")).unwrap();
-        fs::write(dir.join("model.onnx"), b"dummy").unwrap();
-        fs::write(dir.join("dictionary"), b"dummy").unwrap();
-        fs::write(dir.join("bert/model.onnx"), b"dummy").unwrap();
-        assert!(!is_cached_in(ModelKind::VoskRu, &dir));
-    }
-
-    #[cfg(feature = "tts")]
-    #[test]
-    fn is_cached_in_vosk_ru_false_when_bert_missing() {
-        let tmp = tempfile::tempdir().unwrap();
-        let dir = tmp.path().join("models/vosk-ru");
-        fs::create_dir_all(&dir).unwrap();
-        fs::write(dir.join("model.onnx"), b"dummy").unwrap();
-        fs::write(dir.join("dictionary"), b"dummy").unwrap();
-        assert!(!is_cached_in(ModelKind::VoskRu, &dir));
+    fn is_cached_in_vosk_ru_false_when_any_single_file_missing() {
+        for missing in VOSK_RU_FILES {
+            let tmp = tempfile::tempdir().unwrap();
+            let dir = tmp.path().join("models/vosk-ru");
+            fs::create_dir_all(dir.join("bert")).unwrap();
+            for f in VOSK_RU_FILES {
+                if f.rel_path == missing.rel_path {
+                    continue;
+                }
+                let rel = f.rel_path.strip_prefix("models/vosk-ru/").unwrap();
+                let path = dir.join(rel);
+                fs::create_dir_all(path.parent().unwrap()).unwrap();
+                fs::write(path, b"dummy").unwrap();
+            }
+            assert!(
+                !is_cached_in(ModelKind::VoskRu, &dir),
+                "bundle missing {} still reported cached",
+                missing.rel_path
+            );
+        }
     }
 
     #[cfg(all(

--- a/rust/src/models/paths.rs
+++ b/rust/src/models/paths.rs
@@ -434,17 +434,20 @@ pub fn is_cached_in(kind: ModelKind, dir: &Path) -> bool {
     }
 }
 
-/// The five files `Vosk::load` opens — keep this layout check aligned with the
-/// loader. `has_all_files` flattens the manifest to basenames, which would treat
-/// the top-level `model.onnx` and `bert/model.onnx` as duplicates; this custom
-/// walk handles the nested path instead.
+/// Every file in `VOSK_RU_FILES` — the same set `Vosk::load` opens — checked at
+/// its manifest-relative path. `has_all_files` flattens the manifest to basenames,
+/// which would treat the top-level `model.onnx` and `bert/model.onnx` as
+/// duplicates; deriving from the manifest keeps this gate honest when the bundle
+/// grows a sixth file (#1132).
 #[cfg(feature = "tts")]
 fn has_vosk_ru_layout(dir: &Path) -> bool {
-    dir.join("model.onnx").exists()
-        && dir.join("dictionary").exists()
-        && dir.join("config.json").exists()
-        && dir.join("bert/model.onnx").exists()
-        && dir.join("bert/vocab.txt").exists()
+    VOSK_RU_FILES.iter().all(|f| {
+        let rel = f
+            .rel_path
+            .strip_prefix("models/vosk-ru/")
+            .expect("VOSK_RU_FILES rel_paths live under models/vosk-ru/");
+        dir.join(rel).exists()
+    })
 }
 
 /// `.mlpackage` is a directory tree — the runtime-required files live at

--- a/rust/src/models/paths.rs
+++ b/rust/src/models/paths.rs
@@ -434,15 +434,17 @@ pub fn is_cached_in(kind: ModelKind, dir: &Path) -> bool {
     }
 }
 
-/// `vosk_tts::Model::new` opens these three files — keep this layout check
-/// aligned with the loader. `has_all_files` flattens the manifest to basenames,
-/// which would treat the top-level `model.onnx` and `bert/model.onnx` as
-/// duplicates; this custom walk handles the nested path instead.
+/// The five files `Vosk::load` opens — keep this layout check aligned with the
+/// loader. `has_all_files` flattens the manifest to basenames, which would treat
+/// the top-level `model.onnx` and `bert/model.onnx` as duplicates; this custom
+/// walk handles the nested path instead.
 #[cfg(feature = "tts")]
 fn has_vosk_ru_layout(dir: &Path) -> bool {
     dir.join("model.onnx").exists()
         && dir.join("dictionary").exists()
+        && dir.join("config.json").exists()
         && dir.join("bert/model.onnx").exists()
+        && dir.join("bert/vocab.txt").exists()
 }
 
 /// `.mlpackage` is a directory tree — the runtime-required files live at

--- a/src/fluid-asr-cache.ts
+++ b/src/fluid-asr-cache.ts
@@ -41,7 +41,7 @@ export function legacyFluidAsrCachePath(homeDir = diagnosticHomeDir()): string {
 }
 
 /**
- * Where the Parakeet bundle actually is. Mirrors `models.rs::fluidaudio_asr_location`: a
+ * Where the Parakeet bundle actually is. Mirrors `models/paths.rs::fluidaudio_asr_location`: a
  * complete legacy bundle keeps its place so an upgrade never re-downloads ~460 MB, and
  * anything else lives under the Kesha cache, where the engine roots a fresh install (#688).
  */
@@ -59,7 +59,7 @@ export function fluidAsrCachePath(
  * What FluidAudio's own `modelsExist` requires. The encoder is pinned to int8 because
  * the bridge calls `downloadAndLoad(to:)` with its default `useInt8Encoder: true` —
  * accepting `EncoderInt4.mlmodelc` would pass preflight and then let FluidAudio fetch
- * the int8 encoder on first transcribe. Keep in step with `models.rs::FLUID_ASR_REQUIRED`.
+ * the int8 encoder on first transcribe. Keep in step with `models/paths.rs::FLUID_ASR_REQUIRED`.
  */
 export const FLUID_ASR_REQUIRED = [
   "Preprocessor.mlmodelc",
@@ -70,7 +70,7 @@ export const FLUID_ASR_REQUIRED = [
 ];
 
 /**
- * Complete enough to transcribe. Mirrors `models.rs::fluidaudio_asr_ready` — a bare
+ * Complete enough to transcribe. Mirrors `models/paths.rs::fluidaudio_asr_ready` — a bare
  * directory check would call an interrupted fetch healthy, and the engine would then
  * download the remainder on first transcribe (#684).
  *

--- a/src/fluid-roots.ts
+++ b/src/fluid-roots.ts
@@ -34,7 +34,7 @@ export interface FluidExternalRoot {
 }
 
 /**
- * Mirrors `models.rs::dir_has_entries`. Deliberately weak: a false positive keeps a legacy
+ * Mirrors `models/paths.rs::dir_has_entries`. Deliberately weak: a false positive keeps a legacy
  * directory in use, a false negative re-downloads it (#688).
  */
 function dirHasEntries(dir: string): boolean {
@@ -56,7 +56,7 @@ export function kokoroG2pDir(homeDir = diagnosticHomeDir()): string {
 
 /**
  * The Kokoro CoreML bundle root the engine reads. Mirrors
- * `models.rs::fluidaudio_kokoro_location`: any entry at all keeps a legacy tree in use,
+ * `models/paths.rs::fluidaudio_kokoro_location`: any entry at all keeps a legacy tree in use,
  * everything else roots under the Kesha cache (#688).
  */
 export function kokoroBundleRoot(options: FluidRootsOptions = {}): string {
@@ -66,7 +66,7 @@ export function kokoroBundleRoot(options: FluidRootsOptions = {}): string {
     : join(options.cacheRoot ?? keshaCacheDir(), "fluidaudio", "kokoro-82m-coreml");
 }
 
-/** Where `models.rs::stage_fluidaudio_kokoro_assets` puts the English ANE chain. */
+/** Where `models/staging.rs::stage_fluidaudio_kokoro_assets` puts the English ANE chain. */
 export function kokoroAneDir(options: FluidRootsOptions = {}): string {
   return join(kokoroBundleRoot(options), "ANE");
 }
@@ -94,7 +94,7 @@ export function fluidLegacyRootPaths(homeDir = diagnosticHomeDir()): string[] {
 }
 
 /**
- * Where each FluidAudio subsystem's files are. Mirrors `models.rs::fluidaudio_location` and
+ * Where each FluidAudio subsystem's files are. Mirrors `models/paths.rs::fluidaudio_location` and
  * the per-subsystem probes it is called with — strong for ASR (`fluidaudio_asr_ready_in`),
  * `dir_has_entries` for Kokoro and Sortformer — so a legacy bundle that is still being read
  * is counted where it is, and a relocated one is counted only inside the cache (#688).

--- a/src/kokoro-ane.ts
+++ b/src/kokoro-ane.ts
@@ -14,7 +14,7 @@ export const KOKORO_ANE_NOTE =
   "because FluidAudio resolves these paths and no other; the warm-up only compiles them";
 
 /**
- * Top level of `models.rs::ANE_EN_FILES`: the 7-stage ANE chain, its vocab, and the
+ * Top level of `models/manifest.rs::ANE_EN_FILES`: the 7-stage ANE chain, its vocab, and the
  * `af_heart` pack the bundle counts as its own.
  */
 export const KOKORO_ANE_EN_REQUIRED = [
@@ -29,7 +29,7 @@ export const KOKORO_ANE_EN_REQUIRED = [
   "vocab.json",
 ];
 
-/** Top level of `models.rs::KOKORO_G2P_FILES` — the shared BART G2P and the Misaki lexicon. */
+/** Top level of `models/manifest.rs::KOKORO_G2P_FILES` — the shared BART G2P and the Misaki lexicon. */
 export const KOKORO_G2P_REQUIRED = [
   "G2PDecoder.mlmodelc",
   "G2PEncoder.mlmodelc",
@@ -57,11 +57,11 @@ export interface KokoroAneOptions {
 }
 
 /**
- * The two sets `models.rs::stage_fluidaudio_kokoro_assets` stages for any non-`ru` TTS
+ * The two sets `models/staging.rs::stage_fluidaudio_kokoro_assets` stages for any non-`ru` TTS
  * language. The Mandarin (`ANE-zh/`) sibling is deliberately not here: `--tts zh` is a
  * separate opt-in, and its bytes already show up under the cache report's Kokoro ANE root.
  *
- * Top-level existence on purpose, one notch weaker than `models.rs::missing_kokoro_assets`.
+ * Top-level existence on purpose, one notch weaker than `models/staging.rs::missing_kokoro_assets`.
  * That per-file check gates synthesis and must be exact; this one answers "is this install
  * whole" without mirroring ~40 file names into a second language for a diagnostic (#828).
  */

--- a/src/progress.ts
+++ b/src/progress.ts
@@ -133,7 +133,7 @@ export async function applyBackpressure(
 }
 
 /**
- * Age threshold and platform gate mirror `rust/src/models.rs::cleanup_orphan_staging`: a
+ * Age threshold and platform gate mirror `rust/src/models/download.rs::cleanup_orphan_staging`: a
  * concurrent installer's staging file keeps a fresh mtime while bytes stream into it, and
  * Windows leaves last-write time stale while a handle is open, so an in-flight download
  * there could not be told apart from an orphan.
@@ -185,7 +185,7 @@ let stagingSeq = 0;
 /**
  * Downloads into a sibling `.part.<pid>.<n>` file and renames it into place, so an
  * interrupted download can never leave a truncated binary at `destPath` (#770). Mirrors the
- * staging `rust/src/models.rs::write_verified` already does for model files. Staging beside
+ * staging `rust/src/models/download.rs::write_verified` already does for model files. Staging beside
  * the destination keeps the rename within one filesystem, where it is atomic.
  */
 export async function streamResponseToFile(

--- a/src/status.ts
+++ b/src/status.ts
@@ -238,7 +238,7 @@ function showDiskUsage(disk: StatusDiskUsage): void {
   log.info("");
 }
 
-/** Returns the effective `KESHA_MODEL_MIRROR` URL (#121), trimmed; null when unset. Mirrors `model_mirror()` in `rust/src/models.rs`. */
+/** Returns the effective `KESHA_MODEL_MIRROR` URL (#121), trimmed; null when unset. Mirrors `model_mirror()` in `rust/src/models/download.rs`. */
 export function activeModelMirror(): string | null {
   const raw = process.env.KESHA_MODEL_MIRROR ?? "";
   const trimmed = raw.trim().replace(/\/+$/, "");

--- a/src/status.ts
+++ b/src/status.ts
@@ -257,10 +257,12 @@ function listInstalledVoices(): string[] {
     /* Kokoro not installed */
   }
   try {
-    // Mirror `models/paths.rs::has_vosk_ru_layout` — all three or we advertise a voice `resolve_vosk_ru` refuses.
+    // The whole `models/manifest.rs::VOSK_RU_FILES` bundle, which is what `Vosk::load` opens — fewer advertises a voice `say` then refuses.
     statSync(join(cache, "models", "vosk-ru", "model.onnx"));
     statSync(join(cache, "models", "vosk-ru", "dictionary"));
+    statSync(join(cache, "models", "vosk-ru", "config.json"));
     statSync(join(cache, "models", "vosk-ru", "bert", "model.onnx"));
+    statSync(join(cache, "models", "vosk-ru", "bert", "vocab.txt"));
     for (const id of ["f01", "f02", "f03", "m01", "m02"]) {
       voices.push(`ru-vosk-${id}`);
     }

--- a/src/status.ts
+++ b/src/status.ts
@@ -1,5 +1,6 @@
 import { readdirSync, statSync } from "fs";
 import { join } from "path";
+import modelPlan from "../model-plan.json" with { type: "json" };
 import {
   isEngineInstalled,
   getEngineBinPath,
@@ -257,12 +258,8 @@ function listInstalledVoices(): string[] {
     /* Kokoro not installed */
   }
   try {
-    // The whole `models/manifest.rs::VOSK_RU_FILES` bundle, which is what `Vosk::load` opens — fewer advertises a voice `say` then refuses.
-    statSync(join(cache, "models", "vosk-ru", "model.onnx"));
-    statSync(join(cache, "models", "vosk-ru", "dictionary"));
-    statSync(join(cache, "models", "vosk-ru", "config.json"));
-    statSync(join(cache, "models", "vosk-ru", "bert", "model.onnx"));
-    statSync(join(cache, "models", "vosk-ru", "bert", "vocab.txt"));
+    // Joined to `models/manifest.rs::VOSK_RU_FILES` through the plan, so a sixth entry needs no edit here (#1132).
+    for (const { relPath } of modelPlan.voskRu) statSync(join(cache, relPath));
     for (const id of ["f01", "f02", "f03", "m01", "m02"]) {
       voices.push(`ru-vosk-${id}`);
     }

--- a/src/status.ts
+++ b/src/status.ts
@@ -257,8 +257,9 @@ function listInstalledVoices(): string[] {
     /* Kokoro not installed */
   }
   try {
-    // Mirror models::is_vosk_ru_cached — both files required to avoid advertising a partial install.
+    // Mirror `models/paths.rs::has_vosk_ru_layout` — all three or we advertise a voice `resolve_vosk_ru` refuses.
     statSync(join(cache, "models", "vosk-ru", "model.onnx"));
+    statSync(join(cache, "models", "vosk-ru", "dictionary"));
     statSync(join(cache, "models", "vosk-ru", "bert", "model.onnx"));
     for (const id of ["f01", "f02", "f03", "m01", "m02"]) {
       voices.push(`ru-vosk-${id}`);

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -445,6 +445,11 @@ describe("manifest sources stay inside both path filters", () => {
     expect(sources).toContain("rust/src/models/manifest.rs");
   });
 
+  // main() calls collectRuleSources() with no arguments, so narrowing the default reverts the widening silently (#1132 round 3).
+  test("the production default root is rust/src, not the models tree", () => {
+    expect(collectRustSources().map((file) => file.replaceAll("\\", "/"))).toContain("rust/src/text_lang.rs");
+  });
+
   test("collectRustSources returns every .rs under rust/src", () => {
     const tree = repoRelative(collectRustSources(repoPath("rust/src")));
     expect(tree.length).toBeGreaterThanOrEqual(6);

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -8,7 +8,7 @@ import {
   checkFlakeNix,
   collectCacheWriters,
   collectManifestSources,
-  collectModelsTreeSources,
+  collectRustSources,
   collectRuleSources,
   forbidFindPipedToHead,
   forbidLinuxPackaging,
@@ -26,7 +26,7 @@ import {
   requireDepsBeforeBunTest,
   requireFlakeNixInWorkflowsFilter,
   requireManifestSourcesInCodeFilter,
-  requireModelsTreeInCodeFilter,
+  requireRustSourcesInCodeFilter,
   requireManifestSourcesInSeedFilter,
   requireNpmPublishAfterPackaging,
   requirePactVerificationCoversEveryTarget,
@@ -403,7 +403,7 @@ const seedFilter = (paths: string[]) => ({ on: { push: { paths } } });
 
 // readdirSync/join emit win32 separators on Windows; the rules normalise at compare time, so the
 // real-tree assertions have to as well or they only hold on posix (#950 round 3).
-const NO_SOURCES = { manifestSources: [], modelsTreeSources: [] };
+const NO_SOURCES = { manifestSources: [], rustSources: [] };
 
 const repoRelative = (files: string[]) =>
   files.map((file) => file.slice(REPO_ROOT.length + 1).replaceAll("\\", "/"));
@@ -445,11 +445,18 @@ describe("manifest sources stay inside both path filters", () => {
     expect(sources).toContain("rust/src/models/manifest.rs");
   });
 
-  test("collectModelsTreeSources returns every .rs under the models tree", () => {
-    const tree = repoRelative(collectModelsTreeSources(repoPath("rust/src/models")));
+  test("collectRustSources returns every .rs under rust/src", () => {
+    const tree = repoRelative(collectRustSources(repoPath("rust/src")));
     expect(tree.length).toBeGreaterThanOrEqual(6);
     expect(tree).toContain("rust/src/models/paths.rs");
     expect(tree).toContain("rust/src/models/staging.rs");
+    expect(tree).toContain("rust/src/text_lang.rs");
+  });
+
+  // rust-cross-references.test.ts reads all of rust/src, so a rename outside models/ must still fire unit-tests (#1132).
+  test("the real ci.yml code filter covers every Rust source, not just the models tree", () => {
+    const sources = repoRelative(collectRustSources(repoPath("rust/src")));
+    expect(requireRustSourcesInCodeFilter(CI, parseRepoYaml(CI), sources)).toEqual([]);
   });
 
   test("the real ci.yml and cache-seed.yml cover every one of them", () => {
@@ -483,7 +490,7 @@ describe("manifest sources stay inside both path filters", () => {
       "rust/src/models/download.rs", "rust/src/models/manifest.rs", "rust/src/models/mod.rs",
       "rust/src/models/paths.rs", "rust/src/models/progress.rs", "rust/src/models/staging.rs",
     ];
-    const errors = requireModelsTreeInCodeFilter("ci.yml", filters, tree);
+    const errors = requireRustSourcesInCodeFilter("ci.yml", filters, tree);
     expect(errors).toHaveLength(4);
     expect(errors.join("\n")).toContain("rust/src/models/paths.rs");
     expect(errors.join("\n")).toContain("rust/src/models/staging.rs");
@@ -492,7 +499,7 @@ describe("manifest sources stay inside both path filters", () => {
   test("the whole-directory wildcard satisfies the models-tree rule", () => {
     const filters = codeFilter(["rust/src/models/**"]);
     const tree = ["rust/src/models/paths.rs", "rust/src/models/staging.rs"];
-    expect(requireModelsTreeInCodeFilter("ci.yml", filters, tree)).toHaveLength(0);
+    expect(requireRustSourcesInCodeFilter("ci.yml", filters, tree)).toHaveLength(0);
   });
 
   test("a directory wildcard covers the manifests under it", () => {
@@ -531,8 +538,8 @@ describe("manifest sources stay inside both path filters", () => {
     );
   });
 
-  test("an empty modelsTreeSources list fails loudly instead of passing vacuously", () => {
-    const errors = requireModelsTreeInCodeFilter(CI, codeFilter(["rust/src/models/**"]), []);
+  test("an empty rustSources list fails loudly instead of passing vacuously", () => {
+    const errors = requireRustSourcesInCodeFilter(CI, codeFilter(["rust/src/models/**"]), []);
     expect(errors).toHaveLength(1);
     expect(errors[0]).toContain("returned no files");
   });
@@ -548,10 +555,10 @@ describe("manifest sources stay inside both path filters", () => {
   });
 
   test("main pairs each rule with its own collector", () => {
-    const { manifestSources, modelsTreeSources } = collectRuleSources(
+    const { manifestSources, rustSources } = collectRuleSources(
       repoPath("rust/src"), repoPath("rust/src/models"),
     );
-    expect(repoRelative(modelsTreeSources)).toContain("rust/src/models/paths.rs");
+    expect(repoRelative(rustSources)).toContain("rust/src/models/paths.rs");
     expect(repoRelative(manifestSources)).not.toContain("rust/src/models/paths.rs");
   });
 
@@ -564,14 +571,14 @@ describe("manifest sources stay inside both path filters", () => {
     const seed = join(dir, "cache-seed.yml");
     writeFileSync(seed, "on:\n  push:\n    paths:\n      - 'a.rs'\n");
 
-    const sources = { manifestSources: ["a.rs"], modelsTreeSources: ["a.rs", "b.rs"] };
+    const sources = { manifestSources: ["a.rs"], rustSources: ["a.rs", "b.rs"] };
     expect(checkFile(ci, [], [], undefined, sources).filter((e) => e.includes("#950"))).toEqual([]);
     expect(checkFile(seed, [], [], undefined, sources).filter((e) => e.includes("#950"))).toEqual([]);
 
     // Handing the seed rule the models-tree set instead names b.rs, which the push filter never covers.
     const swapped = checkFile(seed, [], [], undefined, {
-      manifestSources: sources.modelsTreeSources,
-      modelsTreeSources: sources.manifestSources,
+      manifestSources: sources.rustSources,
+      rustSources: sources.manifestSources,
     }).filter((e) => e.includes("#950"));
     expect(swapped).toHaveLength(1);
     expect(swapped[0]).toContain("b.rs");
@@ -585,21 +592,21 @@ describe("manifest sources stay inside both path filters", () => {
     const ci = join(dir, "ci.yml");
     writeFileSync(ci, "on: push\njobs:\n  changes:\n    steps:\n      - with:\n          filters: |\n            code:\n              - 'src/**'\n");
     // Distinct fifth and sixth arguments: each rule must name the file from its OWN set, so handing
-    // requireModelsTreeInCodeFilter the manifest set instead of the tree set is visible here (#950 round 3).
+    // requireRustSourcesInCodeFilter the manifest set instead of the tree set is visible here (#950 round 3).
     const errors = checkFile(ci, [], [], undefined, {
       manifestSources: ["rust/src/models/manifest.rs"],
-      modelsTreeSources: ["rust/src/models/paths.rs"],
+      rustSources: ["rust/src/models/paths.rs"],
     }).filter((e) => e.includes("#950"));
     expect(errors).toHaveLength(2);
     expect(errors.join("\n")).toContain("rust/src/models/manifest.rs contains ModelFile literals");
-    expect(errors.join("\n")).toContain("rust/src/models/paths.rs is read by the TS pact suites");
+    expect(errors.join("\n")).toContain("rust/src/models/paths.rs is read by a TS suite");
 
     const seed = join(dir, "cache-seed.yml");
     writeFileSync(seed, "on:\n  push:\n    paths:\n      - 'rust/Cargo.lock'\n");
     expect(
       checkFile(seed, [], [], undefined, {
         manifestSources: ["rust/src/models.rs"],
-        modelsTreeSources: ["rust/src/models.rs"],
+        rustSources: ["rust/src/models.rs"],
       }).filter((e) => e.includes("#950")),
     ).toHaveLength(1);
   });

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -450,6 +450,13 @@ describe("manifest sources stay inside both path filters", () => {
     expect(collectRustSources().map((file) => file.replaceAll("\\", "/"))).toContain("rust/src/text_lang.rs");
   });
 
+  // Same lesson as its sibling above: every test passes an explicit root, leaving the production default unpinned (#1132).
+  test("collectManifestSources' production default root is rust/src", () => {
+    expect(collectManifestSources().map((file) => file.replaceAll("\\", "/"))).toContain(
+      "rust/src/models/manifest.rs",
+    );
+  });
+
   test("collectRustSources returns every .rs under rust/src", () => {
     const tree = repoRelative(collectRustSources(repoPath("rust/src")));
     expect(tree.length).toBeGreaterThanOrEqual(6);

--- a/tests/unit/rust-cross-references.test.ts
+++ b/tests/unit/rust-cross-references.test.ts
@@ -5,7 +5,7 @@ import { readRepoFile, repoPath } from "../helpers/repo";
 
 /**
  * TS comments and hint strings point readers at the Rust symbol they mirror. Nothing kept those
- * pointers honest, so the #950 `models.rs` split left ~15 of them aimed at a deleted file (#1132).
+ * pointers honest, so the #950 `models.rs` split left 14 of them aimed at a deleted file (#1132).
  */
 const REFERENCE = /\b((?:rust\/src\/)?(?:[a-z0-9_]+\/)*[a-z0-9_]+\.rs)(?:::([A-Za-z0-9_]+))?/g;
 
@@ -20,11 +20,9 @@ function tsSources(dir: string): string[] {
 type Reference = { origin: string; rustPath: string; symbol?: string };
 
 const references: Reference[] = tsSources("src").flatMap((origin) =>
-  [...readRepoFile(origin).matchAll(REFERENCE)].map(([, path, symbol]) => ({
-    origin,
-    rustPath: path.replace(/^rust\/src\//, ""),
-    symbol,
-  })),
+  [...readRepoFile(origin).matchAll(REFERENCE)].flatMap(([, path, symbol]) =>
+    path ? [{ origin, rustPath: path.replace(/^rust\/src\//, ""), symbol }] : [],
+  ),
 );
 
 describe("Rust cross-references in TS sources", () => {

--- a/tests/unit/rust-cross-references.test.ts
+++ b/tests/unit/rust-cross-references.test.ts
@@ -7,7 +7,20 @@ import { readRepoFile, repoPath } from "../helpers/repo";
  * TS comments and hint strings point readers at the Rust symbol they mirror. Nothing kept those
  * pointers honest, so the #950 `models.rs` split left 14 of them aimed at a deleted file (#1132).
  */
-const REFERENCE = /\b((?:rust\/src\/)?(?:[a-z0-9_]+\/)*[a-z0-9_]+\.rs)(?:::([A-Za-z0-9_]+))?/g;
+const FILE_REFERENCE = /\b((?:rust\/)?(?:[a-z0-9_]+\/)*[a-z0-9_]+\.rs)(?:::([A-Za-z0-9_]+))?/g;
+
+/** The `mod::sym` form carries no `.rs`; the lookbehind keeps `init.ts::initCommand` and paths out. */
+const MODULE_REFERENCE = /(?<![\w./])([a-z][a-z0-9_]*(?:::[a-z][a-z0-9_]*)*)::([A-Za-z0-9_]+)/g;
+
+const DECLARATION = "(?:fn|const|static|struct|enum|trait|type|union|mod|macro_rules!)";
+
+/**
+ * A declaration, not a mention: a `use` line, a call site or a doc comment must not satisfy a
+ * pointer, or every symbol could be retargeted at `models/mod.rs`'s re-export block (#1132 round 1).
+ */
+function declares(source: string, symbol: string): boolean {
+  return new RegExp(`\\b${DECLARATION}\\s+${symbol}\\b`).test(source);
+}
 
 function tsSources(dir: string): string[] {
   return readdirSync(repoPath(dir), { withFileTypes: true }).flatMap((entry) => {
@@ -17,34 +30,64 @@ function tsSources(dir: string): string[] {
   });
 }
 
-type Reference = { origin: string; rustPath: string; symbol?: string };
+/** `rust/…` is repo-relative on purpose: `rust/build.rs` and `rust/tests/*.rs` are legal targets. */
+function resolveFile(path: string): string {
+  return path.startsWith("rust/") ? path : `rust/src/${path}`;
+}
 
-const references: Reference[] = tsSources("src").flatMap((origin) =>
-  [...readRepoFile(origin).matchAll(REFERENCE)].flatMap(([, path, symbol]) =>
-    path ? [{ origin, rustPath: path.replace(/^rust\/src\//, ""), symbol }] : [],
-  ),
-);
+function resolveModule(path: string): string | undefined {
+  const base = `rust/src/${path.split("::").join("/")}`;
+  return [`${base}.rs`, `${base}/mod.rs`].find((candidate) => existsSync(repoPath(candidate)));
+}
+
+type Reference = { origin: string; label: string; file?: string; symbol?: string; kind: string };
+
+function referencesIn(origin: string): Reference[] {
+  const source = readRepoFile(origin);
+  const files = [...source.matchAll(FILE_REFERENCE)].flatMap<Reference>(([, path, symbol]) =>
+    path
+      ? [
+          {
+            origin,
+            label: symbol ? `${path}::${symbol}` : path,
+            file: resolveFile(path),
+            symbol,
+            kind: symbol ? "file-with-symbol" : "file",
+          },
+        ]
+      : [],
+  );
+  const modules = [...source.matchAll(MODULE_REFERENCE)].flatMap<Reference>(([, path, symbol]) =>
+    path && symbol
+      ? [{ origin, label: `${path}::${symbol}`, file: resolveModule(path), symbol, kind: "module" }]
+      : [],
+  );
+  return [...files, ...modules];
+}
+
+const references: Reference[] = tsSources("src").flatMap(referencesIn);
+
+const countOf = (kind: string) => references.filter((reference) => reference.kind === kind).length;
 
 describe("Rust cross-references in TS sources", () => {
-  // Without this the two gates below would pass by finding nothing to check.
-  test("the scan finds the references it is meant to gate", () => {
-    expect(references.length).toBeGreaterThanOrEqual(20);
+  // Per shape, not a global total: a narrowing that loses one whole form must not pass on the others (#1132 round 1).
+  test("the scan finds every shape it is meant to gate", () => {
+    expect(countOf("file-with-symbol")).toBeGreaterThanOrEqual(20);
+    expect(countOf("file")).toBeGreaterThanOrEqual(2);
+    expect(countOf("module")).toBeGreaterThanOrEqual(1);
   });
 
   test("every referenced Rust file exists", () => {
     const dangling = references
-      .filter(({ rustPath }) => !existsSync(repoPath(`rust/src/${rustPath}`)))
-      .map(({ origin, rustPath }) => `${origin} → rust/src/${rustPath}`);
+      .filter(({ file }) => !file || !existsSync(repoPath(file)))
+      .map(({ origin, label }) => `${origin} → ${label}`);
     expect(dangling).toEqual([]);
   });
 
-  test("every referenced Rust symbol is defined in the file it names", () => {
+  test("every referenced Rust symbol is declared in the file it names", () => {
     const missing = references
-      .filter(({ rustPath, symbol }) => {
-        if (!symbol || !existsSync(repoPath(`rust/src/${rustPath}`))) return false;
-        return !new RegExp(`\\b${symbol}\\b`).test(readRepoFile(`rust/src/${rustPath}`));
-      })
-      .map(({ origin, rustPath, symbol }) => `${origin} → rust/src/${rustPath}::${symbol}`);
+      .filter(({ file, symbol }) => symbol && file && existsSync(repoPath(file)) && !declares(readRepoFile(file), symbol))
+      .map(({ origin, label }) => `${origin} → ${label}`);
     expect(missing).toEqual([]);
   });
 });

--- a/tests/unit/rust-cross-references.test.ts
+++ b/tests/unit/rust-cross-references.test.ts
@@ -14,12 +14,61 @@ const MODULE_REFERENCE = /(?<![\w./])([a-z][a-z0-9_]*(?:::[a-z][a-z0-9_]*)*)::([
 
 const DECLARATION = "(?:fn|const|static|struct|enum|trait|type|union|mod|macro_rules!)";
 
+/** Blanks Rust comments and literals, so declaration-shaped prose inside one cannot satisfy `declares` (#1132 round 2). */
+function stripCommentsAndLiterals(source: string): string {
+  let code = "";
+  let i = 0;
+  while (i < source.length) {
+    const rest = source.slice(i);
+    if (rest.startsWith("//")) {
+      const end = source.indexOf("\n", i);
+      i = end === -1 ? source.length : end;
+      continue;
+    }
+    if (rest.startsWith("/*")) {
+      let depth = 1;
+      i += 2;
+      while (i < source.length && depth > 0) {
+        if (source.startsWith("/*", i)) (depth++, (i += 2));
+        else if (source.startsWith("*/", i)) (depth--, (i += 2));
+        else i++;
+      }
+      continue;
+    }
+    const previous = code.at(-1);
+    if (!previous || !/[A-Za-z0-9_]/.test(previous)) {
+      const raw = /^b?r(#*)"/.exec(rest);
+      if (raw) {
+        const close = `"${raw[1]}`;
+        const end = source.indexOf(close, i + raw[0].length);
+        i = end === -1 ? source.length : end + close.length;
+        continue;
+      }
+      const quoted = /^b?"/.exec(rest);
+      if (quoted) {
+        i += quoted[0].length;
+        while (i < source.length && source[i] !== '"') i += source[i] === "\\" ? 2 : 1;
+        i++;
+        continue;
+      }
+      const character = /^'(?:\\.|[^\\'])'/.exec(rest);
+      if (character) {
+        i += character[0].length;
+        continue;
+      }
+    }
+    code += source[i];
+    i++;
+  }
+  return code;
+}
+
 /**
- * A declaration, not a mention: a `use` line, a call site or a doc comment must not satisfy a
- * pointer, or every symbol could be retargeted at `models/mod.rs`'s re-export block (#1132 round 1).
+ * A declaration, not a mention: a `use` line, a call site, a doc comment or a string must not
+ * satisfy a pointer, or every symbol could be retargeted at `models/mod.rs`'s re-export block.
  */
 function declares(source: string, symbol: string): boolean {
-  return new RegExp(`\\b${DECLARATION}\\s+${symbol}\\b`).test(source);
+  return new RegExp(`\\b${DECLARATION}\\s+${symbol}\\b`).test(stripCommentsAndLiterals(source));
 }
 
 function tsSources(dir: string): string[] {
@@ -68,6 +117,29 @@ function referencesIn(origin: string): Reference[] {
 const references: Reference[] = tsSources("src").flatMap(referencesIn);
 
 const countOf = (kind: string) => references.filter((reference) => reference.kind === kind).length;
+
+describe("declares", () => {
+  const cases: Array<[string, string, boolean]> = [
+    ["pub(super) const ANE_EN_FILES: &[ModelFile] = &[];", "ANE_EN_FILES", true],
+    ["pub fn helper_path() -> PathBuf {}", "helper_path", true],
+    ["macro_rules! trace_fmt {}", "trace_fmt", true],
+    ["// fn helper_path() — removed in #269", "helper_path", false],
+    ["/// Superseded by `fn helper_path`.", "helper_path", false],
+    ["/* fn helper_path() */", "helper_path", false],
+    ["/* outer /* fn helper_path() */ still comment */", "helper_path", false],
+    ['const DOC: &str = "const helper_path";', "helper_path", false],
+    ['let s = r#"pub fn helper_path()"#;', "helper_path", false],
+    ['let s = "escaped \\" fn helper_path";', "helper_path", false],
+    ["use crate::text_lang::helper_path;", "helper_path", false],
+    ["let p = helper_path();", "helper_path", false],
+  ];
+
+  for (const [source, symbol, expected] of cases) {
+    test(`${expected ? "accepts" : "rejects"} ${JSON.stringify(source)}`, () => {
+      expect(declares(source, symbol)).toBe(expected);
+    });
+  }
+});
 
 describe("Rust cross-references in TS sources", () => {
   // Per shape, not a global total: a narrowing that loses one whole form must not pass on the others (#1132 round 1).

--- a/tests/unit/rust-cross-references.test.ts
+++ b/tests/unit/rust-cross-references.test.ts
@@ -136,7 +136,6 @@ describe("declares", () => {
     ['const DOC: &str = "const helper_path";', "helper_path", false],
     ['let s = r#"pub fn helper_path()"#;', "helper_path", false],
     ['let s = "escaped \\" fn helper_path";', "helper_path", false],
-    ["use crate::text_lang::helper_path;", "helper_path", false],
     ["let p = helper_path();", "helper_path", false],
   ];
 
@@ -145,6 +144,16 @@ describe("declares", () => {
       expect(declares(source, symbol)).toBe(expected);
     });
   }
+});
+
+// Runs only where the FS itself accepts the mangled case — exactly the platforms the helper protects.
+const onCaseInsensitiveFs = existsSync(repoPath("rust/src/DEBUG.RS")) ? test : test.skip;
+
+describe("existsExactly", () => {
+  onCaseInsensitiveFs("rejects a case-mangled path that existsSync accepts", () => {
+    expect(existsSync(repoPath("rust/src/Debug.rs"))).toBe(true);
+    expect(existsExactly("rust/src/Debug.rs")).toBe(false);
+  });
 });
 
 describe("Rust cross-references in TS sources", () => {

--- a/tests/unit/rust-cross-references.test.ts
+++ b/tests/unit/rust-cross-references.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { readRepoFile, repoPath } from "../helpers/repo";
+
+/**
+ * TS comments and hint strings point readers at the Rust symbol they mirror. Nothing kept those
+ * pointers honest, so the #950 `models.rs` split left ~15 of them aimed at a deleted file (#1132).
+ */
+const REFERENCE = /\b((?:rust\/src\/)?(?:[a-z0-9_]+\/)*[a-z0-9_]+\.rs)(?:::([A-Za-z0-9_]+))?/g;
+
+function tsSources(dir: string): string[] {
+  return readdirSync(repoPath(dir), { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return tsSources(path);
+    return entry.name.endsWith(".ts") ? [path] : [];
+  });
+}
+
+type Reference = { origin: string; rustPath: string; symbol?: string };
+
+const references: Reference[] = tsSources("src").flatMap((origin) =>
+  [...readRepoFile(origin).matchAll(REFERENCE)].map(([, path, symbol]) => ({
+    origin,
+    rustPath: path.replace(/^rust\/src\//, ""),
+    symbol,
+  })),
+);
+
+describe("Rust cross-references in TS sources", () => {
+  // Without this the two gates below would pass by finding nothing to check.
+  test("the scan finds the references it is meant to gate", () => {
+    expect(references.length).toBeGreaterThanOrEqual(20);
+  });
+
+  test("every referenced Rust file exists", () => {
+    const dangling = references
+      .filter(({ rustPath }) => !existsSync(repoPath(`rust/src/${rustPath}`)))
+      .map(({ origin, rustPath }) => `${origin} → rust/src/${rustPath}`);
+    expect(dangling).toEqual([]);
+  });
+
+  test("every referenced Rust symbol is defined in the file it names", () => {
+    const missing = references
+      .filter(({ rustPath, symbol }) => {
+        if (!symbol || !existsSync(repoPath(`rust/src/${rustPath}`))) return false;
+        return !new RegExp(`\\b${symbol}\\b`).test(readRepoFile(`rust/src/${rustPath}`));
+      })
+      .map(({ origin, rustPath, symbol }) => `${origin} → rust/src/${rustPath}::${symbol}`);
+    expect(missing).toEqual([]);
+  });
+});

--- a/tests/unit/rust-cross-references.test.ts
+++ b/tests/unit/rust-cross-references.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { existsSync, readdirSync } from "node:fs";
+import { existsSync, readdirSync, realpathSync } from "node:fs";
 import { join } from "node:path";
 import { readRepoFile, repoPath } from "../helpers/repo";
 
@@ -7,7 +7,7 @@ import { readRepoFile, repoPath } from "../helpers/repo";
  * TS comments and hint strings point readers at the Rust symbol they mirror. Nothing kept those
  * pointers honest, so the #950 `models.rs` split left 14 of them aimed at a deleted file (#1132).
  */
-const FILE_REFERENCE = /\b((?:rust\/)?(?:[a-z0-9_]+\/)*[a-z0-9_]+\.rs)(?:::([A-Za-z0-9_]+))?/g;
+const FILE_REFERENCE = /\b((?:rust\/)?(?:[A-Za-z0-9_]+\/)*[A-Za-z0-9_]+\.rs)(?:::([A-Za-z0-9_]+))?/g;
 
 /** The `mod::sym` form carries no `.rs`; the lookbehind keeps `init.ts::initCommand` and paths out. */
 const MODULE_REFERENCE = /(?<![\w./])([a-z][a-z0-9_]*(?:::[a-z][a-z0-9_]*)*)::([A-Za-z0-9_]+)/g;
@@ -79,6 +79,12 @@ function tsSources(dir: string): string[] {
   });
 }
 
+/** Case-exact: macOS and Windows resolve `rust/src/Debug.rs` to `debug.rs`, so `existsSync` alone passes here and fails on Linux CI (#1132 round 3). */
+function existsExactly(path: string): boolean {
+  const full = repoPath(path);
+  return existsSync(full) && realpathSync.native(full).replaceAll("\\", "/").endsWith(`/${path}`);
+}
+
 /** `rust/…` is repo-relative on purpose: `rust/build.rs` and `rust/tests/*.rs` are legal targets. */
 function resolveFile(path: string): string {
   return path.startsWith("rust/") ? path : `rust/src/${path}`;
@@ -86,7 +92,7 @@ function resolveFile(path: string): string {
 
 function resolveModule(path: string): string | undefined {
   const base = `rust/src/${path.split("::").join("/")}`;
-  return [`${base}.rs`, `${base}/mod.rs`].find((candidate) => existsSync(repoPath(candidate)));
+  return [`${base}.rs`, `${base}/mod.rs`].find((candidate) => existsExactly(candidate));
 }
 
 type Reference = { origin: string; label: string; file?: string; symbol?: string; kind: string };
@@ -149,16 +155,21 @@ describe("Rust cross-references in TS sources", () => {
     expect(countOf("module")).toBeGreaterThanOrEqual(1);
   });
 
+  // No reference lives below src/ today, so without this a narrowed walk would go unnoticed (#1132 round 3).
+  test("the scan walks below the top level of src/", () => {
+    expect(tsSources("src").filter((path) => path.split(/[\\/]/).length > 2)).not.toEqual([]);
+  });
+
   test("every referenced Rust file exists", () => {
     const dangling = references
-      .filter(({ file }) => !file || !existsSync(repoPath(file)))
+      .filter(({ file }) => !file || !existsExactly(file))
       .map(({ origin, label }) => `${origin} → ${label}`);
     expect(dangling).toEqual([]);
   });
 
   test("every referenced Rust symbol is declared in the file it names", () => {
     const missing = references
-      .filter(({ file, symbol }) => symbol && file && existsSync(repoPath(file)) && !declares(readRepoFile(file), symbol))
+      .filter(({ file, symbol }) => symbol && file && existsExactly(file) && !declares(readRepoFile(file), symbol))
       .map(({ origin, label }) => `${origin} → ${label}`);
     expect(missing).toEqual([]);
   });

--- a/tests/unit/status.test.ts
+++ b/tests/unit/status.test.ts
@@ -15,7 +15,18 @@ import { starSeenPath } from "../../src/star";
 import { saveEngineEnv, stageEngineHome, writeFakeEngine } from "../helpers/fake-engine";
 import modelPlan from "../../model-plan.json" with { type: "json" };
 
-const VOSK_RU_RELPATHS = modelPlan.voskRu.map((file) => file.relPath);
+// Literals, not derived from model-plan.json: a dropped plan entry must go red here, since the Rust binding test skips plan-only PRs (#1132).
+const VOSK_RU_RELPATHS = [
+  "models/vosk-ru/model.onnx",
+  "models/vosk-ru/dictionary",
+  "models/vosk-ru/config.json",
+  "models/vosk-ru/bert/model.onnx",
+  "models/vosk-ru/bert/vocab.txt",
+];
+
+test("model-plan.json's voskRu carries exactly the files the status gate requires", () => {
+  expect(modelPlan.voskRu.map((file) => file.relPath).sort()).toEqual([...VOSK_RU_RELPATHS].sort());
+});
 
 function writeVoskBundle(cache: string): void {
   for (const relPath of VOSK_RU_RELPATHS) {

--- a/tests/unit/status.test.ts
+++ b/tests/unit/status.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "fs";
-import { join, sep } from "path";
+import { dirname, join, sep } from "path";
 import { tmpdir } from "os";
 import {
   formatStatusLine,
@@ -13,6 +13,9 @@ import {
 import { humanBytes } from "../../src/format";
 import { starSeenPath } from "../../src/star";
 import { saveEngineEnv, stageEngineHome, writeFakeEngine } from "../helpers/fake-engine";
+import modelPlan from "../../model-plan.json" with { type: "json" };
+
+const VOSK_RU_RELPATHS = modelPlan.voskRu.map((file) => file.relPath);
 
 const posixEngineTest = process.platform === "win32" ? test.skip : test;
 
@@ -823,45 +826,39 @@ describe("collectStatus voice inventory", () => {
   beforeEach(restoreEnv);
   afterEach(restoreEnv);
 
-  posixEngineTest("a half-downloaded Vosk model advertises no Russian voices", async () => {
+  // One case per manifest file so none is masked by a later one, and the list is joined to VOSK_RU_FILES (#1132).
+  async function voicesWithVoskBundle(present: string[]): Promise<string[]> {
     const dir = mkdtempSync(join(tmpdir(), "kesha-status-vosk-partial-"));
     const cache = join(dir, ".cache", "kesha");
-    const binPath = writeFakeEngine(join(cache, "engine", "bin"));
-    const vosk = join(cache, "models", "vosk-ru");
-    mkdirSync(join(vosk, "bert"), { recursive: true });
-
-    process.env.KESHA_ENGINE_BIN = binPath;
+    process.env.KESHA_ENGINE_BIN = writeFakeEngine(join(cache, "engine", "bin"));
     process.env.KESHA_CACHE_DIR = cache;
     process.env.HOME = dir;
     try {
-      writeFileSync(join(vosk, "bert", "model.onnx"), "bert");
-      expect((await collectStatus()).voices).toEqual([]);
-
-      rmSync(join(vosk, "bert", "model.onnx"));
-      writeFileSync(join(vosk, "model.onnx"), "model");
-      expect((await collectStatus()).voices).toEqual([]);
-
-      // Two of the three files `vosk_tts::Model::new` opens: advertising here offers a voice `resolve_vosk_ru` refuses (#1132).
-      writeFileSync(join(vosk, "bert", "model.onnx"), "bert");
-      expect((await collectStatus()).voices).toEqual([]);
-
-      writeFileSync(join(vosk, "dictionary"), "dictionary");
-      expect((await collectStatus()).voices).toEqual([]);
-
-      writeFileSync(join(vosk, "config.json"), "{}");
-      expect((await collectStatus()).voices).toEqual([]);
-
-      writeFileSync(join(vosk, "bert", "vocab.txt"), "vocab");
-      expect((await collectStatus()).voices).toEqual([
-        "ru-vosk-f01",
-        "ru-vosk-f02",
-        "ru-vosk-f03",
-        "ru-vosk-m01",
-        "ru-vosk-m02",
-      ]);
+      for (const relPath of present) {
+        const file = join(cache, relPath);
+        mkdirSync(dirname(file), { recursive: true });
+        writeFileSync(file, relPath);
+      }
+      return (await collectStatus()).voices;
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  }
+
+  for (const missing of VOSK_RU_RELPATHS) {
+    posixEngineTest(`advertises no Russian voices while ${missing} is missing`, async () => {
+      expect(await voicesWithVoskBundle(VOSK_RU_RELPATHS.filter((p) => p !== missing))).toEqual([]);
+    });
+  }
+
+  posixEngineTest("advertises every speaker once the whole Vosk bundle is present", async () => {
+    expect(await voicesWithVoskBundle(VOSK_RU_RELPATHS)).toEqual([
+      "ru-vosk-f01",
+      "ru-vosk-f02",
+      "ru-vosk-f03",
+      "ru-vosk-m01",
+      "ru-vosk-m02",
+    ]);
   });
 
   posixEngineTest("voices are listed in sorted order across engines", async () => {

--- a/tests/unit/status.test.ts
+++ b/tests/unit/status.test.ts
@@ -169,6 +169,7 @@ exit 2
     writeFileSync(join(cache, "models", "kokoro-82m", "voices", "README.txt"), "ignored");
     mkdirSync(join(cache, "models", "vosk-ru", "bert"), { recursive: true });
     writeFileSync(join(cache, "models", "vosk-ru", "model.onnx"), "model");
+    writeFileSync(join(cache, "models", "vosk-ru", "dictionary"), "dictionary");
     writeFileSync(join(cache, "models", "vosk-ru", "bert", "model.onnx"), "bert");
 
     process.env.KESHA_ENGINE_BIN = binPath;
@@ -838,7 +839,11 @@ describe("collectStatus voice inventory", () => {
       writeFileSync(join(vosk, "model.onnx"), "model");
       expect((await collectStatus()).voices).toEqual([]);
 
+      // Two of the three files `vosk_tts::Model::new` opens: advertising here offers a voice `resolve_vosk_ru` refuses (#1132).
       writeFileSync(join(vosk, "bert", "model.onnx"), "bert");
+      expect((await collectStatus()).voices).toEqual([]);
+
+      writeFileSync(join(vosk, "dictionary"), "dictionary");
       expect((await collectStatus()).voices).toEqual([
         "ru-vosk-f01",
         "ru-vosk-f02",
@@ -861,6 +866,7 @@ describe("collectStatus voice inventory", () => {
     }
     mkdirSync(join(cache, "models", "vosk-ru", "bert"), { recursive: true });
     writeFileSync(join(cache, "models", "vosk-ru", "model.onnx"), "model");
+    writeFileSync(join(cache, "models", "vosk-ru", "dictionary"), "dictionary");
     writeFileSync(join(cache, "models", "vosk-ru", "bert", "model.onnx"), "bert");
 
     process.env.KESHA_ENGINE_BIN = binPath;

--- a/tests/unit/status.test.ts
+++ b/tests/unit/status.test.ts
@@ -170,6 +170,8 @@ exit 2
     mkdirSync(join(cache, "models", "vosk-ru", "bert"), { recursive: true });
     writeFileSync(join(cache, "models", "vosk-ru", "model.onnx"), "model");
     writeFileSync(join(cache, "models", "vosk-ru", "dictionary"), "dictionary");
+    writeFileSync(join(cache, "models", "vosk-ru", "config.json"), "{}");
+    writeFileSync(join(cache, "models", "vosk-ru", "bert", "vocab.txt"), "vocab");
     writeFileSync(join(cache, "models", "vosk-ru", "bert", "model.onnx"), "bert");
 
     process.env.KESHA_ENGINE_BIN = binPath;
@@ -844,6 +846,12 @@ describe("collectStatus voice inventory", () => {
       expect((await collectStatus()).voices).toEqual([]);
 
       writeFileSync(join(vosk, "dictionary"), "dictionary");
+      expect((await collectStatus()).voices).toEqual([]);
+
+      writeFileSync(join(vosk, "config.json"), "{}");
+      expect((await collectStatus()).voices).toEqual([]);
+
+      writeFileSync(join(vosk, "bert", "vocab.txt"), "vocab");
       expect((await collectStatus()).voices).toEqual([
         "ru-vosk-f01",
         "ru-vosk-f02",
@@ -867,6 +875,8 @@ describe("collectStatus voice inventory", () => {
     mkdirSync(join(cache, "models", "vosk-ru", "bert"), { recursive: true });
     writeFileSync(join(cache, "models", "vosk-ru", "model.onnx"), "model");
     writeFileSync(join(cache, "models", "vosk-ru", "dictionary"), "dictionary");
+    writeFileSync(join(cache, "models", "vosk-ru", "config.json"), "{}");
+    writeFileSync(join(cache, "models", "vosk-ru", "bert", "vocab.txt"), "vocab");
     writeFileSync(join(cache, "models", "vosk-ru", "bert", "model.onnx"), "bert");
 
     process.env.KESHA_ENGINE_BIN = binPath;

--- a/tests/unit/status.test.ts
+++ b/tests/unit/status.test.ts
@@ -17,6 +17,14 @@ import modelPlan from "../../model-plan.json" with { type: "json" };
 
 const VOSK_RU_RELPATHS = modelPlan.voskRu.map((file) => file.relPath);
 
+function writeVoskBundle(cache: string): void {
+  for (const relPath of VOSK_RU_RELPATHS) {
+    const file = join(cache, relPath);
+    mkdirSync(dirname(file), { recursive: true });
+    writeFileSync(file, relPath);
+  }
+}
+
 const posixEngineTest = process.platform === "win32" ? test.skip : test;
 
 describe("formatStatusLine", () => {
@@ -170,12 +178,7 @@ exit 2
     mkdirSync(join(cache, "models", "kokoro-82m", "voices"), { recursive: true });
     writeFileSync(join(cache, "models", "kokoro-82m", "voices", "am_michael.bin"), "voice");
     writeFileSync(join(cache, "models", "kokoro-82m", "voices", "README.txt"), "ignored");
-    mkdirSync(join(cache, "models", "vosk-ru", "bert"), { recursive: true });
-    writeFileSync(join(cache, "models", "vosk-ru", "model.onnx"), "model");
-    writeFileSync(join(cache, "models", "vosk-ru", "dictionary"), "dictionary");
-    writeFileSync(join(cache, "models", "vosk-ru", "config.json"), "{}");
-    writeFileSync(join(cache, "models", "vosk-ru", "bert", "vocab.txt"), "vocab");
-    writeFileSync(join(cache, "models", "vosk-ru", "bert", "model.onnx"), "bert");
+    writeVoskBundle(cache);
 
     process.env.KESHA_ENGINE_BIN = binPath;
     process.env.KESHA_CACHE_DIR = cache;
@@ -869,12 +872,7 @@ describe("collectStatus voice inventory", () => {
     for (const name of ["zf_xiaobei.bin", "am_michael.bin", "bf_emma.bin"]) {
       writeFileSync(join(cache, "models", "kokoro-82m", "voices", name), "voice");
     }
-    mkdirSync(join(cache, "models", "vosk-ru", "bert"), { recursive: true });
-    writeFileSync(join(cache, "models", "vosk-ru", "model.onnx"), "model");
-    writeFileSync(join(cache, "models", "vosk-ru", "dictionary"), "dictionary");
-    writeFileSync(join(cache, "models", "vosk-ru", "config.json"), "{}");
-    writeFileSync(join(cache, "models", "vosk-ru", "bert", "vocab.txt"), "vocab");
-    writeFileSync(join(cache, "models", "vosk-ru", "bert", "model.onnx"), "bert");
+    writeVoskBundle(cache);
 
     process.env.KESHA_ENGINE_BIN = binPath;
     process.env.KESHA_CACHE_DIR = cache;


### PR DESCRIPTION
Closes #1132

## Claim

Every Rust cross-reference in a `src/**/*.ts` comment or hint string — both the `<file>.rs[::<symbol>]` form and the `<mod>::<symbol>` form — names a file that exists and a symbol **declared** in that file, and `tests/unit/rust-cross-references.test.ts` fails naming each offender whenever one does not.

If this is wrong, `every referenced Rust file exists` or `every referenced Rust symbol is declared in the file it names` fires with the offending `src/… → …` pair. Before this branch the first fired with 14 of them, all aimed at the `rust/src/models.rs` that #1130 deleted.

## What changed

14 comment and hint strings retargeted to each symbol's post-split home:

| symbol | new home |
| --- | --- |
| `fluidaudio_asr_location`, `fluidaudio_asr_ready`, `FLUID_ASR_REQUIRED`, `dir_has_entries`, `fluidaudio_location`, `fluidaudio_kokoro_location` | `models/paths.rs` |
| `ANE_EN_FILES`, `KOKORO_G2P_FILES` | `models/manifest.rs` |
| `stage_fluidaudio_kokoro_assets`, `missing_kokoro_assets` | `models/staging.rs` |
| `model_mirror`, `cleanup_orphan_staging`, `write_verified` | `models/download.rs` |

## Review round 1 — all six findings, with the probes re-fired

**[P1] + [P2] `rust-cross-references.test.ts:45` — mention-match, not declaration.** The check is now `\b(fn|const|static|struct|enum|trait|type|union|mod|macro_rules!)\s+<symbol>\b`. Re-fired with `just mutate`, all three **PINNED: the mutation was caught**:

| mutation | before | after |
| --- | --- | --- |
| `models/staging.rs::stage_…` → `models/download.rs::stage_…` (a file that only `use`s and calls it) | survived | caught |
| `models/paths.rs::dir_has_entries` → `models/paths.rs::download` (`download` appears only in Rust comments — codex's probe) | survived | caught |
| `models/paths.rs::dir_has_entries` → `models/mod.rs::dir_has_entries` (the re-export block) | survived | caught |

**[P2] `src/status.ts:260` — a dangling `mod::sym` pointer the regex never scanned.** `models::is_vosk_ru_cached` was removed in #269; the live equivalent is `models/paths.rs::has_vosk_ru_layout`, and the pointer now says so. The guard gained a `MODULE_REFERENCE` scan for the `<mod>::<symbol>` shape, which resolves `a::b` to `rust/src/a/b.rs` or `…/b/mod.rs`; a lookbehind keeps `src/cli/init.ts::initCommand` and path segments out. It picks up the previously unguarded `src/voice-routing.ts:3 → tts::voices::DEFAULT_VOICE_ID` (valid — `voices.rs:45`). Re-fired: `just mutate src/status.ts 'models/paths.rs::has_vosk_ru_layout' 'models::is_vosk_ru_cached'` → **caught**.

The finding's bonus was also real and is fixed: Rust requires three files (`model.onnx`, `dictionary`, `bert/model.onnx`), the TS mirror checked two, so `kesha status` advertised `ru-vosk-*` for an install `resolve_vosk_ru` refuses. `tests/unit/status.test.ts`'s half-download case now asserts `[]` at two-of-three and went red before the fix; two fixtures that built a "complete" install from two files were corrected.

**[P2] `ci.yml:98` — the lane that runs the guard was gated on `rust/src/models/**`.** The `code` filter now lists `rust/src/**`, and `collectModelsTreeSources` / `requireModelsTreeInCodeFilter` are renamed to `collectRustSources` / `requireRustSourcesInCodeFilter` and widened to all of `rust/src`, so re-narrowing is a red check rather than a docstring. New assertion `the real ci.yml code filter covers every Rust source, not just the models tree` was red before the ci.yml edit. Re-fired the named probe: `git mv rust/src/text_lang.rs rust/src/text_language.rs` reddens the guard with `src/engine-install.ts → rust/src/text_lang.rs::helper_path`, and the renamed path is now `COVERED by code` (was not); rename reverted.

**[P3] `:36` — paths outside `rust/src/` false-positived.** `rust/`-prefixed references are treated as repo-relative, so `rust/build.rs` and `rust/tests/model_gate.rs` are legal targets. Re-fired the named probe by adding an `rust/build.rs` pointer to a `src/fluid-roots.ts` comment: `NOT PINNED: the mutation survived` — i.e. accepted, no false positive.

**[P3] `:31` — one global floor of 20.** Replaced with a floor per shape: `file-with-symbol ≥ 20` (actual 22), `file ≥ 2` (actual 2), `module ≥ 1` (actual 1). Re-fired: neutralising `MODULE_REFERENCE`'s lookbehind to `(?<![\s\S])`, which drops the whole module shape, is **caught** — the old single global floor would have passed on the surviving 24.

## Deliberately left alone

- `docs/mutation-evidence/*.md` — historical records of the pre-split tree.
- `.claude/hooks/guard-sha-bump.sh` — its case pattern matches the legacy *and* the split paths on purpose.
- `tests/unit/check-workflows.test.ts`'s `rust/src/models.rs` strings — fixture inputs to a path-filter helper, not claims about the tree.


## Review round 2

**[P1] + [P2] `rust-cross-references.test.ts:22` — `declares()` matched declaration-shaped text inside comments and strings.** It now runs against a `stripCommentsAndLiterals` pass that blanks line comments, nested block comments, strings, byte-strings, raw strings (`r#"…"#`) and char literals. Twelve cases pin it, seven of which were red first. Codex's probes re-fired:

| probe | before | after |
| --- | --- | --- |
| `declares("// fn not_a_definition()", …)` | `true` | **`false`** |
| `declares('const DOC = "const not_a_definition";', …)` | `true` | **`false`** |
| `declares("let x = not_a_definition();", …)` (control) | `false` | `false` |
| `declares("pub fn not_a_definition() {}", …)` (control) | `true` | `true` |

Neutralising the stripper — `…test(stripCommentsAndLiterals(source))` → `…test(source)` — is **caught**, so the pass is itself pinned. All four round-1 mutations remain caught.

**[P2] `src/status.ts:263` — three files is still a partial bundle.** `VOSK_RU_FILES` is five files and `Vosk::load` documents that layout, so `listInstalledVoices` was extended to all five. (Round 4 replaces this hand copy with a join to the manifest.)

## Review round 3

**[P2] `src/status.ts:262` — four of five requirements were unpinned.** The staircase only pinned the last file it wrote. Cases are now generated one per entry of `model-plan.json`'s `voskRu`, each building the bundle with exactly that file absent. All six named mutations re-fired, every one now **PINNED**: deleting the `model.onnx`, `dictionary`, `config.json`, `bert/model.onnx` or `bert/vocab.txt` check, and neutralising the `config.json` check to a `statSync` of the `vosk-ru` directory. The first four and the neutralisation were NOT PINNED before.

**[P2] `rust-cross-references.test.ts:10` — the regex admitted only lowercase path components.** Widened to `[A-Za-z0-9_]`. That alone did not re-fire the probe: macOS and Windows resolve `rust/src/Debug.rs` to `debug.rs`, so `existsSync` returns true here and the guard would have gone red only on Linux CI. Existence is now checked case-exactly via `realpathSync.native`. Re-fired: `rust/src/debug.rs::trace_fmt` → `rust/src/Debug.rs::trace_fmt` is **caught**; the lowercase deleted-file control stays caught.

**[P3] `check-workflows.ts:666` — the production default root was unpinned.** Added a case calling `collectRustSources()` with no argument. Re-fired: `root = "rust/src"` → `root = "rust/src/models"` is **caught** (was NOT PINNED).

**[P3] `rust-cross-references.test.ts:99` — the directory recursion was unpinned.** Added a case asserting the walk reaches files below the top level of `src/`. Re-fired: `if (entry.isDirectory()) return tsSources(path);` → `return [];` is **caught** (was NOT PINNED).

**[P3] `openspec/specs/…` — stale pointers the guard does not scan.** Swept all nine (the four named plus five more the same grep finds): `GLOSSARY.md:12`, `engine-contract/spec.md:262-263`, `installation/spec.md:357,408,433,483`, `tts-synthesis/spec.md:233,533`. The two carrying line coordinates now name symbols instead. The scan is deliberately not extended to `openspec/**`, `tests/**` or `.github/scripts/**` — as the finding notes, its regexes flag deliberate fixture literals there (`a.rs`, `use_item.rs`, `brace_literal.rs`).

**[P3] `rust/src/models/paths.rs:440`** — argued in this round, fixed in round 4 below.

## Review round 4

**[P2] + [P3] `src/status.ts:260-265` — the production guard was still a hand copy.** Round 3 fixed only the test; the finding is right. `listInstalledVoices` now loops `model-plan.json`'s `voskRu` — the field `check-model-plan-sizes.test.ts` joins to `VOSK_RU_FILES` and `src/install-plan.ts` already consumes — so the five paths are no longer written down anywhere in `src/`. Two fixtures in `status.test.ts` that still spelled them out build the bundle from the same list.

| mutation | outcome |
| --- | --- |
| append a sixth `voskRu` entry to `model-plan.json` | **NOT PINNED** — production adapts and stays correct with no edit to `status.ts`; against the hand copy this was caught, i.e. `kesha status` was wrong until someone hand-edited it |
| `modelPlan.voskRu` → `.slice(0, 4)` (drop the last requirement) | **caught** |
| `modelPlan.voskRu` → `.slice(1)` (drop the first) | **caught** |

The per-file pins from round 3 survive the refactor in both directions.

**[P3] `rust/src/models/paths.rs:440` — fixed this round rather than argued again.** `has_vosk_ru_layout` now requires all five files. Raised twice with evidence I could act on, and after the status fix it was the remaining half of a user-visible disagreement: `is_cached_in(VoskRu)` called a three-file bundle cached, so `kesha say --list-voices` listed voices `Vosk::load` then failed on for the missing `config.json` it reads `sample_rate` from. A new red-first characterization test, `is_cached_in_vosk_ru_false_without_config_and_vocab`, failed on the old gate (`assertion failed: !is_cached_in(ModelKind::VoskRu, &dir)`) and passes now; `is_cached_in_vosk_ru_true_when_layout_present` was writing three files and now writes five. `populate_vosk_ru` in `voices.rs` already wrote all five, so `resolve_vosk_ru`'s tests were unaffected — 14 vosk tests pass. This touches `rust/**`, so preflight ran the Rust gate; it is not fluidaudio-adjacent, so `verify-darwin-full` is not implicated.
