### PR TITLE
chore(release): engine v1.25.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     }
   },
   "keshaEngine": {
-    "version": "1.24.11"
+    "version": "1.25.0-beta.1"
   },
   "scripts": {
     "test": "bun test --timeout 30000",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "kesha-engine"
-version = "1.24.11"
+version = "1.25.0-beta.1"
 dependencies = [
  "anyhow",
  "audioadapter-buffers",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesha-engine"
-version = "1.24.11"
+version = "1.25.0-beta.1"
 edition = "2021"
 description = "Inference engine for Kesha Voice Kit: ASR + language detection"
 # Not for crates.io. The library target (`src/lib.rs`) exists only for the


### PR DESCRIPTION
## Summary

Engine version bump for `v1.25.0-beta.1`, the first beta of the protocol v4 Engine (v2 refactor stage 1, merged in #1156). Engine fields only: `rust/Cargo.toml`, `rust/Cargo.lock`, `package.json#keshaEngine.version`. The CLI line stays at 1.29.1 (`check:versions` rule 2 holds; rule 3 allows a `-beta.N` pin).

`integration-tests-full` and `check-engine-targets` skip on `release/*` by design: the pinned engine has no release until the tag lands right after this merge.

## Claim

With this merge, `main` pins `1.25.0-beta.1` in every place the drift gate reads, and no published-engine-dependent lane runs on this branch. If false, `bun run check:versions` (the `check-versions` job) fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RKSL2xGHE1y3njSG8oymq
