### PR TITLE
chore(claude): drop MultiEdit matcher, anchor hook paths, make cargo fmt hook worktree-aware

### DIFF
--- a/.claude/hooks/auto-fmt-rust.sh
+++ b/.claude/hooks/auto-fmt-rust.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# PostToolUse hook: auto-format Rust files after Edit/Write/MultiEdit.
+# PostToolUse hook: auto-format Rust files after Edit/Write.
 #
 # Why: Implementer subagents have shipped unformatted Rust mid-session, only
 # for clippy --all-targets to fail at the next commit. Catching fmt drift
@@ -28,18 +28,17 @@ case "$FILE" in
         ;;
 esac
 
-# Need a Cargo.toml at rust/ — defensive (skip if invoked outside the repo).
-if [ ! -f "rust/Cargo.toml" ]; then
+# Resolve the checkout from the edited file: the hook's cwd is the session root, which is the wrong tree when the edit lands in .worktrees/<slug>.
+ROOT="$(cd "$(dirname "$FILE")" 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -z "$ROOT" ] || [ ! -f "$ROOT/rust/Cargo.toml" ]; then
     exit 0
 fi
 
-# Fast path: clean.
-if (cd rust && cargo fmt --check >/dev/null 2>&1); then
+if (cd "$ROOT/rust" && cargo fmt --check >/dev/null 2>&1); then
     exit 0
 fi
 
-# Dirty: format and report.
-if (cd rust && cargo fmt 2>&1); then
+if (cd "$ROOT/rust" && cargo fmt 2>&1); then
     echo "post-edit hook: cargo fmt auto-formatted rust/ (was dirty)" >&2
     exit 0
 else

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -37,28 +37,28 @@
       "Bash(tail *)",
       "Bash(wc *)",
       "Bash(grep *)",
-      "Bash(just:*)"
+      "Bash(just *)"
     ]
   },
   "hooks": {
     "PostToolUse": [
       {
-        "matcher": "Edit|Write|MultiEdit",
+        "matcher": "Edit|Write",
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/auto-fmt-rust.sh"
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/auto-fmt-rust.sh"
           }
         ]
       }
     ],
     "PreToolUse": [
       {
-        "matcher": "Edit|Write|MultiEdit",
+        "matcher": "Edit|Write",
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/guard-sha-bump.sh"
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/guard-sha-bump.sh"
           }
         ]
       }


### PR DESCRIPTION
## What

Config-only cleanup of the tracked `.claude/` surface, checked against the current Claude Code hooks and permissions docs:

- `MultiEdit` dropped from both hook matchers — the tool no longer exists, so the entry was dead.
- Hook commands anchored with `"$CLAUDE_PROJECT_DIR"/...` instead of a bare relative path, the form the hooks reference recommends.
- `Bash(just:*)` moved to the documented `Bash(just *)` spelling (the `:*` suffix is still accepted, but it is the legacy form and every other rule in the file already uses the space form).
- `auto-fmt-rust.sh` resolved `rust/` relative to the hook's cwd. Hooks run with cwd = the session root, so an edit landing in `.worktrees/<slug>/rust/...` ran `cargo fmt --check` against the root checkout and reported nothing. The script now derives the checkout from the edited file's path (`git rev-parse --show-toplevel` from its directory).

## Verification

Pipe-tested from the root checkout with a payload naming a file inside `.worktrees/claude-config-hooks`:

```
+ ROOT=/Users/anton/Personal/repos/kesha-voice-kit/.worktrees/claude-config-hooks
+ cargo fmt --check
```

`bash -n` and `shellcheck` clean; `jq -e` confirms the settings JSON parses with the new matchers. No tests added: formatting/config-only change per CLAUDE.md's exception. `just preflight` run in the worktree before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jwx5grwmatzwweEQfjjGx4
