### PR TITLE
chore(deps): fast-uri 3.1.7 in the lockfile (bun audit: 4 high)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -304,7 +304,7 @@
 
     "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
 
-    "fast-uri": ["fast-uri@3.1.5", "", {}, "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="],
+    "fast-uri": ["fast-uri@3.1.7", "", {}, "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg=="],
 
     "fast-wrap-ansi": ["fast-wrap-ansi@0.2.2", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q=="],
 


### PR DESCRIPTION
## Summary

Lockfile-only bump of the transitive `fast-uri` from 3.1.5 to 3.1.7. `bun audit` flagged four high advisories against 3.1.5 (host confusion and SSRF via IDN / IPv6 / percent-decoding normalisation: GHSA-5jgf-p345-68v8, GHSA-f65p-4m7j-42xc, GHSA-fph4-wmhf-6fwf, GHSA-jqff-g426-hqxp). It is reached only through `ajv` under `@modelcontextprotocol/sdk` and `@stryker-mutator/core`; the CLI never hands it user-controlled URIs, so this closes the audit rather than a live exposure.

Found by the `bun-audit` job on the release PR #1157, which is the first PR since the advisories landed to touch `package.json`. One dependency, one change; `bun install --frozen-lockfile` and `bun audit` are clean locally.

## Claim

After this merge `bun audit --audit-level=high` (the `bun-audit` job's command) exits 0 on `main`. If false, that job fires on this PR. Seven moderate and two low advisories remain below the gate (body-parser and friends, all transitive); the weekly scheduled audit tracks them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RKSL2xGHE1y3njSG8oymq
