### PR TITLE
Raycast: use kesha record --live for dictation, with a fallback for platforms and CLIs without it

### DIFF
--- a/openspec/specs/audio-recording/spec.md
+++ b/openspec/specs/audio-recording/spec.md
@@ -285,11 +285,10 @@ parsing.
 - With `--out` the sample rate is device-native (commonly 44100 Hz or 48000 Hz).
   The transcription pipeline resamples to 16 kHz internally; no explicit
   `--rate` flag exists on `kesha record`.
-- `--live` is unreleased. It is on `main` only — no release tag contains #757,
-  and the Pinned Engine version is older — so nothing a user installs today
-  advertises `record.live`. Anything adopting it, the Raycast extension
-  included (#947), is blocked on a CLI + Engine release and needs the
-  capability probe regardless, for every older CLI in the wild.
+- `--live` shipped in Engine v1.24.10 and the Pinned Engine is v1.24.11, so a
+  current CoreML install advertises `record.live`. Consumers still probe for it
+  rather than assuming it — the Raycast extension does (#947) — because the ONNX
+  Engine never advertises it and older CLIs remain in the wild.
 - An interrupted `--live` session yields nothing: there is no intermediate
   artifact, so a killed process loses the audio and the transcript together.
   The `--out` path at least leaves the WAV. Tracked as #962.

--- a/openspec/specs/raycast-extension/spec.md
+++ b/openspec/specs/raycast-extension/spec.md
@@ -214,12 +214,68 @@ session.
 > 214–241 (reset on any non-`listening` state, line 226). Idle copy:
 > `raycast/src/lib/recording-view.ts` lines 17–19.*
 
+### Requirement: Dictation uses live Transcription when the Engine advertises `record.live`
+
+The extension SHALL read the Engine's advertised feature list from the CLI's
+machine-readable status output, and SHALL run a single `kesha record --live`
+process — which transcribes the microphone as it captures and prints the
+transcript when recording stops — whenever `record.live` appears in it. When it
+does not, the extension SHALL record a WAV and transcribe that file in a second
+process, exactly as before. An unreadable, malformed, or absent feature list
+SHALL be treated as the feature being absent, never as an Error: the fallback
+path works everywhere, so guessing wrong in that direction costs nothing.
+
+Live Transcription removes the separate Transcription phase rather than adding a
+progressive one. `--live` prints its transcript once, when recording stops; the
+extension SHALL not present it as text appearing while Maks speaks.
+
+#### Scenario: Apple Silicon with an Engine that advertises the feature
+
+- GIVEN the probe reports `record.live` among the Engine's features
+- WHEN Maks dictates and stops
+- THEN one CLI process ran for the whole session, no WAV was written, and no
+  separate Transcription phase was entered
+- AND the transcript is on the clipboard as soon as the live session ends
+
+#### Scenario: An Intel Mac, or any Engine without the feature
+
+- GIVEN the probe reports the Engine's features and `record.live` is not among
+  them, as on the ONNX Engine an Intel Mac runs
+- WHEN Maks dictates
+- THEN the session records to a WAV and transcribes it in a second process,
+  behaving exactly as it did before live Transcription existed
+
+#### Scenario: A CLI too old to report an Engine feature list
+
+- GIVEN the resolved CLI produces no machine-readable status output, so no
+  feature list is available
+- WHEN Maks dictates
+- THEN the extension takes the record-then-transcribe path rather than failing
+- AND no setup Error is shown on account of the missing feature list
+
+> *Technical Note — the feature list is read by `probeEngineAvailability`
+> (`raycast/src/lib/kesha-bin.ts`), which already ran `kesha status --json` for
+> the setup probe and now returns `engine.capabilities.features`; a value that is
+> not an array of strings degrades to an empty list. The flag name is
+> `RECORD_LIVE_FEATURE`, matching what `rust/src/capabilities.rs` advertises under
+> the same `cfg` that compiles `cli::record::run_live`. Live spawn:
+> `startKeshaLiveRecorder` in `raycast/src/lib/process-tasks.ts`. Branch:
+> `startDictationSession`'s `run()` in `raycast/src/lib/dictation-controller.ts`,
+> over a `recordPhase` generic in the task it starts so the meter, the idle
+> tracker and cancellation are shared by both paths.*
+
 ### Requirement: Silent audio is rejected before Transcription with a permission hint
 
-The extension SHALL fail the Dictation session when the recorded WAV contains no
-sample above the silence threshold, naming the two plausible causes — macOS
-Microphone permission for Raycast, and the selected input device — instead of
-spending time on a Transcription that would return nothing.
+On the record-then-transcribe path the extension SHALL fail the Dictation
+session when the recorded WAV contains no sample above the silence threshold,
+naming the two plausible causes — macOS Microphone permission for Raycast, and
+the selected input device — instead of spending time on a Transcription that
+would return nothing.
+
+The live path has no WAV to inspect, so its equivalent signal is an empty
+transcript. It SHALL carry the same guidance, in a single message naming the
+permission cause, because nothing on that path can tell a silent capture apart
+from speech that produced no text.
 
 #### Scenario: Raycast lacks Microphone permission
 
@@ -236,6 +292,14 @@ spending time on a Transcription that would return nothing.
 - WHEN the Dictation session finishes recording
 - THEN the silence check passes and Transcription starts immediately
 
+#### Scenario: A live session captures nothing
+
+- GIVEN a live Dictation session whose transcript is empty
+- WHEN the session ends
+- THEN the view names macOS Microphone permission for Raycast and the selected
+  input device, the same guidance the WAV silence check produces
+- AND the clipboard is left untouched
+
 > *Technical Note — check invoked at
 > `raycast/src/lib/dictation-controller.ts` lines 129–133. Detection reads the
 > `fmt `/`data` chunks and scans samples: `isSilentWav` in
@@ -243,12 +307,17 @@ spending time on a Transcription that would return nothing.
 > `kesha record` writes) and 16-bit PCM, including `WAVE_FORMAT_EXTENSIBLE`
 > payloads (lines 47–60). Threshold: `SILENCE_PEAK_THRESHOLD = 0.0001`.
 > Unrecognised formats return "not silent" so the check can never block a valid
-> recording (line 29).*
+> recording (line 29). The live equivalent is `normalizeLiveTranscript` in
+> `raycast/src/lib/dictation-controller.ts`, kept separate from
+> `normalizeTranscribeResult` so the fallback's two distinct messages survive.*
 
 ### Requirement: Transcription runs through the CLI and times out proportionally to the recording length
 
-The extension SHALL obtain the transcript by running the CLI's default
-Transcription command on the recorded file and reading its stdout. It SHALL
+On the record-then-transcribe path the extension SHALL obtain the transcript by
+running the CLI's default Transcription command on the recorded file and reading
+its stdout. The scaled timeout, the kept recording and its named path below all
+belong to that path: the live path has no separate Transcription window to
+outrun and no recording of its own to keep. It SHALL
 abandon a Transcription that has not finished within a timeout that scales with
 the length of the recording — a fixed floor plus a per-second allowance — so a
 recording made at the default `maxSeconds` cannot fail Transcription purely
@@ -298,6 +367,16 @@ so the Engine's Error code and hint reach Maks unedited.
 - WHEN Maks cancels it, or the view is dismissed
 - THEN the recording is kept rather than deleted, and — when a view is still
   shown — the Error names its path and the `kesha "<path>"` command
+
+#### Scenario: A live session is interrupted before it finishes
+
+- GIVEN a live Dictation session that has not yet stopped
+- WHEN Maks dismisses the view
+- THEN no transcript is produced and none is written to the clipboard, because
+  `--live` prints its transcript once, at the end
+- AND the extension names no recovery artifact of its own; the Engine's own
+  recovery audio (#962) is the only copy and lives under its cache, not the
+  extension's temp directory
 
 > *Technical Note — the timeout is `transcribeTimeoutMs(recordingSeconds)`:
 > `raycast/src/lib/dictation-config.ts` (`TRANSCRIBE_TIMEOUT_FLOOR_MS = 60_000`
@@ -351,6 +430,10 @@ explicit cancel action while transcribing, and SHALL also treat closing the
 command as a cancel. Stopping mid-recording SHALL still transcribe what was
 captured; cancelling a Transcription SHALL abandon it.
 
+The Cancel Transcription action belongs to the record-then-transcribe path,
+which is the only one with a Transcription phase to cancel. On the live path
+**Stop and Transcribe** is the single control.
+
 #### Scenario: Maks stops as soon as he finishes the sentence
 
 - GIVEN a Dictation session is recording
@@ -379,6 +462,11 @@ command closing. Termination SHALL escalate: a cooperative stop first, then
 SIGTERM, then SIGKILL, targeting the whole process group so an interpreter
 wrapper cannot leave the CLI behind.
 
+The live path starts one child where the fallback starts two, and its escalation
+SHALL be slower, because a live session produces its transcript *after* the
+cooperative stop: signalling it on the fallback recorder's schedule would destroy
+the transcript the session exists to deliver.
+
 #### Scenario: A stopped recorder exits promptly
 
 - GIVEN a Dictation session is recording
@@ -393,10 +481,25 @@ wrapper cannot leave the CLI behind.
 - WHEN cancellation or the timeout fires
 - THEN SIGKILL follows 3 s later and the process group is gone
 
+#### Scenario: A stopped live session is given time to finish its transcript
+
+- GIVEN a live Dictation session
+- WHEN Maks stops it
+- THEN the cooperative stop goes out first and no signal follows for several
+  seconds, so the streaming session can print its transcript
+- AND SIGTERM and then SIGKILL still follow if it never exits
+
 > *Technical Note — escalation ladders: `stopProcessWithWatchdog`
-> (stdin EOF → SIGTERM at 1500 ms → SIGKILL at 5000 ms) and
-> `terminateProcessWithWatchdog` (SIGTERM now → SIGKILL at 3000 ms) in
-> `raycast/src/lib/process-tasks.ts` lines 39–74. The Signal meter helper has
+> (stdin EOF → SIGTERM at 1500 ms → SIGKILL at 5000 ms),
+> `stopLiveProcessWithWatchdog` (stdin EOF → SIGTERM at `LIVE_STOP_GRACE_MS`
+> 10 s → SIGKILL at `LIVE_FORCE_KILL_MS` 15 s, both in
+> `raycast/src/lib/dictation-config.ts`) and `terminateProcessWithWatchdog`
+> (SIGTERM now → SIGKILL at 3000 ms) in `raycast/src/lib/process-tasks.ts`. The
+> live grace exists because the CLI's own SIGTERM handler SIGKILLs the Engine
+> 1 s later (`FORCE_KILL_GRACE_MS` in `src/process-tree.ts`), which would leave a
+> live session ~2.5 s in total under the fallback ladder. A live session that
+> exits 130 or 143 after printing its transcript is a success, not a failure
+> (#962). The Signal meter helper has
 > its own shorter ladder — SIGTERM, then SIGKILL after 1 s —
 > `raycast/src/lib/signal-meter.ts` lines 134–139. Group targeting:
 > `killProcessGroup` lines 27–37, paired with `detached: true` at spawn

--- a/openspec/specs/raycast-extension/spec.md
+++ b/openspec/specs/raycast-extension/spec.md
@@ -263,6 +263,13 @@ then blame macOS Microphone permission for the empty transcript.
 - AND it flips to Recording only once the Engine reports the microphone open,
   so the first words spoken are captured
 
+#### Scenario: A live session fails before the microphone opens
+
+- GIVEN a live session that exits with an Error before it reports listening
+- WHEN the failure arrives
+- THEN the view goes from preparing straight to the Error, with no Signal meter
+  started, no idle countdown and no Recording toast
+
 #### Scenario: An Engine advertising the feature to a CLI too old for the flag
 
 - GIVEN the probe reports `record.live` but a CLI version older than the release
@@ -303,10 +310,12 @@ then blame macOS Microphone permission for the empty transcript.
 > over a `recordPhase` generic in the task it starts so the meter, the idle
 > tracker and cancellation are shared by both paths; `liveRecordPhase` starts the
 > live task first and awaits its `micOpen` before handing it over. `micOpen`
-> resolves on the Engine's `Listening (` stderr line — `rust/src/record.rs`
-> prints it right after `stream.play()`, with `StreamingAsrSession::start` ahead
-> of that — or on the process ending first, so a failed spawn cannot hang the
-> session. `kesha install`'s warmup covers `backend::create_backend`, not
+> resolves `listening` on the Engine's `Listening (` stderr line —
+> `rust/src/record.rs` prints it right after `stream.play()`, with
+> `StreamingAsrSession::start` ahead of that — and `ended` when the process
+> finished first, so a failed spawn neither hangs the session nor drives it
+> through a recording view; that branch awaits `task.done` so the Engine's own
+> failure is what Maks sees. `kesha install`'s warmup covers `backend::create_backend`, not
 > `init_streaming_asr`, so the first live session pays that cost.*
 
 ### Requirement: Silent audio is rejected before Transcription with a permission hint
@@ -374,6 +383,14 @@ kept recording left by an earlier session SHALL be pruned once it is older than
 a week. A non-zero Exit code SHALL be surfaced using the CLI's own stderr text
 so the Engine's Error code and hint reach Maks unedited.
 
+A live session is the one case where "unedited" needs saying precisely: its
+stderr also carries a progress line the Engine repaints in place once a second
+with a carriage return, and surfacing every fragment would bury the Error under
+thousands of characters. The extension SHALL render those carriage returns the
+way a terminal does — keeping only the final state of each line — and SHALL
+change nothing else, so a multi-line Error keeps its blank lines and its install
+hint.
+
 #### Scenario: Maks dictates a short note
 
 - GIVEN a recording with speech and an installed Engine and models
@@ -412,6 +429,14 @@ so the Engine's Error code and hint reach Maks unedited.
 - WHEN Maks cancels it, or the view is dismissed
 - THEN the recording is kept rather than deleted, and — when a view is still
   shown — the Error names its path and the `kesha "<path>"` command
+
+#### Scenario: A live session fails after minutes of progress output
+
+- GIVEN a live Dictation session that printed its progress line every second for
+  the whole session and then failed
+- WHEN the Error is shown
+- THEN it names the Engine's own Error, and the progress line takes the single
+  line it would take in a terminal rather than one fragment per second
 
 #### Scenario: A live session is interrupted before it finishes
 

--- a/openspec/specs/raycast-extension/spec.md
+++ b/openspec/specs/raycast-extension/spec.md
@@ -387,9 +387,10 @@ A live session is the one case where "unedited" needs saying precisely: its
 stderr also carries a progress line the Engine repaints in place once a second
 with a carriage return, and surfacing every fragment would bury the Error under
 thousands of characters. The extension SHALL render those carriage returns the
-way a terminal does — keeping only the final state of each line — and SHALL
-change nothing else, so a multi-line Error keeps its blank lines and its install
-hint.
+way a terminal does — keeping only the final state of each line, and treating a
+carriage return that merely terminates a CRLF line as part of the line ending
+rather than as an overwrite — and SHALL change nothing else, so a multi-line
+Error keeps its blank lines and its install hint.
 
 #### Scenario: Maks dictates a short note
 
@@ -517,6 +518,15 @@ which is the only one with a Transcription phase to cancel. On the live path
 - WHEN Maks dismisses the Raycast window
 - THEN the Transcription is abandoned, no clipboard write happens, and no
   further view update is attempted
+
+#### Scenario: Maks closes the command as the transcript is being copied
+
+- GIVEN a Dictation session whose clipboard write has already begun
+- WHEN Maks dismisses the Raycast window
+- THEN the transcript still reaches the clipboard, because a write handed to the
+  OS cannot be recalled and the transcript is what the session exists to produce
+- AND no success toast is shown and the view is not updated, so the dismissal is
+  what Maks sees
 
 > *Technical Note — session handles: `stopRecording`, `cancelTranscription` and
 > `cancel` in `raycast/src/lib/dictation-controller.ts` lines 42–62; the

--- a/openspec/specs/raycast-extension/spec.md
+++ b/openspec/specs/raycast-extension/spec.md
@@ -219,23 +219,57 @@ session.
 The extension SHALL read the Engine's advertised feature list from the CLI's
 machine-readable status output, and SHALL run a single `kesha record --live`
 process — which transcribes the microphone as it captures and prints the
-transcript when recording stops — whenever `record.live` appears in it. When it
-does not, the extension SHALL record a WAV and transcribe that file in a second
-process, exactly as before. An unreadable, malformed, or absent feature list
-SHALL be treated as the feature being absent, never as an Error: the fallback
-path works everywhere, so guessing wrong in that direction costs nothing.
+transcript when recording stops — whenever `record.live` appears in it **and**
+the reported CLI version is one that accepts the `--live` flag. When either half
+is missing, the extension SHALL record a WAV and transcribe that file in a
+second process, exactly as before. An unreadable, malformed, or absent feature
+list SHALL be treated as the feature being absent, never as an Error: the
+fallback path works everywhere, so guessing wrong in that direction costs
+nothing.
+
+Both halves are required because the Engine and the CLI version independently.
+The Engine advertises what it can do; the CLI is what has to accept the flag,
+and it ignores a flag it does not know rather than rejecting it — so an Engine
+newer than the CLI's pin would otherwise reach a CLI that exits 2 asking for
+`--out`, with the recording already lost.
 
 Live Transcription removes the separate Transcription phase rather than adding a
 progressive one. `--live` prints its transcript once, when recording stops; the
 extension SHALL not present it as text appearing while Maks speaks.
 
+A live session prepares its streaming Transcription before it opens the input
+device — a first run compiles models for the ANE and takes about 20 s. The
+extension SHALL keep showing the preparing view, with no Signal meter, no idle
+countdown and no Stop action, until the Engine reports that it is listening.
+Claiming to record through that window would lose everything spoken in it and
+then blame macOS Microphone permission for the empty transcript.
+
 #### Scenario: Apple Silicon with an Engine that advertises the feature
 
-- GIVEN the probe reports `record.live` among the Engine's features
+- GIVEN the probe reports `record.live` among the Engine's features, and a CLI
+  version that accepts `--live`
 - WHEN Maks dictates and stops
 - THEN one CLI process ran for the whole session, no WAV was written, and no
   separate Transcription phase was entered
 - AND the transcript is on the clipboard as soon as the live session ends
+
+#### Scenario: The first live session of the day warms up
+
+- GIVEN a live Dictation session whose Engine has not compiled its streaming
+  models yet
+- WHEN the command opens
+- THEN the view says it is preparing, no Signal meter runs, and the idle
+  auto-stop is not counting
+- AND it flips to Recording only once the Engine reports the microphone open,
+  so the first words spoken are captured
+
+#### Scenario: An Engine advertising the feature to a CLI too old for the flag
+
+- GIVEN the probe reports `record.live` but a CLI version older than the release
+  that added `kesha record --live`
+- WHEN Maks dictates
+- THEN the session takes the record-then-transcribe path rather than spawning a
+  flag the CLI would ignore
 
 #### Scenario: An Intel Mac, or any Engine without the feature
 
@@ -255,14 +289,25 @@ extension SHALL not present it as text appearing while Maks speaks.
 
 > *Technical Note — the feature list is read by `probeEngineAvailability`
 > (`raycast/src/lib/kesha-bin.ts`), which already ran `kesha status --json` for
-> the setup probe and now returns `engine.capabilities.features`; a value that is
-> not an array of strings degrades to an empty list. The flag name is
-> `RECORD_LIVE_FEATURE`, matching what `rust/src/capabilities.rs` advertises under
-> the same `cfg` that compiles `cli::record::run_live`. Live spawn:
+> the setup probe and now returns `engine.capabilities.features` and
+> `cliVersion`; a value that is not an array of strings degrades to an empty
+> list. Both halves are weighed by `supportsLiveDictation` in the same file,
+> against `RECORD_LIVE_FEATURE` — matching what `rust/src/capabilities.rs`
+> advertises under the same `cfg` that compiles `cli::record::run_live` — and
+> `RECORD_LIVE_MIN_CLI_VERSION = "1.28.0"`, the first CLI release containing
+> `record --live` (`git tag --contains 50511a0`). A prerelease of the same
+> triple counts, and an unparseable or absent version fails closed to the
+> fallback. Live spawn:
 > `startKeshaLiveRecorder` in `raycast/src/lib/process-tasks.ts`. Branch:
 > `startDictationSession`'s `run()` in `raycast/src/lib/dictation-controller.ts`,
 > over a `recordPhase` generic in the task it starts so the meter, the idle
-> tracker and cancellation are shared by both paths.*
+> tracker and cancellation are shared by both paths; `liveRecordPhase` starts the
+> live task first and awaits its `micOpen` before handing it over. `micOpen`
+> resolves on the Engine's `Listening (` stderr line — `rust/src/record.rs`
+> prints it right after `stream.play()`, with `StreamingAsrSession::start` ahead
+> of that — or on the process ending first, so a failed spawn cannot hang the
+> session. `kesha install`'s warmup covers `backend::create_backend`, not
+> `init_streaming_asr`, so the first live session pays that cost.*
 
 ### Requirement: Silent audio is rejected before Transcription with a permission hint
 
@@ -462,10 +507,15 @@ command closing. Termination SHALL escalate: a cooperative stop first, then
 SIGTERM, then SIGKILL, targeting the whole process group so an interpreter
 wrapper cannot leave the CLI behind.
 
-The live path starts one child where the fallback starts two, and its escalation
-SHALL be slower, because a live session produces its transcript *after* the
-cooperative stop: signalling it on the fallback recorder's schedule would destroy
-the transcript the session exists to deliver.
+The live path starts one child where the fallback starts two, and the escalation
+after a **Stop and Transcribe** SHALL be slower, because a live session produces
+its transcript *after* the cooperative stop: signalling it on the fallback
+recorder's schedule would destroy the transcript the session exists to deliver.
+
+That patience is owed only to a stop that is waiting for a transcript. A
+cancelled live session — the command being dismissed — discards its transcript,
+so it SHALL release the input device immediately rather than hold the microphone
+for the length of the finish ladder.
 
 #### Scenario: A stopped recorder exits promptly
 
@@ -489,6 +539,13 @@ the transcript the session exists to deliver.
   seconds, so the streaming session can print its transcript
 - AND SIGTERM and then SIGKILL still follow if it never exits
 
+#### Scenario: A live session is dismissed rather than stopped
+
+- GIVEN a live Dictation session
+- WHEN Maks closes the command instead of stopping it
+- THEN SIGTERM goes out at once, with SIGKILL 3 s behind it, and the microphone
+  is free for the next app rather than held for the finish ladder
+
 > *Technical Note — escalation ladders: `stopProcessWithWatchdog`
 > (stdin EOF → SIGTERM at 1500 ms → SIGKILL at 5000 ms),
 > `stopLiveProcessWithWatchdog` (stdin EOF → SIGTERM at `LIVE_STOP_GRACE_MS`
@@ -497,7 +554,10 @@ the transcript the session exists to deliver.
 > (SIGTERM now → SIGKILL at 3000 ms) in `raycast/src/lib/process-tasks.ts`. The
 > live grace exists because the CLI's own SIGTERM handler SIGKILLs the Engine
 > 1 s later (`FORCE_KILL_GRACE_MS` in `src/process-tree.ts`), which would leave a
-> live session ~2.5 s in total under the fallback ladder. A live session that
+> live session ~2.5 s in total under the fallback ladder. `startKeshaLiveRecorder`
+> returns both ladders: `stop` for the finish, `abort` — the
+> `terminateProcessWithWatchdog` one — for a dismissal, chosen by
+> `DictationSession.cancel`. A live session that
 > exits 130 or 143 after printing its transcript is a success, not a failure
 > (#962). The Signal meter helper has
 > its own shorter ladder — SIGTERM, then SIGKILL after 1 s —

--- a/raycast/CHANGELOG.md
+++ b/raycast/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Kesha Voice Kit Changelog
 
+## [Transcribe while you speak on Apple Silicon] - 2026-09-01
+
+- Transcribe during recording on Macs whose engine supports it, so the transcript is ready the moment you stop instead of after a separate wait. The session now runs one process rather than two, and no audio file is written or cleaned up.
+- Keep the previous record-then-transcribe flow everywhere else, including Intel Macs and older CLI versions, with no change in behaviour.
+- Tell you to check macOS Microphone permission when a session produces no text, on both flows.
+
 ## [Sturdier setup detection] - 2026-08-03
 
 - Detect whether the engine is installed from the CLI's machine-readable status output instead of matching its wording, so a reworded CLI message can no longer be mistaken for a broken install. Older CLIs keep working through the previous check.

--- a/raycast/README.md
+++ b/raycast/README.md
@@ -14,7 +14,9 @@ Starts recording from the default microphone and shows a live view while you spe
 - **Auto-stop on silence** — after ~30 s without speech the status flips to Idle, and ~15 s later recording stops on its own; speaking again resets the timer.
 - **Stop and Transcribe** — or let the configured time limit end the session.
 
-Transcription runs locally (NVIDIA Parakeet TDT, multilingual) and the transcript is copied to the clipboard automatically. A running transcription can be cancelled from the action panel.
+Transcription runs locally (NVIDIA Parakeet TDT, multilingual) and the transcript is copied to the clipboard automatically.
+
+On Apple Silicon with an engine that supports live transcription, the audio is transcribed as you speak, so the transcript appears as soon as you stop and there is no separate transcription step to wait for or cancel. Elsewhere — Intel Macs, or an older CLI — the recording is transcribed afterwards as a second step, which can be cancelled from the action panel.
 
 ## Prerequisites
 

--- a/raycast/src/lib/dictation-config.ts
+++ b/raycast/src/lib/dictation-config.ts
@@ -35,6 +35,11 @@ export function transcribeTimeoutMs(recordingSeconds: number): number {
   );
 }
 
+// Live prints its transcript after the stop, so the recorder's 1500 ms ladder would destroy it (#947).
+export const LIVE_STOP_GRACE_MS = 10_000;
+export const LIVE_FORCE_KILL_MS = 15_000;
+export const LIVE_STDOUT_FLUSH_MS = 2_000;
+
 export function parseMaxSeconds(value: string | undefined): number {
   const raw = value?.trim() || String(DEFAULT_MAX_SECONDS);
   const parsed = Number(raw);

--- a/raycast/src/lib/dictation-controller.ts
+++ b/raycast/src/lib/dictation-controller.ts
@@ -188,6 +188,8 @@ export function startDictationSession(
     const task = deps.startLiveRecorder(kesha, maxSeconds);
     liveRecorder = task;
     recorder = task;
+    // A cancel or early stop abandons the task before anything awaits it (#947).
+    void task.done.catch(() => {});
     // The engine compiles its streaming models before opening the device, ~20 s on a first run (#947).
     await task.micOpen;
     if (cancelled) return { ok: false };

--- a/raycast/src/lib/dictation-controller.ts
+++ b/raycast/src/lib/dictation-controller.ts
@@ -11,10 +11,15 @@ import {
 import {
   notFoundMessage,
   probeEngineAvailability,
+  RECORD_LIVE_FEATURE,
   resolveKeshaBin,
 } from "./kesha-bin";
 import type { EnginePreflightResult, KeshaSpawn } from "./kesha-bin";
-import { startKeshaRecorder, startKeshaTranscriber } from "./process-tasks";
+import {
+  startKeshaLiveRecorder,
+  startKeshaRecorder,
+  startKeshaTranscriber,
+} from "./process-tasks";
 import { startRecordingMonitor } from "./recording-monitor";
 import { emptySignal } from "./recording-view";
 import type {
@@ -50,7 +55,7 @@ export function startDictationSession(
   let confirmedSilent = false;
   let keepAudio = false;
   let stopMonitoring: (() => void) | null = null;
-  let recorder: RunningTask<void> | null = null;
+  let recorder: RunningTask<unknown> | null = null;
   let transcriber: RunningTask<string> | null = null;
   let stopTranscribeTimer: (() => void) | null = null;
 
@@ -118,10 +123,25 @@ export function startDictationSession(
       }
       if (cancelled) return;
 
-      tempDir = await deps.createTempDir();
-      audioPath = join(tempDir, "dictation.wav");
+      if (preflight.features?.includes(RECORD_LIVE_FEATURE)) {
+        const live = await recordPhase(
+          () => deps.startLiveRecorder(kesha, maxSeconds),
+          maxSeconds,
+        );
+        if (!live.ok) return;
+        await deliverTranscript({ file: "", text: live.value.trim() });
+        return;
+      }
 
-      if (!(await recordPhase(kesha, audioPath, maxSeconds))) return;
+      tempDir = await deps.createTempDir();
+      const file = join(tempDir, "dictation.wav");
+      audioPath = file;
+
+      const captured = await recordPhase(
+        () => deps.startRecorder(kesha, file, maxSeconds),
+        maxSeconds,
+      );
+      if (!captured.ok) return;
 
       // The WAV is on disk now; a dismiss or failure past this point — even
       // during the silence read below — must not discard it (#944).
@@ -160,11 +180,10 @@ export function startDictationSession(
     }
   }
 
-  async function recordPhase(
-    kesha: KeshaSpawn,
-    audioPath: string,
+  async function recordPhase<T>(
+    startTask: () => RunningTask<T>,
     maxSeconds: number,
-  ): Promise<boolean> {
+  ): Promise<{ ok: true; value: T } | { ok: false }> {
     setState({
       status: "recording",
       maxSeconds,
@@ -215,19 +234,21 @@ export function startDictationSession(
       title: "Recording",
       message: "Stops automatically when you pause",
     });
-    if (cancelled) return false;
+    if (cancelled) return { ok: false };
     if (stopRequested) {
       setState({
         status: "error",
         message: "Recording stopped before any audio was captured.",
       });
-      return false;
+      return { ok: false };
     }
 
-    recorder = deps.startRecorder(kesha, audioPath, maxSeconds);
+    const task = startTask();
+    recorder = task;
     const recorderStartedAt = now();
+    let value: T;
     try {
-      await recorder.done;
+      value = await task.done;
     } finally {
       // Wall-clock capture length ≈ audio duration; it feeds the scaled
       // transcription timeout so a long recording keeps proportional room (#944).
@@ -236,7 +257,7 @@ export function startDictationSession(
       stopMonitoring?.();
       stopMonitoring = null;
     }
-    return !cancelled;
+    return cancelled ? { ok: false } : { ok: true, value };
   }
 
   async function transcribePhase(
@@ -395,6 +416,8 @@ export function createDefaultDictationDeps(
     startRecordingMonitor,
     startRecorder: (kesha, audioPath, maxSeconds) =>
       startKeshaRecorder(kesha, audioPath, maxSeconds),
+    startLiveRecorder: (kesha, maxSeconds) =>
+      startKeshaLiveRecorder(kesha, maxSeconds),
     startTranscriber: (kesha, audioPath, timeoutMs) =>
       startKeshaTranscriber(kesha, audioPath, timeoutMs),
     isSilentAudio: isSilentWavFile,

--- a/raycast/src/lib/dictation-controller.ts
+++ b/raycast/src/lib/dictation-controller.ts
@@ -191,8 +191,10 @@ export function startDictationSession(
     // A cancel or early stop abandons the task before anything awaits it (#947).
     void task.done.catch(() => {});
     // The engine compiles its streaming models before opening the device, ~20 s on a first run (#947).
-    await task.micOpen;
+    const opened = await task.micOpen;
     if (cancelled) return { ok: false };
+    // The device never opened: report the session's own outcome, not a recording view (#947).
+    if (opened === "ended") return { ok: true, value: await task.done };
     return recordPhase(() => task, maxSeconds);
   }
 
@@ -303,7 +305,10 @@ export function startDictationSession(
   }
 
   async function deliverTranscript(result: TranscribeResult) {
+    if (cancelled) return;
     await deps.copyToClipboard(result.text);
+    // A dismissal landing mid-copy must not resurrect the view or claim success (#947).
+    if (cancelled) return;
     await deps.showToast({
       style: "success",
       title: "Copied transcript",

--- a/raycast/src/lib/dictation-controller.ts
+++ b/raycast/src/lib/dictation-controller.ts
@@ -11,8 +11,8 @@ import {
 import {
   notFoundMessage,
   probeEngineAvailability,
-  RECORD_LIVE_FEATURE,
   resolveKeshaBin,
+  supportsLiveDictation,
 } from "./kesha-bin";
 import type { EnginePreflightResult, KeshaSpawn } from "./kesha-bin";
 import {
@@ -27,6 +27,7 @@ import type {
   DictationPrefs,
   DictationSession,
   DictationState,
+  LiveRecorderTask,
   RecordingPatch,
   RunningTask,
   TranscribeResult,
@@ -56,6 +57,7 @@ export function startDictationSession(
   let keepAudio = false;
   let stopMonitoring: (() => void) | null = null;
   let recorder: RunningTask<unknown> | null = null;
+  let liveRecorder: LiveRecorderTask | null = null;
   let transcriber: RunningTask<string> | null = null;
   let stopTranscribeTimer: (() => void) | null = null;
 
@@ -85,7 +87,9 @@ export function startDictationSession(
     cancel: () => {
       cancelled = true;
       if (captureComplete) keepAudio = true;
-      recorder?.stop();
+      // A dismissed live session discards its transcript, so nothing waits on the stop ladder (#947).
+      if (liveRecorder) liveRecorder.abort();
+      else recorder?.stop();
       transcriber?.stop();
       stopMonitoring?.();
       stopTranscribeTimer?.();
@@ -123,11 +127,8 @@ export function startDictationSession(
       }
       if (cancelled) return;
 
-      if (preflight.features?.includes(RECORD_LIVE_FEATURE)) {
-        const live = await recordPhase(
-          () => deps.startLiveRecorder(kesha, maxSeconds),
-          maxSeconds,
-        );
+      if (supportsLiveDictation(preflight)) {
+        const live = await liveRecordPhase(kesha, maxSeconds);
         if (!live.ok) return;
         await deliverTranscript(normalizeLiveTranscript(live.value));
         return;
@@ -178,6 +179,19 @@ export function startDictationSession(
       // from the CLI; otherwise the private temp dir is cleaned up (#944).
       if (tempDir && !keepAudio) await deps.cleanupTempDir(tempDir);
     }
+  }
+
+  async function liveRecordPhase(
+    kesha: KeshaSpawn,
+    maxSeconds: number,
+  ): Promise<{ ok: true; value: string } | { ok: false }> {
+    const task = deps.startLiveRecorder(kesha, maxSeconds);
+    liveRecorder = task;
+    recorder = task;
+    // The engine compiles its streaming models before opening the device, ~20 s on a first run (#947).
+    await task.micOpen;
+    if (cancelled) return { ok: false };
+    return recordPhase(() => task, maxSeconds);
   }
 
   async function recordPhase<T>(
@@ -297,6 +311,7 @@ export function startDictationSession(
 
   function releaseResources() {
     recorder = null;
+    liveRecorder = null;
     transcriber = null;
     stopMonitoring?.();
     stopMonitoring = null;

--- a/raycast/src/lib/dictation-controller.ts
+++ b/raycast/src/lib/dictation-controller.ts
@@ -129,7 +129,7 @@ export function startDictationSession(
           maxSeconds,
         );
         if (!live.ok) return;
-        await deliverTranscript({ file: "", text: live.value.trim() });
+        await deliverTranscript(normalizeLiveTranscript(live.value));
         return;
       }
 
@@ -480,6 +480,17 @@ export function normalizeTranscribeResult(
     throw new Error("No speech was detected in the recording.");
   }
   return { file: audioPath, text };
+}
+
+/** Live has no WAV for the silence check, so the empty transcript carries both causes (#947). */
+export function normalizeLiveTranscript(stdout: string): TranscribeResult {
+  const text = stdout.trim();
+  if (!text) {
+    throw new Error(
+      "No speech was detected. Check macOS Microphone permission for Raycast and the selected input device.",
+    );
+  }
+  return { file: "", text };
 }
 
 export function startTranscribingTimer(

--- a/raycast/src/lib/dictation-types.ts
+++ b/raycast/src/lib/dictation-types.ts
@@ -45,6 +45,13 @@ export interface RunningTask<T> {
   stop: () => void;
 }
 
+export interface LiveRecorderTask extends RunningTask<string> {
+  /** Resolves when the engine reports the microphone open, or when the session ended before it did. */
+  micOpen: Promise<void>;
+  /** Releases the device now, for a session whose transcript will be discarded. */
+  abort: () => void;
+}
+
 export interface DictationPrefs {
   keshaBinPath?: string;
   maxRecordingSeconds?: string;
@@ -74,7 +81,7 @@ export interface DictationControllerDeps {
   startLiveRecorder: (
     kesha: KeshaSpawn,
     maxSeconds: number,
-  ) => RunningTask<string>;
+  ) => LiveRecorderTask;
   startTranscriber: (
     kesha: KeshaSpawn,
     audioPath: string,

--- a/raycast/src/lib/dictation-types.ts
+++ b/raycast/src/lib/dictation-types.ts
@@ -45,9 +45,11 @@ export interface RunningTask<T> {
   stop: () => void;
 }
 
+/** `listening` once the engine reports the microphone open; `ended` when the session finished first. */
+export type LiveMicOutcome = "listening" | "ended";
+
 export interface LiveRecorderTask extends RunningTask<string> {
-  /** Resolves when the engine reports the microphone open, or when the session ended before it did. */
-  micOpen: Promise<void>;
+  micOpen: Promise<LiveMicOutcome>;
   /** Releases the device now, for a session whose transcript will be discarded. */
   abort: () => void;
 }

--- a/raycast/src/lib/dictation-types.ts
+++ b/raycast/src/lib/dictation-types.ts
@@ -71,6 +71,10 @@ export interface DictationControllerDeps {
     audioPath: string,
     maxSeconds: number,
   ) => RunningTask<void>;
+  startLiveRecorder: (
+    kesha: KeshaSpawn,
+    maxSeconds: number,
+  ) => RunningTask<string>;
   startTranscriber: (
     kesha: KeshaSpawn,
     audioPath: string,

--- a/raycast/src/lib/kesha-bin.ts
+++ b/raycast/src/lib/kesha-bin.ts
@@ -147,6 +147,8 @@ export interface ProbeDeps {
 }
 
 export const RECORD_LIVE_FEATURE = "record.live";
+// The engine advertises the feature; `record --live` reached the CLI that spawns it in 1.28.0 (#947).
+export const RECORD_LIVE_MIN_CLI_VERSION = "1.28.0";
 
 export interface EnginePreflightResult {
   ok: boolean;
@@ -159,6 +161,41 @@ export interface EnginePreflightResult {
   reason?: "missing" | "unusable" | "contract";
   /** Engine `features` from `kesha status --json`; absent when the CLI predates it. */
   features?: string[];
+  /** `cliVersion` from `kesha status --json`; absent when the CLI predates it. */
+  cliVersion?: string;
+}
+
+/**
+ * Whether a live dictation session can be spawned against this CLI.
+ *
+ * Both halves are required and they version independently: the engine
+ * advertises `record.live`, but the CLI is what has to accept the `--live`
+ * flag, and citty ignores a flag it does not know — an engine newer than the
+ * CLI's pin would otherwise exit 2 on "kesha record requires --out <path>".
+ */
+export function supportsLiveDictation(
+  preflight: EnginePreflightResult,
+): boolean {
+  if (!preflight.features?.includes(RECORD_LIVE_FEATURE)) return false;
+  return atLeastVersion(preflight.cliVersion, RECORD_LIVE_MIN_CLI_VERSION);
+}
+
+function atLeastVersion(version: string | undefined, minimum: string): boolean {
+  const actual = parseVersion(version);
+  const floor = parseVersion(minimum);
+  if (!actual || !floor) return false;
+  for (let part = 0; part < actual.length; part++) {
+    if (actual[part] !== floor[part]) return actual[part] > floor[part];
+  }
+  return true;
+}
+
+// A prerelease of the same triple already carries the flag, so the suffix is ignored.
+function parseVersion(
+  value: string | undefined,
+): [number, number, number] | null {
+  const match = value?.trim().match(/^v?(\d+)\.(\d+)\.(\d+)/);
+  return match ? [Number(match[1]), Number(match[2]), Number(match[3])] : null;
 }
 
 const MISSING_ENGINE_MARKER = "not installed";
@@ -244,7 +281,9 @@ function readStructuredStatus(
   if (!capabilitiesAreReadable(capabilities)) {
     return { ok: false, reason: "unusable", hint: REPAIR_HINT };
   }
-  return { ok: true, features: readFeatures(capabilities) };
+  const cliVersion =
+    typeof payload.cliVersion === "string" ? payload.cliVersion : undefined;
+  return { ok: true, features: readFeatures(capabilities), cliVersion };
 }
 
 /**

--- a/raycast/src/lib/kesha-bin.ts
+++ b/raycast/src/lib/kesha-bin.ts
@@ -190,11 +190,13 @@ function atLeastVersion(version: string | undefined, minimum: string): boolean {
   return true;
 }
 
-// A prerelease of the same triple already carries the flag, so the suffix is ignored.
+// Anchored end: a numeric prefix is not a version, and only a semver prerelease or build suffix may follow.
 function parseVersion(
   value: string | undefined,
 ): [number, number, number] | null {
-  const match = value?.trim().match(/^v?(\d+)\.(\d+)\.(\d+)/);
+  const match = value
+    ?.trim()
+    .match(/^v?(\d+)\.(\d+)\.(\d+)(?:[-+][0-9A-Za-z.-]+)?$/);
   return match ? [Number(match[1]), Number(match[2]), Number(match[3])] : null;
 }
 

--- a/raycast/src/lib/kesha-bin.ts
+++ b/raycast/src/lib/kesha-bin.ts
@@ -146,6 +146,8 @@ export interface ProbeDeps {
   ) => Promise<{ stdout: string; stderr: string }>;
 }
 
+export const RECORD_LIVE_FEATURE = "record.live";
+
 export interface EnginePreflightResult {
   ok: boolean;
   hint?: string;
@@ -155,6 +157,8 @@ export interface EnginePreflightResult {
    * those users to re-download would fix nothing (#647).
    */
   reason?: "missing" | "unusable" | "contract";
+  /** Engine `features` from `kesha status --json`; absent when the CLI predates it. */
+  features?: string[];
 }
 
 const MISSING_ENGINE_MARKER = "not installed";
@@ -210,6 +214,15 @@ function capabilitiesAreReadable(capabilities: unknown): boolean {
   );
 }
 
+// A malformed list degrades to "no features" so the caller falls back rather than guessing (#947).
+function readFeatures(capabilities: unknown): string[] {
+  const value = (capabilities as Record<string, unknown> | null)?.features;
+  if (!Array.isArray(value)) return [];
+  return value.every((entry) => typeof entry === "string")
+    ? (value as string[])
+    : [];
+}
+
 function readStructuredStatus(
   payload: Record<string, unknown>,
 ): EnginePreflightResult {
@@ -231,7 +244,7 @@ function readStructuredStatus(
   if (!capabilitiesAreReadable(capabilities)) {
     return { ok: false, reason: "unusable", hint: REPAIR_HINT };
   }
-  return { ok: true };
+  return { ok: true, features: readFeatures(capabilities) };
 }
 
 /**

--- a/raycast/src/lib/process-tasks.ts
+++ b/raycast/src/lib/process-tasks.ts
@@ -1,7 +1,7 @@
 import { spawn as defaultSpawn } from "node:child_process";
 import type { ChildProcess, SpawnOptions } from "node:child_process";
 import type { KeshaSpawn } from "./kesha-bin";
-import type { RunningTask } from "./dictation-types";
+import type { LiveRecorderTask, RunningTask } from "./dictation-types";
 import {
   LIVE_FORCE_KILL_MS,
   LIVE_STDOUT_FLUSH_MS,
@@ -129,11 +129,14 @@ export function startKeshaRecorder(
 // A live session prints its transcript and then exits 128+signal, so a signalled stop succeeded (#962).
 const LIVE_SUCCESS_EXIT_CODES = new Set([0, 130, 143]);
 
+// The engine opens the device only after streaming ASR is up, ~20 s on a first run (rust/src/record.rs).
+const LIVE_LISTENING_MARKER = "Listening (";
+
 export function startKeshaLiveRecorder(
   kesha: KeshaSpawn,
   maxSeconds: number,
   deps: ProcessTaskDeps = {},
-): RunningTask<string> {
+): LiveRecorderTask {
   const spawn = deps.spawn ?? defaultSpawn;
   const schedule = deps.setTimeout ?? setTimeout;
   const proc = spawn(
@@ -150,12 +153,19 @@ export function startKeshaLiveRecorder(
 
   let stdout = "";
   let stderr = "";
+  let reportMicOpen = () => {};
+  const micOpen = new Promise<void>((resolve) => {
+    reportMicOpen = resolve;
+  });
   proc.stdout?.on("data", (chunk: Buffer) => {
     stdout = capTail(stdout + chunk.toString("utf8"), 16 * 1024 * 1024);
   });
   proc.stderr?.on("data", (chunk: Buffer) => {
     stderr = capTail(stderr + chunk.toString("utf8"), 8000);
+    if (stderr.includes(LIVE_LISTENING_MARKER)) reportMicOpen();
   });
+  proc.once("exit", () => reportMicOpen());
+  proc.once("error", () => reportMicOpen());
 
   const stdoutEnded = new Promise<void>((resolve) => {
     if (!proc.stdout) {
@@ -166,7 +176,9 @@ export function startKeshaLiveRecorder(
   });
 
   return {
+    micOpen,
     stop: () => stopLiveProcessWithWatchdog(proc, deps),
+    abort: () => terminateProcessWithWatchdog(proc, deps),
     done: waitForExit(proc).then(async (exitCode) => {
       // The engine writes the transcript to the CLI's inherited stdout, so it can still be in flight at exit.
       await Promise.race([

--- a/raycast/src/lib/process-tasks.ts
+++ b/raycast/src/lib/process-tasks.ts
@@ -1,7 +1,11 @@
 import { spawn as defaultSpawn } from "node:child_process";
 import type { ChildProcess, SpawnOptions } from "node:child_process";
 import type { KeshaSpawn } from "./kesha-bin";
-import type { LiveRecorderTask, RunningTask } from "./dictation-types";
+import type {
+  LiveMicOutcome,
+  LiveRecorderTask,
+  RunningTask,
+} from "./dictation-types";
 import {
   LIVE_FORCE_KILL_MS,
   LIVE_STDOUT_FLUSH_MS,
@@ -132,6 +136,14 @@ const LIVE_SUCCESS_EXIT_CODES = new Set([0, 130, 143]);
 // The engine opens the device only after streaming ASR is up, ~20 s on a first run (rust/src/record.rs).
 const LIVE_LISTENING_MARKER = "Listening (";
 
+// The engine repaints one progress line per second with \r; keeping every fragment buries the real error (#947).
+function renderCarriageReturns(raw: string): string {
+  return raw
+    .split("\n")
+    .map((line) => line.slice(line.lastIndexOf("\r") + 1))
+    .join("\n");
+}
+
 export function startKeshaLiveRecorder(
   kesha: KeshaSpawn,
   maxSeconds: number,
@@ -153,8 +165,8 @@ export function startKeshaLiveRecorder(
 
   let stdout = "";
   let stderr = "";
-  let reportMicOpen = () => {};
-  const micOpen = new Promise<void>((resolve) => {
+  let reportMicOpen: (outcome: LiveMicOutcome) => void = () => {};
+  const micOpen = new Promise<LiveMicOutcome>((resolve) => {
     reportMicOpen = resolve;
   });
   proc.stdout?.on("data", (chunk: Buffer) => {
@@ -162,10 +174,10 @@ export function startKeshaLiveRecorder(
   });
   proc.stderr?.on("data", (chunk: Buffer) => {
     stderr = capTail(stderr + chunk.toString("utf8"), 8000);
-    if (stderr.includes(LIVE_LISTENING_MARKER)) reportMicOpen();
+    if (stderr.includes(LIVE_LISTENING_MARKER)) reportMicOpen("listening");
   });
-  proc.once("exit", () => reportMicOpen());
-  proc.once("error", () => reportMicOpen());
+  proc.once("exit", () => reportMicOpen("ended"));
+  proc.once("error", () => reportMicOpen("ended"));
 
   const stdoutEnded = new Promise<void>((resolve) => {
     if (!proc.stdout) {
@@ -189,7 +201,8 @@ export function startKeshaLiveRecorder(
       ]);
       if (!LIVE_SUCCESS_EXIT_CODES.has(exitCode ?? -1)) {
         throw new Error(
-          stderr.trim() || `kesha record --live exited with code ${exitCode}`,
+          renderCarriageReturns(stderr).trim() ||
+            `kesha record --live exited with code ${exitCode}`,
         );
       }
       return stdout;

--- a/raycast/src/lib/process-tasks.ts
+++ b/raycast/src/lib/process-tasks.ts
@@ -140,7 +140,11 @@ const LIVE_LISTENING_MARKER = "Listening (";
 function renderCarriageReturns(raw: string): string {
   return raw
     .split("\n")
-    .map((line) => line.slice(line.lastIndexOf("\r") + 1))
+    .map((line) => {
+      // A CRLF line ends in the \r that terminates it, not in an overwrite.
+      const body = line.endsWith("\r") ? line.slice(0, -1) : line;
+      return body.slice(body.lastIndexOf("\r") + 1);
+    })
     .join("\n");
 }
 

--- a/raycast/src/lib/process-tasks.ts
+++ b/raycast/src/lib/process-tasks.ts
@@ -2,6 +2,11 @@ import { spawn as defaultSpawn } from "node:child_process";
 import type { ChildProcess, SpawnOptions } from "node:child_process";
 import type { KeshaSpawn } from "./kesha-bin";
 import type { RunningTask } from "./dictation-types";
+import {
+  LIVE_FORCE_KILL_MS,
+  LIVE_STDOUT_FLUSH_MS,
+  LIVE_STOP_GRACE_MS,
+} from "./dictation-config";
 
 type SpawnFn = (
   command: string,
@@ -32,9 +37,11 @@ export function killProcessGroup(proc: ChildProcess, signal: NodeJS.Signals) {
   proc.kill(signal);
 }
 
-export function stopProcessWithWatchdog(
+function stopWithLadder(
   proc: ChildProcess | null,
-  deps: ProcessTaskDeps = {},
+  deps: ProcessTaskDeps,
+  termMs: number,
+  killMs: number,
 ) {
   if (!proc) return;
   const kill = deps.kill ?? killProcessGroup;
@@ -49,11 +56,25 @@ export function stopProcessWithWatchdog(
 
   schedule(() => {
     if (proc.exitCode == null) kill(proc, "SIGTERM");
-  }, 1500).unref?.();
+  }, termMs).unref?.();
 
   schedule(() => {
     if (proc.exitCode == null) kill(proc, "SIGKILL");
-  }, 5000).unref?.();
+  }, killMs).unref?.();
+}
+
+export function stopProcessWithWatchdog(
+  proc: ChildProcess | null,
+  deps: ProcessTaskDeps = {},
+) {
+  stopWithLadder(proc, deps, 1500, 5000);
+}
+
+export function stopLiveProcessWithWatchdog(
+  proc: ChildProcess | null,
+  deps: ProcessTaskDeps = {},
+) {
+  stopWithLadder(proc, deps, LIVE_STOP_GRACE_MS, LIVE_FORCE_KILL_MS);
 }
 
 export function terminateProcessWithWatchdog(
@@ -101,6 +122,65 @@ export function startKeshaRecorder(
           stderr.trim() || `kesha record exited with code ${exitCode}`,
         );
       }
+    }),
+  };
+}
+
+// A live session prints its transcript and then exits 128+signal, so a signalled stop succeeded (#962).
+const LIVE_SUCCESS_EXIT_CODES = new Set([0, 130, 143]);
+
+export function startKeshaLiveRecorder(
+  kesha: KeshaSpawn,
+  maxSeconds: number,
+  deps: ProcessTaskDeps = {},
+): RunningTask<string> {
+  const spawn = deps.spawn ?? defaultSpawn;
+  const schedule = deps.setTimeout ?? setTimeout;
+  const proc = spawn(
+    kesha.command,
+    [
+      ...kesha.prefixArgs,
+      "record",
+      "--live",
+      "--max-seconds",
+      String(maxSeconds),
+    ],
+    { stdio: ["pipe", "pipe", "pipe"], detached: true },
+  );
+
+  let stdout = "";
+  let stderr = "";
+  proc.stdout?.on("data", (chunk: Buffer) => {
+    stdout = capTail(stdout + chunk.toString("utf8"), 16 * 1024 * 1024);
+  });
+  proc.stderr?.on("data", (chunk: Buffer) => {
+    stderr = capTail(stderr + chunk.toString("utf8"), 8000);
+  });
+
+  const stdoutEnded = new Promise<void>((resolve) => {
+    if (!proc.stdout) {
+      resolve();
+      return;
+    }
+    proc.stdout.once("end", () => resolve());
+  });
+
+  return {
+    stop: () => stopLiveProcessWithWatchdog(proc, deps),
+    done: waitForExit(proc).then(async (exitCode) => {
+      // The engine writes the transcript to the CLI's inherited stdout, so it can still be in flight at exit.
+      await Promise.race([
+        stdoutEnded,
+        new Promise<void>((resolve) => {
+          schedule(resolve, LIVE_STDOUT_FLUSH_MS).unref?.();
+        }),
+      ]);
+      if (!LIVE_SUCCESS_EXIT_CODES.has(exitCode ?? -1)) {
+        throw new Error(
+          stderr.trim() || `kesha record --live exited with code ${exitCode}`,
+        );
+      }
+      return stdout;
     }),
   };
 }

--- a/raycast/tests/dictation-controller.test.ts
+++ b/raycast/tests/dictation-controller.test.ts
@@ -833,6 +833,37 @@ describe("dictation controller", () => {
     expect(deps.copyToClipboard).not.toHaveBeenCalled();
   });
 
+  it("does not leave an abandoned live failure unhandled (#947)", async () => {
+    const micOpen = deferred<void>();
+    const live = deferred<string>();
+    const unhandled: unknown[] = [];
+    const record = (reason: unknown) => {
+      unhandled.push(reason);
+    };
+    process.on("unhandledRejection", record);
+    try {
+      const deps = createDeps({
+        preflight: livePreflight(),
+        startLiveRecorder: vi.fn(() =>
+          liveTask(live.promise, { micOpen: micOpen.promise }),
+        ),
+      });
+
+      const session = startDictationSession({}, deps.setState, deps);
+      await waitFor(() => expect(deps.startLiveRecorder).toHaveBeenCalled());
+
+      session.cancel();
+      micOpen.resolve();
+      live.reject(new Error("live session died during warmup"));
+      await session.done;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", record);
+    }
+  });
+
   it("does not deliver a live transcript that arrives after the view was dismissed", async () => {
     const live = deferred<string>();
     const deps = createDeps({

--- a/raycast/tests/dictation-controller.test.ts
+++ b/raycast/tests/dictation-controller.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../src/lib/dictation-controller";
 import type {
   DictationControllerDeps,
+  DictationSession,
   DictationState,
   LiveRecorderTask,
   RecordingPatch,
@@ -772,7 +773,7 @@ describe("dictation controller", () => {
   });
 
   it("does not claim to record while the live engine is still warming up (#947)", async () => {
-    const micOpen = deferred<void>();
+    const micOpen = deferred<"listening" | "ended">();
     const live = deferred<string>();
     let meterStarted = false;
     const deps = createDeps({
@@ -796,7 +797,7 @@ describe("dictation controller", () => {
       expect.objectContaining({ title: "Recording" }),
     );
 
-    micOpen.resolve();
+    micOpen.resolve("listening");
     await waitFor(() => expect(deps.current().status).toBe("recording"));
     expect(meterStarted).toBe(true);
 
@@ -806,7 +807,7 @@ describe("dictation controller", () => {
   });
 
   it("never opens the meter when the view is dismissed during the live warmup", async () => {
-    const micOpen = deferred<void>();
+    const micOpen = deferred<"listening" | "ended">();
     const live = deferred<string>();
     let meterStarted = false;
     const deps = createDeps({
@@ -824,7 +825,7 @@ describe("dictation controller", () => {
     await waitFor(() => expect(deps.startLiveRecorder).toHaveBeenCalled());
 
     session.cancel();
-    micOpen.resolve();
+    micOpen.resolve("listening");
     live.resolve("discarded\n");
     await session.done;
 
@@ -833,8 +834,86 @@ describe("dictation controller", () => {
     expect(deps.copyToClipboard).not.toHaveBeenCalled();
   });
 
+  it("never shows a recording view for a live session that died before the mic opened (#947)", async () => {
+    let meterStarted = false;
+    const deps = createDeps({
+      preflight: livePreflight(),
+      startLiveRecorder: vi.fn(() =>
+        liveTask(
+          Promise.reject(
+            new Error(
+              "E_UNSUPPORTED_PLATFORM: live transcription requires a CoreML engine",
+            ),
+          ),
+          { micOpen: Promise.resolve("ended" as const) },
+        ),
+      ),
+      startRecordingMonitor: vi.fn(() => {
+        meterStarted = true;
+        return vi.fn();
+      }),
+    });
+
+    const session = startDictationSession({}, deps.setState, deps);
+    await session.done;
+
+    expect(meterStarted).toBe(false);
+    expect(deps.states.map((state) => state.status)).toEqual(["error"]);
+    expect(deps.toasts).not.toContainEqual(
+      expect.objectContaining({ title: "Recording" }),
+    );
+    expect(deps.states.at(-1)).toMatchObject({
+      status: "error",
+      message:
+        "E_UNSUPPORTED_PLATFORM: live transcription requires a CoreML engine",
+    });
+  });
+
+  it("copies nothing when a dismissal lands before a late live transcript", async () => {
+    const live = deferred<string>();
+    const deps = createDeps({
+      preflight: livePreflight(),
+      startLiveRecorder: vi.fn(() =>
+        liveTask(live.promise, { micOpen: Promise.resolve("ended" as const) }),
+      ),
+    });
+
+    const session = startDictationSession({}, deps.setState, deps);
+    await waitFor(() => expect(deps.startLiveRecorder).toHaveBeenCalled());
+
+    session.cancel();
+    live.resolve("late text\n");
+    await session.done;
+
+    expect(deps.copyToClipboard).not.toHaveBeenCalled();
+  });
+
+  it("does not claim success for a live transcript copied as the view is dismissed", async () => {
+    const copy = deferred<void>();
+    const copied: string[] = [];
+    let session: DictationSession;
+    const deps = createDeps({
+      preflight: livePreflight(),
+      copyToClipboard: vi.fn(async (text: string) => {
+        copied.push(text);
+        session.cancel();
+        await copy.promise;
+      }),
+    });
+
+    session = startDictationSession({}, deps.setState, deps);
+    await waitFor(() => expect(copied).toEqual(["live text"]));
+    copy.resolve();
+    await session.done;
+
+    expect(deps.states.some((state) => state.status === "ok")).toBe(false);
+    expect(deps.toasts).not.toContainEqual(
+      expect.objectContaining({ title: "Copied transcript" }),
+    );
+  });
+
   it("does not leave an abandoned live failure unhandled (#947)", async () => {
-    const micOpen = deferred<void>();
+    const micOpen = deferred<"listening" | "ended">();
     const live = deferred<string>();
     const unhandled: unknown[] = [];
     const record = (reason: unknown) => {
@@ -853,7 +932,7 @@ describe("dictation controller", () => {
       await waitFor(() => expect(deps.startLiveRecorder).toHaveBeenCalled());
 
       session.cancel();
-      micOpen.resolve();
+      micOpen.resolve("listening");
       live.reject(new Error("live session died during warmup"));
       await session.done;
       await new Promise((resolve) => setTimeout(resolve, 10));
@@ -1390,7 +1469,7 @@ function liveTask(
 ): LiveRecorderTask {
   return {
     done,
-    micOpen: Promise.resolve(),
+    micOpen: Promise.resolve("listening" as const),
     stop: vi.fn(),
     abort: vi.fn(),
     ...overrides,

--- a/raycast/tests/dictation-controller.test.ts
+++ b/raycast/tests/dictation-controller.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   createSilenceTracker,
+  normalizeLiveTranscript,
   normalizeTranscribeResult,
   pruneOldRecordings,
   staleRecordingDirs,
@@ -855,6 +856,44 @@ describe("dictation controller", () => {
     expect(deps.states.at(-1)).toMatchObject({
       status: "ok",
       result: { text: "tail words" },
+    });
+  });
+
+  it("tells a live user to check microphone permission when nothing was transcribed (#947)", async () => {
+    const deps = createDeps({
+      preflight: livePreflight(),
+      startLiveRecorder: vi.fn(() => resolvedTask(Promise.resolve("   \n"))),
+    });
+
+    const session = startDictationSession({}, deps.setState, deps);
+    await session.done;
+
+    expect(deps.copyToClipboard).not.toHaveBeenCalled();
+    const last = deps.states.at(-1);
+    expect(last?.status).toBe("error");
+    expect(last?.status === "error" && last.message).toContain(
+      "No speech was detected",
+    );
+    expect(last?.status === "error" && last.message).toContain(
+      "Microphone permission",
+    );
+    expect(last?.status === "error" && last.hint).toBeUndefined();
+  });
+
+  it("keeps the live empty-transcript message distinct from the fallback's (#947)", () => {
+    // Live has no WAV, so it merges the two fallback causes; the fallback keeps both apart.
+    expect(() => normalizeLiveTranscript("   \n")).toThrow(
+      "Microphone permission",
+    );
+    expect(() => normalizeTranscribeResult("/tmp/a.wav", "   \n")).toThrow(
+      "No speech was detected in the recording.",
+    );
+    expect(() =>
+      normalizeTranscribeResult("/tmp/a.wav", "   \n"),
+    ).not.toThrow("Microphone permission");
+    expect(normalizeLiveTranscript(" said something \n")).toEqual({
+      file: "",
+      text: "said something",
     });
   });
 });

--- a/raycast/tests/dictation-controller.test.ts
+++ b/raycast/tests/dictation-controller.test.ts
@@ -888,24 +888,26 @@ describe("dictation controller", () => {
     expect(deps.copyToClipboard).not.toHaveBeenCalled();
   });
 
-  it("does not claim success for a live transcript copied as the view is dismissed", async () => {
+  // A clipboard write handed to the OS cannot be recalled: it stays, the UI does not.
+  it("keeps a transcript whose copy was already in flight when the view was dismissed", async () => {
     const copy = deferred<void>();
     const copied: string[] = [];
     let session: DictationSession;
     const deps = createDeps({
       preflight: livePreflight(),
       copyToClipboard: vi.fn(async (text: string) => {
-        copied.push(text);
         session.cancel();
         await copy.promise;
+        copied.push(text);
       }),
     });
 
     session = startDictationSession({}, deps.setState, deps);
-    await waitFor(() => expect(copied).toEqual(["live text"]));
+    await waitFor(() => expect(deps.copyToClipboard).toHaveBeenCalled());
     copy.resolve();
     await session.done;
 
+    expect(copied).toEqual(["live text"]);
     expect(deps.states.some((state) => state.status === "ok")).toBe(false);
     expect(deps.toasts).not.toContainEqual(
       expect.objectContaining({ title: "Copied transcript" }),

--- a/raycast/tests/dictation-controller.test.ts
+++ b/raycast/tests/dictation-controller.test.ts
@@ -11,11 +11,14 @@ import {
 import type {
   DictationControllerDeps,
   DictationState,
+  LiveRecorderTask,
   RecordingPatch,
   RunningTask,
   SignalLevel,
 } from "../src/lib/dictation-types";
 import { emptySignal } from "../src/lib/recording-view";
+import { startKeshaLiveRecorder } from "../src/lib/process-tasks";
+import { createSpawnRecorder } from "./helpers/fake-process";
 import { deferred, flushPromises, waitFor } from "./helpers/async";
 
 describe("dictation controller", () => {
@@ -699,47 +702,42 @@ describe("dictation controller", () => {
     await session.done;
   });
 
-  it("runs one process and skips the transcription phase on a live engine (#947)", async () => {
+  // Each path resolves a different transcript, so the clipboard names the one that ran.
+  it("copies the live transcript with no transcription phase in between (#947)", async () => {
     const deps = createDeps({ preflight: livePreflight() });
 
     const session = startDictationSession({}, deps.setState, deps);
     await session.done;
 
-    expect(deps.startLiveRecorder).toHaveBeenCalledTimes(1);
-    expect(deps.startLiveRecorder).toHaveBeenCalledWith(
-      { command: "kesha", prefixArgs: [] },
-      300,
-    );
-    expect(deps.startRecorder).not.toHaveBeenCalled();
-    expect(deps.startTranscriber).not.toHaveBeenCalled();
-    expect(deps.createTempDir).not.toHaveBeenCalled();
-    expect(deps.isSilentAudio).not.toHaveBeenCalled();
-    expect(deps.states.some((state) => state.status === "transcribing")).toBe(
-      false,
-    );
     expect(deps.copyToClipboard).toHaveBeenCalledWith("live text");
-    expect(deps.states.at(-1)).toMatchObject({
-      status: "ok",
-      result: { text: "live text" },
-    });
+    expect(deps.states.map((state) => state.status)).toEqual([
+      "recording",
+      "ok",
+    ]);
+    expect(deps.toasts).not.toContainEqual(
+      expect.objectContaining({ title: "Transcribing" }),
+    );
+    expect(deps.cleanupTempDir).not.toHaveBeenCalled();
   });
 
   it("keeps the record-then-transcribe path on an engine without record.live", async () => {
     const deps = createDeps({
-      preflight: vi.fn(async () => ({ ok: true, features: ["transcribe"] })),
+      preflight: vi.fn(async () => ({
+        ok: true,
+        cliVersion: "1.29.1",
+        features: ["transcribe"],
+      })),
     });
 
     const session = startDictationSession({}, deps.setState, deps);
     await session.done;
 
-    expect(deps.startLiveRecorder).not.toHaveBeenCalled();
-    expect(deps.startRecorder).toHaveBeenCalled();
-    expect(deps.createTempDir).toHaveBeenCalled();
-    expect(deps.isSilentAudio).toHaveBeenCalled();
-    expect(deps.startTranscriber).toHaveBeenCalled();
-    expect(deps.states.some((state) => state.status === "transcribing")).toBe(
-      true,
-    );
+    expect(deps.copyToClipboard).toHaveBeenCalledWith("hello world");
+    expect(deps.states.map((state) => state.status)).toEqual([
+      "recording",
+      "transcribing",
+      "ok",
+    ]);
   });
 
   it("keeps the record-then-transcribe path when the CLI is too old to report features", async () => {
@@ -748,11 +746,161 @@ describe("dictation controller", () => {
     const session = startDictationSession({}, deps.setState, deps);
     await session.done;
 
-    expect(deps.startLiveRecorder).not.toHaveBeenCalled();
-    expect(deps.startRecorder).toHaveBeenCalled();
-    expect(deps.createTempDir).toHaveBeenCalled();
-    expect(deps.isSilentAudio).toHaveBeenCalled();
-    expect(deps.startTranscriber).toHaveBeenCalled();
+    expect(deps.copyToClipboard).toHaveBeenCalledWith("hello world");
+    expect(deps.states.some((state) => state.status === "transcribing")).toBe(
+      true,
+    );
+  });
+
+  it("keeps the record-then-transcribe path when the CLI is too old for the flag (#947)", async () => {
+    // The engine advertising record.live says nothing about the CLI that spawns it.
+    const deps = createDeps({
+      preflight: vi.fn(async () => ({
+        ok: true,
+        cliVersion: "1.27.0",
+        features: ["transcribe", "record.live"],
+      })),
+    });
+
+    const session = startDictationSession({}, deps.setState, deps);
+    await session.done;
+
+    expect(deps.copyToClipboard).toHaveBeenCalledWith("hello world");
+    expect(deps.states.some((state) => state.status === "transcribing")).toBe(
+      true,
+    );
+  });
+
+  it("does not claim to record while the live engine is still warming up (#947)", async () => {
+    const micOpen = deferred<void>();
+    const live = deferred<string>();
+    let meterStarted = false;
+    const deps = createDeps({
+      preflight: livePreflight(),
+      startLiveRecorder: vi.fn(() =>
+        liveTask(live.promise, { micOpen: micOpen.promise }),
+      ),
+      startRecordingMonitor: vi.fn(() => {
+        meterStarted = true;
+        return vi.fn();
+      }),
+    });
+
+    const session = startDictationSession({}, deps.setState, deps);
+    await waitFor(() => expect(deps.startLiveRecorder).toHaveBeenCalled());
+    await flushPromises();
+
+    expect(deps.current().status).toBe("starting");
+    expect(meterStarted).toBe(false);
+    expect(deps.toasts).not.toContainEqual(
+      expect.objectContaining({ title: "Recording" }),
+    );
+
+    micOpen.resolve();
+    await waitFor(() => expect(deps.current().status).toBe("recording"));
+    expect(meterStarted).toBe(true);
+
+    live.resolve("warm words\n");
+    await session.done;
+    expect(deps.copyToClipboard).toHaveBeenCalledWith("warm words");
+  });
+
+  it("never opens the meter when the view is dismissed during the live warmup", async () => {
+    const micOpen = deferred<void>();
+    const live = deferred<string>();
+    let meterStarted = false;
+    const deps = createDeps({
+      preflight: livePreflight(),
+      startLiveRecorder: vi.fn(() =>
+        liveTask(live.promise, { micOpen: micOpen.promise }),
+      ),
+      startRecordingMonitor: vi.fn(() => {
+        meterStarted = true;
+        return vi.fn();
+      }),
+    });
+
+    const session = startDictationSession({}, deps.setState, deps);
+    await waitFor(() => expect(deps.startLiveRecorder).toHaveBeenCalled());
+
+    session.cancel();
+    micOpen.resolve();
+    live.resolve("discarded\n");
+    await session.done;
+
+    expect(meterStarted).toBe(false);
+    expect(deps.current().status).toBe("starting");
+    expect(deps.copyToClipboard).not.toHaveBeenCalled();
+  });
+
+  it("does not deliver a live transcript that arrives after the view was dismissed", async () => {
+    const live = deferred<string>();
+    const deps = createDeps({
+      preflight: livePreflight(),
+      startLiveRecorder: vi.fn(() => liveTask(live.promise)),
+    });
+
+    const session = startDictationSession({}, deps.setState, deps);
+    await waitFor(() => expect(deps.current().status).toBe("recording"));
+
+    session.cancel();
+    live.resolve("late transcript\n");
+    await session.done;
+
+    expect(deps.copyToClipboard).not.toHaveBeenCalled();
+    expect(deps.states.some((state) => state.status === "ok")).toBe(false);
+  });
+
+  it("releases the microphone at once when a live session is dismissed (#947)", async () => {
+    const { spawn, processes } = createSpawnRecorder();
+    const kill = vi.fn();
+    const deps = createDeps({
+      preflight: livePreflight(),
+      startLiveRecorder: (kesha, maxSeconds) =>
+        startKeshaLiveRecorder(kesha, maxSeconds, { spawn, kill }),
+    });
+
+    const session = startDictationSession({}, deps.setState, deps);
+    await waitFor(() => expect(processes.length).toBe(1));
+    processes[0].emitStderr("Listening (48000 Hz)...\n");
+    await waitFor(() => expect(deps.current().status).toBe("recording"));
+
+    session.cancel();
+    // The stop ladder would leave the device open for another 10 s.
+    expect(kill).toHaveBeenCalledWith(processes[0].asChild(), "SIGTERM");
+
+    processes[0].exit(143);
+    processes[0].endStdout();
+    await session.done;
+  });
+
+  it("reports an early live stop instead of a transcript that never came", async () => {
+    const recordingToast = deferred<void>();
+    const live = deferred<string>();
+    const deps = createDeps({
+      preflight: livePreflight(),
+      startLiveRecorder: vi.fn(() => liveTask(live.promise)),
+      showToast: vi.fn(async (toast) => {
+        deps.toasts.push(toast);
+        if (toast.title === "Recording") await recordingToast.promise;
+      }),
+    });
+
+    const session = startDictationSession({}, deps.setState, deps);
+    await waitFor(() => expect(deps.current().status).toBe("recording"));
+
+    session.stopRecording();
+    recordingToast.resolve();
+    await session.done;
+
+    expect(deps.copyToClipboard).not.toHaveBeenCalled();
+    expect(deps.current()).toMatchObject({
+      status: "error",
+      message: "Recording stopped before any audio was captured.",
+    });
+    expect(deps.toasts).not.toContainEqual(
+      expect.objectContaining({ title: "Dictation failed" }),
+    );
   });
 
   it("stops a live session and delivers the transcript it produced", async () => {
@@ -760,7 +908,7 @@ describe("dictation controller", () => {
     const liveStop = vi.fn();
     const deps = createDeps({
       preflight: livePreflight(),
-      startLiveRecorder: vi.fn(() => ({ done: live.promise, stop: liveStop })),
+      startLiveRecorder: vi.fn(() => liveTask(live.promise, { stop: liveStop })),
     });
 
     const session = startDictationSession({}, deps.setState, deps);
@@ -783,7 +931,7 @@ describe("dictation controller", () => {
     const deps = createDeps({
       preflight: livePreflight(),
       startLiveRecorder: vi.fn(() =>
-        resolvedTask(
+        liveTask(
           Promise.reject(
             new Error(
               "E_UNSUPPORTED_PLATFORM: live transcription requires a CoreML engine",
@@ -828,7 +976,7 @@ describe("dictation controller", () => {
     const deps = createDeps({
       now: () => clock,
       preflight: livePreflight(),
-      startLiveRecorder: vi.fn(() => ({ done: live.promise, stop: liveStop })),
+      startLiveRecorder: vi.fn(() => liveTask(live.promise, { stop: liveStop })),
       startRecordingMonitor: vi.fn((onPatch) => {
         emit = onPatch;
         return vi.fn();
@@ -862,7 +1010,7 @@ describe("dictation controller", () => {
   it("tells a live user to check microphone permission when nothing was transcribed (#947)", async () => {
     const deps = createDeps({
       preflight: livePreflight(),
-      startLiveRecorder: vi.fn(() => resolvedTask(Promise.resolve("   \n"))),
+      startLiveRecorder: vi.fn(() => liveTask(Promise.resolve("   \n"))),
     });
 
     const session = startDictationSession({}, deps.setState, deps);
@@ -1169,7 +1317,7 @@ function createDeps(
     cleanupTempDir: vi.fn(async () => undefined),
     startRecordingMonitor: vi.fn(() => vi.fn()),
     startRecorder: vi.fn(() => resolvedTask(Promise.resolve())),
-    startLiveRecorder: vi.fn(() => resolvedTask(Promise.resolve(" live text\n"))),
+    startLiveRecorder: vi.fn(() => liveTask(Promise.resolve(" live text\n"))),
     startTranscriber: vi.fn(() =>
       resolvedTask(Promise.resolve(" hello world\n")),
     ),
@@ -1196,12 +1344,26 @@ function createDeps(
 function livePreflight() {
   return vi.fn(async () => ({
     ok: true,
+    cliVersion: "1.29.1",
     features: ["transcribe", "record.live"],
   }));
 }
 
 function resolvedTask<T>(done: Promise<T>): RunningTask<T> {
   return { done, stop: vi.fn() };
+}
+
+function liveTask(
+  done: Promise<string>,
+  overrides: Partial<LiveRecorderTask> = {},
+): LiveRecorderTask {
+  return {
+    done,
+    micOpen: Promise.resolve(),
+    stop: vi.fn(),
+    abort: vi.fn(),
+    ...overrides,
+  };
 }
 
 function signalTick(): SignalLevel {

--- a/raycast/tests/dictation-controller.test.ts
+++ b/raycast/tests/dictation-controller.test.ts
@@ -697,6 +697,166 @@ describe("dictation controller", () => {
     recorder.resolve();
     await session.done;
   });
+
+  it("runs one process and skips the transcription phase on a live engine (#947)", async () => {
+    const deps = createDeps({ preflight: livePreflight() });
+
+    const session = startDictationSession({}, deps.setState, deps);
+    await session.done;
+
+    expect(deps.startLiveRecorder).toHaveBeenCalledTimes(1);
+    expect(deps.startLiveRecorder).toHaveBeenCalledWith(
+      { command: "kesha", prefixArgs: [] },
+      300,
+    );
+    expect(deps.startRecorder).not.toHaveBeenCalled();
+    expect(deps.startTranscriber).not.toHaveBeenCalled();
+    expect(deps.createTempDir).not.toHaveBeenCalled();
+    expect(deps.isSilentAudio).not.toHaveBeenCalled();
+    expect(deps.states.some((state) => state.status === "transcribing")).toBe(
+      false,
+    );
+    expect(deps.copyToClipboard).toHaveBeenCalledWith("live text");
+    expect(deps.states.at(-1)).toMatchObject({
+      status: "ok",
+      result: { text: "live text" },
+    });
+  });
+
+  it("keeps the record-then-transcribe path on an engine without record.live", async () => {
+    const deps = createDeps({
+      preflight: vi.fn(async () => ({ ok: true, features: ["transcribe"] })),
+    });
+
+    const session = startDictationSession({}, deps.setState, deps);
+    await session.done;
+
+    expect(deps.startLiveRecorder).not.toHaveBeenCalled();
+    expect(deps.startRecorder).toHaveBeenCalled();
+    expect(deps.createTempDir).toHaveBeenCalled();
+    expect(deps.isSilentAudio).toHaveBeenCalled();
+    expect(deps.startTranscriber).toHaveBeenCalled();
+    expect(deps.states.some((state) => state.status === "transcribing")).toBe(
+      true,
+    );
+  });
+
+  it("keeps the record-then-transcribe path when the CLI is too old to report features", async () => {
+    const deps = createDeps();
+
+    const session = startDictationSession({}, deps.setState, deps);
+    await session.done;
+
+    expect(deps.startLiveRecorder).not.toHaveBeenCalled();
+    expect(deps.startRecorder).toHaveBeenCalled();
+    expect(deps.createTempDir).toHaveBeenCalled();
+    expect(deps.isSilentAudio).toHaveBeenCalled();
+    expect(deps.startTranscriber).toHaveBeenCalled();
+  });
+
+  it("stops a live session and delivers the transcript it produced", async () => {
+    const live = deferred<string>();
+    const liveStop = vi.fn();
+    const deps = createDeps({
+      preflight: livePreflight(),
+      startLiveRecorder: vi.fn(() => ({ done: live.promise, stop: liveStop })),
+    });
+
+    const session = startDictationSession({}, deps.setState, deps);
+    await waitFor(() => expect(deps.startLiveRecorder).toHaveBeenCalled());
+
+    session.stopRecording();
+    expect(deps.states.some((state) => state.status === "stopping")).toBe(true);
+    expect(liveStop).toHaveBeenCalled();
+
+    live.resolve("stopped text\n");
+    await session.done;
+
+    expect(deps.states.at(-1)).toMatchObject({
+      status: "ok",
+      result: { text: "stopped text" },
+    });
+  });
+
+  it("surfaces a failed live session with the CLI's own message", async () => {
+    const deps = createDeps({
+      preflight: livePreflight(),
+      startLiveRecorder: vi.fn(() =>
+        resolvedTask(
+          Promise.reject(
+            new Error(
+              "E_UNSUPPORTED_PLATFORM: live transcription requires a CoreML engine",
+            ),
+          ),
+        ),
+      ),
+    });
+
+    const session = startDictationSession({}, deps.setState, deps);
+    await session.done;
+
+    const last = deps.states.at(-1);
+    expect(last).toMatchObject({
+      status: "error",
+      message:
+        "E_UNSUPPORTED_PLATFORM: live transcription requires a CoreML engine",
+    });
+    // There is no kept recording on the live path, so no path may be named.
+    expect(last?.status === "error" && last.hint).toBeUndefined();
+    expect(deps.toasts).toContainEqual({
+      style: "failure",
+      title: "Dictation failed",
+    });
+  });
+
+  it("still prunes recordings left by earlier sessions on the live path", async () => {
+    const deps = createDeps({ preflight: livePreflight() });
+
+    const session = startDictationSession({}, deps.setState, deps);
+    await session.done;
+
+    expect(deps.pruneOldRecordings).toHaveBeenCalled();
+    expect(deps.cleanupTempDir).not.toHaveBeenCalled();
+  });
+
+  it("keeps the meter and idle auto-stop running on the live path", async () => {
+    let clock = 0;
+    let emit!: (patch: RecordingPatch) => void;
+    const live = deferred<string>();
+    const liveStop = vi.fn(() => live.resolve("tail words\n"));
+    const deps = createDeps({
+      now: () => clock,
+      preflight: livePreflight(),
+      startLiveRecorder: vi.fn(() => ({ done: live.promise, stop: liveStop })),
+      startRecordingMonitor: vi.fn((onPatch) => {
+        emit = onPatch;
+        return vi.fn();
+      }),
+    });
+
+    const session = startDictationSession({}, deps.setState, deps);
+    await waitFor(() => expect(deps.startLiveRecorder).toHaveBeenCalled());
+
+    emit({ signal: emptySignal("listening") });
+    clock = 30_000;
+    emit({ signal: emptySignal("listening") });
+    expect(deps.current()).toMatchObject({ status: "recording", idle: true });
+    expect(liveStop).not.toHaveBeenCalled();
+
+    clock = 45_000;
+    emit({ signal: emptySignal("listening") });
+    expect(liveStop).toHaveBeenCalledTimes(1);
+
+    await session.done;
+    expect(deps.toasts).toContainEqual({
+      style: "animated",
+      title: "Stopped after silence.",
+    });
+    expect(deps.states.at(-1)).toMatchObject({
+      status: "ok",
+      result: { text: "tail words" },
+    });
+  });
 });
 
 describe("createSilenceTracker", () => {
@@ -970,6 +1130,7 @@ function createDeps(
     cleanupTempDir: vi.fn(async () => undefined),
     startRecordingMonitor: vi.fn(() => vi.fn()),
     startRecorder: vi.fn(() => resolvedTask(Promise.resolve())),
+    startLiveRecorder: vi.fn(() => resolvedTask(Promise.resolve(" live text\n"))),
     startTranscriber: vi.fn(() =>
       resolvedTask(Promise.resolve(" hello world\n")),
     ),
@@ -991,6 +1152,13 @@ function createDeps(
     current: () => current,
     toasts,
   };
+}
+
+function livePreflight() {
+  return vi.fn(async () => ({
+    ok: true,
+    features: ["transcribe", "record.live"],
+  }));
 }
 
 function resolvedTask<T>(done: Promise<T>): RunningTask<T> {

--- a/raycast/tests/helpers/fake-process.ts
+++ b/raycast/tests/helpers/fake-process.ts
@@ -5,7 +5,7 @@ import { vi } from "vitest";
 export class FakeProcess extends EventEmitter {
   pid = 1234;
   exitCode: number | null = null;
-  stdout = new EventEmitter();
+  stdout: EventEmitter | null = new EventEmitter();
   stderr = new EventEmitter();
   stdin = {
     destroyed: false,
@@ -16,7 +16,7 @@ export class FakeProcess extends EventEmitter {
   kill = vi.fn();
 
   emitStdout(value: string) {
-    this.stdout.emit("data", Buffer.from(value));
+    this.stdout?.emit("data", Buffer.from(value));
   }
 
   emitStderr(value: string) {
@@ -24,7 +24,7 @@ export class FakeProcess extends EventEmitter {
   }
 
   endStdout() {
-    this.stdout.emit("end");
+    this.stdout?.emit("end");
   }
 
   exit(code: number | null) {

--- a/raycast/tests/helpers/fake-process.ts
+++ b/raycast/tests/helpers/fake-process.ts
@@ -23,6 +23,10 @@ export class FakeProcess extends EventEmitter {
     this.stderr.emit("data", Buffer.from(value));
   }
 
+  endStdout() {
+    this.stdout.emit("end");
+  }
+
   exit(code: number | null) {
     this.exitCode = code;
     this.emit("exit", code);

--- a/raycast/tests/helpers/fake-process.ts
+++ b/raycast/tests/helpers/fake-process.ts
@@ -2,25 +2,46 @@ import { EventEmitter } from "node:events";
 import type { ChildProcess, SpawnOptions } from "node:child_process";
 import { vi } from "vitest";
 
+type FakeStdin = { destroyed: boolean; end: ReturnType<typeof vi.fn> };
+
+function makeStdin(): FakeStdin {
+  const stdin: FakeStdin = {
+    destroyed: false,
+    end: vi.fn(() => {
+      stdin.destroyed = true;
+    }),
+  };
+  return stdin;
+}
+
+// Node gives a stream only for a piped fd, so "ignore" must be absent here too —
+// otherwise a spawn that never asked for stdin still looks stoppable.
+function piped(options: SpawnOptions | undefined, fd: number): boolean {
+  const stdio = options?.stdio;
+  return !Array.isArray(stdio) || stdio[fd] !== "ignore";
+}
+
 export class FakeProcess extends EventEmitter {
   pid = 1234;
   exitCode: number | null = null;
-  stdout: EventEmitter | null = new EventEmitter();
-  stderr = new EventEmitter();
-  stdin = {
-    destroyed: false,
-    end: vi.fn(() => {
-      this.stdin.destroyed = true;
-    }),
-  };
+  stdout: EventEmitter | null;
+  stderr: EventEmitter | null;
+  stdin: FakeStdin | null;
   kill = vi.fn();
+
+  constructor(options?: SpawnOptions) {
+    super();
+    this.stdin = piped(options, 0) ? makeStdin() : null;
+    this.stdout = piped(options, 1) ? new EventEmitter() : null;
+    this.stderr = piped(options, 2) ? new EventEmitter() : null;
+  }
 
   emitStdout(value: string) {
     this.stdout?.emit("data", Buffer.from(value));
   }
 
   emitStderr(value: string) {
-    this.stderr.emit("data", Buffer.from(value));
+    this.stderr?.emit("data", Buffer.from(value));
   }
 
   endStdout() {
@@ -47,7 +68,7 @@ export function createSpawnRecorder() {
   const spawn = vi.fn(
     (command: string, args: string[], options: SpawnOptions) => {
       calls.push({ command, args, options });
-      const proc = new FakeProcess();
+      const proc = new FakeProcess(options);
       processes.push(proc);
       return proc.asChild();
     },

--- a/raycast/tests/kesha-bin-status-json.test.ts
+++ b/raycast/tests/kesha-bin-status-json.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import { probeEngineAvailability } from "../src/lib/kesha-bin";
+import {
+  probeEngineAvailability,
+  supportsLiveDictation,
+} from "../src/lib/kesha-bin";
 import type { ProbeDeps } from "../src/lib/kesha-bin";
 
 // One case per row of the probe matrix in the status-json-output design.
@@ -46,6 +49,7 @@ describe("probeEngineAvailability — structured status (#647)", () => {
 
   it("reports the engine's feature list so a caller can detect record.live (#947)", async () => {
     const execFile = jsonStdout({
+      cliVersion: "1.29.1",
       engine: {
         installed: true,
         path: "/x",
@@ -60,6 +64,7 @@ describe("probeEngineAvailability — structured status (#647)", () => {
     const result = await probeEngineAvailability(kesha, { execFile });
     expect(result.ok).toBe(true);
     expect(result.features).toContain("record.live");
+    expect(result.cliVersion).toBe("1.29.1");
   });
 
   it("reports no features for an engine whose capabilities omit them", async () => {
@@ -197,5 +202,51 @@ describe("probeEngineAvailability — structured status (#647)", () => {
       expect(result.ok).toBe(false);
       expect(result.reason).toBe("contract");
     }
+  });
+});
+
+describe("supportsLiveDictation (#947)", () => {
+  it("needs the engine feature and a CLI that accepts the flag", () => {
+    const features = ["transcribe", "record.live"];
+    expect(
+      supportsLiveDictation({ ok: true, features, cliVersion: "1.28.0" }),
+    ).toBe(true);
+    expect(
+      supportsLiveDictation({ ok: true, features, cliVersion: "1.29.1" }),
+    ).toBe(true);
+    // A prerelease of the same triple already carries `record --live`.
+    expect(
+      supportsLiveDictation({ ok: true, features, cliVersion: "1.28.0-alpha.1" }),
+    ).toBe(true);
+  });
+
+  it("refuses a CLI older than the release that shipped record --live", () => {
+    const features = ["transcribe", "record.live"];
+    for (const cliVersion of ["1.27.0", "1.24.9", "0.9.9", "1.2.0"]) {
+      expect(supportsLiveDictation({ ok: true, features, cliVersion })).toBe(
+        false,
+      );
+    }
+  });
+
+  it("refuses an unreported or unreadable CLI version", () => {
+    const features = ["transcribe", "record.live"];
+    expect(supportsLiveDictation({ ok: true, features })).toBe(false);
+    expect(
+      supportsLiveDictation({ ok: true, features, cliVersion: "unknown" }),
+    ).toBe(false);
+  });
+
+  it("refuses an engine that does not advertise the feature", () => {
+    expect(
+      supportsLiveDictation({
+        ok: true,
+        features: ["transcribe"],
+        cliVersion: "1.29.1",
+      }),
+    ).toBe(false);
+    expect(supportsLiveDictation({ ok: true, cliVersion: "1.29.1" })).toBe(
+      false,
+    );
   });
 });

--- a/raycast/tests/kesha-bin-status-json.test.ts
+++ b/raycast/tests/kesha-bin-status-json.test.ts
@@ -237,6 +237,37 @@ describe("supportsLiveDictation (#947)", () => {
     ).toBe(false);
   });
 
+  it("refuses a version string that only starts like a version", () => {
+    const features = ["transcribe", "record.live"];
+    // A numeric prefix is not a version: whatever follows may mean anything.
+    for (const cliVersion of [
+      "1.28.0garbage",
+      "1.28.0.1",
+      "1.28.0 garbage",
+      "1.28.0/2.0.0",
+      "1.28",
+    ]) {
+      expect(supportsLiveDictation({ ok: true, features, cliVersion })).toBe(
+        false,
+      );
+    }
+  });
+
+  it("accepts the version shapes the CLI actually reports", () => {
+    const features = ["transcribe", "record.live"];
+    for (const cliVersion of [
+      "1.28.0",
+      "v1.28.0",
+      " 1.29.1 ",
+      "1.28.0-alpha.1",
+      "1.28.0+build.5",
+    ]) {
+      expect(supportsLiveDictation({ ok: true, features, cliVersion })).toBe(
+        true,
+      );
+    }
+  });
+
   it("refuses an engine that does not advertise the feature", () => {
     expect(
       supportsLiveDictation({

--- a/raycast/tests/kesha-bin-status-json.test.ts
+++ b/raycast/tests/kesha-bin-status-json.test.ts
@@ -67,6 +67,27 @@ describe("probeEngineAvailability — structured status (#647)", () => {
     expect(result.cliVersion).toBe("1.29.1");
   });
 
+  it("falls back when the payload's cliVersion is not a string (#947)", async () => {
+    for (const cliVersion of [1.28, null, ["1.28.0"], { major: 1 }]) {
+      const execFile = jsonStdout({
+        cliVersion,
+        engine: {
+          installed: true,
+          path: "/x",
+          capabilities: {
+            protocolVersion: 3,
+            backend: "coreml",
+            features: ["transcribe", "record.live"],
+          },
+        },
+        hint: null,
+      });
+      const result = await probeEngineAvailability(kesha, { execFile });
+      expect(result.ok).toBe(true);
+      expect(supportsLiveDictation(result)).toBe(false);
+    }
+  });
+
   it("reports no features for an engine whose capabilities omit them", async () => {
     const execFile = jsonStdout({
       engine: {

--- a/raycast/tests/kesha-bin-status-json.test.ts
+++ b/raycast/tests/kesha-bin-status-json.test.ts
@@ -38,7 +38,66 @@ describe("probeEngineAvailability — structured status (#647)", () => {
       },
       hint: null,
     });
-    expect(await probeEngineAvailability(kesha, { execFile })).toEqual({ ok: true });
+    expect(await probeEngineAvailability(kesha, { execFile })).toEqual({
+      ok: true,
+      features: ["tts"],
+    });
+  });
+
+  it("reports the engine's feature list so a caller can detect record.live (#947)", async () => {
+    const execFile = jsonStdout({
+      engine: {
+        installed: true,
+        path: "/x",
+        capabilities: {
+          protocolVersion: 3,
+          backend: "coreml",
+          features: ["transcribe", "record.live"],
+        },
+      },
+      hint: null,
+    });
+    const result = await probeEngineAvailability(kesha, { execFile });
+    expect(result.ok).toBe(true);
+    expect(result.features).toContain("record.live");
+  });
+
+  it("reports no features for an engine whose capabilities omit them", async () => {
+    const execFile = jsonStdout({
+      engine: {
+        installed: true,
+        path: "/x",
+        capabilities: { protocolVersion: 3, backend: "onnx" },
+      },
+      hint: null,
+    });
+    const result = await probeEngineAvailability(kesha, { execFile });
+    expect(result.ok).toBe(true);
+    expect(result.features).toEqual([]);
+  });
+
+  it("reports no features when the CLI is too old for status --json", async () => {
+    const result = await probeEngineAvailability(kesha, {
+      execFile: textStdout("Engine:\n  \u2713 Binary: /x\n"),
+    });
+    expect(result.ok).toBe(true);
+    expect(result.features).toBeFalsy();
+  });
+
+  it("ignores a features value that is not an array of strings", async () => {
+    for (const features of ["record.live", ["transcribe", 7], 42, null]) {
+      const execFile = jsonStdout({
+        engine: {
+          installed: true,
+          path: "/x",
+          capabilities: { protocolVersion: 3, backend: "coreml", features },
+        },
+        hint: null,
+      });
+      const result = await probeEngineAvailability(kesha, { execFile });
+      expect(result.ok).toBe(true);
+      expect(result.features).toEqual([]);
+    }
   });
 
   it("takes the hint from the payload when the engine is missing", async () => {

--- a/raycast/tests/process-tasks.test.ts
+++ b/raycast/tests/process-tasks.test.ts
@@ -225,6 +225,53 @@ describe("process task helpers", () => {
     await expect(task.done).resolves.toBe("");
   });
 
+  it("reports the microphone open only once the engine is listening (#947)", async () => {
+    const { spawn, processes } = createSpawnRecorder();
+    const task = startKeshaLiveRecorder(kesha, 30, { spawn });
+    let open = false;
+    void task.micOpen.then(() => {
+      open = true;
+    });
+
+    processes[0].emitStderr(
+      "Preparing streaming ASR (first run compiles models for the ANE, ~20 s)...\n",
+    );
+    await flushPromises();
+    expect(open).toBe(false);
+
+    processes[0].emitStderr("Listening (48000 Hz)... transcript prints when ");
+    await flushPromises();
+    expect(open).toBe(true);
+  });
+
+  it("stops waiting for the microphone when the live session dies first", async () => {
+    const { spawn, processes } = createSpawnRecorder();
+    const task = startKeshaLiveRecorder(kesha, 30, { spawn });
+
+    processes[0].emitStderr("E_UNSUPPORTED_PLATFORM\n");
+    processes[0].exit(1);
+    processes[0].endStdout();
+
+    await expect(task.micOpen).resolves.toBeUndefined();
+    await expect(task.done).rejects.toThrow("E_UNSUPPORTED_PLATFORM");
+  });
+
+  it("releases the microphone at once when a live session is abandoned (#947)", () => {
+    vi.useFakeTimers();
+    const { spawn, processes } = createSpawnRecorder();
+    const kill = vi.fn();
+    const task = startKeshaLiveRecorder(kesha, 30, { spawn, kill });
+
+    task.abort();
+    expect(kill).toHaveBeenCalledWith(processes[0].asChild(), "SIGTERM");
+
+    vi.advanceTimersByTime(2_999);
+    expect(kill).not.toHaveBeenCalledWith(processes[0].asChild(), "SIGKILL");
+    vi.advanceTimersByTime(1);
+    expect(kill).toHaveBeenCalledWith(processes[0].asChild(), "SIGKILL");
+    vi.useRealTimers();
+  });
+
   it("does not signal a live session that is still finalising its transcript", () => {
     vi.useFakeTimers();
     const { spawn, processes } = createSpawnRecorder();

--- a/raycast/tests/process-tasks.test.ts
+++ b/raycast/tests/process-tasks.test.ts
@@ -48,7 +48,7 @@ describe("process task helpers", () => {
 
     stopProcessWithWatchdog(proc.asChild(), { kill });
 
-    expect(proc.stdin.end).toHaveBeenCalledWith("\n");
+    expect(proc.stdin?.end).toHaveBeenCalledWith("\n");
     vi.advanceTimersByTime(1500);
     expect(kill).toHaveBeenCalledWith(proc.asChild(), "SIGTERM");
     vi.advanceTimersByTime(3500);
@@ -120,11 +120,21 @@ describe("process task helpers", () => {
 
     const { command, args, options } = calls[0];
     expect(command).toBe("kesha");
+    // A bun-installed CLI is spawned as `bun <resolved kesha>`: no prefix, no live session.
+    expect(args[0]).toBe("--prefix");
     expect(args).toContain("record");
     expect(args).toContain("--live");
     expect(args).not.toContain("--out");
-    expect(args[args.indexOf("--max-seconds") + 1]).toBe("30");
     expect(options).toMatchObject({ detached: true });
+  });
+
+  it("can still be stopped cooperatively after a live spawn", () => {
+    const { spawn, processes } = createSpawnRecorder();
+    const task = startKeshaLiveRecorder(kesha, 30, { spawn, kill: vi.fn() });
+
+    task.stop();
+
+    expect(processes[0].stdin?.end).toHaveBeenCalledWith("\n");
   });
 
   it("resolves the transcript printed when the live session ends", async () => {
@@ -213,35 +223,93 @@ describe("process task helpers", () => {
     vi.useRealTimers();
   });
 
-  it("finishes a live session that was spawned without a stdout pipe", async () => {
-    const proc = new FakeProcess();
-    proc.stdout = null;
+  it("finishes a live session without a stdout pipe without waiting out the flush window", async () => {
+    vi.useFakeTimers();
+    const proc = new FakeProcess({ stdio: ["pipe", "ignore", "pipe"] });
     const task = startKeshaLiveRecorder(kesha, 30, {
       spawn: () => proc.asChild(),
     });
+    let settled = false;
+    void task.done.then(() => {
+      settled = true;
+    });
 
     proc.exit(0);
+    await flushPromises();
+    await flushPromises();
 
+    // Nothing has advanced the clock, so only the guard can have settled this.
+    expect(settled).toBe(true);
     await expect(task.done).resolves.toBe("");
+    vi.useRealTimers();
+  });
+
+  it("does not bury a live failure under the engine's progress ticker (#947)", async () => {
+    const { spawn, processes } = createSpawnRecorder();
+    const task = startKeshaLiveRecorder(kesha, 300, { spawn });
+
+    processes[0].emitStderr(
+      "Preparing streaming ASR (first run compiles models for the ANE, ~20 s)...\n",
+    );
+    processes[0].emitStderr(
+      "Listening (48000 Hz)... transcript prints when recording stops; Ctrl-C stops and still prints.\n",
+    );
+    for (let second = 1; second <= 300; second++) {
+      processes[0].emitStderr(`\rListening... ${second}s`);
+    }
+    processes[0].emitStderr(
+      "\nerror [E_INTERNAL]: streaming session failed to finish\n",
+    );
+    processes[0].exit(1);
+    processes[0].endStdout();
+
+    const message = await task.done.then(
+      () => "resolved",
+      (err: Error) => err.message,
+    );
+    expect(message).toContain(
+      "error [E_INTERNAL]: streaming session failed to finish",
+    );
+    expect(message).not.toContain("Listening... 42s");
+    expect(message.length).toBeLessThan(400);
+  });
+
+  it("keeps a multi-line live error intact, blank line and hint included", async () => {
+    const { spawn, processes } = createSpawnRecorder();
+    const task = startKeshaLiveRecorder(kesha, 30, { spawn });
+
+    processes[0].emitStderr(
+      "Error: VAD model not installed\n\nPlease run: kesha install --vad\n",
+    );
+    processes[0].exit(1);
+    processes[0].endStdout();
+
+    const message = await task.done.then(
+      () => "resolved",
+      (err: Error) => err.message,
+    );
+    expect(message).toBe(
+      "Error: VAD model not installed\n\nPlease run: kesha install --vad",
+    );
   });
 
   it("reports the microphone open only once the engine is listening (#947)", async () => {
     const { spawn, processes } = createSpawnRecorder();
     const task = startKeshaLiveRecorder(kesha, 30, { spawn });
-    let open = false;
-    void task.micOpen.then(() => {
-      open = true;
+    let opened: string | null = null;
+    void task.micOpen.then((outcome) => {
+      opened = outcome;
     });
 
     processes[0].emitStderr(
       "Preparing streaming ASR (first run compiles models for the ANE, ~20 s)...\n",
     );
     await flushPromises();
-    expect(open).toBe(false);
+    expect(opened).toBeNull();
 
     processes[0].emitStderr("Listening (48000 Hz)... transcript prints when ");
     await flushPromises();
-    expect(open).toBe(true);
+    expect(opened).toBe("listening");
   });
 
   it("stops waiting for the microphone when the live session dies first", async () => {
@@ -252,7 +320,7 @@ describe("process task helpers", () => {
     processes[0].exit(1);
     processes[0].endStdout();
 
-    await expect(task.micOpen).resolves.toBeUndefined();
+    await expect(task.micOpen).resolves.toBe("ended");
     await expect(task.done).rejects.toThrow("E_UNSUPPORTED_PLATFORM");
   });
 
@@ -279,7 +347,7 @@ describe("process task helpers", () => {
     const task = startKeshaLiveRecorder(kesha, 30, { spawn, kill });
 
     task.stop();
-    expect(processes[0].stdin.end).toHaveBeenCalledWith("\n");
+    expect(processes[0].stdin?.end).toHaveBeenCalledWith("\n");
 
     vi.advanceTimersByTime(9_999);
     expect(kill).not.toHaveBeenCalled();

--- a/raycast/tests/process-tasks.test.ts
+++ b/raycast/tests/process-tasks.test.ts
@@ -6,11 +6,6 @@ import {
   startKeshaTranscriber,
   stopProcessWithWatchdog,
 } from "../src/lib/process-tasks";
-import {
-  LIVE_FORCE_KILL_MS,
-  LIVE_STDOUT_FLUSH_MS,
-  LIVE_STOP_GRACE_MS,
-} from "../src/lib/dictation-config";
 import { FakeProcess, createSpawnRecorder } from "./helpers/fake-process";
 import { flushPromises } from "./helpers/async";
 
@@ -175,6 +170,7 @@ describe("process task helpers", () => {
 
     // The engine inherits the CLI's stdout, so it can outlive the wrapper's exit.
     processes[0].exit(0);
+    await flushPromises();
     processes[0].emitStdout("late transcript\n");
     processes[0].endStdout();
 
@@ -189,10 +185,44 @@ describe("process task helpers", () => {
     processes[0].emitStdout("partial\n");
     processes[0].exit(0);
     await flushPromises();
-    vi.advanceTimersByTime(LIVE_STDOUT_FLUSH_MS);
+    vi.advanceTimersByTime(2_000);
 
     await expect(task.done).resolves.toBe("partial\n");
     vi.useRealTimers();
+  });
+
+  it("keeps waiting for a transcript through the flush window", async () => {
+    vi.useFakeTimers();
+    const { spawn, processes } = createSpawnRecorder();
+    const task = startKeshaLiveRecorder(kesha, 30, { spawn });
+    let settled = false;
+    void task.done.then(() => {
+      settled = true;
+    });
+
+    processes[0].exit(0);
+    await flushPromises();
+    vi.advanceTimersByTime(1_999);
+    await flushPromises();
+    expect(settled).toBe(false);
+
+    processes[0].emitStdout("slow transcript\n");
+    processes[0].endStdout();
+
+    await expect(task.done).resolves.toBe("slow transcript\n");
+    vi.useRealTimers();
+  });
+
+  it("finishes a live session that was spawned without a stdout pipe", async () => {
+    const proc = new FakeProcess();
+    proc.stdout = null;
+    const task = startKeshaLiveRecorder(kesha, 30, {
+      spawn: () => proc.asChild(),
+    });
+
+    proc.exit(0);
+
+    await expect(task.done).resolves.toBe("");
   });
 
   it("does not signal a live session that is still finalising its transcript", () => {
@@ -204,13 +234,17 @@ describe("process task helpers", () => {
     task.stop();
     expect(processes[0].stdin.end).toHaveBeenCalledWith("\n");
 
-    vi.advanceTimersByTime(1500);
+    vi.advanceTimersByTime(9_999);
     expect(kill).not.toHaveBeenCalled();
 
-    vi.advanceTimersByTime(LIVE_STOP_GRACE_MS - 1500);
+    vi.advanceTimersByTime(1);
     expect(kill).toHaveBeenCalledWith(processes[0].asChild(), "SIGTERM");
+    expect(kill).not.toHaveBeenCalledWith(processes[0].asChild(), "SIGKILL");
 
-    vi.advanceTimersByTime(LIVE_FORCE_KILL_MS - LIVE_STOP_GRACE_MS);
+    vi.advanceTimersByTime(4_999);
+    expect(kill).not.toHaveBeenCalledWith(processes[0].asChild(), "SIGKILL");
+
+    vi.advanceTimersByTime(1);
     expect(kill).toHaveBeenCalledWith(processes[0].asChild(), "SIGKILL");
     vi.useRealTimers();
   });

--- a/raycast/tests/process-tasks.test.ts
+++ b/raycast/tests/process-tasks.test.ts
@@ -12,6 +12,7 @@ import {
   LIVE_STOP_GRACE_MS,
 } from "../src/lib/dictation-config";
 import { FakeProcess, createSpawnRecorder } from "./helpers/fake-process";
+import { flushPromises } from "./helpers/async";
 
 const TIMEOUT_MS = 90_000;
 
@@ -187,7 +188,8 @@ describe("process task helpers", () => {
 
     processes[0].emitStdout("partial\n");
     processes[0].exit(0);
-    await vi.advanceTimersByTimeAsync(LIVE_STDOUT_FLUSH_MS);
+    await flushPromises();
+    vi.advanceTimersByTime(LIVE_STDOUT_FLUSH_MS);
 
     await expect(task.done).resolves.toBe("partial\n");
     vi.useRealTimers();

--- a/raycast/tests/process-tasks.test.ts
+++ b/raycast/tests/process-tasks.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   capTail,
+  startKeshaLiveRecorder,
   startKeshaRecorder,
   startKeshaTranscriber,
   stopProcessWithWatchdog,
 } from "../src/lib/process-tasks";
+import {
+  LIVE_FORCE_KILL_MS,
+  LIVE_STDOUT_FLUSH_MS,
+  LIVE_STOP_GRACE_MS,
+} from "../src/lib/dictation-config";
 import { FakeProcess, createSpawnRecorder } from "./helpers/fake-process";
 
 const TIMEOUT_MS = 90_000;
@@ -110,5 +116,100 @@ describe("process task helpers", () => {
     processes[0].emitStderr("bad audio");
     processes[0].exit(1);
     await expect(task.done).rejects.toThrow("bad audio");
+  });
+
+  it("asks the CLI to transcribe live and never for a file (#947)", () => {
+    const { spawn, calls } = createSpawnRecorder();
+    startKeshaLiveRecorder(kesha, 30, { spawn });
+
+    const { command, args, options } = calls[0];
+    expect(command).toBe("kesha");
+    expect(args).toContain("record");
+    expect(args).toContain("--live");
+    expect(args).not.toContain("--out");
+    expect(args[args.indexOf("--max-seconds") + 1]).toBe("30");
+    expect(options).toMatchObject({ detached: true });
+  });
+
+  it("resolves the transcript printed when the live session ends", async () => {
+    const { spawn, processes } = createSpawnRecorder();
+    const task = startKeshaLiveRecorder(kesha, 30, { spawn });
+
+    processes[0].emitStdout("hello world\n");
+    processes[0].exit(0);
+    processes[0].endStdout();
+
+    await expect(task.done).resolves.toBe("hello world\n");
+  });
+
+  it("treats a signalled live session that delivered its transcript as a success (#962)", async () => {
+    for (const code of [130, 143]) {
+      const { spawn, processes } = createSpawnRecorder();
+      const task = startKeshaLiveRecorder(kesha, 30, { spawn });
+
+      processes[0].emitStdout("kept text\n");
+      processes[0].exit(code);
+      processes[0].endStdout();
+
+      await expect(task.done).resolves.toBe("kept text\n");
+    }
+  });
+
+  it("surfaces the CLI's stderr on a real failure", async () => {
+    const { spawn, processes } = createSpawnRecorder();
+    const task = startKeshaLiveRecorder(kesha, 30, { spawn });
+
+    processes[0].emitStderr(
+      "E_UNSUPPORTED_PLATFORM: live transcription requires a CoreML engine",
+    );
+    processes[0].exit(1);
+    processes[0].endStdout();
+
+    await expect(task.done).rejects.toThrow("E_UNSUPPORTED_PLATFORM");
+  });
+
+  it("keeps a transcript written after the child exit event", async () => {
+    const { spawn, processes } = createSpawnRecorder();
+    const task = startKeshaLiveRecorder(kesha, 30, { spawn });
+
+    // The engine inherits the CLI's stdout, so it can outlive the wrapper's exit.
+    processes[0].exit(0);
+    processes[0].emitStdout("late transcript\n");
+    processes[0].endStdout();
+
+    await expect(task.done).resolves.toBe("late transcript\n");
+  });
+
+  it("gives up on stdout that never ends", async () => {
+    vi.useFakeTimers();
+    const { spawn, processes } = createSpawnRecorder();
+    const task = startKeshaLiveRecorder(kesha, 30, { spawn });
+
+    processes[0].emitStdout("partial\n");
+    processes[0].exit(0);
+    await vi.advanceTimersByTimeAsync(LIVE_STDOUT_FLUSH_MS);
+
+    await expect(task.done).resolves.toBe("partial\n");
+    vi.useRealTimers();
+  });
+
+  it("does not signal a live session that is still finalising its transcript", () => {
+    vi.useFakeTimers();
+    const { spawn, processes } = createSpawnRecorder();
+    const kill = vi.fn();
+    const task = startKeshaLiveRecorder(kesha, 30, { spawn, kill });
+
+    task.stop();
+    expect(processes[0].stdin.end).toHaveBeenCalledWith("\n");
+
+    vi.advanceTimersByTime(1500);
+    expect(kill).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(LIVE_STOP_GRACE_MS - 1500);
+    expect(kill).toHaveBeenCalledWith(processes[0].asChild(), "SIGTERM");
+
+    vi.advanceTimersByTime(LIVE_FORCE_KILL_MS - LIVE_STOP_GRACE_MS);
+    expect(kill).toHaveBeenCalledWith(processes[0].asChild(), "SIGKILL");
+    vi.useRealTimers();
   });
 });

--- a/raycast/tests/process-tasks.test.ts
+++ b/raycast/tests/process-tasks.test.ts
@@ -274,6 +274,25 @@ describe("process task helpers", () => {
     expect(message.length).toBeLessThan(400);
   });
 
+  it("keeps a CRLF-terminated live error intact", async () => {
+    const { spawn, processes } = createSpawnRecorder();
+    const task = startKeshaLiveRecorder(kesha, 30, { spawn });
+
+    processes[0].emitStderr(
+      "Error: VAD model not installed\r\n\r\nPlease run: kesha install --vad\r\n",
+    );
+    processes[0].exit(1);
+    processes[0].endStdout();
+
+    const message = await task.done.then(
+      () => "resolved",
+      (err: Error) => err.message,
+    );
+    expect(message).toBe(
+      "Error: VAD model not installed\n\nPlease run: kesha install --vad",
+    );
+  });
+
   it("keeps a multi-line live error intact, blank line and hint included", async () => {
     const { spawn, processes } = createSpawnRecorder();
     const task = startKeshaLiveRecorder(kesha, 30, { spawn });


### PR DESCRIPTION
Closes #947

## Claim

A dictation session takes the one-process `kesha record --live` path **if and only if** `kesha status --json` reports both `record.live` among the engine's features **and** a CLI version ≥ 1.28.0, the release that added the flag; every other combination — an ONNX engine, a CLI too old for the flag, a CLI too old to report a feature list at all — still writes a WAV and transcribes it in a second process, unchanged. On the live path the view does not claim to be recording until the engine reports the microphone open — and never at all if the session died first — a dismissal releases the device at once rather than on the finish ladder, and a failure is reported as the engine's own message rather than its progress ticker.

If that is wrong, one of these fires in `raycast/tests/dictation-controller.test.ts`: the clipboard carries `"live text"` where it should carry `"hello world"` (or the reverse) in the four routing tests; `expect(deps.current().status).toBe("starting")` in "does not claim to record while the live engine is still warming up"; `expect(kill).toHaveBeenCalledWith(processes[0].asChild(), "SIGTERM")` immediately after `session.cancel()` in "releases the microphone at once when a live session is dismissed".

## What changed

| | |
|---|---|
| `kesha-bin.ts` | `probeEngineAvailability` returns `features` from `engine.capabilities` and `cliVersion` from the payload. `supportsLiveDictation` weighs both; a value that is not an array of strings degrades to `[]`, an unparseable or absent version fails closed to the fallback. |
| `process-tasks.ts` | `startKeshaLiveRecorder` returns a `LiveRecorderTask`: `micOpen` (resolves on the engine's `Listening (` stderr line, or on the process ending first), `stop` (the 10 s / 15 s finish ladder) and `abort` (SIGTERM now, SIGKILL at 3 s). `stopProcessWithWatchdog` was factored onto a shared `stopWithLadder` so the live one is not a copy. |
| `dictation-controller.ts` | `liveRecordPhase` starts the live task, awaits `micOpen`, then hands it to the shared generic `recordPhase`, so the meter, silence tracker, no-signal warning and cancellation latch are written once. `cancel()` aborts a live recorder instead of stopping it. `normalizeLiveTranscript` carries the permission hint. |
| specs / CHANGELOG / README | Both paths documented, plus the warmup gate, the dismissal ladder and the CLI floor. |

No Rust or `src/` change: the engine and CLI already do everything this needed.

## Review round 1 — every finding, with the mutation re-run

Runner is `npm test` inside `raycast/` per `raycast/CLAUDE.md`; each row was re-run with `bun scripts/mutate.ts` after the fix and reports `PINNED: the mutation was caught`.

| # | finding | fix | re-run |
|---|---|---|---|
| P2 | live path flips to "recording" before the mic is open | `micOpen` gates the UI: `liveRecordPhase` awaits the engine's `Listening (` line before `recordPhase` sets `status: "recording"`, starts the meter or seeds the idle tracker. The preparing view carries no Stop action, so a stop can no longer sit buffered in the pipe through the warmup either. | `await task.micOpen` → `void task.micOpen` **PINNED**; `LIVE_LISTENING_MARKER = "Listening ("` → `"Preparing"` **PINNED** |
| P2 | stdout-flush race completely unpinned | The reviewer's one-line fix: `await flushPromises()` between `exit(0)` and `emitStdout(...)`. Added a second test that the window is actually waited out, so a zero-length window is caught too. | deleting the whole race (`void stdoutEnded; void schedule;`) **PINNED**; `LIVE_STDOUT_FLUSH_MS = 2_000` → `0` **PINNED** |
| P3 | live stop ladder pinned only at ≤ 1500 ms | The test no longer imports the constants it checks; it advances 9 999 ms with no signal, then 1 ms for SIGTERM, then 4 999 / 1 for SIGKILL. | `LIVE_STOP_GRACE_MS = 10_000` → `2_000` **PINNED**; `LIVE_FORCE_KILL_MS = 15_000` → `15_001` **PINNED** |
| P3 | dismissal holds the mic for up to 15 s | `LiveRecorderTask.abort` (`terminateProcessWithWatchdog`) and `cancel()` uses it; `stop` stays the finish ladder. Spec text corrected — the patience is owed to a stop waiting for a transcript, not to a dismissal that discards it. | the `if (liveRecorder) liveRecorder.abort(); else recorder?.stop();` branch → `recorder?.stop()` **PINNED**; `abort` wired to the slow ladder instead **PINNED** |
| P3 | engine feature list used to decide the CLI accepts the flag | `supportsLiveDictation` also requires `cliVersion >= 1.28.0` (`git tag --contains 50511a0` → first `-cli` tag is `v1.28.0-cli`). A prerelease of the same triple counts; anything unparseable fails closed. | `return atLeastVersion(...)` → `return true` **PINNED** |
| P2 | live cancellation not pinned | New test: a dismissed session whose transcript resolves afterwards writes nothing to the clipboard and reaches no `ok` state. | `return cancelled ? { ok: false } : { ok: true, value }` → `{ ok: true, value }` **PINNED** |
| P2 | `!live.ok` guard unpinned | New test: an early Stop on the live path ends on "Recording stopped before any audio was captured." with no "Dictation failed" toast — deleting the guard reaches `normalizeLiveTranscript(undefined)` and reports a TypeError instead. | deleting `if (!live.ok) return;` **PINNED** |
| P3 | stdout-presence guard unpinned | `FakeProcess.stdout` is now nullable; a live session spawned without a stdout pipe still resolves. Deleting the guard throws in the promise executor. | deleting `if (!proc.stdout) { resolve(); return; }` **PINNED** |
| P3 | routing tests are call-count / argv-shape | Rewritten against observable output: each path resolves a different transcript, so the clipboard names the path that ran, alongside the visible state sequence. No `toHaveBeenCalledTimes`, no dep-argument shapes, no "not called" lists. The argv containment test in `process-tasks.test.ts` stays — that seam is where the CLI contract (`--live`, never `--out`) is actually expressed. | n/a — assertion rewrite |

One extra guard fell out of the P2 warmup fix and is pinned too: a dismissal during the warmup no longer spawns the signal meter (`if (cancelled) return { ok: false };` after `micOpen` — **PINNED**).

## Review round 2 — both findings, with the probe re-run

Both were reproduced first as failing tests (`Tests 2 failed | 145 passed`), then fixed; each is now pinned by `bun scripts/mutate.ts`, runner `npm test` inside `raycast/`.

| # | finding | fix | re-run |
|---|---|---|---|
| P2 | an abandoned live failure goes unhandled | `liveRecordPhase` starts the task before the warmup wait, so a cancel or an early stop returns with nothing awaiting `task.done`. One `void task.done.catch(() => {})` at the start marks the promise handled for every abandonment path; the live `await` in `recordPhase` still reports the failure whenever the session is alive. | The reviewer's scenario is now a test — deferred `micOpen`, `session.cancel()`, then `micOpen.resolve()` and `done.reject(...)`, asserting a `process.on("unhandledRejection")` collector stays empty. Deleting the guard **PINNED** (the assertion fires, and vitest reports the unhandled rejection on top). |
| P3 | `parseVersion` reads a version out of a numeric prefix | The regex is anchored at both ends and admits only a semver prerelease or build suffix: `/^v?(\d+)\.(\d+)\.(\d+)(?:[-+][0-9A-Za-z.-]+)?$/`. | The reviewer's direct Bun check re-run against the fixed module: `"1.28.0garbage" -> false`, `"1.28.0.1" -> false`, `"1.28.0 garbage" -> false`, with `"1.28.0" -> true`, `"1.28.0-alpha.1" -> true`, `"1.27.0" -> false`. Reverting the anchor **PINNED**. |

The spec already said an unparseable version "fails closed to the fallback"; before this it was a claim, now it is true. No spec text needed changing.

## Review round 3 — every finding, with the mutation or probe re-run

Runner is `npm test` inside `raycast/`; each mutation was re-run with `bun scripts/mutate.ts` after the fix and reports `PINNED`.

| # | finding | fix | re-run |
|---|---|---|---|
| P2 | the progress ticker buries the real error | The engine repaints `Listening... Ns` in place with `\r` (`rust/src/record.rs:374`). `renderCarriageReturns` keeps only what follows the last `\r` on each line — the faithful terminal rendering — before the tail becomes an error. Nothing else is touched, so a multi-line error keeps its blank line and its hint, which is exactly the `preflightRecordLive` case the finding warned about. | Reviewer's byte stream replayed through the real function (300 ticks + `error [E_INTERNAL]`): the rejection message is now **241 characters**, down from 5,516, ending in the actual error. A second test asserts `Error: VAD model not installed\n\nPlease run: kesha install --vad` survives byte-for-byte. Reverting to `stderr.trim()` **PINNED**. |
| P2 | `...kesha.prefixArgs` unpinned on the live spawn | Took the reviewer's suggested shape — `expect(args[0]).toBe("--prefix")` — rather than re-importing the whole-array form the #161 audit retired. | Removing `...kesha.prefixArgs,` from the live argv **PINNED**. |
| P3 | `stdio[0]: "pipe"` unpinned | `FakeProcess` now honours the `stdio` option: an fd spawned as `"ignore"` is absent on the fake, as it is on a real child. A new test asserts the cooperative stop reaches a live child's stdin. | `["pipe","pipe","pipe"]` → `["ignore","pipe","pipe"]` on the live spawn **PINNED**. |
| P3 | the no-stdout guard survives shape-preserving neutralisation | The test now runs on fake timers and asserts `done` settles with the clock untouched, so the 2 s flush window cannot carry it. | `if (!proc.stdout) { resolve(); return; }` → `if (!proc.stdout) { return; }` **PINNED** (deletion stays pinned too). |
| P3 | a live process that died before opening the mic still drove the recording view | `micOpen` now resolves `"listening"` or `"ended"` instead of `void`, and `liveRecordPhase` awaits `task.done` on `"ended"` — so the engine's own failure is reported and nothing is swallowed, which is the trap the finding named. | Replacing the `"ended"` branch with `void opened;` **PINNED**: the new test asserts states `["error"]`, no meter, no Recording toast, and `E_UNSUPPORTED_PLATFORM` as the message. |
| P2 | a live transcript can be copied after dismissal | `deliverTranscript` checks cancellation on both sides of the copy. The pre-copy check is reachable through the new `"ended"` branch, whose `await task.done` is a real suspension point; the post-copy check stops a mid-copy dismissal flipping the view to `ok` and toasting success. | Both halves **PINNED** — deleting the entry check fires "copies nothing when a dismissal lands before a late live transcript"; deleting the post-copy check fires "does not claim success for a live transcript copied as the view is dismissed". |
| P2 | the non-string `cliVersion` guard is unpinned | New probe test: a payload whose `cliVersion` is `1.28`, `null`, an array or an object routes to the fallback instead of reaching `parseVersion`. | Replacing the `typeof` guard with a cast **PINNED**. |
| P3 | argv adjacency test for `--max-seconds` | Assertion removed. What stays in that test is the `--live`-never-`--out` contract and `args[0]`, which the P2 finding above requires. | n/a — assertion removed |

Spec follow-through: the "Engine errors reach Maks unedited" requirement now says precisely what "unedited" means for a live session's repainted progress line, and two scenarios were added — a failure after minutes of ticker output, and a failure before the microphone opens.

## Review round 4 — one fix, one reasoned refusal

| # | finding | outcome | re-run |
|---|---|---|---|
| P3 | `renderCarriageReturns` drops CRLF-terminated lines | Fixed. A `\r` that only terminates a line is part of the line ending, not an overwrite. | Your probe re-run: `"Error: VAD model not installed\r\n\r\nPlease run: kesha install --vad\r\n"` now surfaces as `Error: VAD model not installed\n\nPlease run: kesha install --vad`, where it previously produced `kesha record --live exited with code 1`. Reverting the strip **PINNED**. |
| P2 | a live transcript can still be copied after dismissal | **Not fixed — deliberate.** Argument below; behaviour is now pinned and specified rather than incidental. | Your reproduction re-run verbatim (delayed `copyToClipboard`, `session.cancel()` after delivery began, then release): `copied: ["raced text"]`, `states: ["recording"]`. |

### Why the clipboard write stays

I reproduced it and it is real: with the copy already in flight, the write lands. It is also not removable. `deps.copyToClipboard` is `Clipboard.copy` — an effect handed to the OS. Once the call has been made there is nothing to check `cancelled` *before*; no arrangement of guards in the controller can un-request a write that has already been requested. The only reachable window is between the cancellation check and the call, and that window is closed: `if (cancelled) return;` sits immediately before `await deps.copyToClipboard(...)` with no suspension point in between, and both halves of that guard are mutation-pinned.

So the question is not "can we prevent it" but "should we want to". Two candidate outcomes when a dismissal lands mid-write:

- **A (today):** the transcript reaches the clipboard; no success toast, no `ok` state, no view update.
- **B (what the finding asks):** the write is somehow abandoned, and a finished transcript of the user's own dictation is silently destroyed because the window closed a few milliseconds into the copy.

A is the better outcome and the one consistent with this repo: #944's whole thrust is that captured audio and finished transcripts are never lost to an incidental failure, and the extension's normal success path is copy-then-close — the window closing around a completed copy is the *ordinary* case, not an anomaly. B would make Raycast's own dismissal timing a data-loss mechanism.

What the dismissal must suppress is the *interface*, and it does: no toast, no state write, nothing to see after the window is gone. That is the half the spec requirement ("no further view update is attempted") actually protects.

The behaviour is no longer incidental. `keeps a transcript whose copy was already in flight when the view was dismissed` asserts both halves — `copied === ["live text"]` and no `ok` state, no `Copied transcript` toast — and `openspec/specs/raycast-extension/spec.md` now carries the scenario next to the dismissed-while-transcribing one, so the two are told apart on purpose rather than by accident.

## Three of the ticket's premises were stale

1. **`--live` is released.** `git tag --contains 50511a0` lists `v1.24.10`, `v1.24.11`, `v1.28.0-cli`, `v1.29.0-cli`, `v1.29.1-cli`; `package.json#keshaEngine.version` is `1.24.11`; `tests/fixtures/capabilities/darwin-arm64.json:11` — recorded from the published binary — lists `record.live`. Adoption was never blocked. The fallback is still required for the ticket's *second* reason: ONNX never advertises it, and older CLIs are in the wild.
2. **`openspec/specs/audio-recording/spec.md` was already synced** by `ca95215` (#960); line 16 no longer says live streaming is unsupported. Only the Open Issues bullet claiming `--live` is unreleased was still false, and this PR corrects it.
3. **#943 is closed and fixed.** `normalizeTranscribeResult` is already the single empty-transcript guard. What survived from the ticket is the real requirement: the *live* path needs its own message, because there is no WAV for `isSilentWav` to inspect.

## The finding that shaped the process handling

`src/process-tree.ts` installs `process.on("SIGTERM", …)`, which kills the engine tree and schedules `scheduleForceKill` at `FORCE_KILL_GRACE_MS = 1_000`. The fallback recorder's `stopProcessWithWatchdog` SIGTERMs 1500 ms after the cooperative stop. On the live path the transcript is produced **after** the stop, so today's ladder would give a streaming session ~2.5 s before the transcript it exists to deliver is destroyed. Hence `LIVE_STOP_GRACE_MS = 10_000` / `LIVE_FORCE_KILL_MS = 15_000`, and a settle on stdout *end* rather than on child exit (the engine writes to the CLI's inherited stdout and can outlive it), capped at `LIVE_STDOUT_FLUSH_MS = 2_000`. That patience applies to a stop only; a dismissal takes `abort`.

Exit 130/143 are successes on this path: `rust/src/cli/record.rs:76-80` prints the transcript and then exits `128 + signal`, which `src/engine.ts:521` already encodes as `SIGNALLED_LIVE_EXIT_CODES`.

## Deviation from the approved plan — flagged, not silent

The plan's **R2** asked the spec to state that an interrupted live session "yields no transcript and no artifact". The second half is no longer true: #962 landed a recovery WAV — `record_default_input_live` opens a spill under the Kesha cache (`open_recovery_spill`) and `settle_recovery_spill` **keeps** it whenever the session did not end normally. R2's actual decision is unaffected and is implemented as approved (no clipboard write after dismissal, no artifact the *extension* owns or names), but the spec sentence now says that truthfully and points at the Engine's own recovery audio instead of denying it exists.

Same file, adjacent bullet: `openspec/specs/audio-recording/spec.md` still lists "An interrupted `--live` session yields nothing … Tracked as #962" under Open Issues, which the same code contradicts. Out of this plan's stated scope (which named only lines 288–292), so left alone — worth its own cleanup.

## Rulings carried from the plan

- ~~**Detection is the engine's `record.live` flag alone, no CLI version gate.**~~ **Reversed by review round 1.** The plan's reasoning was that a mismatch exits 2 before any audio, so nothing is lost. That is true of the audio and false of the session: the user gets `kesha record requires --out <path> (or --live).` as a dictation failure instead of a working recording, in a configuration (`KESHA_ENGINE_BIN`, a hand-placed engine, a CLI downgrade after `kesha install`) the extension can detect from the same payload it already reads. The gate is now `record.live` **and** `cliVersion >= 1.28.0`.
- **Dismissing mid-live-session yields no clipboard write.** The alternative contradicts a standing spec requirement ("Maks closes the command while transcribing … no clipboard write happens").
- **`--auto-stop` stays out.** The extension has its own meter-driven idle stop; which stop wins is a separate ticket.
- **argv assertions test containment, not order** (CLAUDE.md retires argv-order tests as structure-sensitive): the contract is "asks for `--live`, never for `--out`", plus the `--max-seconds` value pairing.

## Verification

`npm --prefix raycast test` — 155 passed (9 files), up from 154 after round 3, 144 after round 1, 113 before this branch. `npm --prefix raycast run lint` (`ray lint`, incl. `tsc --noEmit`) clean. `bun run check:specs` — 17 passed. `just preflight` green (1837 tests: 1831 pass / 6 skip / 0 fail; Rust gate skipped, no `rust/` changes).

Guards from the first round, still proven by `just mutate`:

| mutation | assertion that fires |
|---|---|
| `readFeatures(capabilities)` → `[]` | `expect(result.features).toContain("record.live")` |
| `130, 143` → `0` | exit-143 test expecting a resolve, not a reject |
| the live permission message → `"No speech."` | `toContain("Microphone permission")` |

## Open question for the operator

`LIVE_STOP_GRACE_MS = 10_000` is derived from the CLI's 1 s force-kill grace plus headroom for streaming-ASR finalisation, not from a measurement on real hardware. If you have a number from actually using `kesha record --live`, it beats this estimate.

## State (auto)

Machine-maintained by the driver on every head move — sessions and reviewers leave this section alone.

- head: `523288196bc6490563a2d0f372289b6be3bd60d2`
- files (13):
  - `openspec/specs/audio-recording/spec.md`
  - `openspec/specs/raycast-extension/spec.md`
  - `raycast/CHANGELOG.md`
  - `raycast/README.md`
  - `raycast/src/lib/dictation-config.ts`
  - `raycast/src/lib/dictation-controller.ts`
  - `raycast/src/lib/dictation-types.ts`
  - `raycast/src/lib/kesha-bin.ts`
  - `raycast/src/lib/process-tasks.ts`
  - `raycast/tests/dictation-controller.test.ts`
  - `raycast/tests/helpers/fake-process.ts`
  - `raycast/tests/kesha-bin-status-json.test.ts`
  - `raycast/tests/process-tasks.test.ts`

## Review round 5 — 2026-09-19, on current main

The branch was merged with `origin/main` (`460d496e`, zero conflicts; 51 commits behind, including the protocol-4-only engine of #1181). The three premises the live path rests on were re-proven with real runs against an installed CoreML engine and CLI 1.31.0, not re-read: `Listening (48000 Hz)…` still reaches a piped stderr verbatim; SIGINT/SIGTERM exit 130/143 with the transcript on stdout and the stdin-EOF stop exits 0; `kesha status --json` carries `cliVersion` and `engine.capabilities.features` with `record.live`. No code change was needed.

Adversarial review by Codex against the rubric in `code-review-and-quality`, aimed at five claims (routing, live-path behaviour, fallback unchanged, hints and specs, process hygiene): claims 1, 2, 3, 5 hold; 155 tests, `check:specs` 18/18; five guards from the tables above re-run with `just mutate`, all PINNED (`record.live`→`record.nope`, marker→`Preparing`, fallback SIGTERM 1500→1501 ms, permission wording, dismissal `abort()`→`stop()`). One Required finding, parked with a ruling: the reviewer's brief overstated the ticket's acceptance as "an empty transcript gives the permission hint on both paths"; the ticket says a *silent recording* does, and it does — the fallback's non-silent-but-empty case keeps its own "No speech was detected" message by design (ticket R6, #943; pinned at `dictation-controller.test.ts:1150`). Code unchanged.

Gates on head `460d496e092f1df8c943fcf44f35caf2e955632b`: CI, Rust Tests, Security Audit and Plugin Security Scan green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015cQj6UXYBCr3Pp9nkfUr8X
