### PR TITLE
test: refresh engine capability pacts for v1.24.11

### DIFF
--- a/tests/fixtures/capabilities/darwin-arm64.provenance.json
+++ b/tests/fixtures/capabilities/darwin-arm64.provenance.json
@@ -1,6 +1,6 @@
 {
-  "engineVersion": "1.24.10",
+  "engineVersion": "1.24.11",
   "assetName": "kesha-engine-darwin-arm64",
-  "sha256": "9ad642d63ec170fffa5371391b92af9346bf8ead2b3b927012788493f284bd58",
-  "recordedFrom": "kesha-engine-darwin-arm64 from release v1.24.10"
+  "sha256": "bb32c0fd142be959fedd02759e4f163874c6065b27fc510f7a20484ea2dc670c",
+  "recordedFrom": "kesha-engine-darwin-arm64 from release v1.24.11"
 }

--- a/tests/fixtures/capabilities/linux-x64.provenance.json
+++ b/tests/fixtures/capabilities/linux-x64.provenance.json
@@ -1,6 +1,6 @@
 {
-  "engineVersion": "1.24.10",
+  "engineVersion": "1.24.11",
   "assetName": "kesha-engine-linux-x64",
-  "sha256": "562da15e9996377e99a9c8ac103a4e7deac7145b3e1aafee268026a1f9d2b83c",
-  "recordedFrom": "kesha-engine-linux-x64 from release v1.24.10"
+  "sha256": "a8a37de2d7f8f5b1d699b347fa0e3b8e5b6a8e56f68ca62a577822d5a13cf60f",
+  "recordedFrom": "kesha-engine-linux-x64 from release v1.24.11"
 }

--- a/tests/fixtures/capabilities/win32-x64.provenance.json
+++ b/tests/fixtures/capabilities/win32-x64.provenance.json
@@ -1,6 +1,6 @@
 {
-  "engineVersion": "1.24.10",
+  "engineVersion": "1.24.11",
   "assetName": "kesha-engine-windows-x64.exe",
-  "sha256": "35c2c7f2708eb6021ef897c7b051f5be01fe97362c22f6d5eab27e37a41b9022",
-  "recordedFrom": "kesha-engine-windows-x64.exe from release v1.24.10"
+  "sha256": "2b0d5d52d6fcc7749020dffe8b8fa4b3fdbc56b27691e306d2839e401da47439",
+  "recordedFrom": "kesha-engine-windows-x64.exe from release v1.24.11"
 }

--- a/tests/unit/capabilities-pact.test.ts
+++ b/tests/unit/capabilities-pact.test.ts
@@ -152,7 +152,7 @@ describe("capability pact — recordings", () => {
       expect(pact.backend).toBe(backend);
     });
 
-    // Unlike engineVersion, neither moves in a release PR, so drift here is a hand-edit (#1138).
+    // assetName is pinned against an independent authority; recordedFrom below is only shape-consistency (a consistent multi-field edit passes) — the hash itself belongs to the pact workflow's verify mode (#1138).
     it(`${key} names the asset src/engine-targets.ts publishes`, () => {
       expect(provenance.assetName).toBe(engineTarget(platform, arch)!.assetName);
     });

--- a/tests/unit/capabilities-pact.test.ts
+++ b/tests/unit/capabilities-pact.test.ts
@@ -34,7 +34,7 @@ import {
   type EngineCapabilities,
 } from "../../src/engine";
 import { buildEngineInstallArgs, validateDiarize } from "../../src/engine-install";
-import { engineTargetEntries, targetKey } from "../../src/engine-targets";
+import { engineTarget, engineTargetEntries, targetKey } from "../../src/engine-targets";
 import { buildSayArgs, type SayOptions } from "../../src/synth";
 import { pickVoiceForLang } from "../../src/voice-routing";
 import { readRepoFile, repoPath } from "../helpers/repo";
@@ -147,9 +147,20 @@ describe("capability pact — recordings", () => {
     expect([...new Set(TARGETS.map((t) => t.provenance.engineVersion))]).toHaveLength(1);
   });
 
