### PR TITLE
ci: the rust/build.rs and rust/tests/** code-filter entries are not mutation-pinned

### DIFF
--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -614,10 +614,25 @@ export function requireDepsBeforeBunTest(path: string, document: unknown): strin
 
 const coveredBy = (patterns: string[], file: string) => {
   const posixFile = file.replaceAll("\\", "/");
-  return patterns.some((pattern) =>
-    pattern.endsWith("/**") ? posixFile.startsWith(pattern.slice(0, -2)) : pattern === posixFile,
-  );
+  const matches = (pattern: string) =>
+    pattern.endsWith("/**") ? posixFile.startsWith(pattern.slice(0, -2)) : pattern === posixFile;
+  // dorny/paths-filter drops what a `!` entry matches, so an exclusion is the absence of coverage, never coverage (#1141 review round 1).
+  if (patterns.some((pattern) => pattern.startsWith("!") && matches(pattern.slice(1)))) return false;
+  return patterns.some((pattern) => !pattern.startsWith("!") && matches(pattern));
 };
+
+export type CodeFilter = { code: string[] } | { errors: string[] };
+
+/** ci.yml's `changes` job inline paths-filter `code` list, or the error the caller returns verbatim — four rules read it and each private copy of the parser was one more place to drift (#1141 review round 1). */
+export function codeFilterOf(path: string, document: unknown): CodeFilter {
+  const raw = jobSteps(document, "changes")?.find((step) => typeof step?.with?.filters === "string")?.with?.filters;
+  if (typeof raw !== "string") return { errors: [`${path}: expected a \`changes\` job with inline paths-filter filters`] };
+
+  const code = (parse(raw) as Record<string, string[]>)?.code;
+  if (!Array.isArray(code)) return { errors: [`${path}: paths-filter is missing a \`code\` list`] };
+
+  return { code };
+}
 
 export function requireTestedScriptsInCodeFilter(
   path: string,
@@ -626,11 +641,9 @@ export function requireTestedScriptsInCodeFilter(
 ): string[] {
   if (!path.endsWith("ci.yml")) return [];
 
-  const raw = jobSteps(document, "changes")?.find((step) => typeof step?.with?.filters === "string")?.with?.filters;
-  if (typeof raw !== "string") return [`${path}: expected a \`changes\` job with inline paths-filter filters`];
-
-  const code = (parse(raw) as Record<string, string[]>)?.code;
-  if (!Array.isArray(code)) return [`${path}: paths-filter is missing a \`code\` list`];
+  const filter = codeFilterOf(path, document);
+  if ("errors" in filter) return filter.errors;
+  const { code } = filter;
 
   return testedScripts
     .filter((file) => !coveredBy(code, file))
@@ -671,13 +684,9 @@ export function collectRustSources(root = "rust/src"): string[] {
     .sort();
 }
 
-/** rust/build.rs and every .rs under rust/tests: no TS suite reads them today, but tests/unit/rust-cross-references.test.ts's resolveFile accepts them as reference targets, so a rename there must still fire unit-tests (#1141). */
+/** Every .rs under rust/: tests/unit/rust-cross-references.test.ts's resolveFile returns any `rust/…` path unchanged, so the guarded set is the whole tree — naming build.rs and tests/ left rust/vendor out and a future rust/benches would too (#1141, review round 1). */
 export function collectRustReferenceTargets(crateRoot = "rust"): string[] {
-  const buildScript = join(crateRoot, "build.rs");
-  return [
-    ...(existsSync(buildScript) ? [buildScript] : []),
-    ...collectRustSources(join(crateRoot, "tests")),
-  ];
+  return collectRustSources(crateRoot);
 }
 
 /** The pair main() feeds the two #950 rules — exported so the pairing is pinnable: handing the all-rust/src rule the manifest set is silent inside main(), and the sets overlap enough to look right. */
@@ -707,11 +716,9 @@ export function requireRustSourcesInCodeFilter(
 ): string[] {
   if (!path.endsWith("ci.yml")) return [];
 
-  const raw = jobSteps(document, "changes")?.find((step) => typeof step?.with?.filters === "string")?.with?.filters;
-  if (typeof raw !== "string") return [`${path}: expected a \`changes\` job with inline paths-filter filters`];
-
-  const code = (parse(raw) as Record<string, string[]>)?.code;
-  if (!Array.isArray(code)) return [`${path}: paths-filter is missing a \`code\` list`];
+  const filter = codeFilterOf(path, document);
+  if ("errors" in filter) return filter.errors;
+  const { code } = filter;
 
   if (rustSources.length === 0) {
     return [
@@ -735,11 +742,9 @@ export function requireRustReferenceTargetsInCodeFilter(
 ): string[] {
   if (!path.endsWith("ci.yml")) return [];
 
-  const raw = jobSteps(document, "changes")?.find((step) => typeof step?.with?.filters === "string")?.with?.filters;
-  if (typeof raw !== "string") return [`${path}: expected a \`changes\` job with inline paths-filter filters`];
-
-  const code = (parse(raw) as Record<string, string[]>)?.code;
-  if (!Array.isArray(code)) return [`${path}: paths-filter is missing a \`code\` list`];
+  const filter = codeFilterOf(path, document);
+  if ("errors" in filter) return filter.errors;
+  const { code } = filter;
 
   if (referenceTargets.length === 0) {
     return [
@@ -763,11 +768,9 @@ export function requireManifestSourcesInCodeFilter(
 ): string[] {
   if (!path.endsWith("ci.yml")) return [];
 
-  const raw = jobSteps(document, "changes")?.find((step) => typeof step?.with?.filters === "string")?.with?.filters;
-  if (typeof raw !== "string") return [`${path}: expected a \`changes\` job with inline paths-filter filters`];
-
-  const code = (parse(raw) as Record<string, string[]>)?.code;
-  if (!Array.isArray(code)) return [`${path}: paths-filter is missing a \`code\` list`];
+  const filter = codeFilterOf(path, document);
+  if ("errors" in filter) return filter.errors;
+  const { code } = filter;
 
   if (manifestSources.length === 0) {
     return [

--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -671,16 +671,31 @@ export function collectRustSources(root = "rust/src"): string[] {
     .sort();
 }
 
+/** rust/build.rs and every .rs under rust/tests: no TS suite reads them today, but tests/unit/rust-cross-references.test.ts's resolveFile accepts them as reference targets, so a rename there must still fire unit-tests (#1141). */
+export function collectRustReferenceTargets(crateRoot = "rust"): string[] {
+  const buildScript = join(crateRoot, "build.rs");
+  return [
+    ...(existsSync(buildScript) ? [buildScript] : []),
+    ...collectRustSources(join(crateRoot, "tests")),
+  ];
+}
+
 /** The pair main() feeds the two #950 rules — exported so the pairing is pinnable: handing the all-rust/src rule the manifest set is silent inside main(), and the sets overlap enough to look right. */
 export interface RuleSources {
   manifestSources: string[];
   rustSources: string[];
+  referenceTargets: string[];
 }
 
-export function collectRuleSources(rustRoot?: string, rustSourcesRoot?: string): RuleSources {
+export function collectRuleSources(
+  rustRoot?: string,
+  rustSourcesRoot?: string,
+  crateRoot?: string,
+): RuleSources {
   return {
     manifestSources: collectManifestSources(rustRoot),
     rustSources: collectRustSources(rustSourcesRoot),
+    referenceTargets: collectRustReferenceTargets(crateRoot),
   };
 }
 
@@ -709,6 +724,34 @@ export function requireRustSourcesInCodeFilter(
     .map(
       (file) =>
         `${path}: ${file} is read by a TS suite but no path in the \`code\` filter matches it, so an edit to it skips unit-tests (#950, #1132)`,
+    );
+}
+
+/** Fails when a rust/ cross-reference target falls out of ci.yml's `code` filter: renaming it then skips the suite that catches the now-stale pointer (#1141). */
+export function requireRustReferenceTargetsInCodeFilter(
+  path: string,
+  document: unknown,
+  referenceTargets: string[],
+): string[] {
+  if (!path.endsWith("ci.yml")) return [];
+
+  const raw = jobSteps(document, "changes")?.find((step) => typeof step?.with?.filters === "string")?.with?.filters;
+  if (typeof raw !== "string") return [`${path}: expected a \`changes\` job with inline paths-filter filters`];
+
+  const code = (parse(raw) as Record<string, string[]>)?.code;
+  if (!Array.isArray(code)) return [`${path}: paths-filter is missing a \`code\` list`];
+
+  if (referenceTargets.length === 0) {
+    return [
+      `${path}: collectRustReferenceTargets() returned no files — it ran against the wrong cwd or rust/build.rs and rust/tests/ both moved, either way the guard cannot pass vacuously (#1141)`,
+    ];
+  }
+
+  return referenceTargets
+    .filter((file) => !coveredBy(code, file))
+    .map(
+      (file) =>
+        `${path}: ${file} is a legal rust/… cross-reference target for rust-cross-references.test.ts but no path in the \`code\` filter matches it, so a rename there skips the test that catches the stale pointer (#1141)`,
     );
 }
 
@@ -1099,6 +1142,7 @@ export function checkFile(
       ...requireTestedScriptsInCodeFilter(path, document, testedScripts),
       ...requireManifestSourcesInCodeFilter(path, document, sources.manifestSources),
       ...requireRustSourcesInCodeFilter(path, document, sources.rustSources),
+      ...requireRustReferenceTargetsInCodeFilter(path, document, sources.referenceTargets),
       ...requireManifestSourcesInSeedFilter(path, document, sources.manifestSources),
       ...requireFlakeNixInWorkflowsFilter(path, document),
       ...(rustToolchain ? requirePinnedRustToolchain(path, document, rustToolchain) : []),

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,8 @@ jobs:
               # resolveFile also accepts rust/build.rs and rust/tests/*.rs as reference targets, so a rename there must fire the cross-reference test too (#1132).
               - 'rust/build.rs'
               - 'rust/tests/**'
+              # Same reason, and tracked: rust/vendor/vosk-tts/src/*.rs are legal rust/… reference targets too (#1141 review round 1).
+              - 'rust/vendor/**'
             integration:
               - 'src/**'
               - 'tests/integration/**'

--- a/docs/mutation-evidence/issue-1141.md
+++ b/docs/mutation-evidence/issue-1141.md
@@ -17,19 +17,42 @@ it.
 
 | Guard | Asserts | Where it runs |
 |---|---|---|
-| `collectRustReferenceTargets` | `rust/build.rs` plus every `.rs` under `rust/tests`, from the crate root `main()` actually uses | `collectRuleSources`, called by `main()` with no arguments |
+| `collectRustReferenceTargets` | Every `.rs` under `rust/`, from the crate root `main()` actually uses | `collectRuleSources`, called by `main()` with no arguments |
 | `requireRustReferenceTargetsInCodeFilter` | Every one of those targets is covered by some path in ci.yml's `code` filter, and an empty target list fails rather than passing vacuously | `checkFile`, `ci.yml` only |
 
 It is a sibling rule, not an extension of `requireRustSourcesInCodeFilter`, because the
 justification differs. Every `.rs` reference in `src/**` points inside `rust/src/`, so no TS suite
-reads `rust/build.rs` or `rust/tests/*.rs` today; the existing rule's "is read by a TS suite"
-wording would have been false. The new message says *legal cross-reference target* instead.
+reads `rust/build.rs`, `rust/tests/*.rs` or `rust/vendor/**` today; the existing rule's "is read by
+a TS suite" wording would have been false. The new message says *legal cross-reference target*
+instead.
 
 The rule probes coverage with the shared `coveredBy` helper rather than matching the literal
 strings `- 'rust/build.rs'` / `- 'rust/tests/**'`. A literal match (the shape
 `requireFlakeNixInWorkflowsFilter` uses) would reject a legitimate broadening to `rust/**` as a
 regression; the probe accepts it, still fails on deletion, and names the specific files a narrowing
 strands. Row 3 below is the row that distinguishes the two shapes.
+
+## Review round 1
+
+Three findings changed the shape above, and one landed next door.
+
+**The collector enumerates the tree instead of naming two roots.** `resolveFile` returns any
+`rust/…` path unchanged, so the guarded set is every `.rs` under `rust/` — not just `build.rs` and
+`tests/`. The first cut left `rust/vendor/vosk-tts/src/*.rs` (six tracked files) unguarded and
+uncovered by ci.yml, and a future `rust/benches` or `rust/examples` would have reopened the exact
+gap #1141 closed. The collector is now `collectRustSources("rust")`, and ci.yml's `code` filter
+gains `rust/vendor/**` so the widened set is actually covered. That entry is the only change this
+PR makes to ci.yml, and row 7 pins it.
+
+**`coveredBy` read a dorny negation as coverage.** `["rust/tests/**", "!rust/tests/model_gate.rs"]`
+reported `model_gate.rs` covered, while dorny would exclude it and the unit-tests lane would not
+fire — the same silent skip the rule exists to prevent. A `!` entry that matches now means *not*
+covered. Pre-existing helper, shared by all four filter rules; row 8 pins it.
+
+**The filter-parsing preamble was a fourth verbatim copy.** `codeFilterOf(path, document)` now
+returns either the `code` list or the error the caller returns verbatim, and the four rules share
+it. The two duplicated per-rule test pairs collapse into one parameterised block asserting every
+rule surfaces the shared parser's errors; row 9 pins that propagation.
 
 ## Mutation proof
 
@@ -41,18 +64,30 @@ text `rust/build.rs` occurs twice in ci.yml, once in the justifying comment abov
 | # | File | Mutation | Test | Result |
 |---|---|---|---|---|
 | 1 | `.github/workflows/ci.yml` | `- 'rust/build.rs'` entry deleted from the `code` filter | `bun run check:workflows` | **PINNED** — exit 1, 1 check failed: `` ci.yml: rust/build.rs is a legal rust/… cross-reference target … (#1141) `` |
-| 2 | `.github/workflows/ci.yml` | `- 'rust/tests/**'` entry deleted from the `code` filter | `bun run check:workflows` | **PINNED** — exit 1, 21 checks failed, one per `.rs` under `rust/tests` (`model_gate.rs`, `common/mod.rs`, … `vad_spans.rs`) |
-| 3 | `.github/workflows/ci.yml` | `- 'rust/tests/**'` → `- 'rust/tests/common/**'` — a plausible narrowing rather than a deletion | `bun run check:workflows` | **PINNED** — exit 1, 20 checks failed; `rust/tests/common/mod.rs` is correctly absent from the list, the other 20 are named |
-| 4 | `.github/scripts/check-workflows.ts` | `checkFile`'s `...requireRustReferenceTargetsInCodeFilter(path, document, sources.referenceTargets),` spread → deleted | `bun test tests/unit/check-workflows.test.ts` | **PINNED** — 230 pass, 1 fail (`the file gate actually runs all three`) |
-| 5 | `.github/scripts/check-workflows.ts` | `collectRustReferenceTargets(crateRoot = "rust")` → `crateRoot = "rust/src"` — the default `main()` uses, silently pointed at a tree with no `build.rs` and no `tests/` | `bun test tests/unit/check-workflows.test.ts` | **PINNED** — 229 pass, 2 fail (`the production default crate root is rust`, `collectRuleSources fills all three sets from their own roots`) |
-| 6 | `.github/scripts/check-workflows.ts` | `if (referenceTargets.length === 0) {` → `if (false) {` — the vacuous-pass guard neutralised | `bun test tests/unit/check-workflows.test.ts` | **PINNED** — 230 pass, 1 fail (`an empty target list fails loudly instead of passing vacuously`) |
+| 2 | `.github/workflows/ci.yml` | `- 'rust/tests/**'` entry deleted from the `code` filter | `bun run check:workflows` | **PINNED** — exit 1, 21 checks failed, one per `.rs` under `rust/tests` |
+| 3 | `.github/workflows/ci.yml` | `- 'rust/tests/**'` → `- 'rust/tests/common/**'` — a plausible narrowing rather than a deletion | `bun run check:workflows` | **PINNED** — exit 1, 20 checks failed; `rust/tests/common/mod.rs` is correctly absent, the other 20 are named |
+| 4 | `.github/scripts/check-workflows.ts` | `checkFile`'s `...requireRustReferenceTargetsInCodeFilter(path, document, sources.referenceTargets),` spread → deleted | `bun test tests/unit/check-workflows.test.ts` | **PINNED** — 239 pass, 1 fail (`the file gate actually runs all three`) |
+| 5 | `.github/scripts/check-workflows.ts` | `collectRustReferenceTargets(crateRoot = "rust")` → `crateRoot = "rust/src"` — the default `main()` uses, silently narrowed | `bun test tests/unit/check-workflows.test.ts` | **PINNED** — 238 pass, 2 fail (`the production default crate root is rust`, `collectRuleSources fills all three sets from their own roots`) |
+| 6 | `.github/scripts/check-workflows.ts` | `if (referenceTargets.length === 0) {` → `if (false) {` — the vacuous-pass guard neutralised | `bun test tests/unit/check-workflows.test.ts` | **PINNED** — 239 pass, 1 fail (`an empty target list fails loudly instead of passing vacuously`) |
+| 7 | `.github/workflows/ci.yml` | `- 'rust/vendor/**'` entry deleted — round 1's first finding | `bun run check:workflows` | **PINNED** — exit 1, 6 checks failed, one per `.rs` under `rust/vendor/vosk-tts/src` |
+| 8 | `.github/scripts/check-workflows.ts` | `coveredBy`'s negation line deleted, restoring "a `!` entry counts as coverage" | `bun test tests/unit/check-workflows.test.ts` | **PINNED** — 239 pass, 1 fail (`a negation entry excluding a target is not coverage`) |
+| 9 | `.github/scripts/check-workflows.ts` | `codeFilterOf`'s missing-`code` branch → `return { code: [] }` — the shared parser fails open | `bun test tests/unit/check-workflows.test.ts` | **PINNED** — 235 pass, 5 fail (all four rules' propagation cases plus `codeFilterOf` itself) |
+| 10 | `tests/unit/rust-cross-references.test.ts` | `refs.filter(flagged)` → `refs.filter(() => false)` — round 1's P2, the neutralisation that used to survive at 16 pass / 0 fail | `bun test tests/unit/rust-cross-references.test.ts` | **PINNED** — 22 pass, 1 fail (`the report names the origin and label of every flagged reference and nothing else`) |
+| 11 | `tests/unit/rust-cross-references.test.ts` | `isDangling` → `() => false` | `bun test tests/unit/rust-cross-references.test.ts` | **PINNED** — 20 pass, 3 fail |
+| 12 | `tests/unit/rust-cross-references.test.ts` | `isMissingSymbol`'s body → `false` | `bun test tests/unit/rust-cross-references.test.ts` | **PINNED** — 22 pass, 1 fail (`a symbol the named file does not declare is missing`) |
 
-Rows 1–3 reproduce the defect class end to end, independent of the unit suite: each was green
-before this PR. Rows 4–6 are the registration-and-default rows that
+Rows 1–3 and 7 reproduce the defect class end to end, independent of the unit suite: each was
+green before this PR. Rows 4–6 are the registration-and-default rows that
 `issue-1088.md` rows 3–5 and `issue-1105.md` row 2 exist to cover — a rule whose definition is
 correct and directly tested, but whose wiring into `checkFile` or whose production default has
 nothing driving it. Row 5 is #1132 round 3's specific lesson: there, every test passed an explicit
 root, so the default the script actually runs with went unpinned.
+
+Rows 10–12 close review round 1's P2, which is next door in
+`tests/unit/rust-cross-references.test.ts`: the two suite-level reports asserted the real tree is
+clean, and the real tree *is* clean, so neutralising either filter changed nothing anyone could
+observe. Extracting `isDangling`, `isMissingSymbol` and `report`, then driving them from synthetic
+references, makes the predicates and the filtering itself fail on mutation.
 
 ## Deliberately out of scope
 

--- a/docs/mutation-evidence/issue-1141.md
+++ b/docs/mutation-evidence/issue-1141.md
@@ -1,0 +1,61 @@
+# Mutation evidence — #1141 (`rust/build.rs` and `rust/tests/**` code-filter entries were not pinned)
+
+`.github/workflows/ci.yml`'s `changes` job carries three Rust entries in its `code` filter. #1132
+widened the first from `rust/src/models/**` to `rust/src/**` and pinned that widening through a
+collector (`collectRustSources`) plus a rule (`requireRustSourcesInCodeFilter`). The other two —
+`rust/build.rs` and `rust/tests/**` — landed in #1134, #1132's review fix pass, with a justifying
+comment but no guard: deleting either left `bun run check:workflows` green and no test in the repo
+mentioned the strings. Conveyor review round 1 on PR #1140 found this and ruled it out of that
+PR's scope.
+
+The gap matters because those entries are what routes a rename under `rust/tests/` or an edit to
+`rust/build.rs` into the 🧪 CI `unit-tests` lane, where
+`tests/unit/rust-cross-references.test.ts` runs. Its `resolveFile` accepts any `rust/…` path as a
+reference target, so a stale pointer into `rust/build.rs` or `rust/tests/*.rs` is exactly what that
+suite exists to catch — and without the filter entries it would never run on the change that broke
+it.
+
+| Guard | Asserts | Where it runs |
+|---|---|---|
+| `collectRustReferenceTargets` | `rust/build.rs` plus every `.rs` under `rust/tests`, from the crate root `main()` actually uses | `collectRuleSources`, called by `main()` with no arguments |
+| `requireRustReferenceTargetsInCodeFilter` | Every one of those targets is covered by some path in ci.yml's `code` filter, and an empty target list fails rather than passing vacuously | `checkFile`, `ci.yml` only |
+
+It is a sibling rule, not an extension of `requireRustSourcesInCodeFilter`, because the
+justification differs. Every `.rs` reference in `src/**` points inside `rust/src/`, so no TS suite
+reads `rust/build.rs` or `rust/tests/*.rs` today; the existing rule's "is read by a TS suite"
+wording would have been false. The new message says *legal cross-reference target* instead.
+
+The rule probes coverage with the shared `coveredBy` helper rather than matching the literal
+strings `- 'rust/build.rs'` / `- 'rust/tests/**'`. A literal match (the shape
+`requireFlakeNixInWorkflowsFilter` uses) would reject a legitimate broadening to `rust/**` as a
+regression; the probe accepts it, still fails on deletion, and names the specific files a narrowing
+strands. Row 3 below is the row that distinguishes the two shapes.
+
+## Mutation proof
+
+Every row ran through `just mutate <file> <find> <replace> <test…>`, which restores the mutated
+file in a `finally` and exits 0 only when the mutation was **caught**. `git status --short` was
+clean after every row. Rows 1 and 2 use the `- '…'` form of the find string on purpose: the bare
+text `rust/build.rs` occurs twice in ci.yml, once in the justifying comment above the entry.
+
+| # | File | Mutation | Test | Result |
+|---|---|---|---|---|
+| 1 | `.github/workflows/ci.yml` | `- 'rust/build.rs'` entry deleted from the `code` filter | `bun run check:workflows` | **PINNED** — exit 1, 1 check failed: `` ci.yml: rust/build.rs is a legal rust/… cross-reference target … (#1141) `` |
+| 2 | `.github/workflows/ci.yml` | `- 'rust/tests/**'` entry deleted from the `code` filter | `bun run check:workflows` | **PINNED** — exit 1, 21 checks failed, one per `.rs` under `rust/tests` (`model_gate.rs`, `common/mod.rs`, … `vad_spans.rs`) |
+| 3 | `.github/workflows/ci.yml` | `- 'rust/tests/**'` → `- 'rust/tests/common/**'` — a plausible narrowing rather than a deletion | `bun run check:workflows` | **PINNED** — exit 1, 20 checks failed; `rust/tests/common/mod.rs` is correctly absent from the list, the other 20 are named |
+| 4 | `.github/scripts/check-workflows.ts` | `checkFile`'s `...requireRustReferenceTargetsInCodeFilter(path, document, sources.referenceTargets),` spread → deleted | `bun test tests/unit/check-workflows.test.ts` | **PINNED** — 230 pass, 1 fail (`the file gate actually runs all three`) |
+| 5 | `.github/scripts/check-workflows.ts` | `collectRustReferenceTargets(crateRoot = "rust")` → `crateRoot = "rust/src"` — the default `main()` uses, silently pointed at a tree with no `build.rs` and no `tests/` | `bun test tests/unit/check-workflows.test.ts` | **PINNED** — 229 pass, 2 fail (`the production default crate root is rust`, `collectRuleSources fills all three sets from their own roots`) |
+| 6 | `.github/scripts/check-workflows.ts` | `if (referenceTargets.length === 0) {` → `if (false) {` — the vacuous-pass guard neutralised | `bun test tests/unit/check-workflows.test.ts` | **PINNED** — 230 pass, 1 fail (`an empty target list fails loudly instead of passing vacuously`) |
+
+Rows 1–3 reproduce the defect class end to end, independent of the unit suite: each was green
+before this PR. Rows 4–6 are the registration-and-default rows that
+`issue-1088.md` rows 3–5 and `issue-1105.md` row 2 exist to cover — a rule whose definition is
+correct and directly tested, but whose wiring into `checkFile` or whose production default has
+nothing driving it. Row 5 is #1132 round 3's specific lesson: there, every test passed an explicit
+root, so the default the script actually runs with went unpinned.
+
+## Deliberately out of scope
+
+`.github/workflows/rust-test.yml` lists `rust/build.rs` in its own paths filter too, and that entry
+is also unpinned. It gates the 🧪 Rust Tests lane rather than the 🧪 CI `unit-tests` lane this
+ticket names, for a different reason, so it is left alone.

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -8,6 +8,7 @@ import {
   checkFlakeNix,
   collectCacheWriters,
   collectManifestSources,
+  collectRustReferenceTargets,
   collectRustSources,
   collectRuleSources,
   forbidFindPipedToHead,
@@ -26,6 +27,7 @@ import {
   requireDepsBeforeBunTest,
   requireFlakeNixInWorkflowsFilter,
   requireManifestSourcesInCodeFilter,
+  requireRustReferenceTargetsInCodeFilter,
   requireRustSourcesInCodeFilter,
   requireManifestSourcesInSeedFilter,
   requireNpmPublishAfterPackaging,
@@ -403,7 +405,7 @@ const seedFilter = (paths: string[]) => ({ on: { push: { paths } } });
 
 // readdirSync/join emit win32 separators on Windows; the rules normalise at compare time, so the
 // real-tree assertions have to as well or they only hold on posix (#950 round 3).
-const NO_SOURCES = { manifestSources: [], rustSources: [] };
+const NO_SOURCES = { manifestSources: [], rustSources: [], referenceTargets: [] };
 
 const repoRelative = (files: string[]) =>
   files.map((file) => file.slice(REPO_ROOT.length + 1).replaceAll("\\", "/"));
@@ -583,7 +585,7 @@ describe("manifest sources stay inside both path filters", () => {
     const seed = join(dir, "cache-seed.yml");
     writeFileSync(seed, "on:\n  push:\n    paths:\n      - 'a.rs'\n");
 
-    const sources = { manifestSources: ["a.rs"], rustSources: ["a.rs", "b.rs"] };
+    const sources = { manifestSources: ["a.rs"], rustSources: ["a.rs", "b.rs"], referenceTargets: ["a.rs"] };
     expect(checkFile(ci, [], [], undefined, sources).filter((e) => e.includes("#950"))).toEqual([]);
     expect(checkFile(seed, [], [], undefined, sources).filter((e) => e.includes("#950"))).toEqual([]);
 
@@ -591,6 +593,7 @@ describe("manifest sources stay inside both path filters", () => {
     const swapped = checkFile(seed, [], [], undefined, {
       manifestSources: sources.rustSources,
       rustSources: sources.manifestSources,
+      referenceTargets: sources.referenceTargets,
     }).filter((e) => e.includes("#950"));
     expect(swapped).toHaveLength(1);
     expect(swapped[0]).toContain("b.rs");
@@ -599,19 +602,25 @@ describe("manifest sources stay inside both path filters", () => {
   });
 
   // A gate is only a gate if checkFile still calls it; the real tree cannot notice an unwired one.
-  test("the file gate actually runs both", () => {
+  test("the file gate actually runs all three", () => {
     const dir = mkdtempSync(join(tmpdir(), "kesha-wf-"));
     const ci = join(dir, "ci.yml");
     writeFileSync(ci, "on: push\njobs:\n  changes:\n    steps:\n      - with:\n          filters: |\n            code:\n              - 'src/**'\n");
     // Distinct fifth and sixth arguments: each rule must name the file from its OWN set, so handing
     // requireRustSourcesInCodeFilter the manifest set instead of the tree set is visible here (#950 round 3).
-    const errors = checkFile(ci, [], [], undefined, {
+    const sources = {
       manifestSources: ["rust/src/models/manifest.rs"],
       rustSources: ["rust/src/models/paths.rs"],
-    }).filter((e) => e.includes("#950"));
+      referenceTargets: ["rust/build.rs"],
+    };
+    const errors = checkFile(ci, [], [], undefined, sources).filter((e) => e.includes("#950"));
     expect(errors).toHaveLength(2);
     expect(errors.join("\n")).toContain("rust/src/models/manifest.rs contains ModelFile literals");
     expect(errors.join("\n")).toContain("rust/src/models/paths.rs is read by a TS suite");
+
+    const stranded = checkFile(ci, [], [], undefined, sources).filter((e) => e.includes("#1141"));
+    expect(stranded).toHaveLength(1);
+    expect(stranded[0]).toContain("rust/build.rs");
 
     const seed = join(dir, "cache-seed.yml");
     writeFileSync(seed, "on:\n  push:\n    paths:\n      - 'rust/Cargo.lock'\n");
@@ -619,8 +628,81 @@ describe("manifest sources stay inside both path filters", () => {
       checkFile(seed, [], [], undefined, {
         manifestSources: ["rust/src/models.rs"],
         rustSources: ["rust/src/models.rs"],
+        referenceTargets: ["rust/build.rs"],
       }).filter((e) => e.includes("#950")),
     ).toHaveLength(1);
+  });
+});
+
+describe("cross-reference targets outside rust/src stay inside the code filter", () => {
+  const TARGETS = ["rust/build.rs", "rust/tests/model_gate.rs"];
+
+  test("collectRustReferenceTargets finds build.rs and every .rs under rust/tests", () => {
+    const targets = repoRelative(collectRustReferenceTargets(repoPath("rust")));
+    expect(targets).toContain("rust/build.rs");
+    expect(targets).toContain("rust/tests/model_gate.rs");
+    expect(targets).toContain("rust/tests/common/mod.rs");
+    expect(targets.length).toBeGreaterThanOrEqual(20);
+  });
+
+  // #1132 round 3's lesson: every test passed an explicit root, so the default main() actually uses went unpinned.
+  test("the production default crate root is rust", () => {
+    expect(collectRustReferenceTargets().map((file) => file.replaceAll("\\", "/"))).toContain("rust/build.rs");
+  });
+
+  test("the real ci.yml covers every cross-reference target", () => {
+    const targets = repoRelative(collectRustReferenceTargets(repoPath("rust")));
+    expect(requireRustReferenceTargetsInCodeFilter(CI, parseRepoYaml(CI), targets)).toEqual([]);
+  });
+
+  test("dropping the rust/tests entry names the files it strands", () => {
+    const document = codeFilter(["rust/src/**", "rust/build.rs"]);
+    const errors = requireRustReferenceTargetsInCodeFilter(CI, document, TARGETS);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("rust/tests/model_gate.rs");
+  });
+
+  test("dropping the rust/build.rs entry names it", () => {
+    const document = codeFilter(["rust/src/**", "rust/tests/**"]);
+    const errors = requireRustReferenceTargetsInCodeFilter(CI, document, TARGETS);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("rust/build.rs");
+  });
+
+  // A legitimate widening must not read as a regression, which is why the rule probes coverage, not the literal entries.
+  test("a broader rust wildcard satisfies the rule", () => {
+    expect(requireRustReferenceTargetsInCodeFilter(CI, codeFilter(["rust/**"]), TARGETS)).toEqual([]);
+  });
+
+  test("an empty target list fails loudly instead of passing vacuously", () => {
+    const errors = requireRustReferenceTargetsInCodeFilter(CI, codeFilter(["rust/**"]), []);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("returned no files");
+  });
+
+  test("ignores every other workflow", () => {
+    expect(requireRustReferenceTargetsInCodeFilter(PATH, codeFilter([]), ["rust/build.rs"])).toEqual([]);
+  });
+
+  test("fails when the code list is gone", () => {
+    const document = job("changes", [{ with: { filters: "integration:\n  - 'src/**'\n" } }]);
+    expect(requireRustReferenceTargetsInCodeFilter(CI, document, [])[0]).toContain("missing a `code` list");
+  });
+
+  test("fails when the changes job has no inline filters", () => {
+    expect(requireRustReferenceTargetsInCodeFilter(CI, { jobs: { changes: {} } }, [])[0]).toContain(
+      "expected a `changes` job",
+    );
+  });
+
+  test("collectRuleSources fills all three sets from their own roots", () => {
+    const normalise = (files: string[]) => files.map((file) => file.replaceAll("\\", "/"));
+    const { manifestSources, rustSources, referenceTargets } = collectRuleSources();
+    expect(normalise(rustSources)).toContain("rust/src/text_lang.rs");
+    expect(normalise(rustSources)).not.toContain("rust/build.rs");
+    expect(normalise(referenceTargets)).toContain("rust/build.rs");
+    expect(normalise(referenceTargets)).not.toContain("rust/src/text_lang.rs");
+    expect(normalise(manifestSources)).toContain("rust/src/models/manifest.rs");
   });
 });
 

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, test } from "bun:test";
 import { parse } from "yaml";
 import {
   checkFile,
+  codeFilterOf,
   checkFlakeNix,
   collectCacheWriters,
   collectManifestSources,
@@ -360,6 +361,46 @@ describe("requireNpmPublishAfterPackaging", () => {
 const codeFilter = (paths: string[]) =>
   job("changes", [{ with: { filters: `code:\n${paths.map((p) => `  - '${p}'`).join("\n")}\n` } }]);
 
+const NO_CODE_LIST = job("changes", [{ with: { filters: "integration:\n  - 'src/**'\n" } }]);
+const NO_INLINE_FILTERS = { jobs: { changes: {} } };
+
+describe("codeFilterOf", () => {
+  test("returns the code list", () => {
+    expect(codeFilterOf(CI, codeFilter(["src/**"]))).toEqual({ code: ["src/**"] });
+  });
+
+  test("names a filters block carrying no code list", () => {
+    expect(codeFilterOf(CI, NO_CODE_LIST)).toEqual({
+      errors: [`${CI}: paths-filter is missing a \`code\` list`],
+    });
+  });
+
+  test("names a changes job with no inline filters", () => {
+    expect(codeFilterOf(CI, NO_INLINE_FILTERS)).toEqual({
+      errors: [`${CI}: expected a \`changes\` job with inline paths-filter filters`],
+    });
+  });
+});
+
+// One parameterised pin replaces the per-rule copies of this pair: every rule reads the same parser,
+// so what needs pinning is that each one surfaces its errors rather than crashing (#1141 review round 1).
+describe("every code-filter rule surfaces the shared parser's errors", () => {
+  const rules: Array<[string, (document: unknown) => string[]]> = [
+    ["requireTestedScriptsInCodeFilter", (d) => requireTestedScriptsInCodeFilter(CI, d, [".github/scripts/check-versions.ts"])],
+    ["requireManifestSourcesInCodeFilter", (d) => requireManifestSourcesInCodeFilter(CI, d, ["rust/src/models.rs"])],
+    ["requireRustSourcesInCodeFilter", (d) => requireRustSourcesInCodeFilter(CI, d, ["rust/src/models.rs"])],
+    ["requireRustReferenceTargetsInCodeFilter", (d) => requireRustReferenceTargetsInCodeFilter(CI, d, ["rust/build.rs"])],
+  ];
+
+  test.each(rules)("%s reports a missing code list", (_name, rule) => {
+    expect(rule(NO_CODE_LIST)[0]).toContain("missing a `code` list");
+  });
+
+  test.each(rules)("%s reports a changes job with no inline filters", (_name, rule) => {
+    expect(rule(NO_INLINE_FILTERS)[0]).toContain("expected a `changes` job");
+  });
+});
+
 describe("requireTestedScriptsInCodeFilter", () => {
   test("passes on the real ci.yml", () => {
     const document = parseRepoYaml(CI);
@@ -388,15 +429,6 @@ describe("requireTestedScriptsInCodeFilter", () => {
     const errors = requireTestedScriptsInCodeFilter(CI, document, scripts);
     expect(errors).toHaveLength(1);
     expect(errors[0]).toContain("check-versions.ts");
-  });
-
-  test("fails when the code list is gone", () => {
-    const document = job("changes", [{ with: { filters: "integration:\n  - 'src/**'\n" } }]);
-    expect(requireTestedScriptsInCodeFilter(CI, document, [])[0]).toContain("missing a `code` list");
-  });
-
-  test("fails when the changes job has no inline filters", () => {
-    expect(requireTestedScriptsInCodeFilter(CI, { jobs: { changes: {} } }, [])[0]).toContain("expected a `changes` job");
   });
 });
 
@@ -634,14 +666,18 @@ describe("manifest sources stay inside both path filters", () => {
   });
 });
 
-describe("cross-reference targets outside rust/src stay inside the code filter", () => {
+describe("cross-reference targets stay inside the code filter", () => {
   const TARGETS = ["rust/build.rs", "rust/tests/model_gate.rs"];
 
-  test("collectRustReferenceTargets finds build.rs and every .rs under rust/tests", () => {
+  // resolveFile returns any `rust/…` path unchanged, so the set is the whole tree: naming build.rs and
+  // tests/ left rust/vendor unguarded and a future rust/benches would reopen the gap (#1141 review round 1).
+  test("collectRustReferenceTargets finds every .rs under rust, not just build.rs and tests", () => {
     const targets = repoRelative(collectRustReferenceTargets(repoPath("rust")));
     expect(targets).toContain("rust/build.rs");
     expect(targets).toContain("rust/tests/model_gate.rs");
     expect(targets).toContain("rust/tests/common/mod.rs");
+    expect(targets).toContain("rust/vendor/vosk-tts/src/lib.rs");
+    expect(targets).toContain("rust/src/text_lang.rs");
     expect(targets.length).toBeGreaterThanOrEqual(20);
   });
 
@@ -684,15 +720,17 @@ describe("cross-reference targets outside rust/src stay inside the code filter",
     expect(requireRustReferenceTargetsInCodeFilter(PATH, codeFilter([]), ["rust/build.rs"])).toEqual([]);
   });
 
-  test("fails when the code list is gone", () => {
-    const document = job("changes", [{ with: { filters: "integration:\n  - 'src/**'\n" } }]);
-    expect(requireRustReferenceTargetsInCodeFilter(CI, document, [])[0]).toContain("missing a `code` list");
+  // A dorny `!` entry excludes the file it matches, so reading it as coverage is the silent skip #1141 exists to prevent (#1141 review round 1).
+  test("a negation entry excluding a target is not coverage", () => {
+    const document = codeFilter(["rust/tests/**", "!rust/tests/model_gate.rs"]);
+    const errors = requireRustReferenceTargetsInCodeFilter(CI, document, ["rust/tests/model_gate.rs"]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("rust/tests/model_gate.rs");
   });
 
-  test("fails when the changes job has no inline filters", () => {
-    expect(requireRustReferenceTargetsInCodeFilter(CI, { jobs: { changes: {} } }, [])[0]).toContain(
-      "expected a `changes` job",
-    );
+  test("a negation entry matching nothing leaves the rest covered", () => {
+    const document = codeFilter(["rust/tests/**", "!rust/tests/absent.rs"]);
+    expect(requireRustReferenceTargetsInCodeFilter(CI, document, ["rust/tests/model_gate.rs"])).toEqual([]);
   });
 
   test("collectRuleSources fills all three sets from their own roots", () => {
@@ -701,8 +739,9 @@ describe("cross-reference targets outside rust/src stay inside the code filter",
     expect(normalise(rustSources)).toContain("rust/src/text_lang.rs");
     expect(normalise(rustSources)).not.toContain("rust/build.rs");
     expect(normalise(referenceTargets)).toContain("rust/build.rs");
-    expect(normalise(referenceTargets)).not.toContain("rust/src/text_lang.rs");
+    expect(normalise(referenceTargets)).toContain("rust/vendor/vosk-tts/src/lib.rs");
     expect(normalise(manifestSources)).toContain("rust/src/models/manifest.rs");
+    expect(normalise(manifestSources)).not.toContain("rust/build.rs");
   });
 });
 

--- a/tests/unit/rust-cross-references.test.ts
+++ b/tests/unit/rust-cross-references.test.ts
@@ -124,6 +124,58 @@ const references: Reference[] = tsSources("src").flatMap(referencesIn);
 
 const countOf = (kind: string) => references.filter((reference) => reference.kind === kind).length;
 
+const isDangling = ({ file }: Reference) => !file || !existsExactly(file);
+
+/** A pointer into a file that is not on disk is the dangling report's finding, so this one stays silent on it. */
+const isMissingSymbol = ({ file, symbol }: Reference) =>
+  Boolean(symbol && file && existsExactly(file) && !declares(readRepoFile(file), symbol));
+
+const report = (refs: Reference[], flagged: (reference: Reference) => boolean) =>
+  refs.filter(flagged).map(({ origin, label }) => `${origin} → ${label}`);
+
+// The real tree is clean, so both reports below can be neutralised with no assertion firing — these
+// synthetic references pin the predicates and the report itself instead (#1141 review round 1).
+describe("the dangling and missing-symbol predicates", () => {
+  const reference = (over: Partial<Reference>): Reference => ({
+    origin: "src/synthetic.ts",
+    label: "synthetic",
+    kind: "file",
+    ...over,
+  });
+
+  test("a reference to a file that is not on disk is dangling", () => {
+    expect(isDangling(reference({ file: "rust/src/no_such_file.rs" }))).toBe(true);
+  });
+
+  test("a reference the scan could not resolve to any file is dangling", () => {
+    expect(isDangling(reference({ file: undefined }))).toBe(true);
+  });
+
+  test("a reference to a file that is on disk is not dangling", () => {
+    expect(isDangling(reference({ file: "rust/src/text_lang.rs" }))).toBe(false);
+  });
+
+  test("a symbol the named file does not declare is missing", () => {
+    expect(isMissingSymbol(reference({ file: "rust/src/text_lang.rs", symbol: "no_such_symbol" }))).toBe(true);
+  });
+
+  test("a symbol the named file declares is not missing", () => {
+    expect(isMissingSymbol(reference({ file: "rust/src/text_lang.rs", symbol: "detect_text_language" }))).toBe(false);
+  });
+
+  test("a symbol inside a file that is not on disk is left to the dangling report", () => {
+    expect(isMissingSymbol(reference({ file: "rust/src/no_such_file.rs", symbol: "anything" }))).toBe(false);
+  });
+
+  test("the report names the origin and label of every flagged reference and nothing else", () => {
+    const refs = [
+      reference({ origin: "src/a.ts", label: "gone.rs", file: "rust/src/gone.rs" }),
+      reference({ origin: "src/b.ts", label: "text_lang.rs", file: "rust/src/text_lang.rs" }),
+    ];
+    expect(report(refs, isDangling)).toEqual(["src/a.ts → gone.rs"]);
+  });
+});
+
 describe("declares", () => {
   const cases: Array<[string, string, boolean]> = [
     ["pub(super) const ANE_EN_FILES: &[ModelFile] = &[];", "ANE_EN_FILES", true],
@@ -170,16 +222,10 @@ describe("Rust cross-references in TS sources", () => {
   });
 
   test("every referenced Rust file exists", () => {
-    const dangling = references
-      .filter(({ file }) => !file || !existsExactly(file))
-      .map(({ origin, label }) => `${origin} → ${label}`);
-    expect(dangling).toEqual([]);
+    expect(report(references, isDangling)).toEqual([]);
   });
 
   test("every referenced Rust symbol is declared in the file it names", () => {
-    const missing = references
-      .filter(({ file, symbol }) => symbol && file && existsExactly(file) && !declares(readRepoFile(file), symbol))
-      .map(({ origin, label }) => `${origin} → ${label}`);
-    expect(missing).toEqual([]);
+    expect(report(references, isMissingSymbol)).toEqual([]);
   });
 });


### PR DESCRIPTION
Closes #1141

## Claim

Deleting any of `- 'rust/build.rs'`, `- 'rust/tests/**'` or `- 'rust/vendor/**'` from ci.yml's `code` filter now fails `bun run check:workflows` naming the stranded files — if this is wrong, `just mutate .github/workflows/ci.yml "              - 'rust/build.rs'\n" "" bun run check:workflows` reports NOT PINNED, exactly as it did on `origin/main`.

## What changed

`collectRustReferenceTargets` + `requireRustReferenceTargetsInCodeFilter` in `.github/scripts/check-workflows.ts`, wired into `checkFile` and `collectRuleSources`, with a red-first test block in `tests/unit/check-workflows.test.ts`.

A **sibling** rule rather than an extension of `requireRustSourcesInCodeFilter`, because the justification differs. Every `.rs` reference in `src/**` points inside `rust/src/`, so nothing reads `rust/build.rs`, `rust/tests/*.rs` or `rust/vendor/**` today — the existing rule's "is read by a TS suite" message would have been false. These are *legal `rust/…` cross-reference targets* for `tests/unit/rust-cross-references.test.ts`'s `resolveFile`, and the new message says so.

The rule probes coverage via the shared `coveredBy` helper rather than matching the literal filter strings, so a legitimate broadening to `rust/**` passes while a narrowing fails naming the files it strands (row 3 below is what separates the two shapes).

## Review round 1 — all four findings addressed

**[P3] the collector hardcoded two roots.** Fixed. `resolveFile` returns any `rust/…` path unchanged, so the guarded set is every `.rs` under `rust/`, not just `build.rs` and `tests/`. The collector is now `collectRustSources("rust")`. That exposed the six tracked `rust/vendor/vosk-tts/src/*.rs` files the reviewer named as genuinely uncovered, so ci.yml's `code` filter gains **`- 'rust/vendor/**'`** — the only ci.yml change in this PR, and a knowing narrowing of the plan's "ci.yml unchanged" ruling, which was about not re-litigating the existing entries rather than about refusing to close a hole. A future `rust/benches` or `rust/examples` is now guarded by construction. Re-fired as row 7.

**[P3] `coveredBy` read a dorny negation as coverage.** Fixed. Re-ran the reviewer's probe: `requireRustReferenceTargetsInCodeFilter(CI, <["rust/tests/**", "!rust/tests/model_gate.rs"]>, ["rust/tests/model_gate.rs"])` now returns 1 error naming `model_gate.rs`, where it returned `[]` before. A `!` entry that matches a file means the file is excluded, never covered. Pre-existing helper shared by all four filter rules; the reviewer's noted safe direction (single-star `rust/tests/*` erroring) is unchanged. Re-fired as row 8.

**[P3] fourth verbatim copy of the filter parser.** Fixed. `codeFilterOf(path, document)` returns either `{ code }` or `{ errors }`, and all four rules share it — 24 lines of duplicated parsing and both duplicated error literals gone. The two per-rule `code list is gone` / `no inline filters` pairs collapse into one `test.each` block asserting all four rules surface the shared parser's errors: the duplication goes, the propagation coverage widens from two rules to four. Re-fired as row 9.

**[P2] the cross-reference guards survived `.filter(() => false)`.** Fixed. Reproduced first at 16 pass / 0 fail, exactly as reported. `isDangling`, `isMissingSymbol` and `report` are now named functions driven by synthetic dangling-file and missing-symbol references, so the predicates *and* the filtering are pinned. The cited mutation now fails. Re-fired as rows 10–12.

## Evidence

All twelve mutation rows PINNED; `git status --short` clean after each. Full write-up in `docs/mutation-evidence/issue-1141.md`.

| # | Mutation | Test | Result |
|---|---|---|---|
| 1 | ci.yml: `- 'rust/build.rs'` deleted | `bun run check:workflows` | exit 1, 1 check failed naming `rust/build.rs` |
| 2 | ci.yml: `- 'rust/tests/**'` deleted | `bun run check:workflows` | exit 1, 21 checks failed, one per `.rs` under `rust/tests` |
| 3 | ci.yml: `rust/tests/**` → `rust/tests/common/**` (narrowing) | `bun run check:workflows` | exit 1, 20 checks failed; `common/mod.rs` correctly absent |
| 4 | `checkFile`'s registration spread deleted | `bun test tests/unit/check-workflows.test.ts` | 239 pass, 1 fail (`the file gate actually runs all three`) |
| 5 | `crateRoot = "rust"` → `"rust/src"` (the production default) | same | 238 pass, 2 fail |
| 6 | vacuous-pass guard → `if (false)` | same | 239 pass, 1 fail |
| 7 | **round 1:** ci.yml `- 'rust/vendor/**'` deleted | `bun run check:workflows` | exit 1, 6 checks failed, one per vendored `.rs` |
| 8 | **round 1:** `coveredBy`'s negation line deleted | `bun test tests/unit/check-workflows.test.ts` | 239 pass, 1 fail (`a negation entry excluding a target is not coverage`) |
| 9 | **round 1:** `codeFilterOf`'s missing-`code` branch → `return { code: [] }` | same | 235 pass, 5 fail (all four rules plus `codeFilterOf`) |
| 10 | **round 1 P2:** `refs.filter(flagged)` → `refs.filter(() => false)` | `bun test tests/unit/rust-cross-references.test.ts` | 22 pass, 1 fail — was 16 pass / 0 fail before |
| 11 | **round 1 P2:** `isDangling` → `() => false` | same | 20 pass, 3 fail |
| 12 | **round 1 P2:** `isMissingSymbol`'s body → `false` | same | 22 pass, 1 fail |

`just preflight` exit 0 (Rust gate skipped by design — no `rust/**` change).

## Rulings carried from the plan

- **The existing entries are not re-litigated.** #1134 landed them with a stated justification; this ticket adds the missing pin. The one entry added (`rust/vendor/**`) closes a hole the review found, it does not revisit the three that were there.
- **ci.yml's `workflows` filter is not widened.** Any weakening of these entries is itself a ci.yml edit, which `.github/workflows/**` already routes to `workflow-lint`.
- **`rust-test.yml`'s own unpinned `rust/build.rs` entry is out of scope** — it gates the 🧪 Rust Tests lane, not the 🧪 CI `unit-tests` lane this ticket names.

## State (auto)

Machine-maintained by the driver on every head move — sessions and reviewers leave this section alone.

- head: `9f12e5b458e5098396bdaa0d806539becfa246f2`
- files (5):
  - `.github/scripts/check-workflows.ts`
  - `.github/workflows/ci.yml`
  - `docs/mutation-evidence/issue-1141.md`
  - `tests/unit/check-workflows.test.ts`
  - `tests/unit/rust-cross-references.test.ts`