### PR TITLE
refactor(engine): three unreachable panics the type system could rule out (KokoroSlot, CharsiuCache, ChildGuard)

### DIFF
--- a/rust/src/process_tree.rs
+++ b/rust/src/process_tree.rs
@@ -3,7 +3,7 @@
 #![allow(dead_code)]
 
 use std::io;
-use std::process::{Child, ChildStdin, ExitStatus, Output};
+use std::process::{Child, ChildStdin, Output};
 
 pub(crate) struct ChildGuard {
     child: Option<Child>,
@@ -24,18 +24,11 @@ impl ChildGuard {
         }
     }
 
-    pub(crate) fn try_wait(&mut self) -> io::Result<Option<ExitStatus>> {
-        self.child
-            .as_mut()
-            .expect("ChildGuard missing child")
-            .try_wait()
-    }
-
     pub(crate) fn wait_with_output(mut self) -> io::Result<Output> {
-        self.child
-            .take()
-            .expect("ChildGuard missing child")
-            .wait_with_output()
+        match self.child.take() {
+            Some(child) => child.wait_with_output(),
+            None => Err(io::Error::other("ChildGuard: child already reaped")),
+        }
     }
 
     pub(crate) fn kill_and_wait_with_output(mut self) -> io::Result<Output> {

--- a/rust/src/process_tree.rs
+++ b/rust/src/process_tree.rs
@@ -106,6 +106,18 @@ mod tests {
     }
 
     #[test]
+    fn wait_with_output_reports_a_reaped_guard_instead_of_asserting() {
+        let err = ChildGuard { child: None }
+            .wait_with_output()
+            .expect_err("a guard with no child cannot produce output");
+        assert_eq!(err.kind(), io::ErrorKind::Other);
+        assert!(
+            err.to_string().contains("already reaped"),
+            "unhelpful error for a reaped guard: {err}"
+        );
+    }
+
+    #[test]
     fn wait_with_output_disarms_drop_cleanup() {
         let child = Command::new("sh")
             .arg("-c")

--- a/rust/src/tts/sessions.rs
+++ b/rust/src/tts/sessions.rs
@@ -271,8 +271,12 @@ mod tests {
     #[test]
     fn kokoro_slot_reuses_a_loaded_session_and_survives_a_failed_swap() {
         let mini = mini_kokoro_dir();
-        let model = mini.join("model.onnx");
         let voice = mini.join("am_michael.bin");
+
+        // Staged so it can be deleted: a slot that re-reads the checkpoint cannot answer below.
+        let staged = tempfile::tempdir().expect("tempdir");
+        let model = staged.path().join("model.onnx");
+        std::fs::copy(mini.join("model.onnx"), &model).expect("stage the mini checkpoint");
 
         let mut slot = KokoroSlot::default();
         let first = slot
@@ -282,14 +286,18 @@ mod tests {
             .expect("mini synthesises");
         assert!(!first.is_empty(), "mini returned no samples");
 
+        std::fs::remove_file(&model).expect("unstage the mini checkpoint");
+
         let second = slot
             .get(&model)
-            .expect("second get reuses the loaded session")
+            .unwrap_or_else(|e| {
+                panic!("a loaded slot must answer without re-reading the checkpoint: {e:#}")
+            })
             .infer_ipa("həlˈoʊ", &voice, 1.0)
             .expect("mini synthesises");
         assert_eq!(first, second, "reused session returned different samples");
 
-        let err = match slot.get(&mini.join("no-such-model.onnx")) {
+        let err = match slot.get(&staged.path().join("no-such-model.onnx")) {
             Ok(_) => panic!("a swap to a missing checkpoint must fail"),
             Err(e) => e,
         };
@@ -306,7 +314,7 @@ mod tests {
         assert_eq!(first, after, "slot lost its session after a failed swap");
     }
 
-    /// Gated on CHARSIU_ONNX env var (mirrors charsiu::tests); skipped in CI.
+    /// Requires CHARSIU_ONNX; the coverage job stages byt5-tiny, so this is not skipped in CI.
     #[test]
     fn charsiu_cache_reuses_one_session_and_evicts_a_different_dir() {
         let Some(dir_os) = std::env::var_os("CHARSIU_ONNX") else {
@@ -320,10 +328,24 @@ mod tests {
         };
         let dir = std::path::PathBuf::from(dir_os);
 
+        // Staged so a required file can be removed: a cache that reloads per call fails the last call.
+        let staged_dir = tempfile::tempdir().expect("tempdir");
+        let staged = staged_dir.path();
+        for file in [
+            "encoder_model.onnx",
+            "decoder_model.onnx",
+            "decoder_with_past_model.onnx",
+        ] {
+            let (src, dst) = (dir.join(file), staged.join(file));
+            std::fs::hard_link(&src, &dst)
+                .or_else(|_| std::fs::copy(&src, &dst).map(|_| ()))
+                .expect("stage the g2p model");
+        }
+
         let mut cache = CharsiuCache::default();
         assert!(!cache.is_loaded(), "cache must start empty");
 
-        let ipa1 = cache.to_ipa(&dir, "hola", "es").unwrap();
+        let ipa1 = cache.to_ipa(staged, "hola", "es").unwrap();
         assert!(!ipa1.is_empty(), "first call: empty IPA for 'hola'");
         assert!(
             cache.is_loaded(),
@@ -331,13 +353,13 @@ mod tests {
         );
 
         // Charsiu is deterministic; same input must return identical IPA and not reload.
-        let ipa2 = cache.to_ipa(&dir, "hola", "es").unwrap();
+        let ipa2 = cache.to_ipa(staged, "hola", "es").unwrap();
         assert_eq!(
             ipa1, ipa2,
             "second call returned different IPA — session may have been reloaded"
         );
 
-        let ipa_fr = cache.to_ipa(&dir, "bonjour", "fr").unwrap();
+        let ipa_fr = cache.to_ipa(staged, "bonjour", "fr").unwrap();
         assert!(!ipa_fr.is_empty(), "French 'bonjour' returned empty IPA");
 
         let empty = tempfile::tempdir().expect("tempdir");
@@ -349,12 +371,13 @@ mod tests {
             format!("{err:#}").contains("G2P model not installed"),
             "wrong error for an empty g2p dir: {err:#}"
         );
-        assert!(
-            !cache.is_loaded(),
-            "a different dir must evict the cached session before the file check fails"
-        );
-
-        let ipa3 = cache.to_ipa(&dir, "hola", "es").unwrap();
+        let ipa3 = cache.to_ipa(staged, "hola", "es").unwrap();
         assert_eq!(ipa1, ipa3, "slot did not refill after eviction");
+
+        std::fs::remove_file(staged.join("encoder_model.onnx")).expect("unstage the encoder");
+        let ipa4 = cache.to_ipa(staged, "hola", "es").unwrap_or_else(|e| {
+            panic!("a loaded cache must answer without re-reading the model: {e:#}")
+        });
+        assert_eq!(ipa1, ipa4, "reused session returned different IPA");
     }
 }

--- a/rust/src/tts/sessions.rs
+++ b/rust/src/tts/sessions.rs
@@ -306,7 +306,7 @@ mod tests {
 
     /// Gated on CHARSIU_ONNX env var (mirrors charsiu::tests); skipped in CI.
     #[test]
-    fn charsiu_cache_loads_once_and_reuses() {
+    fn charsiu_cache_reuses_one_session_and_evicts_a_different_dir() {
         let Some(dir_os) = std::env::var_os("CHARSIU_ONNX") else {
             assert!(
                 std::env::var_os("KESHA_REQUIRE_G2P_TESTS").is_none(),
@@ -337,5 +337,22 @@ mod tests {
 
         let ipa_fr = cache.to_ipa(&dir, "bonjour", "fr").unwrap();
         assert!(!ipa_fr.is_empty(), "French 'bonjour' returned empty IPA");
+
+        let empty = tempfile::tempdir().expect("tempdir");
+        let err = match cache.to_ipa(empty.path(), "hola", "es") {
+            Ok(ipa) => panic!("a g2p dir with no model must fail, got {ipa:?}"),
+            Err(e) => e,
+        };
+        assert!(
+            format!("{err:#}").contains("G2P model not installed"),
+            "wrong error for an empty g2p dir: {err:#}"
+        );
+        assert!(
+            !cache.is_loaded(),
+            "a different dir must evict the cached session before the file check fails"
+        );
+
+        let ipa3 = cache.to_ipa(&dir, "hola", "es").unwrap();
+        assert_eq!(ipa1, ipa3, "slot did not refill after eviction");
     }
 }

--- a/rust/src/tts/sessions.rs
+++ b/rust/src/tts/sessions.rs
@@ -258,6 +258,52 @@ impl CharsiuCache {
 mod tests {
     use super::*;
 
+    fn mini_kokoro_dir() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("rust/ has a parent")
+            .join("tests/fixtures/mini-models/kokoro")
+    }
+
+    /// The mini pins slot bookkeeping, never audio fidelity — no quality assertion belongs here.
+    #[test]
+    fn kokoro_slot_reuses_a_loaded_session_and_survives_a_failed_swap() {
+        let mini = mini_kokoro_dir();
+        let model = mini.join("model.onnx");
+        let voice = mini.join("am_michael.bin");
+
+        let mut slot = KokoroSlot::default();
+        let first = slot
+            .get(&model)
+            .expect("first get loads the mini")
+            .infer_ipa("həlˈoʊ", &voice, 1.0)
+            .expect("mini synthesises");
+        assert!(!first.is_empty(), "mini returned no samples");
+
+        let second = slot
+            .get(&model)
+            .expect("second get reuses the loaded session")
+            .infer_ipa("həlˈoʊ", &voice, 1.0)
+            .expect("mini synthesises");
+        assert_eq!(first, second, "reused session returned different samples");
+
+        let err = match slot.get(&mini.join("no-such-model.onnx")) {
+            Ok(_) => panic!("a swap to a missing checkpoint must fail"),
+            Err(e) => e,
+        };
+        assert!(
+            format!("{err:#}").contains("reload"),
+            "swap failure did not go through ensure_model: {err:#}"
+        );
+
+        let after = slot
+            .get(&model)
+            .expect("a failed swap must leave the slot loaded")
+            .infer_ipa("həlˈoʊ", &voice, 1.0)
+            .expect("mini synthesises");
+        assert_eq!(first, after, "slot lost its session after a failed swap");
+    }
+
     /// Gated on CHARSIU_ONNX env var (mirrors charsiu::tests); skipped in CI.
     #[test]
     fn charsiu_cache_loads_once_and_reuses() {

--- a/rust/src/tts/sessions.rs
+++ b/rust/src/tts/sessions.rs
@@ -228,12 +228,14 @@ impl CharsiuCache {
                 self.inner = None;
             }
         }
-        if self.inner.is_none() {
-            super::g2p::check_charsiu_files(model_dir)?;
-            let g = Charsiu::load(model_dir)?;
-            self.inner = Some((model_dir.to_path_buf(), g));
-        }
-        Ok(&mut self.inner.as_mut().unwrap().1)
+        Ok(match &mut self.inner {
+            Some((_, g)) => g,
+            slot => {
+                super::g2p::check_charsiu_files(model_dir)?;
+                let g = Charsiu::load(model_dir)?;
+                &mut slot.insert((model_dir.to_path_buf(), g)).1
+            }
+        })
     }
 
     /// Phonemize `text` in `lang` (es/fr/it/pt) using the cached session.

--- a/rust/src/tts/sessions.rs
+++ b/rust/src/tts/sessions.rs
@@ -129,13 +129,13 @@ pub struct KokoroSlot {
 impl KokoroSlot {
     pub fn get(&mut self, model_path: &Path) -> anyhow::Result<&mut KokoroSession> {
         use anyhow::Context;
-        match self.inner.as_mut() {
-            Some(sess) => sess.ensure_model(model_path).context("kokoro reload")?,
-            None => {
-                self.inner = Some(KokoroSession::load(model_path).context("kokoro load")?);
+        Ok(match &mut self.inner {
+            Some(sess) => {
+                sess.ensure_model(model_path).context("kokoro reload")?;
+                sess
             }
-        }
-        Ok(self.inner.as_mut().expect("kokoro session just ensured"))
+            slot => slot.insert(KokoroSession::load(model_path).context("kokoro load")?),
+        })
     }
 }
 


### PR DESCRIPTION
Closes #956

## Claim

`KokoroSlot` and `CharsiuCache` each load at most once per slot lifetime, and `ChildGuard::wait_with_output` reports rather than panics on a reaped guard — to refute, name a mutation that defeats one of those three and still leaves the suite green.

## What

Three panics that existed because a type said a state was possible when the code guaranteed it was not. None could fire today; each was a place where a future edit could make the panic reachable with no signal.

| Site | Before | After |
|---|---|---|
| `tts/sessions.rs` `KokoroSlot::get` | `.expect("kokoro session just ensured")` | `Option::insert` returns the `&mut` it just stored |
| `tts/sessions.rs` `CharsiuCache::ensure` | `.unwrap()` on the slot the line above filled | same, via `&mut slot.insert(..).1` |
| `process_tree.rs` `ChildGuard` | two `.expect("ChildGuard missing child")` | `try_wait` deleted (zero call sites); `wait_with_output` answers with an `io::Error` |

`ChildGuard::try_wait` had no caller under any feature combination — `text_lang.rs` and `avspeech.rs` use only `stdin_mut` / `close_stdin` / `wait_with_output`, and the `try_wait` inside `Drop` is `std::process::Child`'s. It survived behind the module-level `#![allow(dead_code)]`, so it is deleted rather than rewritten; `ExitStatus` became unused and went with it. No `unsafe`, no `ManuallyDrop`.

Signatures are unchanged, so `say.rs::kokoro_session` and both `ChildGuard` call sites are untouched. Error strings (`kokoro reload`, `kokoro load`, `G2P model not installed…`) are preserved exactly.

## Mutation evidence

A guard is only a guard if removing it goes red. Every pin below was proved with `just mutate`, which refuses when the text does not occur and restores the file in a `finally`.

**M1 — Kokoro reload arm** (pre-refactor)
```
'Some(sess) => sess.ensure_model(model_path).context("kokoro reload")?,' → 'Some(_) => (),'
→ panicked at sessions.rs:291: a swap to a missing checkpoint must fail — PINNED
```

**M2 — the ticket's thesis** (pre-refactor)
```
'self.inner = Some(KokoroSession::load(model_path).context("kokoro load")?);'
  → 'KokoroSession::load(model_path).context("kokoro load")?;'
→ panicked at sessions.rs:138: kokoro session just ensured — PINNED
```
One dropped store turns the "unreachable" panic into a reachable one. **After the refactor this mutation has no analogue** — `Option::insert` cannot leave the slot empty. That asymmetry is the point of the PR.

**M1′ — same pin, post-refactor text**
```
'sess.ensure_model(model_path).context("kokoro reload")?;' → 'let _ = model_path;'
→ panicked at sessions.rs:293: a swap to a missing checkpoint must fail — PINNED
```

**M3 — Charsiu eviction**, with the pinned byt5-tiny staged locally (all three SHA-256 match `models/manifest.rs`)
```
CHARSIU_ONNX=~/.cache/kesha/models/g2p/byt5-tiny KESHA_REQUIRE_G2P_TESTS=1 \
  just mutate rust/src/tts/sessions.rs 'self.inner = None;' ''
→ panicked at sessions.rs:343: a g2p dir with no model must fail, got "olao" — PINNED
```

**ChildGuard** — no new test (a deletion plus an unreachable branch has no new behaviour to pin); the two existing tests are the net, and both are mutation-proved:
```
'Some(child) => child.wait_with_output(),'
  → 'Some(mut child) => { let _ = child.kill(); child.wait_with_output() },'
→ panicked at process_tree.rs:119: assertion failed: output.status.success() — PINNED

$'let _ = child.kill();\n                let _ = child.wait();' → ''
→ FAIL [2.060s] panicked at process_tree.rs:104: child pid 59503 survived guard drop — PINNED
```

> **Deviation from the approved plan, recorded rather than silent.** The plan specified the second mutation as `'let _ = child.kill();' → ''`, claiming it was "bounded by the existing 2 s `wait_until_dead`". It is not: that text occurs twice, so it also strips the `kill()` from `Drop`, leaving `Drop` blocked forever in `child.wait()` on a helper that ignores `TERM` — `Drop` runs *before* the assertion is ever reached. The run hung for 11 minutes with no output and had to be killed. The mutation above neutralises the whole `Drop` cleanup arm instead: it terminates in 2.06 s and fires exactly the assertion the plan named.

## Verification

- `cargo fmt`, `cargo clippy --all-targets -- -D warnings` — clean
- `just rust-test` — 626 passed, 1 skipped
- `just verify-darwin-full` — required here (`rust/src/tts/**` touched, and it is the only recipe that compiles `text_lang.rs` / `avspeech.rs`, the sole `ChildGuard` call sites)
- `just preflight`

## Review round 1 — all six findings addressed

Head `b2ef27c3d4b9a906dd043d271cec2112e4444904`. Every mutation named in the review was re-run after the fix; each was **NOT PINNED before** and is **PINNED after**.

**[P2] `sessions.rs:272` — reuse unpinned.** The mini is a deterministic generator, so a slot reloading the graph on every `get()` returns byte-identical samples and `assert_eq!(first, second)` cannot see it. Applied the reviewer's verified fix: stage the checkpoint in a tempdir, load, delete it, require the second `get()` to succeed.
```
'if self.model_path == path { return Ok(()); }' → ''
→ sessions.rs:292: a loaded slot must answer without re-reading the checkpoint:
  kokoro reload: File at `/var/…/T/.tmpdPUTFZ/model.onnx` does not exist — PINNED
```

**[P3] `sessions.rs:227` — the same gap on the Charsiu half.** The g2p dir is now staged as hard links (no 106 MB copy; the test still runs in 0.42 s) and the encoder is removed before a final call.
```
'if dir != model_dir {' → 'if true || dir != model_dir {'
→ sessions.rs:379: a loaded cache must answer without re-reading the model:
  G2P model not installed. — PINNED
```

**[P2] `process_tree.rs:27` + [P3] `process_tree.rs:30` — the `None` arm was unreachable and unpinned in both directions.** `ManuallyDrop` would make the state unrepresentable, but buys that with `unsafe` plus a double-drop hazard — a worse trade than the unreachable panic it removes. The arm is pinned instead: `mod tests` can construct `ChildGuard { child: None }`, which the consuming API cannot. Both previously-surviving mutations now fire.
```
match arm reverted to `.expect("ChildGuard missing child")`
→ process_tree.rs:30: ChildGuard missing child — PINNED
error text changed
→ process_tree.rs:114: unhelpful error for a reaped guard — PINNED
```

**[P3] `sessions.rs:309` — false doc line**, corrected. `rust-test.yml:297` sets `KESHA_REQUIRE_G2P_TESTS` on the coverage job and `rust/ci/kokoro-env.sh:42` exports `CHARSIU_ONNX`, so the test is required in CI, not skipped.

**[P3] `sessions.rs:353` — redundant `is_loaded` read removed.** Confirmed the eviction stays pinned in both directions without it — deleting `self.inner = None;` and neutralising the comparison to `if false && …` both fire `sessions.rs:367 a g2p dir with no model must fail, got "olao"`.

Gates after the fix: `clippy --all-targets -D warnings` clean · `just rust-test` 627/627 · `just verify-darwin-full` clean · `just preflight` exit 0.

## Out of scope

`VoskCache::ensure` and `KokoroSession::voice` (already `Entry`-based, panic nowhere); `ChildGuard::kill_and_wait_with_output` (also dead, but carries no panic — its own ticket); the module-level `#![allow(dead_code)]`; the stale `Gated on CHARSIU_ONNX … skipped in CI` doc line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

