### PR TITLE
mutants-ts cannot reach the code that enforces the repo's rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,8 @@ jobs:
               - '.github/workflows/build-engine.yml'
               # Most of these scripts have unit tests; without this a script-only edit skips the tests that cover it (check-workflows.ts enforces it). Deliberately no count — the one that lived here read 16 against an actual 25.
               - '.github/scripts/**'
+              # Same reason for the repo's own scripts: mutants-ts.ts, mutate.ts and release-tag.ts all have unit suites, and a scripts-only edit skipped every one of them (#1091 review).
+              - 'scripts/**'
               # The two halves of the install-plan join (#920): the size canary's unit test
               # asserts every plan entry still resolves to a URL in the manifest, and a change
               # to either file alone would otherwise never run it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -224,10 +224,17 @@ just mutants-ts src/voice-routing.ts                           # TypeScript (Str
 just mutants-ts --with-integration src/engine.ts src/cli/main.ts # several files
 just mutants-ts --with-integration src/foo.ts # include integration suites (slower)
 
+just mutants-ts .github/scripts/check-workflows.ts             # the CI gates are mutable too
+
 just mutants-rust src/errors.rs # Rust: cargo-mutants; clean rust/ tree required
 ```
 
 Or via npm scripts: `bun run mutants:ts -- src/voice-routing.ts`.
+
+Mutable roots are `src/`, `scripts/` and `.github/scripts/` — the gates enforce
+the rules in CLAUDE.md, so they earn the same measurement (#1091). Selection is
+by import, so a suite that only *spawns* a script cannot be found automatically;
+the run says so and exits non-zero rather than reporting zero mutants.
 
 The default TypeScript roots are `tests/unit/` only. For engine spawn, CLI
 contracts, or install hints, pass `--with-integration` so the relevant

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -225,16 +225,19 @@ just mutants-ts --with-integration src/engine.ts src/cli/main.ts # several files
 just mutants-ts --with-integration src/foo.ts # include integration suites (slower)
 
 just mutants-ts .github/scripts/check-workflows.ts             # the CI gates are mutable too
+just mutants-ts .github/scripts/npm-dist-tag.mjs               # so is the .mjs release path
 
 just mutants-rust src/errors.rs # Rust: cargo-mutants; clean rust/ tree required
 ```
 
 Or via npm scripts: `bun run mutants:ts -- src/voice-routing.ts`.
 
