### PR TITLE
ci: rust-test.yml's own rust/build.rs code-filter entry is not mutation-pinned

### DIFF
--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -624,7 +624,7 @@ const coveredBy = (patterns: string[], file: string) => {
 
 export type NamedFilter = { entries: string[] } | { errors: string[] };
 
-/** The named list from a `changes` job's inline paths-filter, or the error the caller returns verbatim — five rules read one of these and each private copy of the parser was one more place to drift (#1141 review round 1, generalised over the filter name in #1145). */
+/** The named list from a `changes` job's inline paths-filter, or the error the caller returns verbatim — every paths-filter rule reads one of these and each private copy of the parser was one more place to drift (#1141 review round 1, generalised over the filter name in #1145). */
 export function namedFilterOf(path: string, document: unknown, name: string): NamedFilter {
   const raw = jobSteps(document, "changes")?.find((step) => typeof step?.with?.filters === "string")?.with?.filters;
   if (typeof raw !== "string") return { errors: [`${path}: expected a \`changes\` job with inline paths-filter filters`] };

--- a/.github/scripts/check-workflows.ts
+++ b/.github/scripts/check-workflows.ts
@@ -19,6 +19,7 @@ import { engineTargetEntries, targetKey } from "../../src/engine-targets";
 const dirs = [".github/workflows", ".github/actions"];
 const RUST_TOOLCHAIN_FILE = "rust-toolchain.toml";
 const FLAKE_NIX = "flake.nix";
+const RUST_BUILD_SCRIPT = "rust/build.rs";
 
 export type RustToolchainPin = {
   channel: string;
@@ -621,17 +622,17 @@ const coveredBy = (patterns: string[], file: string) => {
   return patterns.some((pattern) => !pattern.startsWith("!") && matches(pattern));
 };
 
-export type CodeFilter = { code: string[] } | { errors: string[] };
+export type NamedFilter = { entries: string[] } | { errors: string[] };
 
-/** ci.yml's `changes` job inline paths-filter `code` list, or the error the caller returns verbatim — four rules read it and each private copy of the parser was one more place to drift (#1141 review round 1). */
-export function codeFilterOf(path: string, document: unknown): CodeFilter {
+/** The named list from a `changes` job's inline paths-filter, or the error the caller returns verbatim — five rules read one of these and each private copy of the parser was one more place to drift (#1141 review round 1, generalised over the filter name in #1145). */
+export function namedFilterOf(path: string, document: unknown, name: string): NamedFilter {
   const raw = jobSteps(document, "changes")?.find((step) => typeof step?.with?.filters === "string")?.with?.filters;
   if (typeof raw !== "string") return { errors: [`${path}: expected a \`changes\` job with inline paths-filter filters`] };
 
-  const code = (parse(raw) as Record<string, string[]>)?.code;
-  if (!Array.isArray(code)) return { errors: [`${path}: paths-filter is missing a \`code\` list`] };
+  const entries = (parse(raw) as Record<string, string[]>)?.[name];
+  if (!Array.isArray(entries)) return { errors: [`${path}: paths-filter is missing a \`${name}\` list`] };
 
-  return { code };
+  return { entries };
 }
 
 export function requireTestedScriptsInCodeFilter(
@@ -641,9 +642,9 @@ export function requireTestedScriptsInCodeFilter(
 ): string[] {
   if (!path.endsWith("ci.yml")) return [];
 
-  const filter = codeFilterOf(path, document);
+  const filter = namedFilterOf(path, document, "code");
   if ("errors" in filter) return filter.errors;
-  const { code } = filter;
+  const code = filter.entries;
 
   return testedScripts
     .filter((file) => !coveredBy(code, file))
@@ -716,9 +717,9 @@ export function requireRustSourcesInCodeFilter(
 ): string[] {
   if (!path.endsWith("ci.yml")) return [];
 
-  const filter = codeFilterOf(path, document);
+  const filter = namedFilterOf(path, document, "code");
   if ("errors" in filter) return filter.errors;
-  const { code } = filter;
+  const code = filter.entries;
 
   if (rustSources.length === 0) {
     return [
@@ -742,9 +743,9 @@ export function requireRustReferenceTargetsInCodeFilter(
 ): string[] {
   if (!path.endsWith("ci.yml")) return [];
 
-  const filter = codeFilterOf(path, document);
+  const filter = namedFilterOf(path, document, "code");
   if ("errors" in filter) return filter.errors;
-  const { code } = filter;
+  const code = filter.entries;
 
   if (referenceTargets.length === 0) {
     return [
@@ -768,9 +769,9 @@ export function requireManifestSourcesInCodeFilter(
 ): string[] {
   if (!path.endsWith("ci.yml")) return [];
 
-  const filter = codeFilterOf(path, document);
+  const filter = namedFilterOf(path, document, "code");
   if ("errors" in filter) return filter.errors;
-  const { code } = filter;
+  const code = filter.entries;
 
   if (manifestSources.length === 0) {
     return [
@@ -816,15 +817,26 @@ export function requireManifestSourcesInSeedFilter(
 export function requireFlakeNixInWorkflowsFilter(path: string, document: unknown): string[] {
   if (!path.endsWith("ci.yml")) return [];
 
-  const raw = jobSteps(document, "changes")?.find((step) => typeof step?.with?.filters === "string")?.with?.filters;
-  if (typeof raw !== "string") return [`${path}: expected a \`changes\` job with inline paths-filter filters`];
+  const filter = namedFilterOf(path, document, "workflows");
+  if ("errors" in filter) return filter.errors;
 
-  const workflows = (parse(raw) as Record<string, string[]>)?.workflows;
-  if (!Array.isArray(workflows)) return [`${path}: paths-filter is missing a \`workflows\` list`];
-
-  return workflows.includes(FLAKE_NIX)
+  return filter.entries.includes(FLAKE_NIX)
     ? []
     : [`${path}: \`workflows\` filter must include \`${FLAKE_NIX}\`, or checkFlakeNix's guard never runs in CI (#1088)`];
+}
+
+/** Fails when rust-test.yml's `coreml` filter stops covering rust/build.rs: `coreml-regression` is the only lane that links and runs the coreml feature, and CLAUDE.md's build triple makes the build script's `/usr/lib/swift` rpath emit part of that link surface (#1145). */
+export function requireBuildScriptInCoremlFilter(path: string, document: unknown): string[] {
+  if (!path.endsWith("rust-test.yml")) return [];
+
+  const filter = namedFilterOf(path, document, "coreml");
+  if ("errors" in filter) return filter.errors;
+
+  return coveredBy(filter.entries, RUST_BUILD_SCRIPT)
+    ? []
+    : [
+        `${path}: no path in the \`coreml\` filter matches ${RUST_BUILD_SCRIPT}, so an edit breaking its \`/usr/lib/swift\` rpath emit skips coreml-regression — the only lane that links and runs the coreml feature (#1145)`,
+      ];
 }
 
 function collectTestedScripts(): string[] {
@@ -1148,6 +1160,7 @@ export function checkFile(
       ...requireRustReferenceTargetsInCodeFilter(path, document, sources.referenceTargets),
       ...requireManifestSourcesInSeedFilter(path, document, sources.manifestSources),
       ...requireFlakeNixInWorkflowsFilter(path, document),
+      ...requireBuildScriptInCoremlFilter(path, document),
       ...(rustToolchain ? requirePinnedRustToolchain(path, document, rustToolchain) : []),
     ];
   } catch (err) {

--- a/docs/mutation-evidence/issue-1145.md
+++ b/docs/mutation-evidence/issue-1145.md
@@ -1,9 +1,10 @@
 # Mutation evidence — #1145 (`rust-test.yml`'s own `rust/build.rs` code-filter entry was not pinned)
 
 `.github/workflows/rust-test.yml`'s `changes` job carries a curated eight-entry `coreml` filter,
-and `rust/build.rs` is one of them. Nothing read that filter: before this ticket the only rule in
-`check-workflows.ts` that touched `rust-test.yml` at all was
-`requireRustTestCancelsSupersededRuns` (#1105, concurrency). Deleting the entry left
+and `rust/build.rs` is one of them. Nothing read that filter: before this ticket the only
+rust-test.yml-specific rule in `check-workflows.ts` was
+`requireRustTestCancelsSupersededRuns` (#1105, concurrency), and none of the dozen file-agnostic
+rules `checkFile` dispatches over every workflow looks at a paths-filter. Deleting the entry left
 `bun run check:workflows` green.
 
 #1141/#1144 closed the same reach-gap class one workflow over, for `ci.yml`'s `code` filter, and
@@ -46,7 +47,7 @@ the `a narrowing that misses the build script is caught` case covers the other d
 
 | Guard | Asserts | Where it runs |
 |---|---|---|
-| `namedFilterOf(path, document, name)` | The named list from a `changes` job's inline paths-filter, or the caller's verbatim error | Five rules across `ci.yml` and `rust-test.yml` |
+| `namedFilterOf(path, document, name)` | The named list from a `changes` job's inline paths-filter, or the caller's verbatim error | Every paths-filter rule, across `ci.yml` and `rust-test.yml` |
 | `requireBuildScriptInCoremlFilter` | Some path in `rust-test.yml`'s `coreml` filter covers `rust/build.rs` | `checkFile`, `rust-test.yml` only |
 
 `codeFilterOf` became `namedFilterOf` rather than gaining a sibling: #1144's round-1 P3 noted the
@@ -97,3 +98,32 @@ new one asks for `code`.
   `unit-tests` and never runs that suite. It does not block this ticket — the new rule runs in
   `workflow-lint`, which *is* gated on `.github/workflows/**` — and the fix widens which jobs run
   on every workflow PR, so it is left for its own ticket.
+
+## Review round 1
+
+**The real-file case over-pinned.** Its first cut asserted
+`arrayContaining(["rust/build.rs", "rust/src/backend/fluidaudio.rs"])`, which pinned a second
+`coreml` entry — contradicting this document's own scope above, and pinning it in the wrong lane.
+`unit-tests` rides `ci.yml`'s `code` filter, and `.github/workflows/rust-test.yml` appears nowhere
+in that filter, so a re-curation PR touching only `rust-test.yml` would have merged green and
+reddened the *next* unrelated PR touching `tests/**`, `src/**` or `.github/scripts/**`. The
+assertion now names `rust/build.rs` only.
+
+| Probe | Before the fix | After |
+|---|---|---|
+| `- 'rust/src/backend/fluidaudio.rs'` deleted → `bun test tests/unit/check-workflows.test.ts` | **PINNED**, failing `namedFilterOf > reads a filter other than code, from the real rust-test.yml` | **NOT PINNED** — 252 pass, 0 fail |
+| `- 'rust/src/backend/fluidaudio.rs'` deleted → `bun run check:workflows` | **NOT PINNED** (unchanged: that entry is out of scope by design) | **NOT PINNED** |
+| row 7, `?.[name]` → `?.code` | 241 pass, 11 fail | **unchanged** — 241 pass, 11 fail, still including `namedFilterOf > reads a filter other than code…`, `requireBuildScriptInCoremlFilter > passes on the real rust-test.yml` and `requireFlakeNixInWorkflowsFilter > passes on the real ci.yml` |
+| row 1, the entry deleted → `bun run check:workflows` | **PINNED** | **PINNED** — exit 1, 1 check failed |
+
+Narrowing the assertion costs nothing: the generalisation it exists to pin is still held by eleven
+assertions, two of which read real workflow files.
+
+**Two checkable comment claims were false.** `namedFilterOf`'s doc counted "five rules" against an
+actual six — the count was right pre-diff at four and was updated to five while *two* callers were
+added. The numeral is gone rather than corrected, following the ruling already recorded beside
+`ci.yml`'s `code` filter ("Deliberately no count — the one that lived here read 16 against an
+actual 25"). And the opening paragraph's "the only rule that touched `rust-test.yml` at all" was
+false as written: `checkFile` dispatches a dozen file-agnostic rules over every workflow. Only the
+*rust-test.yml-specific* rules numbered one, and the load-bearing claim — that nothing read the
+`coreml` filter — stands: row 1 runs **NOT PINNED** against base `4dbe3b5` and **PINNED** at head.

--- a/docs/mutation-evidence/issue-1145.md
+++ b/docs/mutation-evidence/issue-1145.md
@@ -1,0 +1,99 @@
+# Mutation evidence — #1145 (`rust-test.yml`'s own `rust/build.rs` code-filter entry was not pinned)
+
+`.github/workflows/rust-test.yml`'s `changes` job carries a curated eight-entry `coreml` filter,
+and `rust/build.rs` is one of them. Nothing read that filter: before this ticket the only rule in
+`check-workflows.ts` that touched `rust-test.yml` at all was
+`requireRustTestCancelsSupersededRuns` (#1105, concurrency). Deleting the entry left
+`bun run check:workflows` green.
+
+#1141/#1144 closed the same reach-gap class one workflow over, for `ci.yml`'s `code` filter, and
+[`issue-1141.md`](issue-1141.md) closes by naming this entry as deliberately out of its scope.
+
+## The stranded lane is `coreml-regression`, not all of 🧪 Rust Tests
+
+The ticket text says deleting the entry "lets future `rust/build.rs` changes skip the 🧪 Rust Tests
+lane". It does not, and the rule's message says so precisely instead. `rust-test.yml`'s `rust`
+filter opens with the wildcard `rust/**`, which still matches `rust/build.rs`, so `lint-ubuntu`,
+`test` and `coverage` all still fire. What is actually stranded is `coreml-regression` — the only
+job gated on `needs.changes.outputs.coreml`, and the only lane that *links and runs* the `coreml`
+feature. The per-PR `macos-14` lane stops at `cargo check --features coreml` and rides the `rust`
+filter.
+
+That is exactly the surface CLAUDE.md's COREML BUILD TRIPLE condition 3 describes: `rust/build.rs`
+emits `-Wl,-rpath,/usr/lib/swift` under `cfg(any(coreml, system_kokoro, system_diarize))`. An edit
+breaking that emit is a link-time failure, and without the filter entry no lane that links `coreml`
+would run on it. If a future edit narrows the `rust` filter off `rust/**`, the ticket's wider claim
+becomes true and this message should widen with it.
+
+## Only `rust/build.rs` is pinned, not the other seven entries
+
+`rust/build.rs` is the one entry in that list whose presence follows from a written repo invariant
+rather than from curation. The rest — `rust/src/backend/fluidaudio.rs`, `rust/src/fluid_stdout.rs`,
+`rust/src/transcribe/diarize.rs`, `rust/Cargo.toml`, `rust/Cargo.lock`, the benchmark fixture and
+the workflow itself — are a judgment call about what constitutes the CoreML regression surface,
+recorded in the comments above the list. Pinning them would freeze that judgment and red every
+legitimate re-curation. There is no derivable set behind the
+`coreml` filter the way `collectRustSources` backs the #950/#1132 rules, so this is a
+named-constant membership rule, not a collector-driven one — and with a compile-time constant as
+its target it needs no `length === 0` vacuous-pass branch, unlike its three collector-driven
+siblings.
+
+Coverage is probed with the shared `coveredBy` helper rather than matched literally, for
+`issue-1141.md`'s reason: a literal `.includes()` would reject a legitimate broadening of the
+filter to `rust/**` as a regression. Row 4 below is the mutation that distinguishes the two shapes;
+the `a narrowing that misses the build script is caught` case covers the other direction, a
+`rust/src/**` narrowing that neither shape may let through.
+
+| Guard | Asserts | Where it runs |
+|---|---|---|
+| `namedFilterOf(path, document, name)` | The named list from a `changes` job's inline paths-filter, or the caller's verbatim error | Five rules across `ci.yml` and `rust-test.yml` |
+| `requireBuildScriptInCoremlFilter` | Some path in `rust-test.yml`'s `coreml` filter covers `rust/build.rs` | `checkFile`, `rust-test.yml` only |
+
+`codeFilterOf` became `namedFilterOf` rather than gaining a sibling: #1144's round-1 P3 noted the
+parser preamble was four verbatim copies, and it was actually five —
+`requireFlakeNixInWorkflowsFilter` kept a private copy because it reads `workflows`, not `code`,
+with two error strings byte-identical to the shared parser's. Generalising over the filter name
+folds that fifth copy in and serves the new rule at the same time. Keeping `codeFilterOf` as a
+wrapper would have been the "exists for later" surface CLAUDE.md's NO SPECULATIVE FIELDS rule
+targets.
+
+## Mutation proof
+
+Every row ran through `just mutate <file> <find> <replace> <test…>`, which restores the mutated
+file in a `finally` and exits 0 only when the mutation was **caught**. `git status --short` was
+clean after every row. `rust/build.rs` occurs exactly once in `rust-test.yml` and carries no
+adjacent comment naming it, so the bare `- 'rust/build.rs'` form is unambiguous — unlike
+`issue-1141.md` rows 1–2, where `ci.yml` carried the string twice.
+
+| # | File | Mutation | Test | Result |
+|---|---|---|---|---|
+| 1 | `.github/workflows/rust-test.yml` | `- 'rust/build.rs'` entry deleted from the `coreml` filter | `bun run check:workflows` | **PINNED** — exit 1, 1 check failed: `` rust-test.yml: no path in the `coreml` filter matches rust/build.rs … (#1145) `` |
+| 2 | `.github/workflows/rust-test.yml` | `- 'rust/build.rs'` → `- 'rust/build.rs.bak'` — a typo rather than a deletion | `bun run check:workflows` | **PINNED** — exit 1, 1 check failed |
+| 3 | `.github/scripts/check-workflows.ts` | rule body short-circuited to `return [];` | `bun test tests/unit/check-workflows.test.ts` | **PINNED** — 247 pass, 5 fail (the four negative cases plus `the file gate actually runs it`) |
+| 4 | `.github/scripts/check-workflows.ts` | `coveredBy(filter.entries, RUST_BUILD_SCRIPT)` → `filter.entries.includes(RUST_BUILD_SCRIPT)` | `bun test tests/unit/check-workflows.test.ts` | **PINNED** — 251 pass, 1 fail (`a broader rust wildcard satisfies the rule`) |
+| 5 | `.github/scripts/check-workflows.ts` | `if (!path.endsWith("rust-test.yml")) return [];` deleted | `bun test tests/unit/check-workflows.test.ts` | **PINNED** — 251 pass, 1 fail (`ignores every other workflow`) |
+| 6 | `.github/scripts/check-workflows.ts` | `checkFile`'s `...requireBuildScriptInCoremlFilter(path, document),` spread deleted | `bun test tests/unit/check-workflows.test.ts` | **PINNED** — 251 pass, 1 fail (`the file gate actually runs it`) |
+| 7 | `.github/scripts/check-workflows.ts` | `namedFilterOf`'s `?.[name]` → `?.code` — the generalisation reverted | `bun test tests/unit/check-workflows.test.ts` | **PINNED** — 241 pass, 11 fail |
+| 8 | `.github/scripts/check-workflows.ts` | the missing-list message's `${name}` → `code` | `bun test tests/unit/check-workflows.test.ts` | **PINNED** — 248 pass, 4 fail (`names the list it was asked for, not code` plus the three cases asserting a non-`code` list by name) |
+| 9 | `.github/scripts/check-workflows.ts` | the missing-list branch → `return { entries: [] }` — the shared parser fails open | `bun test tests/unit/check-workflows.test.ts` | **PINNED** — 243 pass, 9 fail (all five rows of the parameterised block plus four direct cases) |
+| 10 | `.github/scripts/check-workflows.ts` | `requireFlakeNixInWorkflowsFilter`'s `namedFilterOf(…, "workflows")` → `"code"` | `bun test tests/unit/check-workflows.test.ts` | **PINNED** — 246 pass, 6 fail |
+
+Rows 1 and 2 reproduce the defect end to end, independent of the unit suite: both were **green**
+before this PR. Row 6 is the registration row `issue-1088.md` rows 3–5, `issue-1105.md` row 2 and
+`issue-1141.md` row 4 exist to cover — a rule that is correct and directly tested but never wired
+into `checkFile`. Rows 7–10 are the generalisation's own rows: row 7 is the revert, row 10 is the
+caller passing the wrong list name, and both would otherwise be silent because every caller but the
+new one asks for `code`.
+
+## Deliberately out of scope
+
+- The other seven entries in the `coreml` filter, and the `rust` filter's own entries. Both lists
+  are unpinned by the same argument as above.
+- `.github/workflows/rust-test.yml` is not edited by this PR. The entry already exists and is
+  already correct; the ticket adds the guard, not the entry.
+- **An adjacent gap of the same class, found while mapping and not fixed here:** `ci.yml`'s `code`
+  filter does not list `.github/workflows/rust-test.yml`, yet `tests/unit/lane-exclusive-tests.test.ts`
+  parses that file's nextest `-E` expression. A `rust-test.yml`-only edit therefore skips
+  `unit-tests` and never runs that suite. It does not block this ticket — the new rule runs in
+  `workflow-lint`, which *is* gated on `.github/workflows/**` — and the fix widens which jobs run
+  on every workflow PR, so it is left for its own ticket.

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, test } from "bun:test";
 import { parse } from "yaml";
 import {
   checkFile,
-  codeFilterOf,
+  namedFilterOf,
   checkFlakeNix,
   collectCacheWriters,
   collectManifestSources,
@@ -19,6 +19,7 @@ import {
   requireBashOnWindowsRunSteps,
   requireConcurrencyOnPullRequestWorkflows,
   requireBuildEngineSerialisesRunsPerRef,
+  requireBuildScriptInCoremlFilter,
   requireReleaseVerifiesTagIsCurrent,
   requireRustTestCancelsSupersededRuns,
   requirePipefailShell,
@@ -42,6 +43,7 @@ import { parseRepoYaml, readRepoFile, repoPath, REPO_ROOT } from "../helpers/rep
 
 const PATH = ".github/workflows/build-engine.yml";
 const CI = ".github/workflows/ci.yml";
+const RUST_TEST = ".github/workflows/rust-test.yml";
 const RELEASE_CLI = ".github/workflows/release-cli.yml";
 const PACT = ".github/workflows/capability-pact.yml";
 
@@ -364,19 +366,31 @@ const codeFilter = (paths: string[]) =>
 const NO_CODE_LIST = job("changes", [{ with: { filters: "integration:\n  - 'src/**'\n" } }]);
 const NO_INLINE_FILTERS = { jobs: { changes: {} } };
 
-describe("codeFilterOf", () => {
-  test("returns the code list", () => {
-    expect(codeFilterOf(CI, codeFilter(["src/**"]))).toEqual({ code: ["src/**"] });
+describe("namedFilterOf", () => {
+  test("returns the named list", () => {
+    expect(namedFilterOf(CI, codeFilter(["src/**"]), "code")).toEqual({ entries: ["src/**"] });
+  });
+
+  test("reads a filter other than code, from the real rust-test.yml", () => {
+    expect(namedFilterOf(RUST_TEST, parseRepoYaml(RUST_TEST), "coreml")).toEqual({
+      entries: expect.arrayContaining(["rust/build.rs", "rust/src/backend/fluidaudio.rs"]),
+    });
+  });
+
+  test("names the list it was asked for, not code", () => {
+    expect(namedFilterOf(CI, codeFilter(["src/**"]), "coreml")).toEqual({
+      errors: [`${CI}: paths-filter is missing a \`coreml\` list`],
+    });
   });
 
   test("names a filters block carrying no code list", () => {
-    expect(codeFilterOf(CI, NO_CODE_LIST)).toEqual({
+    expect(namedFilterOf(CI, NO_CODE_LIST, "code")).toEqual({
       errors: [`${CI}: paths-filter is missing a \`code\` list`],
     });
   });
 
   test("names a changes job with no inline filters", () => {
-    expect(codeFilterOf(CI, NO_INLINE_FILTERS)).toEqual({
+    expect(namedFilterOf(CI, NO_INLINE_FILTERS, "code")).toEqual({
       errors: [`${CI}: expected a \`changes\` job with inline paths-filter filters`],
     });
   });
@@ -384,16 +398,17 @@ describe("codeFilterOf", () => {
 
 // One parameterised pin replaces the per-rule copies of this pair: every rule reads the same parser,
 // so what needs pinning is that each one surfaces its errors rather than crashing (#1141 review round 1).
-describe("every code-filter rule surfaces the shared parser's errors", () => {
-  const rules: Array<[string, (document: unknown) => string[]]> = [
-    ["requireTestedScriptsInCodeFilter", (d) => requireTestedScriptsInCodeFilter(CI, d, [".github/scripts/check-versions.ts"])],
-    ["requireManifestSourcesInCodeFilter", (d) => requireManifestSourcesInCodeFilter(CI, d, ["rust/src/models.rs"])],
-    ["requireRustSourcesInCodeFilter", (d) => requireRustSourcesInCodeFilter(CI, d, ["rust/src/models.rs"])],
-    ["requireRustReferenceTargetsInCodeFilter", (d) => requireRustReferenceTargetsInCodeFilter(CI, d, ["rust/build.rs"])],
+describe("every paths-filter rule surfaces the shared parser's errors", () => {
+  const rules: Array<[string, (document: unknown) => string[], string]> = [
+    ["requireTestedScriptsInCodeFilter", (d) => requireTestedScriptsInCodeFilter(CI, d, [".github/scripts/check-versions.ts"]), "code"],
+    ["requireManifestSourcesInCodeFilter", (d) => requireManifestSourcesInCodeFilter(CI, d, ["rust/src/models.rs"]), "code"],
+    ["requireRustSourcesInCodeFilter", (d) => requireRustSourcesInCodeFilter(CI, d, ["rust/src/models.rs"]), "code"],
+    ["requireRustReferenceTargetsInCodeFilter", (d) => requireRustReferenceTargetsInCodeFilter(CI, d, ["rust/build.rs"]), "code"],
+    ["requireFlakeNixInWorkflowsFilter", (d) => requireFlakeNixInWorkflowsFilter(CI, d), "workflows"],
   ];
 
-  test.each(rules)("%s reports a missing code list", (_name, rule) => {
-    expect(rule(NO_CODE_LIST)[0]).toContain("missing a `code` list");
+  test.each(rules)("%s reports a missing list", (_name, rule, expectedList) => {
+    expect(rule(NO_CODE_LIST)[0]).toContain(`missing a \`${expectedList}\` list`);
   });
 
   test.each(rules)("%s reports a changes job with no inline filters", (_name, rule) => {
@@ -781,6 +796,54 @@ describe("requireFlakeNixInWorkflowsFilter", () => {
     const path = join(mkdtempSync(join(tmpdir(), "kesha-wf-")), "ci.yml");
     writeFileSync(path, yaml);
     expect(checkFile(path, [], [], undefined, NO_SOURCES).filter((e) => e.includes("#1088"))).toHaveLength(1);
+  });
+});
+
+const coremlFilter = (paths: string[]) =>
+  job("changes", [{ with: { filters: `coreml:\n${paths.map((p) => `  - '${p}'`).join("\n")}\n` } }]);
+
+describe("requireBuildScriptInCoremlFilter", () => {
+  test("passes on the real rust-test.yml", () => {
+    expect(requireBuildScriptInCoremlFilter(RUST_TEST, parseRepoYaml(RUST_TEST))).toEqual([]);
+  });
+
+  test("dropping the rust/build.rs entry names it", () => {
+    const errors = requireBuildScriptInCoremlFilter(
+      RUST_TEST,
+      coremlFilter(["rust/src/backend/fluidaudio.rs", "rust/Cargo.lock"]),
+    );
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("rust/build.rs");
+    expect(errors[0]).toContain("coreml-regression");
+  });
+
+  test("a narrowing that misses the build script is caught", () => {
+    expect(requireBuildScriptInCoremlFilter(RUST_TEST, coremlFilter(["rust/src/**"]))).toHaveLength(1);
+  });
+
+  test("a broader rust wildcard satisfies the rule", () => {
+    expect(requireBuildScriptInCoremlFilter(RUST_TEST, coremlFilter(["rust/**"]))).toEqual([]);
+  });
+
+  test("a negation excluding the build script is not coverage", () => {
+    expect(requireBuildScriptInCoremlFilter(RUST_TEST, coremlFilter(["rust/**", "!rust/build.rs"]))).toHaveLength(1);
+  });
+
+  test("ignores every other workflow", () => {
+    expect(requireBuildScriptInCoremlFilter(CI, parseRepoYaml(CI))).toEqual([]);
+  });
+
+  test("reports a coreml filter that is gone entirely", () => {
+    const document = job("changes", [{ with: { filters: "rust:\n  - 'rust/**'\n" } }]);
+    expect(requireBuildScriptInCoremlFilter(RUST_TEST, document)[0]).toContain("missing a `coreml` list");
+  });
+
+  test("the file gate actually runs it", () => {
+    const yaml =
+      "on:\n  pull_request:\njobs:\n  changes:\n    steps:\n      - with:\n          filters: |\n            coreml:\n              - 'rust/src/backend/fluidaudio.rs'\n";
+    const path = join(mkdtempSync(join(tmpdir(), "kesha-wf-")), "rust-test.yml");
+    writeFileSync(path, yaml);
+    expect(checkFile(path, [], [], undefined, NO_SOURCES).filter((e) => e.includes("#1145"))).toHaveLength(1);
   });
 });
 

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -373,7 +373,7 @@ describe("namedFilterOf", () => {
 
   test("reads a filter other than code, from the real rust-test.yml", () => {
     expect(namedFilterOf(RUST_TEST, parseRepoYaml(RUST_TEST), "coreml")).toEqual({
-      entries: expect.arrayContaining(["rust/build.rs", "rust/src/backend/fluidaudio.rs"]),
+      entries: expect.arrayContaining(["rust/build.rs"]),
     });
   });
 


### PR DESCRIPTION
Closes #1145

## Claim

Deleting `- 'rust/build.rs'` from `rust-test.yml`'s `coreml` paths-filter now fails `bun run check:workflows`; if that is wrong, mutation row 1 fires — `just mutate .github/workflows/rust-test.yml` on that entry reports **NOT PINNED** instead of **PINNED**, and `requireBuildScriptInCoremlFilter > dropping the rust/build.rs entry names it` in `tests/unit/check-workflows.test.ts` passes with an empty error list.

## The gap

Before this branch no rule in `.github/scripts/check-workflows.ts` read `rust-test.yml`'s paths-filter, so deleting the `rust/build.rs` entry left the check green. (`requireRustTestCancelsSupersededRuns`, #1105, was the one `rust-test.yml`-specific rule, and it reads `concurrency`; the dozen file-agnostic rules `checkFile` dispatches over every workflow never look at a paths-filter.) This is the reach-gap class #1141/#1144 closed for `ci.yml`, one workflow over; [`issue-1141.md`](https://github.com/drakulavich/kesha-voice-kit/blob/main/docs/mutation-evidence/issue-1141.md) closes by naming this entry as out of its scope.

## Correction to the ticket text

The ticket says deleting the entry lets `rust/build.rs` changes "skip the 🧪 Rust Tests lane". It does not: `rust-test.yml`'s `rust` filter opens with `rust/**`, which still matches, so `lint-ubuntu`, `test` and `coverage` all still fire. What is stranded is **`coreml-regression`** — the only job gated on `needs.changes.outputs.coreml` (line 468) and the only lane that links and *runs* the `coreml` feature; the per-PR `macos-14` lane stops at `cargo check --features coreml` and rides the `rust` filter. The rule's error message says `coreml-regression`, not the wider claim.

## Shape

- `codeFilterOf(path, document)` → `namedFilterOf(path, document, name)`, returning `{ entries }`. #1144's round-1 P3 counted four verbatim copies of the parser preamble; there were five — `requireFlakeNixInWorkflowsFilter` kept a private copy because it reads `workflows`, not `code`, with two error strings byte-identical to the shared parser's. Generalising over the filter name folds that fifth copy in and serves the new rule.
- `requireBuildScriptInCoremlFilter` probes coverage with the shared `coveredBy` helper rather than matching the literal string, for `issue-1141.md`'s reason: a literal `.includes()` would reject a legitimate broadening to `rust/**` as a regression. Broadening stays legal; deletion, a `rust/src/**` narrowing, and a `!rust/build.rs` negation all go red.
- Only `rust/build.rs` is pinned. It is the one entry in that curated eight-entry list whose presence follows from a written repo invariant — CLAUDE.md's COREML BUILD TRIPLE condition 3, the `-Wl,-rpath,/usr/lib/swift` emit. Pinning the other seven would freeze a judgment call about what constitutes the CoreML regression surface and red every legitimate re-curation.
- No vacuous-pass branch: the rule's target is a compile-time constant, not a collector's output, so the failure mode its three siblings guard against does not exist here.
- **`.github/workflows/rust-test.yml` is not edited.** The entry already exists and is already correct; this adds the guard, not the entry.

## Evidence

Ten mutation rows in [`docs/mutation-evidence/issue-1145.md`](docs/mutation-evidence/issue-1145.md), each run through `just mutate` with `git status --short` clean after. Rows 1 and 2 reproduce the defect end to end against `bun run check:workflows`, independent of the unit suite — both were **green** before this branch.

`just preflight` exit 0 (TS + every `check:*`; the Rust and CoreML gates skip, the diff is TS + docs only). `bun test tests/unit/check-workflows.test.ts`: 252 pass, 0 fail.

## Review round 1 — all three findings addressed at `4e38b74d5132f06603d024b2d8f4256849d64d58`

**[P2] over-pinned real-file case — fixed.** The assertion is now `arrayContaining(["rust/build.rs"])` only. The finding is confirmed as reported: `unit-tests` rides `ci.yml`'s `code` filter, `.github/workflows/rust-test.yml` appears in that file only at line 710 inside a comment, so pinning a second `coreml` entry there would have let a re-curation PR merge green and reddened the next unrelated PR touching `tests/**`, `src/**` or `.github/scripts/**`.

Every probe the finding named, re-run after the fix (`git status --short` clean each time):

| Probe | Before | After |
|---|---|---|
| `- 'rust/src/backend/fluidaudio.rs'` deleted → `bun test tests/unit/check-workflows.test.ts` | **PINNED**, failing `namedFilterOf > reads a filter other than code…` | **NOT PINNED** — 252 pass, 0 fail |
| same mutation → `bun run check:workflows` | **NOT PINNED** | **NOT PINNED** (unchanged — that entry is out of scope by design, and `workflow-lint` is the lane that would have to hold it) |
| row 7, `?.[name]` → `?.code` | 241 pass, 11 fail | **unchanged** — 241 pass, 11 fail |
| row 1, `- 'rust/build.rs'` deleted → `bun run check:workflows` | **PINNED** | **PINNED** — exit 1, 1 check failed |

The finding's "second-order is nil" prediction holds exactly: row 7 still reds 11 assertions, including both real-file cases it named (`requireBuildScriptInCoremlFilter > passes on the real rust-test.yml`, `requireFlakeNixInWorkflowsFilter > passes on the real ci.yml`) plus the narrowed case itself.

**[P3] `namedFilterOf` doc counted five rules against six — fixed.** The numeral is dropped rather than corrected to six, following the ruling already recorded beside `ci.yml`'s `code` filter: *"Deliberately no count — the one that lived here read 16 against an actual 25."* `issue-1145.md`'s repeat of the count is fixed the same way.

**[P3] "the only rule that touched rust-test.yml at all" — fixed.** Now reads *rust-test.yml-specific*, with the dozen file-agnostic rules named explicitly. The load-bearing claim is unchanged and re-confirmed: row 1 runs **NOT PINNED** against base `4dbe3b5` and **PINNED** at head.

`just preflight` exit 0 and 252 pass / 0 fail after the fix pass.

## Adjacent gap, filed nowhere yet

`ci.yml`'s `code` filter does not list `.github/workflows/rust-test.yml`, yet `tests/unit/lane-exclusive-tests.test.ts` parses that file's nextest `-E` expression. A `rust-test.yml`-only edit therefore skips `unit-tests` and never runs that suite — the same reach-gap class, one filter over, and the same mechanism the round-1 P2 turns on. It does not block this PR (the new rule runs in `workflow-lint`, which *is* gated on `.github/workflows/**`), and the fix widens which jobs run on every workflow PR, so it wants its own ticket.

## State (auto)

Machine-maintained by the driver on every head move — sessions and reviewers leave this section alone.

- head: `4e38b74d5132f06603d024b2d8f4256849d64d58`
- files (3):
  - `.github/scripts/check-workflows.ts`
  - `docs/mutation-evidence/issue-1145.md`
  - `tests/unit/check-workflows.test.ts`