-  for (const { key, backend, pact } of TARGETS) {
+  for (const { key, platform, arch, backend, pact, provenance } of TARGETS) {
     it(`${key} reports the backend src/engine-targets.ts claims it ships`, () => {
       expect(pact.backend).toBe(backend);
+    });
+
+    // Unlike engineVersion, neither moves in a release PR, so drift here is a hand-edit (#1138).
+    it(`${key} names the asset src/engine-targets.ts publishes`, () => {
+      expect(provenance.assetName).toBe(engineTarget(platform, arch)!.assetName);
+    });
+
+    it(`${key} says it was recorded from the asset and release it recorded`, () => {
+      expect(provenance.recordedFrom).toBe(
+        `${provenance.assetName} from release v${provenance.engineVersion}`,
+      );
     });
   }
 


### PR DESCRIPTION
## Claim

The three `tests/fixtures/capabilities/<target>.json` pact files are byte-identical across engine v1.24.10 → v1.24.11, so this PR changes provenance only and no per-PR flag-routing assertion changes meaning. If that is wrong, `git diff --name-only` on this branch would list a `<target>.json` file — it lists exactly the three `*.provenance.json` files plus `tests/unit/capabilities-pact.test.ts` (836bd94's additive `assetName`/`recordedFrom` pins; no existing assertion changed meaning).

## What the failing run proved

Scheduled run [33386166880](https://github.com/drakulavich/kesha-voice-kit/actions/runs/33386166880) (2026-08-31, head `33621300c7fa41bf0009b1e631d0cf4d2b3c2440`) failed on all three matrix rows. Each `🔍 Verify` step emitted exactly two failure lines and **no `--- committed` / `+++` diff** — `verify()` pushes the JSON diff as a third failure when `committed !== recorded`, and it did not fire.

Root cause: release #1102 (`chore(release): kesha-engine 1.24.11`, 2026-08-28) bumped `package.json#keshaEngine.version` without re-recording. The weekly cron is the designed backstop and it worked. Second occurrence — v1.24.10 produced #1050–#1052, closed by PR #1053.

## Red, before the change

```
$ bun .github/scripts/record-capability-pacts.ts --from-release --target darwin-arm64 --check
FAIL: darwin-arm64 drifted from the real binary. Re-record per .github/workflows/capability-pact.yml: dispatch it with `record: true` and commit the artifacts it uploads.

recorded from engine v1.24.10 but keshaEngine.version pins v1.24.11
binary hashes to bb32c0fd142be959fedd02759e4f163874c6065b27fc510f7a20484ea2dc670c, provenance records 9ad642d63ec170fffa5371391b92af9346bf8ead2b3b927012788493f284bd58
EXIT=1
```

## Green, after

```
$ bun .github/scripts/record-capability-pacts.ts --from-release --target darwin-arm64 --check
darwin-arm64: pact matches the published binary (engine v1.24.11).
EXIT=0
```

`linux-x64` and `win32-x64` cannot be checked from a macOS host (`parseArgs` refuses a `--target` that disagrees with `targetKey()`). They are verified by **verify-mode** run [33468370741](https://github.com/drakulavich/kesha-voice-kit/actions/runs/33468370741), dispatched on this branch at head `ca7cb5ecb704f4d51047f0c7492a8c7b4343c6d2` — every `🔍 Verify` step reports `success` and every `📝 Re-record` step reports `skipped`, on all three rows:

```
$ gh api repos/drakulavich/kesha-voice-kit/actions/runs/33468370741/jobs \
    --jq '.jobs[] | {name, headSha: .head_sha, steps: [.steps[] | select(.name|test("Verify|Re-record")) | {name, conclusion}]}'
{"headSha":"ca7cb5ecb704f4d51047f0c7492a8c7b4343c6d2","name":"pact (windows-latest, win32-x64)","steps":[{"conclusion":"success","name":"🔍 Verify win32-x64 against the published binary"},{"conclusion":"skipped","name":"📝 Re-record win32-x64"}]}
{"headSha":"ca7cb5ecb704f4d51047f0c7492a8c7b4343c6d2","name":"pact (macos-14, darwin-arm64)","steps":[{"conclusion":"success","name":"🔍 Verify darwin-arm64 against the published binary"},{"conclusion":"skipped","name":"📝 Re-record darwin-arm64"}]}
{"headSha":"ca7cb5ecb704f4d51047f0c7492a8c7b4343c6d2","name":"pact (ubuntu-latest, linux-x64)","steps":[{"conclusion":"success","name":"🔍 Verify linux-x64 against the published binary"},{"conclusion":"skipped","name":"📝 Re-record linux-x64"}]}
```

## Provenance only — evidence

Re-recorded by dispatching `capability-pact.yml --ref main -f record=true`, run [33466520627](https://github.com/drakulavich/kesha-voice-kit/actions/runs/33466520627) (all three rows green), and committing the three `capability-pact-<target>` artifacts verbatim. Nothing was hand-edited.

```
$ git diff --name-only origin/main...HEAD
tests/fixtures/capabilities/darwin-arm64.provenance.json
tests/fixtures/capabilities/linux-x64.provenance.json
tests/fixtures/capabilities/win32-x64.provenance.json
tests/unit/capabilities-pact.test.ts
```

The recorder rewrote all six files; only the three provenance files differ from what was committed (the fourth path is `836bd94`'s additive pin tests, not recorder output). The capability shape is unchanged on every target.

Each `sha256` was cross-checked against the `SHA256SUMS` asset published on `v1.24.11` **and** independently against the three CI failure lines:

| file | engineVersion | sha256 |
|---|---|---|
| `darwin-arm64.provenance.json` | `1.24.11` | `bb32c0fd142be959fedd02759e4f163874c6065b27fc510f7a20484ea2dc670c` |
| `linux-x64.provenance.json` | `1.24.11` | `a8a37de2d7f8f5b1d699b347fa0e3b8e5b6a8e56f68ca62a577822d5a13cf60f` |
| `win32-x64.provenance.json` | `1.24.11` | `2b0d5d52d6fcc7749020dffe8b8fa4b3fdbc56b27691e306d2839e401da47439` |

Re-checked against the published asset, comparing `assetName` → `SHA256SUMS` entry rather than eyeballing the table:

```
darwin-arm64: assetName=kesha-engine-darwin-arm64 match=true published=bb32c0fd142be959fedd02759e4f163874c6065b27fc510f7a20484ea2dc670c
linux-x64: assetName=kesha-engine-linux-x64 match=true published=a8a37de2d7f8f5b1d699b347fa0e3b8e5b6a8e56f68ca62a577822d5a13cf60f
win32-x64: assetName=kesha-engine-windows-x64.exe match=true published=2b0d5d52d6fcc7749020dffe8b8fa4b3fdbc56b27691e306d2839e401da47439
```

## Why all three targets, not just darwin-arm64

`tests/unit/capabilities-pact.test.ts` asserts one distinct `engineVersion` across all pacts:

```ts
it("records every target from the same engine release", () => {
  expect([...new Set(TARGETS.map((t) => t.provenance.engineVersion))]).toHaveLength(1);
});
```

Committing darwin-arm64 at 1.24.11 while the other two read 1.24.10 turns that red. #1137 and #1139 are the same failure from the same run and land here. PR #1053 set this precedent.

## Verification

- `bun test tests/unit/capabilities-pact.test.ts` — 27 pass, 0 fail at `836bd94` (21 at `ca7cb5ec`; the delta is the six added pin tests). Full unit lane at `836bd94`: 1525 pass, 0 fail.
- `just preflight` — exit 0 (TS + every `check:*`; Rust and CoreML gates correctly skipped, no `rust/**` changes). `check:engine-targets` green, so `sizeBytes` needed no change.
- `📜 Capability Pact` verify-mode run [33468370741](https://github.com/drakulavich/kesha-voice-kit/actions/runs/33468370741) on head `ca7cb5ec` — three rows green, all three `🔍 Verify` steps executed.
- CI on head `ca7cb5ec`: `🧪 CI`, `🧪 Rust Tests` and `🛡️ Security Audit` all `success` (`gh run list --commit ca7cb5ec…`).
- Greptile: silent on this PR — `gh api repos/drakulavich/kesha-voice-kit/pulls/1140/reviews` returns `0`. Recorded, not blocked on.

`836bd94` adds six tests: an `assetName` and a `recordedFrom` pin per target (two-directionally mutation-verified for `assetName`; the `recordedFrom` pin catches a single-field edit and is comment-scoped accordingly — see the test's own comment). The pre-existing guard that judges the fixtures fired unaided in CI, which is the mutation evidence for the provenance refresh itself.

## Review round 1 — response

Four findings, all P3, none of them a defect in the three committed files. Every probe named in the round was re-run against the round's head `ca7cb5ec`; the head has since moved to `836bd94`, which adds the `assetName`/`recordedFrom` pins to `tests/unit/capabilities-pact.test.ts` (see the Superseded note in §2). The round's one substantive complaint — an unverified claim in this body — is backed by a real verify-mode run.

### 1. [P3] `darwin-arm64.provenance.json:0` — the payload is unpinned in the PR lane

**Re-fired, confirmed, unchanged by design.** Restored all three `*.provenance.json` files from `origin/main` (`engineVersion` 1.24.10) and ran the unit suite:

```
$ git restore --source=origin/main --staged --worktree tests/fixtures/capabilities/*.provenance.json
$ grep -h engineVersion tests/fixtures/capabilities/*.provenance.json
  "engineVersion": "1.24.10"
  "engineVersion": "1.24.10"
  "engineVersion": "1.24.10"
$ bun run test:unit
 1519 pass
 0 fail
 3260 expect() calls
Ran 1519 tests across 93 files. [96.46s]
```

Files restored from `HEAD`; `git status --short` empty afterwards.

The reviewer's own reading is the right one and I am not proposing a fix. Both ends of the pact state why: `tests/unit/capabilities-pact.test.ts`'s header — *"it also owns the pinned-version check, which cannot live here because a release PR bumps `keshaEngine.version` before the tag it names exists"* — and `capability-pact.yml`'s — *"it is the check the PR lane deliberately does not carry, because a release PR must be able to go green before the tag it names exists."* A PR-lane version pin would red every release PR, which is a worse failure than a weekly backstop, and the backstop demonstrably works: it is what filed #1138.

What this PR can do instead of weakening that design is close the gap for *itself*, which run 33468370741 above now does at this exact head.

### 2. [P3] `linux-x64.provenance.json:4` — `sha256` / `assetName` / `recordedFrom` have no PR-lane reader

**Both arms re-fired, both reproduce exactly.**

```
$ bun scripts/mutate.ts tests/fixtures/capabilities/linux-x64.provenance.json \
    'a8a37de2d7f8f5b1d699b347fa0e3b8e5b6a8e56f68ca62a577822d5a13cf60f' \
    '0000000000000000000000000000000000000000000000000000000000000000' \
    bun run test:unit
 1519 pass
 0 fail
Ran 1519 tests across 93 files. [87.30s]
==> restored tests/fixtures/capabilities/linux-x64.provenance.json
NOT PINNED: the mutation survived — nothing failed when 'a8a37de…cf60f' was replaced
```

Contrast arm, same file, `engineVersion` instead:

```
$ bun scripts/mutate.ts tests/fixtures/capabilities/linux-x64.provenance.json \
    '"engineVersion": "1.24.11"' '"engineVersion": "1.24.10"' bun run test:unit
 1518 pass
 1 fail
Ran 1519 tests across 93 files. [87.77s]
==> restored tests/fixtures/capabilities/linux-x64.provenance.json
PINNED: the mutation was caught
```

`git status --short` empty after both.

**Superseded at 836bd94** (this section's original argument rejected any offline pin; the head ships two, and the premise was wrong): `--check` reads only `engineVersion` and `sha256` (`verify()` in record-capability-pacts.ts), so it never owned an `assetName`/`recordedFrom` comparison — those move only by hand-edit, and 836bd94 pins them against `src/engine-targets.ts`'s own table (mutation-verified: PINNED). `sha256` stays deliberately unpinned in the PR lane: its only authority is the published binary, the PR lane downloads nothing on purpose, and the pact workflow's verify mode owns the hash.

The design's answer to a falsified hash is the dispatch, and this PR now carries one that re-derived all three hashes from the real artifacts at this head.

### 3. [P3] `win32-x64.provenance.json:0` — the body claimed a section that did not exist

**Fixed.** The sentence *"they are covered by the post-merge verification dispatch below"* was false in both halves: there was no such section, and no verify-mode run had happened — run 33466520627 was `record: true`, whose `🔍 Verify` step is `skipped` on all three rows. A reviewer trusting it would have believed `linux-x64` and `win32-x64` were checked against the published binary when nothing had checked them.

Rather than soften the claim, I made it true: `capability-pact.yml` was dispatched with `record=false` on `chore/issue-1138`, producing run [33468370741](https://github.com/drakulavich/kesha-voice-kit/actions/runs/33468370741) at head `ca7cb5ecb704f4d51047f0c7492a8c7b4343c6d2`, with all three `🔍 Verify` steps `success` and all three `📝 Re-record` steps `skipped` (step-level output quoted in *Green, after* above). The two non-macOS targets are now verified against the published binary, not asserted to be.

The reviewer's independent corroboration — artifact byte-equality and the three hashes against the published `SHA256SUMS` — was also re-run here and reproduces; see the `match=true` block above.

### 4. [P3] `darwin-arm64.provenance.json:0` — the round's diff package was built against a stale `origin/main`

**Confirmed, harness artifact, nothing to change in the repo.**

```
$ gh api repos/drakulavich/kesha-voice-kit/commits/main --jq .sha
cbe6f416a8b185068ab38c77061aabd9c3859e55
$ git rev-parse main
6df95531303b2902935c103f536ba2a8f1ecea80        # stale local ref
$ git diff --name-only main...HEAD | wc -l
21
$ git diff --name-only origin/main...HEAD
tests/fixtures/capabilities/darwin-arm64.provenance.json
tests/fixtures/capabilities/linux-x64.provenance.json
tests/fixtures/capabilities/win32-x64.provenance.json
$ gh pr view 1140 --json files --jq '.files[].path'
tests/fixtures/capabilities/darwin-arm64.provenance.json
tests/fixtures/capabilities/linux-x64.provenance.json
tests/fixtures/capabilities/win32-x64.provenance.json
```

`cbe6f41` is this branch's own grandparent, so the extra 18 files are #1134, already merged. This PR's file list is the three provenance files. Reviewing #1134's content as this PR's work would be incorrect — recorded so the next round does not repeat it.

Closes #1138, closes #1137, closes #1139