-Mutable roots are `src/`, `scripts/` and `.github/scripts/` — the gates enforce
-the rules in CLAUDE.md, so they earn the same measurement (#1091). Selection is
-by import, so a suite that only *spawns* a script cannot be found automatically;
-the run says so and exits non-zero rather than reporting zero mutants.
+Mutable roots are `src/`, `scripts/` and `.github/scripts/`, in `.ts` or `.mjs`
+— the gates enforce the rules in CLAUDE.md and the release path is written in
+`.mjs`, so both earn the same measurement (#1091). Selection is by import, so a
+suite that only *spawns* a script cannot be found automatically; the run says so
+and exits non-zero rather than reporting zero mutants, and it only points at
+`--with-integration` when an integration suite would actually reach the source.
 
 The default TypeScript roots are `tests/unit/` only. For engine spawn, CLI
 contracts, or install hints, pass `--with-integration` so the relevant

--- a/justfile
+++ b/justfile
@@ -164,7 +164,7 @@ mutants-rust FILE:
     @git diff --quiet -- rust || { echo "rust/ has uncommitted changes; --in-place mutates the tree" >&2; exit 2; }
     cd rust && cargo mutants --in-place -f "$1" --features {{ FEATURES }} -- -E '{{ if TEST_FILTER == "" { "all()" } else { TEST_FILTER } }}'
 
-# Mutation-test TypeScript sources against whichever suites import them, e.g. just mutants-ts src/engine.ts
+# Mutation-test src/, scripts/ or .github/scripts/ against whichever suites import them, e.g. just mutants-ts src/engine.ts
 [positional-arguments]
 mutants-ts *FILES:
     bun scripts/mutants-ts.ts "$@"

--- a/scripts/mutants-ts.ts
+++ b/scripts/mutants-ts.ts
@@ -10,20 +10,30 @@ const INTEGRATION_ROOT = "tests/integration";
 const GENERATED_CONFIG = `stryker.generated.${process.pid}.json`;
 
 // `src/` alone left the CI gates and the repo's own scripts unmeasurable (#1091).
-export const MUTABLE_ROOTS = ["src/", "scripts/", ".github/scripts/"];
+const MUTABLE_ROOTS = ["src/", "scripts/", ".github/scripts/"];
+// The release path under `.github/scripts/` is written in `.mjs`; `.ts` alone hid all of it (#1091 review).
+const MUTABLE_EXTENSIONS = [".ts", ".mjs"];
 
 const USAGE = [
-  "usage: bun scripts/mutants-ts.ts [--with-integration] <file.ts> [more.ts ...]",
+  "usage: bun scripts/mutants-ts.ts [--with-integration] <file.ts|file.mjs> [more ...]",
   "",
   "Mutation-tests the named sources against whichever suites import them.",
   "A survivor is an edit no test noticed — read it as a missing assertion,",
   "not as a number to drive up. CLAUDE.md names the kinds worth leaving alive.",
 ].join("\n");
 
-/** The reason `source` cannot be mutated, naming the accepted roots, or null when it can. */
+/** The reason `source` cannot be mutated, naming what is accepted, or null when it can. */
 export function mutableSourceRejection(source: string): string | null {
-  if (source.endsWith(".ts") && MUTABLE_ROOTS.some((root) => source.startsWith(root))) return null;
-  return `not a mutable source file: ${source} — expected a .ts file under ${MUTABLE_ROOTS.join(", ")}`;
+  const mutable =
+    MUTABLE_EXTENSIONS.some((extension) => source.endsWith(extension)) &&
+    MUTABLE_ROOTS.some((root) => source.startsWith(root));
+  if (mutable) return null;
+  return `not a mutable source file: ${source} — expected a ${MUTABLE_EXTENSIONS.join(" or ")} file under ${MUTABLE_ROOTS.join(", ")}`;
+}
+
+/** The refusal when nothing measures `sources`; the retry is only named when it would find suites. */
+export function noSuiteRefusal(sources: string[], roots: string[], integrationHelps: boolean): string {
+  return `no suite in ${roots.join(", ")} reaches ${sources.join(", ")} — mutation testing measures assertions, so there is nothing to measure yet${integrationHelps ? " (retry with --with-integration)" : ""}`;
 }
 
 export function testFileCandidates(roots: string[] = TEST_ROOTS): string[] {
@@ -128,9 +138,12 @@ export function selectCoveringTests(
   return rankCoveringTests(sources, tests, readModule).map((test) => test.path);
 }
 
-/** Resolves an extensionless module path the way the bundler does: `x.ts`, then `x/index.ts`. */
+/** Resolves an extensionless module path the way the bundler does: `x.ts`, then `x/index.ts`; a `.mjs` specifier keeps its extension, so it resolves verbatim (#1091 review). */
 function readModuleSync(path: string): string | null {
-  for (const candidate of [`${path}.ts`, `${path}.tsx`, join(path, "index.ts")]) {
+  const candidates = path.endsWith(".mjs")
+    ? [path]
+    : [`${path}.ts`, `${path}.tsx`, join(path, "index.ts")];
+  for (const candidate of candidates) {
     try {
       return readFileSync(candidate, "utf8");
     } catch {
@@ -140,7 +153,7 @@ function readModuleSync(path: string): string | null {
   return null;
 }
 
-async function coveringTests(
+export async function coveringTests(
   sources: string[],
   roots: string[],
 ): Promise<Array<{ path: string; hops: number }>> {
@@ -175,9 +188,10 @@ async function main(argv: string[]): Promise<number> {
 
   const ranked = await coveringTests(sources, roots);
   if (ranked.length === 0) {
-    console.error(
-      `no suite in ${roots.join(", ")} reaches ${sources.join(", ")} — mutation testing measures assertions, so there is nothing to measure yet${withIntegration ? "" : " (retry with --with-integration)"}`,
-    );
+    // Probed rather than assumed: no integration suite imports anything under scripts/ or .github/scripts/, so the blanket hint sent the operator nowhere (#1091 review).
+    const integrationHelps =
+      !withIntegration && (await coveringTests(sources, [INTEGRATION_ROOT])).length > 0;
+    console.error(noSuiteRefusal(sources, roots, integrationHelps));
     return 1;
   }
 

--- a/scripts/mutants-ts.ts
+++ b/scripts/mutants-ts.ts
@@ -9,13 +9,22 @@ const TEST_ROOTS = ["tests/unit"];
 const INTEGRATION_ROOT = "tests/integration";
 const GENERATED_CONFIG = `stryker.generated.${process.pid}.json`;
 
+// `src/` alone left the CI gates and the repo's own scripts unmeasurable (#1091).
+export const MUTABLE_ROOTS = ["src/", "scripts/", ".github/scripts/"];
+
 const USAGE = [
-  "usage: bun scripts/mutants-ts.ts [--with-integration] <src/file.ts> [more.ts ...]",
+  "usage: bun scripts/mutants-ts.ts [--with-integration] <file.ts> [more.ts ...]",
   "",
   "Mutation-tests the named sources against whichever suites import them.",
   "A survivor is an edit no test noticed — read it as a missing assertion,",
   "not as a number to drive up. CLAUDE.md names the kinds worth leaving alive.",
 ].join("\n");
+
+/** The reason `source` cannot be mutated, naming the accepted roots, or null when it can. */
+export function mutableSourceRejection(source: string): string | null {
+  if (source.endsWith(".ts") && MUTABLE_ROOTS.some((root) => source.startsWith(root))) return null;
+  return `not a mutable source file: ${source} — expected a .ts file under ${MUTABLE_ROOTS.join(", ")}`;
+}
 
 export function testFileCandidates(roots: string[] = TEST_ROOTS): string[] {
   const walk = (dir: string): string[] => {
@@ -153,8 +162,9 @@ async function main(argv: string[]): Promise<number> {
   }
 
   for (const source of sources) {
-    if (!source.startsWith("src/") || !source.endsWith(".ts")) {
-      console.error(`not a mutable source file: ${source}`);
+    const rejection = mutableSourceRejection(source);
+    if (rejection !== null) {
+      console.error(rejection);
       return 2;
     }
     if (!(await Bun.file(source).exists())) {

--- a/stryker.conf.mjs
+++ b/stryker.conf.mjs
@@ -1,7 +1,7 @@
 // Mutation testing for the TypeScript side. A surviving mutant is a coverage gap stated as the
 // exact edit no test noticed — this found `confidence < 0.5` never exercised at the boundary.
 //
-//   just mutants-ts src/foo.ts   # generates a config from this one; the pairing below is the fallback
+//   just mutants-ts src/foo.ts   # or scripts/, or .github/scripts/; the pairing below is the fallback
 //
 // Scoped runs are fast: 44 mutants in ~1s, 1.3 tests per mutant, because `perTest` coverage
 // re-runs only the covering tests rather than the suite.

--- a/tests/unit/mutants-ts-selection.test.ts
+++ b/tests/unit/mutants-ts-selection.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   importedModules,
+  mutableSourceRejection,
   rankCoveringTests,
   reachableModules,
   selectCoveringTests,
@@ -129,5 +130,39 @@ describe("which suites are measured against a source", () => {
     expect(testFileCandidates(["tests/integration"])).toContain(
       "tests/integration/cli-contracts.test.ts",
     );
+  });
+});
+
+/**
+ * The enumerator used to accept `src/` alone, so the CI gates and the repo's own scripts —
+ * the code that enforces every rule in CLAUDE.md — could not be mutated at all (#1091).
+ */
+describe("which sources may be mutated", () => {
+  test("the CLI, the repo scripts and the CI gates are all mutable", () => {
+    expect(mutableSourceRejection("src/voice-routing.ts")).toBeNull();
+    expect(mutableSourceRejection("scripts/mutate.ts")).toBeNull();
+    expect(mutableSourceRejection(".github/scripts/check-workflows.ts")).toBeNull();
+  });
+
+  test("a non-TypeScript file is rejected", () => {
+    expect(mutableSourceRejection("src/engine.json")).toContain("src/engine.json");
+    expect(mutableSourceRejection("rust/src/main.rs")).toContain("rust/src/main.rs");
+  });
+
+  test("a TypeScript file outside every mutable root is rejected", () => {
+    expect(mutableSourceRejection("tests/unit/engine.test.ts")).not.toBeNull();
+    expect(mutableSourceRejection("raycast/src/index.ts")).not.toBeNull();
+  });
+
+  // `relative()` renders a path outside the repo as `../…`, which no root prefix may swallow.
+  test("a path outside the repository is rejected", () => {
+    expect(mutableSourceRejection("../other-worktree/src/engine.ts")).not.toBeNull();
+  });
+
+  // "not mutable" without the accepted set leaves the caller guessing, as #1091 did.
+  test("the rejection names every accepted root", () => {
+    const message = mutableSourceRejection("docs/notes.ts") ?? "";
+
+    for (const root of ["src/", "scripts/", ".github/scripts/"]) expect(message).toContain(root);
   });
 });

--- a/tests/unit/mutants-ts-selection.test.ts
+++ b/tests/unit/mutants-ts-selection.test.ts
@@ -159,10 +159,10 @@ describe("which sources may be mutated", () => {
     expect(mutableSourceRejection("../other-worktree/src/engine.ts")).not.toBeNull();
   });
 
-  // "not mutable" without the accepted set leaves the caller guessing, as #1091 did.
-  test("the rejection names every accepted root", () => {
-    const message = mutableSourceRejection("docs/notes.ts") ?? "";
-
-    for (const root of ["src/", "scripts/", ".github/scripts/"]) expect(message).toContain(root);
+  // Whole message, not `toContain`: that reads `src/scripts/.github/scripts/` as three roots.
+  test("the rejection lists every accepted root, legibly", () => {
+    expect(mutableSourceRejection("docs/notes.ts")).toBe(
+      "not a mutable source file: docs/notes.ts — expected a .ts file under src/, scripts/, .github/scripts/",
+    );
   });
 });

--- a/tests/unit/mutants-ts-selection.test.ts
+++ b/tests/unit/mutants-ts-selection.test.ts
@@ -1,13 +1,16 @@
 import { describe, expect, test } from "bun:test";
 import {
+  coveringTests,
   importedModules,
   mutableSourceRejection,
+  noSuiteRefusal,
   rankCoveringTests,
   reachableModules,
   selectCoveringTests,
   testFileCandidates,
   toPosix,
 } from "../../scripts/mutants-ts";
+import { REPO_ROOT } from "../helpers/repo";
 
 /**
  * Under `coverageAnalysis: "perTest"` a suite that never loads the mutant cannot kill it, so an
@@ -144,9 +147,16 @@ describe("which sources may be mutated", () => {
     expect(mutableSourceRejection(".github/scripts/check-workflows.ts")).toBeNull();
   });
 
-  test("a non-TypeScript file is rejected", () => {
+  // The release path — dist-tag, version bumps, the Homebrew formula — is `.mjs` (#1091 review).
+  test("the .mjs gates are mutable too", () => {
+    expect(mutableSourceRejection(".github/scripts/npm-dist-tag.mjs")).toBeNull();
+    expect(mutableSourceRejection(".github/scripts/update-homebrew-tap.mjs")).toBeNull();
+  });
+
+  test("a file in neither mutable language is rejected", () => {
     expect(mutableSourceRejection("src/engine.json")).toContain("src/engine.json");
     expect(mutableSourceRejection("rust/src/main.rs")).toContain("rust/src/main.rs");
+    expect(mutableSourceRejection(".github/scripts/npm-dist-tag.d.mts")).not.toBeNull();
   });
 
   test("a TypeScript file outside every mutable root is rejected", () => {
@@ -162,7 +172,66 @@ describe("which sources may be mutated", () => {
   // Whole message, not `toContain`: that reads `src/scripts/.github/scripts/` as three roots.
   test("the rejection lists every accepted root, legibly", () => {
     expect(mutableSourceRejection("docs/notes.ts")).toBe(
-      "not a mutable source file: docs/notes.ts — expected a .ts file under src/, scripts/, .github/scripts/",
+      "not a mutable source file: docs/notes.ts — expected a .ts or .mjs file under src/, scripts/, .github/scripts/",
     );
+  });
+});
+
+/**
+ * The guard above is only a guard once `main` consults it: neutralising the call left the whole
+ * unit suite green while `tests/unit/foo.test.ts` reached Stryker (#1091 review).
+ */
+describe("the command refuses before it reaches Stryker", () => {
+  const run = async (...args: string[]) => {
+    const proc = Bun.spawn(["bun", `${REPO_ROOT}/scripts/mutants-ts.ts`, ...args], {
+      cwd: REPO_ROOT,
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+    const stderr = await new Response(proc.stderr).text();
+    return { code: await proc.exited, stderr };
+  };
+
+  test("an existing file outside the mutable roots is refused, not mutated", async () => {
+    const { code, stderr } = await run("rust/src/main.rs");
+
+    expect(code).toBe(2);
+    expect(stderr.trim()).toBe(
+      "not a mutable source file: rust/src/main.rs — expected a .ts or .mjs file under src/, scripts/, .github/scripts/",
+    );
+  });
+
+  test("a gate no suite imports is refused without a hint that leads nowhere", async () => {
+    const { code, stderr } = await run(".github/scripts/check-versions.ts");
+
+    expect(code).toBe(1);
+    expect(stderr.trim()).toBe(
+      noSuiteRefusal([".github/scripts/check-versions.ts"], ["tests/unit"], false),
+    );
+    expect(stderr).not.toContain("--with-integration");
+  });
+});
+
+/** Selection is by import, and a `.mjs` gate is reached only through other `.mjs` (#1091 review). */
+describe("which suites measure a .mjs gate", () => {
+  test("a direct importer is found", async () => {
+    expect(await coveringTests([".github/scripts/npm-dist-tag.mjs"], ["tests/unit"])).toEqual([
+      { path: "tests/unit/npm-dist-tag.test.ts", hops: 1 },
+    ]);
+  });
+
+  test("a gate reached only through another .mjs is found too", async () => {
+    const ranked = await coveringTests([".github/scripts/script-entry.mjs"], ["tests/unit"]);
+
+    expect(ranked.map((test) => test.path)).toContain("tests/unit/release-tag-grammar.test.ts");
+  });
+});
+
+describe("the refusal when nothing measures a source", () => {
+  test("the retry is named only when the integration root would find suites", () => {
+    expect(noSuiteRefusal(["src/foo.ts"], ["tests/unit"], true)).toContain(
+      "(retry with --with-integration)",
+    );
+    expect(noSuiteRefusal(["src/foo.ts"], ["tests/unit"], false)).not.toContain("--with-integration");
   });
 });


### PR DESCRIPTION
Closes #1091

## Claim

`just mutants-ts` enumerates mutants in `scripts/` and `.github/scripts/` against the suites that import them, and refuses loudly rather than reporting an empty run when no suite reaches a file — if that is wrong, `tests/unit/mutants-ts-selection.test.ts::"the CLI, the repo scripts and the CI gates are all mutable"` fires, or `just mutants-ts .github/scripts/check-workflows.ts` exits non-zero instead of instrumenting 1497 mutants.

## What changed

`scripts/mutants-ts.ts:156` required `source.startsWith("src/")`, so the enumerator reached the CLI and nothing else — not the `check:*` gates, not the repo's own scripts. `MUTABLE_ROOTS` now lists `src/`, `scripts/` and `.github/scripts/`, and `mutableSourceRejection` replaces the inline prefix check, naming the accepted roots when it refuses.

Each root, the `.ts` extension check, and `startsWith` versus `includes` (which would admit `docs/scripts/x.ts`) are pinned with `just mutate` — all five mutations caught.

## Verified in the order the issue asked

1. **Stryker resolves the test files.** `tests/unit/check-workflows.test.ts` imports `../../.github/scripts/check-workflows`; relative resolution out of `.github/` works unchanged — 1497 mutants, 1048 killed.
2. **The sandbox copies `.github/`.** `Found 1 of 686 file(s) to be mutated`; `ignorePatterns` needed no change.
3. **Runtime is tolerable.** 1497 mutants in 1m18s at 4.27 tests per mutant. Every gate finished under two minutes.

| file | mutants | killed | survived | score | time |
|---|---|---|---|---|---|
| `check-workflows.ts` | 1497 | 1048 | 294 | 70.15% | 1m18s |
| `check-recipes.ts` | 553 | 397 | 117 | 71.79% | 1m31s |
| `check-model-plan-sizes.ts` | 405 | 225 | 76 | 55.56% | 1m45s |
| `scripts/mutants-ts.ts` | 186 | 81 | 29 | 43.55% | 43s |
| `scripts/mutate.ts` | 62 | 10 | 2 | 16.13% | 1s |

The full survivor reading — which ~15 are the #1085/#1086 "decision in a guard with no assertion over it" shape, and which 98 OptionalChaining plus 51 Regex survivors are noise — is on [the issue](https://github.com/drakulavich/kesha-voice-kit/issues/1091#issuecomment-5474460829).

## It fired on the change that widened it

The first run over `scripts/mutants-ts.ts` reported `MUTABLE_ROOTS.join(", ")` → `join("")` as a survivor: the assertion I had just written used `toContain(root)` per root, which still passes against `src/scripts/.github/scripts/`. Same shape as the `lineText` survivor from #1086. 47b589f asserts the whole rendered message instead.

`PIPEFAIL_SHELLS` (line 370) has **no** survivor — removing an entry is killed. That is the direct evidence the enumerator would have listed the original `cmd` survivor had these roots been open at #1086.

## Reported, not widened around

Three gates exit 1 with `no suite in tests/unit reaches …`, which is a loud refusal rather than a zero-mutant report that reads like a clean one:

- `check-versions.ts` — its suite **spawns** the script instead of importing it, so the import graph cannot see it. Naming the suite by hand works (36 killed / 16 survived). Only one file in both roots has a same-named suite with no importer, so a name-based fallback would buy one file and contradict the deliberate "parsed rather than grepped" design note in `mutants-ts.ts`.
- `check-coverage.ts`, `check-engine-targets.ts` — no `.test.ts` reaches them at all. "Nothing to measure yet" is the honest answer.

The issue's table also names `scripts/backlog-conveyor.ts`, `scripts/gate-evidence.ts` and `scripts/review-prompt.ts`, which do not exist on `main`; `check-workflows.ts` is 1151 lines now, not 563.

## Not in this PR

The guard-shaped survivors are missing assertions in the gates' suites, not defects in the gates — each guard is correct as written. Closing them is a separate pass; this ticket's ask was to make them enumerable and read them.

## Verification

`just preflight` green (exit 0) on 7be04b1. `bun run lint` clean, `bun run test:unit` 1491 pass / 0 fail.

## Review round 1 — fixes and re-fired evidence

Head `7be04b1a1af262d9982ab57a677f1017ad127cd6`. Every P1/P2/P3 finding is addressed in one commit; each probe the review named was re-run against that head.

**[P2] `mutants-ts.ts:166` — the guard is pinned only as a pure function.** `main()` now has an end-to-end pin: `tests/unit/mutants-ts-selection.test.ts::"the command refuses before it reaches Stryker"` spawns `bun scripts/mutants-ts.ts`, on a file that exists but sits outside every root, and asserts the whole refusal plus exit 2.

- `just mutate scripts/mutants-ts.ts 'if (rejection !== null) {' 'if (false) {' bun run test:unit` → **PINNED: the mutation was caught** (round 1: `NOT PINNED`, 1485 pass / 0 fail).
- The four body-level mutations still fire, re-run verbatim against the new predicate: `'if (mutable) return null;'` → `'return null;'`, `'source.startsWith(root)'` → `'source.includes(root)'`, `MUTABLE_ROOTS` without `.github/scripts/`, and `MUTABLE_ROOTS.join(", ")` → `join("")` — **all four PINNED**.

**[P2] `CONTRIBUTING.md:234` — `.endsWith(".ts")` excluded the whole `.mjs` release path.** `MUTABLE_EXTENSIONS` is now `[".ts", ".mjs"]`, and `readModuleSync` resolves a `.mjs` specifier verbatim — the second-order break the finding named, since a `.mjs` reached only through another `.mjs` otherwise resolves to nothing and selects no suite.

- `bun scripts/mutants-ts.ts .github/scripts/npm-dist-tag.mjs` → runs with no patch: 39 mutants, 24 killed, 15 survived, **53.33%** — the same numbers the finding produced under its temporary `just mutate`, including the `import.meta.url === …` → `!==` survivor.
- `bun scripts/mutants-ts.ts .github/scripts/script-entry.mjs` → `mutating … against 10 suite(s)`, every one of them 2–3 hops away through other `.mjs` files, 21 mutants instrumented. Extension-only widening selects zero suites here.
- `just mutate scripts/mutants-ts.ts 'const MUTABLE_EXTENSIONS = [".ts", ".mjs"];' 'const MUTABLE_EXTENSIONS = [".ts"];' bun run test:unit` → **PINNED**.
- `just mutate scripts/mutants-ts.ts 'path.endsWith(".mjs")' 'false' bun run test:unit` → **PINNED**.

**[P3] `mutants-ts.ts:179` — the `--with-integration` hint was a dead end.** The retry is probed rather than assumed: on a no-suite refusal the run asks whether `tests/integration` reaches the source and names the retry only when it does.

- `bun scripts/mutants-ts.ts .github/scripts/check-versions.ts` → exit 1, `no suite in tests/unit reaches … so there is nothing to measure yet`, no hint.
- `bun scripts/mutants-ts.ts --with-integration .github/scripts/check-versions.ts` → exit 1, same refusal naming both roots.
- `just mutate scripts/mutants-ts.ts '!withIntegration && (await coveringTests(sources, [INTEGRATION_ROOT])).length > 0' 'true' bun run test:unit` → **PINNED**.

**[P3] `ci.yml:93` — a scripts-only change skipped `unit-tests`.** `- 'scripts/**'` added to the `code` filter beside `.github/scripts/**`, for the same stated reason: `scripts/mutants-ts.ts`, `scripts/mutate.ts` and `scripts/release-tag.ts` all have unit suites.

- `grep -rn "'scripts/\*\*'" .github/workflows/` → `ci.yml:95` (round 1: no match outside the two `.github/scripts/**` entries).

**[P3] `mutants-ts.ts:13` — `MUTABLE_ROOTS` exported with no consumer.** Un-exported.

- `grep -rn MUTABLE_ROOTS scripts/ tests/ src/ .github/` → three occurrences, all inside `scripts/mutants-ts.ts`, none an `export`.

**[P3] closing keyword.** The body has carried `Closes #1091` on line 1 since the PR was opened; the reviewer's clone had `origin` pointing at a local path, so `gh pr view 1135` could not read it. The consolidation commit now carries it as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

