### PR TITLE
fix(transcribe): every failure on the transcribe path is a coded KeshaError; one gate per caller (stage 2, PR 2)

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -52,7 +52,8 @@ code never needs sanitizing.
   it could report success or by giving up waiting for the lock.
 - The CLI also raises `E_MODEL_MISSING` before spawning when `--speakers` needs a diarization
   or VAD model that `kesha install --diarize` / `--vad` has not placed, and `E_INTERNAL` when the
-  engine's transcription JSON cannot be read; both render exactly like the engine's own.
+  engine's transcription JSON cannot be read or the engine exits non-zero without reporting an
+  error event; both render exactly like the engine's own.
 - **`E_INVALID_ARG`** and **`E_INPUT_NOT_FOUND`** are emitted by *both* the
   engine and the TypeScript CLI: the CLI validates arguments, checks input
   existence up front and refuses a cache path it cannot write the engine into,

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -50,6 +50,9 @@ code never needs sanitizing.
   an installed engine whose protocol version the CLI does not speak, and an
   install that lost the cache to another one, whether by being overwritten before
   it could report success or by giving up waiting for the lock.
+- The CLI also raises `E_MODEL_MISSING` before spawning when `--speakers` needs a diarization
+  or VAD model that `kesha install --diarize` / `--vad` has not placed, and `E_INTERNAL` when the
+  engine's transcription JSON cannot be read; both render exactly like the engine's own.
 - **`E_INVALID_ARG`** and **`E_INPUT_NOT_FOUND`** are emitted by *both* the
   engine and the TypeScript CLI: the CLI validates arguments, checks input
   existence up front and refuses a cache path it cannot write the engine into,

--- a/openspec/changes/protocol-v4/tasks.md
+++ b/openspec/changes/protocol-v4/tasks.md
@@ -1,34 +1,34 @@
 ## 1. Engine schema
 
-- [ ] 1.1 Add `Describe` to `Commands` in `rust/src/main.rs` and `rust/src/protocol/describe.rs` that assembles the document from `CommandFactory::command()` plus a gate table
-- [ ] 1.2 Unit test: the set of flags clap knows equals the set the gate table lists, per subcommand
+- [x] 1.1 Add `Describe` to `Commands` in `rust/src/main.rs` and `rust/src/protocol/describe.rs` that assembles the document from `CommandFactory::command()` plus a gate table
+- [x] 1.2 Unit test: the set of flags clap knows equals the set the gate table lists, per subcommand
 - [ ] 1.3 Fold `errors::error_codes_json` and `capabilities::get_capabilities` into the document; delete the two flags
-- [ ] 1.4 Gate table rows carry `whenUngated` (`reject` by default, `drop` for `--no-expand-abbrev`) and a `gate` that is one feature or an any-of list
+- [x] 1.4 Gate table rows carry `whenUngated` (`reject` by default, `drop` for `--no-expand-abbrev`) and a `gate` that is one feature or an any-of list
 
 ## 2. Event stream
 
-- [ ] 2.1 `rust/src/protocol/events.rs`: `progress`, `warn`, `error`, `debug` emitters writing one JSON object per line to stderr
-- [ ] 2.2 Replace every `eprintln!` in `rust/src` (84 calls, 21 files) with an emitter call; `report` in `errors.rs` emits an `error` event
+- [x] 2.1 `rust/src/protocol/events.rs`: `progress`, `warn`, `error`, `debug` emitters writing one JSON object per line to stderr
+- [x] 2.2 Replace every `eprintln!` in `rust/src` (84 calls, 21 files) with an emitter call; `report` in `errors.rs` emits an `error` event
 - [ ] 2.3 `say --stdin-loop` status lines become events
 - [ ] 2.4 Delete the `KESHA_DEBUG_FD` descriptor path in `rust/src/debug.rs`; debug lines become `debug` events
-- [ ] 2.5 v3 renderer + `KESHA_PROTOCOL` window: keep `--capabilities-json`, `--error-codes-json`, the `error [CODE]:` line, the `diarize:` prefix and the `KESHA_DEBUG_FD` sink whenever `KESHA_PROTOCOL` is unset; `KESHA_PROTOCOL=4` selects the event stream, so `tts-e2e`'s v3 CLI keeps working against the source-built Engine
+- [x] 2.5 v3 renderer + `KESHA_PROTOCOL` window: keep `--capabilities-json`, `--error-codes-json`, the `error [CODE]:` line, the `diarize:` prefix and the `KESHA_DEBUG_FD` sink whenever `KESHA_PROTOCOL` is unset; `KESHA_PROTOCOL=4` selects the event stream, so `tts-e2e`'s v3 CLI keeps working against the source-built Engine
 
 ## 3. Direct consumers
 
-- [ ] 3.2 `release-install-smoke.sh` calls `describe`
+- [x] 3.2 `release-install-smoke.sh` calls `describe`
 - [ ] 3.3 Rust tests `error_codes_cli.rs`, `diarize_e2e.rs`, `kokoro_rate_e2e.rs`, `tts_smoke.rs`, `debug_ndjson_fd.rs` assert on events
-- [ ] 3.4 `docs/errors.md` checked two-way against `describe` (`rust/tests/error_codes_docs.rs`), not generated; `docs/nix-install.md` example updated
+- [x] 3.4 `docs/errors.md` checked two-way against `describe` (`rust/tests/error_codes_docs.rs`), not generated; `docs/nix-install.md` example updated
 
 ## 4. Carrier release
 
-- [ ] 4.1 Tag `v1.25.0-beta.1`, un-draft by hand, verify `kesha install --engine-version 1.25.0-beta.1` downloads it
+- [x] 4.1 Tag `v1.25.0-beta.1`, un-draft by hand, verify `kesha install --engine-version 1.25.0-beta.1` downloads it
 - [ ] 4.2 Remove the `KESHA_PROTOCOL` window (delete the v3 renderer, `--capabilities-json`, `--error-codes-json`), cut `v1.25.0-beta.2`
 
 ## 5. CLI (stage 2, tracked here for completeness)
 
 - [x] 5.1 Pin the beta; `src/engine/describe.ts` with cache, version gate and `validateArgv` (files created in stage 2; the `src/engine/` layout is finalised in stage 5)
 - [x] 5.2 `src/engine/events.ts` parser and `KeshaError` carrying `code`, `hint`, `exitCode`, `stderr`; delete `src/error-codes.ts`, `preflight*`, `assert*Supported`, `spawnStdioWithDebugFd` (files created in stage 2; the `src/engine/` layout is finalised in stage 5)
-- [ ] 5.3 One PR per command: transcribe, say, install, record, MCP
+- [ ] 5.3 One PR per command: transcribe, say, install, record, MCP — transcribe: this PR
 - [ ] 5.4 `record-capability-pacts.ts` and `tests/fixtures/capabilities/*.json` record `describe`, moved here from stage 1 because they record the published Engine pin, which switches to `v1.25.0-beta.2` at 4.2
 
 ## 6. Downstream spec sweeps

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -253,16 +253,19 @@ function assertDiarizeModelInstalled(): void {
   const envPath = process.env.KESHA_DIARIZE_MODEL_PATH;
   if (envPath !== undefined) {
     if (existsSync(envPath)) return;
-    throw new Error(
-      `speaker diarization requires a model path\n\nCaused by:\n    KESHA_DIARIZE_MODEL_PATH set but path does not exist: ${envPath}`,
+    throw new KeshaError(
+      "E_MODEL_MISSING",
+      `speaker diarization requires a model path: KESHA_DIARIZE_MODEL_PATH set but path does not exist: ${envPath}`,
+      { hint: `point KESHA_DIARIZE_MODEL_PATH at the model, or unset it and run \`${installHint("--diarize")}\`` },
     );
   }
 
   const modelPath = defaultDiarizeModelPath();
   if (hasDiarizeModelLayout(modelPath)) return;
-  throw new Error(
-    `speaker diarization requires a model path\n\nCaused by:\n    diarization model not found at ${modelPath}. ` +
-      `Run \`${installHint("--diarize")}\` (or set KESHA_DIARIZE_MODEL_PATH).`,
+  throw new KeshaError(
+    "E_MODEL_MISSING",
+    `speaker diarization requires a model path: diarization model not found at ${modelPath}`,
+    { hint: `run \`${installHint("--diarize")}\` (or set KESHA_DIARIZE_MODEL_PATH)` },
   );
 }
 
@@ -270,10 +273,10 @@ function assertDiarizeModelInstalled(): void {
 function assertVadModelInstalled(): void {
   const modelPath = join(keshaCacheDir(), "models", "silero-vad", "silero_vad.onnx");
   if (existsSync(modelPath)) return;
-  throw new Error(
-    "speaker diarization requires the VAD model: --speakers windows the audio with Silero VAD " +
-      `so each speech span can be labeled.\n\nCaused by:\n    VAD model not found at ${modelPath}. ` +
-      `Run \`${installHint("--vad")}\`.`,
+  throw new KeshaError(
+    "E_MODEL_MISSING",
+    `speaker diarization requires the VAD model: --speakers windows the audio with Silero VAD so each speech span can be labeled; VAD model not found at ${modelPath}`,
+    { hint: `run \`${installHint("--vad")}\`` },
   );
 }
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -336,7 +336,7 @@ function parseWordTimings(raw: unknown): WordTiming[] | undefined {
 export function parseTranscriptionOutput(stdout: string): TranscriptionOutput {
   const parsed = JSON.parse(stdout);
   if (typeof parsed?.text !== "string" || !Array.isArray(parsed?.segments)) {
-    throw new Error("Invalid transcription JSON returned by kesha-engine");
+    throw new KeshaError("E_INTERNAL", "Invalid transcription JSON returned by kesha-engine");
   }
 
   const segments = parsed.segments.map((segment: unknown) => {
@@ -346,7 +346,7 @@ export function parseTranscriptionOutput(stdout: string): TranscriptionOutput {
       typeof s.end !== "number" ||
       typeof s.text !== "string"
     ) {
-      throw new Error("Invalid transcription segment returned by kesha-engine");
+      throw new KeshaError("E_INTERNAL", "Invalid transcription segment returned by kesha-engine");
     }
     const out: TranscriptionSegment = { start: s.start, end: s.end, text: s.text };
     if (typeof s.speaker === "number") out.speaker = s.speaker;
@@ -369,7 +369,8 @@ export async function transcribeEngineWithSegments(
   try {
     return parseTranscriptionOutput(run.stdout);
   } catch (err: unknown) {
-    throw new Error(`${errorMessage(err)}: ${run.stdout}`);
+    const message = err instanceof Error ? err.message : String(err);
+    throw new KeshaError("E_INTERNAL", `${message}: ${run.stdout}`);
   }
 }
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -370,7 +370,7 @@ export async function transcribeEngineWithSegments(
     return parseTranscriptionOutput(run.stdout);
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
-    throw new KeshaError("E_INTERNAL", `${message}: ${run.stdout}`);
+    throw new KeshaError(err instanceof KeshaError ? err.code : "E_INTERNAL", `${message}: ${run.stdout}`);
   }
 }
 

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -5,6 +5,7 @@ import {
   type TranscribeOptions,
 } from "./transcribe";
 import { downloadEngine } from "./engine-install";
+import { KeshaError } from "./engine/events";
 
 export type { TranscribeOptions };
 export type { TranscriptionOutput, TranscriptionSegment, WordTiming } from "./engine";
@@ -47,7 +48,7 @@ export async function transcribe(
   options: TranscribeOptions = {},
 ): Promise<string> {
   if (!existsSync(audioPath)) {
-    throw new Error(`File not found: ${audioPath}`);
+    throw new KeshaError("E_INPUT_NOT_FOUND", `File not found: ${audioPath}`);
   }
 
   return internalTranscribe(audioPath, options);
@@ -58,7 +59,7 @@ export async function transcribeWithTimestamps(
   options: TranscribeOptions = {},
 ) {
   if (!existsSync(audioPath)) {
-    throw new Error(`File not found: ${audioPath}`);
+    throw new KeshaError("E_INPUT_NOT_FOUND", `File not found: ${audioPath}`);
   }
 
   return internalTranscribeWithSegments(audioPath, {

--- a/src/transcribe.ts
+++ b/src/transcribe.ts
@@ -1,5 +1,6 @@
 import {
   assertSpeakerModelsInstalled,
+  getDescribe,
   isEngineInstalled,
   transcribeEngine,
   transcribeEngineWithSegments,
@@ -38,13 +39,14 @@ export async function transcribe(audioPath: string, opts: TranscribeOptions = {}
   return (await transcribeWithSegments(audioPath, opts)).text;
 }
 
-/** The CLI's gate before any progress UI: the engine and the model files a request needs; argv is checked at the spawn. */
+/** The CLI's gate before any progress UI: the engine, its describe document, and the model files a request needs; argv is checked at the spawn. */
 export async function validateTranscribeRequest(opts: TranscribeOptions = {}): Promise<void> {
   if (!isEngineInstalled()) {
     throw new KeshaError("E_ENGINE_SPAWN", "No transcription backend is installed", {
       hint: `bun add -g @drakulavich/kesha-voice-kit, then ${installHint()}`,
     });
   }
+  await getDescribe();
   if (opts.speakers) assertSpeakerModelsInstalled();
 }
 

--- a/src/transcribe.ts
+++ b/src/transcribe.ts
@@ -1,5 +1,6 @@
 import {
   assertSpeakerModelsInstalled,
+  buildTranscribeArgs,
   getDescribe,
   isEngineInstalled,
   transcribeEngine,
@@ -7,6 +8,7 @@ import {
   type TranscriptionOutput,
   type VadMode,
 } from "./engine";
+import { validateArgv } from "./engine/describe";
 import { KeshaError } from "./engine/events";
 import { installHint } from "./install-hint";
 
@@ -39,14 +41,21 @@ export async function transcribe(audioPath: string, opts: TranscribeOptions = {}
   return (await transcribeWithSegments(audioPath, opts)).text;
 }
 
-/** The CLI's gate before any progress UI: the engine, its describe document, and the model files a request needs; argv is checked at the spawn. */
+/** The CLI's gate before any progress UI: the engine, its describe document, the request's flags, and the model files a request needs; the argv actually sent is validated again at the spawn. */
 export async function validateTranscribeRequest(opts: TranscribeOptions = {}): Promise<void> {
   if (!isEngineInstalled()) {
     throw new KeshaError("E_ENGINE_SPAWN", "No transcription backend is installed", {
       hint: `bun add -g @drakulavich/kesha-voice-kit, then ${installHint()}`,
     });
   }
-  await getDescribe();
+  validateArgv(
+    buildTranscribeArgs(
+      "<input>",
+      { vad: opts.vad, speakers: opts.speakers, itn: opts.itn },
+      Boolean(opts.timestamps || opts.speakers),
+    ),
+    await getDescribe(),
+  );
   if (opts.speakers) assertSpeakerModelsInstalled();
 }
 

--- a/src/transcribe.ts
+++ b/src/transcribe.ts
@@ -1,14 +1,12 @@
 import {
   assertSpeakerModelsInstalled,
-  buildTranscribeArgs,
-  getDescribe,
   isEngineInstalled,
   transcribeEngine,
   transcribeEngineWithSegments,
   type TranscriptionOutput,
   type VadMode,
 } from "./engine";
-import { validateArgv } from "./engine/describe";
+import { KeshaError } from "./engine/events";
 import { installHint } from "./install-hint";
 
 export type { VadMode };
@@ -40,19 +38,13 @@ export async function transcribe(audioPath: string, opts: TranscribeOptions = {}
   return (await transcribeWithSegments(audioPath, opts)).text;
 }
 
-/** Refuses a request the installed engine cannot serve, before any progress UI or spawn. */
+/** The CLI's gate before any progress UI: the engine and the model files a request needs; argv is checked at the spawn. */
 export async function validateTranscribeRequest(opts: TranscribeOptions = {}): Promise<void> {
   if (!isEngineInstalled()) {
-    throw new Error(
-      "Error: No transcription backend is installed.\n\n" +
-        "Run the following to get started:\n\n" +
-        "    bun add -g @drakulavich/kesha-voice-kit\n" +
-        `    ${installHint()}`,
-    );
+    throw new KeshaError("E_ENGINE_SPAWN", "No transcription backend is installed", {
+      hint: `bun add -g @drakulavich/kesha-voice-kit, then ${installHint()}`,
+    });
   }
-  const json = Boolean(opts.timestamps || opts.speakers);
-  const engineOpts = { vad: opts.vad, speakers: opts.speakers, itn: opts.itn };
-  validateArgv(buildTranscribeArgs("<input>", engineOpts, json), await getDescribe());
   if (opts.speakers) assertSpeakerModelsInstalled();
 }
 
@@ -60,8 +52,6 @@ export async function transcribeWithSegments(
   audioPath: string,
   opts: TranscribeOptions = {},
 ): Promise<TranscriptionOutput> {
-  await validateTranscribeRequest(opts);
-
   if (opts.timestamps || opts.speakers) {
     return transcribeEngineWithSegments(audioPath, {
       vad: opts.vad,

--- a/tests/integration/cli-contracts.test.ts
+++ b/tests/integration/cli-contracts.test.ts
@@ -906,7 +906,11 @@ describe("CLI contracts", () => {
     const missingDiarize = await runCli([mediaPath, "--json", "--speakers"], { env: missingDiarizeEnv });
     expectContract(missingDiarize, {
       exitCode: 1,
-      stderrContains: ["diarization model not found"],
+      stderrContains: [
+        "error [E_MODEL_MISSING]: ",
+        "diarization model not found",
+        "hint: run `kesha install --diarize`",
+      ],
       stderrNotContains: ["Transcribing", "Transcribed"],
       stdoutNotContains: ["Привет с воркшопа"],
     });

--- a/tests/integration/cli-contracts.test.ts
+++ b/tests/integration/cli-contracts.test.ts
@@ -606,6 +606,7 @@ describe("CLI contracts", () => {
     expectContract(res, {
       exitCode: 1,
       stderrContains: ["error [E_ENGINE_PROTOCOL]: ", "hint: run `kesha install`"],
+      stderrNotContains: ["Transcribing"],
     });
     const parsed = JSON.parse(res.stdout);
     expect(parsed.errors[0]).toMatchObject({ file: mediaPath, code: "E_ENGINE_PROTOCOL" });

--- a/tests/integration/cli-contracts.test.ts
+++ b/tests/integration/cli-contracts.test.ts
@@ -581,6 +581,36 @@ describe("CLI contracts", () => {
     ]);
   });
 
+  test("transcribe with no engine installed exits 1 with E_ENGINE_SPAWN and the install hint", async () => {
+    const dir = makeTempDir("kesha-cli-contract-no-engine-");
+    const mediaPath = join(dir, "meeting.ogg");
+    writeFileSync(mediaPath, "fake media");
+    const env = { ...isolatedEnv(dir), KESHA_ENGINE_BIN: join(dir, "absent-kesha-engine") };
+    const res = await runCli([mediaPath], { env });
+    expectContract(res, {
+      exitCode: 1,
+      stderrContains: [`${mediaPath}: error [E_ENGINE_SPAWN]: No transcription backend is installed`, "hint: bun add -g @drakulavich/kesha-voice-kit"],
+      stderrNotContains: ["Transcribing", "npm i"],
+    });
+  });
+
+  test("transcribe against a protocol-3 engine exits 1 with E_ENGINE_PROTOCOL pointing at kesha install", async () => {
+    if (process.platform === "win32") return;
+    const dir = makeTempDir("kesha-cli-contract-stale-engine-");
+    const enginePath = join(dir, "kesha-engine");
+    writeFileSync(enginePath, "#!/bin/sh\necho 'error: unrecognized subcommand describe' >&2\nexit 2\n");
+    chmodSync(enginePath, 0o755);
+    const mediaPath = join(dir, "meeting.ogg");
+    writeFileSync(mediaPath, "fake media");
+    const res = await runCli([mediaPath, "--json", "--include-errors"], { env: { ...isolatedEnv(dir), KESHA_ENGINE_BIN: enginePath } });
+    expectContract(res, {
+      exitCode: 1,
+      stderrContains: ["error [E_ENGINE_PROTOCOL]: ", "hint: run `kesha install`"],
+    });
+    const parsed = JSON.parse(res.stdout);
+    expect(parsed.errors[0]).toMatchObject({ file: mediaPath, code: "E_ENGINE_PROTOCOL" });
+  });
+
   test("kesha record without an installed engine fails with an install hint, not a stack trace", async () => {
     const dir = makeTempDir("kesha-cli-contract-record-");
     const outPath = join(dir, "hello.wav");

--- a/tests/integration/cli-contracts.test.ts
+++ b/tests/integration/cli-contracts.test.ts
@@ -612,6 +612,25 @@ describe("CLI contracts", () => {
     expect(parsed.errors[0]).toMatchObject({ file: mediaPath, code: "E_ENGINE_PROTOCOL" });
   });
 
+  test("transcribe with a flag the build lacks exits 1 with E_INVALID_ARG before any progress line", async () => {
+    if (process.platform === "win32") return;
+    const dir = makeTempDir("kesha-cli-contract-flag-gate-");
+    const enginePath = join(dir, "kesha-engine");
+    writeFileSync(
+      enginePath,
+      `#!/bin/sh\nif [ "$1" = "describe" ]; then\n  printf '%s\\n' '${describeJson({ features: ["transcribe", "transcribe.segments"] })}'\n  exit 0\nfi\nexit 2\n`,
+    );
+    chmodSync(enginePath, 0o755);
+    const mediaPath = join(dir, "meeting.ogg");
+    writeFileSync(mediaPath, "fake media");
+    const res = await runCli([mediaPath, "--itn"], { env: { ...isolatedEnv(dir), KESHA_ENGINE_BIN: enginePath } });
+    expectContract(res, {
+      exitCode: 1,
+      stderrContains: ["error [E_INVALID_ARG]: ", "--itn"],
+      stderrNotContains: ["Transcribing"],
+    });
+  });
+
   test("kesha record without an installed engine fails with an install hint, not a stack trace", async () => {
     const dir = makeTempDir("kesha-cli-contract-record-");
     const outPath = join(dir, "hello.wav");

--- a/tests/unit/engine.test.ts
+++ b/tests/unit/engine.test.ts
@@ -259,12 +259,13 @@ describe("engine", () => {
     });
   });
 
-  fakeEngineTest("validateTranscribeRequest leaves argv validation to the engine layer", async () => {
-    // A build without diarization: the request is accepted here, refused at the spawn.
+  fakeEngineTest("validateTranscribeRequest refuses a flag the build lacks before any spawn", async () => {
     await withEngineEnv(fakeEngine(["transcribe", "transcribe.segments"]), async () => {
-      await expect(validateTranscribeRequest({ speakers: false, itn: true })).resolves.toBeUndefined();
-      const err = await failure(() => transcribeEngineWithSegments("audio.wav", { itn: true }));
+      const err = await failure(() => validateTranscribeRequest({ itn: true }));
       expect(err.code).toBe("E_INVALID_ARG");
+      expect(err.message).toContain("--itn");
+      const engineErr = await failure(() => transcribeEngineWithSegments("audio.wav", { itn: true }));
+      expect(engineErr.code).toBe("E_INVALID_ARG");
     });
   });
 

--- a/tests/unit/engine.test.ts
+++ b/tests/unit/engine.test.ts
@@ -761,7 +761,7 @@ describe("the engine boundary refuses to pass a malformed reply through", () => 
       await withEngineEnv(transcribingEngine(payload), async () => {
         const err = await failure(() => transcribeEngineWithSegments("audio.wav"));
         expect(err.code).toBe("E_INTERNAL");
-        expect(errorMessage(err)).toMatch(/^error \[E_INTERNAL\]: Invalid transcription JSON returned by kesha-engine/);
+        expect(errorMessage(err)).toBe(`error [E_INTERNAL]: Invalid transcription JSON returned by kesha-engine: ${payload}`);
       });
     });
   }
@@ -775,7 +775,7 @@ describe("the engine boundary refuses to pass a malformed reply through", () => 
       await withEngineEnv(transcribingEngine(payload), async () => {
         const err = await failure(() => transcribeEngineWithSegments("audio.wav"));
         expect(err.code).toBe("E_INTERNAL");
-        expect(errorMessage(err)).toMatch(/^error \[E_INTERNAL\]: Invalid transcription segment returned by kesha-engine/);
+        expect(errorMessage(err)).toBe(`error [E_INTERNAL]: Invalid transcription segment returned by kesha-engine: ${payload}`);
       });
     });
   }

--- a/tests/unit/engine.test.ts
+++ b/tests/unit/engine.test.ts
@@ -759,9 +759,9 @@ describe("the engine boundary refuses to pass a malformed reply through", () => 
   ] as const) {
     fakeEngineTest(`${shape} is rejected, with the payload named`, async () => {
       await withEngineEnv(transcribingEngine(payload), async () => {
-        await expect(transcribeEngineWithSegments("audio.wav")).rejects.toThrow(
-          `Invalid transcription JSON returned by kesha-engine: ${payload}`,
-        );
+        const err = await failure(() => transcribeEngineWithSegments("audio.wav"));
+        expect(err.code).toBe("E_INTERNAL");
+        expect(errorMessage(err)).toMatch(/^error \[E_INTERNAL\]: Invalid transcription JSON returned by kesha-engine/);
       });
     });
   }
@@ -773,9 +773,9 @@ describe("the engine boundary refuses to pass a malformed reply through", () => 
   ] as const) {
     fakeEngineTest(`a segment whose ${field} has the wrong type is rejected`, async () => {
       await withEngineEnv(transcribingEngine(payload), async () => {
-        await expect(transcribeEngineWithSegments("audio.wav")).rejects.toThrow(
-          "Invalid transcription segment returned by kesha-engine",
-        );
+        const err = await failure(() => transcribeEngineWithSegments("audio.wav"));
+        expect(err.code).toBe("E_INTERNAL");
+        expect(errorMessage(err)).toMatch(/^error \[E_INTERNAL\]: Invalid transcription segment returned by kesha-engine/);
       });
     });
   }

--- a/tests/unit/engine.test.ts
+++ b/tests/unit/engine.test.ts
@@ -11,6 +11,7 @@ import {
   getEngineBinPath,
   getEngineCapabilities,
   parseLangResult,
+  parseTranscriptionOutput,
   recordEngine,
   spawnEngineProcess,
   textLangFailureWarning,
@@ -810,6 +811,18 @@ describe("the engine boundary refuses to pass a malformed reply through", () => 
         segments: [{ start: 0, end: 1.5, text: "ok", speaker: 2 }],
       });
     });
+  });
+
+  // Pinned by inspection only: transcribeEngineWithSegments's catch forwards this code rather than hardcoding it.
+  test("parseTranscriptionOutput throws a KeshaError with code E_INTERNAL on a malformed reply", () => {
+    let thrown: unknown;
+    try {
+      parseTranscriptionOutput('{"text":1,"segments":[]}');
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(KeshaError);
+    expect((thrown as KeshaError).code).toBe("E_INTERNAL");
   });
 
   // #647: a non-null return means "it described itself" — callers reach straight for .features.

--- a/tests/unit/engine.test.ts
+++ b/tests/unit/engine.test.ts
@@ -335,9 +335,10 @@ describe("engine", () => {
     await withEngineEnv(
       fakeEngine(["transcribe.segments", "transcribe.diarize"]),
       async () => {
-        await expect(transcribeEngineWithSegments("audio.wav", { speakers: true })).rejects.toThrow(
-          "KESHA_DIARIZE_MODEL_PATH set but path does not exist",
-        );
+        const err = await failure(() => transcribeEngineWithSegments("audio.wav", { speakers: true }));
+        expect(err.code).toBe("E_MODEL_MISSING");
+        expect(err.hint).toContain("kesha install --diarize");
+        expect(err.message).toContain("KESHA_DIARIZE_MODEL_PATH set but path does not exist");
       },
       { KESHA_DIARIZE_MODEL_PATH: "/tmp/kesha-missing-diarize-model" },
     );
@@ -349,9 +350,10 @@ describe("engine", () => {
     await withEngineEnv(
       fakeEngine(["transcribe.segments", "transcribe.diarize"]),
       async () => {
-        await expect(transcribeEngineWithSegments("audio.wav", { speakers: true })).rejects.toThrow(
-          "speaker diarization requires the VAD model",
-        );
+        const err = await failure(() => transcribeEngineWithSegments("audio.wav", { speakers: true }));
+        expect(err.code).toBe("E_MODEL_MISSING");
+        expect(err.hint).toContain("kesha install --vad");
+        expect(err.message).toContain("speaker diarization requires the VAD model");
       },
       {
         KESHA_DIARIZE_MODEL_PATH: modelPath,

--- a/tests/unit/engine.test.ts
+++ b/tests/unit/engine.test.ts
@@ -247,6 +247,18 @@ describe("engine", () => {
     });
   });
 
+  fakeEngineTest("validateTranscribeRequest against an engine that cannot describe itself is E_ENGINE_PROTOCOL", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-engine-old-transcribe-"));
+    const old = join(dir, "kesha-engine");
+    writeFileSync(old, "#!/bin/sh\necho 'error: unrecognized subcommand describe' >&2\nexit 2\n");
+    chmodSync(old, 0o755);
+    await withEngineEnv(old, async () => {
+      const err = await failure(() => validateTranscribeRequest({}));
+      expect(err.code).toBe("E_ENGINE_PROTOCOL");
+      expect(err.hint).toContain("kesha install");
+    });
+  });
+
   fakeEngineTest("validateTranscribeRequest leaves argv validation to the engine layer", async () => {
     // A build without diarization: the request is accepted here, refused at the spawn.
     await withEngineEnv(fakeEngine(["transcribe", "transcribe.segments"]), async () => {

--- a/tests/unit/engine.test.ts
+++ b/tests/unit/engine.test.ts
@@ -11,7 +11,6 @@ import {
   getEngineBinPath,
   getEngineCapabilities,
   parseLangResult,
-  parseTranscriptionOutput,
   recordEngine,
   spawnEngineProcess,
   textLangFailureWarning,
@@ -794,6 +793,14 @@ describe("the engine boundary refuses to pass a malformed reply through", () => 
     });
   }
 
+  fakeEngineTest("a reply that is not JSON at all is rejected, with the payload named", async () => {
+    await withEngineEnv(transcribingEngine("kesha-engine: segfault"), async () => {
+      const err = await failure(() => transcribeEngineWithSegments("audio.wav"));
+      expect(err.code).toBe("E_INTERNAL");
+      expect(errorMessage(err)).toMatch(/^error \[E_INTERNAL\]: .+: kesha-engine: segfault$/);
+    });
+  });
+
   // A speaker label is optional, so a bad one is dropped rather than failing the transcript.
   fakeEngineTest("a non-numeric speaker is dropped instead of forwarded", async () => {
     const payload = '{"text":"ok","segments":[{"start":0,"end":1,"text":"ok","speaker":"alice"}]}';
@@ -811,18 +818,6 @@ describe("the engine boundary refuses to pass a malformed reply through", () => 
         segments: [{ start: 0, end: 1.5, text: "ok", speaker: 2 }],
       });
     });
-  });
-
-  // Pinned by inspection only: transcribeEngineWithSegments's catch forwards this code rather than hardcoding it.
-  test("parseTranscriptionOutput throws a KeshaError with code E_INTERNAL on a malformed reply", () => {
-    let thrown: unknown;
-    try {
-      parseTranscriptionOutput('{"text":1,"segments":[]}');
-    } catch (err) {
-      thrown = err;
-    }
-    expect(thrown).toBeInstanceOf(KeshaError);
-    expect((thrown as KeshaError).code).toBe("E_INTERNAL");
   });
 
   // #647: a non-null return means "it described itself" — callers reach straight for .features.

--- a/tests/unit/engine.test.ts
+++ b/tests/unit/engine.test.ts
@@ -20,7 +20,7 @@ import {
 } from "../../src/engine";
 import { KeshaError } from "../../src/engine/events";
 import { errorMessage } from "../../src/error-utils";
-import { validateTranscribeRequest } from "../../src/transcribe";
+import { transcribeWithSegments, validateTranscribeRequest } from "../../src/transcribe";
 
 /** The thrown KeshaError, so a test can assert on code and hint rather than on prose. */
 async function failure(run: () => Promise<unknown>): Promise<KeshaError> {
@@ -226,13 +226,42 @@ describe("engine", () => {
       for (const run of [
         () => transcribeEngine("audio.wav", { itn: true }),
         () => transcribeEngineWithSegments("audio.wav", { itn: true }),
-        () => validateTranscribeRequest({ itn: true }),
       ]) {
         const err = await failure(run);
         expect(err.code).toBe("E_INVALID_ARG");
         expect(err.message).toContain("--itn");
         expect(err.hint).toContain("bun add -g @drakulavich/kesha-voice-kit@latest");
       }
+    });
+  });
+
+  fakeEngineTest("validateTranscribeRequest with no engine is E_ENGINE_SPAWN naming the install step", async () => {
+    const empty = mkdtempSync(join(tmpdir(), "kesha-engine-absent-"));
+    await withEngineEnv(join(empty, "kesha-engine"), async () => {
+      const err = await failure(() => validateTranscribeRequest({}));
+      expect(err.code).toBe("E_ENGINE_SPAWN");
+      expect(err.message).toContain("No transcription backend is installed");
+      expect(err.hint).toContain("bun add -g @drakulavich/kesha-voice-kit");
+      expect(err.hint).toContain("kesha install");
+      expect(errorMessage(err)).toMatch(/^error \[E_ENGINE_SPAWN\]: No transcription backend is installed\n  hint: /);
+    });
+  });
+
+  fakeEngineTest("validateTranscribeRequest leaves argv validation to the engine layer", async () => {
+    // A build without diarization: the request is accepted here, refused at the spawn.
+    await withEngineEnv(fakeEngine(["transcribe", "transcribe.segments"]), async () => {
+      await expect(validateTranscribeRequest({ speakers: false, itn: true })).resolves.toBeUndefined();
+      const err = await failure(() => transcribeEngineWithSegments("audio.wav", { itn: true }));
+      expect(err.code).toBe("E_INVALID_ARG");
+    });
+  });
+
+  fakeEngineTest("a library call with no engine is E_ENGINE_SPAWN from the engine layer", async () => {
+    const empty = mkdtempSync(join(tmpdir(), "kesha-engine-absent-lib-"));
+    await withEngineEnv(join(empty, "kesha-engine"), async () => {
+      const err = await failure(() => transcribeWithSegments("audio.wav"));
+      expect(err.code).toBe("E_ENGINE_SPAWN");
+      expect(err.hint).toContain("kesha install");
     });
   });
 
@@ -248,7 +277,7 @@ describe("engine", () => {
     await withEngineEnv(
       fakeEngine(["transcribe.segments", "transcribe.diarize"]),
       async () => {
-        const err = await failure(() => validateTranscribeRequest({ speakers: true, vad: "off" }));
+        const err = await failure(() => transcribeEngineWithSegments("audio.wav", { speakers: true, vad: "off" }));
         expect(err.code).toBe("E_INVALID_ARG");
         expect(err.message).toContain("--no-vad");
       },

--- a/tests/unit/lib.test.ts
+++ b/tests/unit/lib.test.ts
@@ -115,7 +115,7 @@ describe("lib API", () => {
   });
 
   // transcribeWithSegments skips the CLI gate, so the refusal comes from the spawn-side validation (#710).
-  fakeEngineIt("preflights itn support on the plain-text path", async () => {
+  fakeEngineIt("refuses itn on the plain-text path when the engine lacks it", async () => {
     await withEngine(fakeEngine(["transcribe.segments"]), async () => {
       await expect(transcribeWithSegments("audio.wav", { itn: true })).rejects.toThrow(
         "--itn needs transcribe.itn",
@@ -123,7 +123,7 @@ describe("lib API", () => {
     });
   });
 
-  fakeEngineIt("preflights itn support alongside timestamps", async () => {
+  fakeEngineIt("refuses itn alongside timestamps when the engine lacks it", async () => {
     await withEngine(fakeEngine(["transcribe.segments"]), async () => {
       await expect(
         transcribeWithSegments("audio.wav", { timestamps: true, itn: true }),

--- a/tests/unit/lib.test.ts
+++ b/tests/unit/lib.test.ts
@@ -114,7 +114,7 @@ describe("lib API", () => {
     });
   });
 
-  // validateTranscribeRequest no longer checks argv, so this fires at the transcribeEngine spawn (#710).
+  // transcribeWithSegments skips the CLI gate, so the refusal comes from the spawn-side validation (#710).
   fakeEngineIt("preflights itn support on the plain-text path", async () => {
     await withEngine(fakeEngine(["transcribe.segments"]), async () => {
       await expect(transcribeWithSegments("audio.wav", { itn: true })).rejects.toThrow(

--- a/tests/unit/lib.test.ts
+++ b/tests/unit/lib.test.ts
@@ -4,11 +4,8 @@ import { tmpdir } from "os";
 import { join } from "path";
 import { transcribe } from "../../src/lib";
 import { writeTranscribingEngine } from "../helpers/fake-engine";
-import {
-  transcribe as transcribeWrapper,
-  transcribeWithSegments,
-  validateTranscribeRequest,
-} from "../../src/transcribe";
+import { transcribeWithSegments, validateTranscribeRequest } from "../../src/transcribe";
+import { KeshaError } from "../../src/engine/events";
 
 function fakeEngine(features: string[]): string {
   return writeTranscribingEngine(
@@ -62,15 +59,15 @@ describe("lib API", () => {
     const saved = process.env.KESHA_ENGINE_BIN;
     process.env.KESHA_ENGINE_BIN = `/tmp/kesha-missing-engine-${Date.now()}`;
     try {
-      let message = "";
+      let hint = "";
       try {
-        await transcribeWrapper("audio.wav");
+        await validateTranscribeRequest({});
       } catch (err) {
-        message = err instanceof Error ? err.message : String(err);
+        hint = err instanceof KeshaError ? (err.hint ?? "") : String(err);
       }
-      expect(message).toContain("bun add -g @drakulavich/kesha-voice-kit");
-      expect(message).toContain("kesha install");
-      expect(message).not.toContain("bunx");
+      expect(hint).toContain("bun add -g @drakulavich/kesha-voice-kit");
+      expect(hint).toContain("kesha install");
+      expect(hint).not.toContain("bunx");
     } finally {
       if (saved === undefined) delete process.env.KESHA_ENGINE_BIN;
       else process.env.KESHA_ENGINE_BIN = saved;
@@ -81,9 +78,15 @@ describe("lib API", () => {
     const saved = process.env.KESHA_ENGINE_BIN;
     try {
       process.env.KESHA_ENGINE_BIN = join(mkdtempSync(join(tmpdir(), "kesha-no-engine-")), "absent");
-      await expect(
-        validateTranscribeRequest({ speakers: true, vad: "off" }),
-      ).rejects.toThrow("No transcription backend is installed");
+      let err: unknown;
+      try {
+        await validateTranscribeRequest({ speakers: true, vad: "off" });
+      } catch (e) {
+        err = e;
+      }
+      expect(err).toBeInstanceOf(KeshaError);
+      expect((err as KeshaError).code).toBe("E_ENGINE_SPAWN");
+      expect((err as KeshaError).hint).toContain("kesha install");
     } finally {
       if (saved === undefined) delete process.env.KESHA_ENGINE_BIN;
       else process.env.KESHA_ENGINE_BIN = saved;
@@ -108,12 +111,10 @@ describe("lib API", () => {
     });
   });
 
-  // The itn gate sits above the `timestamps || speakers` short-circuit, so it
-  // has to fire on the plain-text path too — the one that otherwise reaches the
-  // engine with no preflight at all (#710).
+  // validateTranscribeRequest no longer checks argv, so this fires at the transcribeEngine spawn (#710).
   fakeEngineIt("preflights itn support on the plain-text path", async () => {
     await withEngine(fakeEngine(["transcribe.segments"]), async () => {
-      await expect(validateTranscribeRequest({ itn: true })).rejects.toThrow(
+      await expect(transcribeWithSegments("audio.wav", { itn: true })).rejects.toThrow(
         "--itn needs transcribe.itn",
       );
     });
@@ -122,7 +123,7 @@ describe("lib API", () => {
   fakeEngineIt("preflights itn support alongside timestamps", async () => {
     await withEngine(fakeEngine(["transcribe.segments"]), async () => {
       await expect(
-        validateTranscribeRequest({ timestamps: true, itn: true }),
+        transcribeWithSegments("audio.wav", { timestamps: true, itn: true }),
       ).rejects.toThrow("--itn needs transcribe.itn");
     });
   });

--- a/tests/unit/lib.test.ts
+++ b/tests/unit/lib.test.ts
@@ -34,7 +34,10 @@ async function withEngine<T>(enginePath: string, fn: () => T | Promise<T>): Prom
 
 describe("lib API", () => {
   it("rejects missing file", async () => {
-    await expect(transcribe("/nonexistent/audio.wav")).rejects.toThrow("File not found");
+    const err = await transcribe("/nonexistent/audio.wav").catch((e) => e);
+    expect(err).toBeInstanceOf(KeshaError);
+    expect((err as KeshaError).code).toBe("E_INPUT_NOT_FOUND");
+    expect((err as KeshaError).message).toContain("File not found");
   });
 
   it("keeps transcribeWithSegments as a compatibility alias", async () => {


### PR DESCRIPTION
## Summary

Stage 2 of the v2 contract-first refactor, PR 2 of the per-command series (transcribe): every failure on the transcribe path is a `KeshaError` with a documented code, and a transcribe request is validated in one TS layer per caller.

- `validateTranscribeRequest` (`src/transcribe.ts`) is the CLI's gate before any progress UI: engine installed (`E_ENGINE_SPAWN`, hint `bun add -g @drakulavich/kesha-voice-kit, then kesha install`), engine describes itself (`E_ENGINE_PROTOCOL`), the request's flags are accepted (`E_INVALID_ARG`), the speaker model files exist (`E_MODEL_MISSING`). The spawn validates the argv it actually sends; `transcribeWithSegments` no longer re-validates in between.
- A missing diarization or VAD model (or a `KESHA_DIARIZE_MODEL_PATH` pointing nowhere) is `E_MODEL_MISSING` with the `kesha install --diarize` / `--vad` hint; transcription JSON the CLI cannot read is `E_INTERNAL`. The message substrings scripts may match (`diarization model not found`, `speaker diarization requires the VAD model`, `Invalid transcription JSON returned by kesha-engine`) are unchanged.
- `cli-contracts` pins the rendered lines for a missing engine and a protocol-3 engine (`error [E_ENGINE_PROTOCOL]:` + `kesha install` hint, exit 1, no `Transcribing` line, `code` in the `--json --include-errors` envelope).
- `docs/errors.md` names the CLI-side codes transcribe raises; the openspec ledger ticks the stage-1 tasks that shipped in #1156 / #1157, each verified by a named command.

Exit codes are unchanged. Follows #1159 (stage 2, PR 1). Refs `openspec/changes/protocol-v4` task 5.3 (transcribe).

## Claim

On the `v1.25.0-beta.1` pin, every failure `kesha <file>` can report before or after the engine spawn on the transcribe path carries a code from `docs/errors.md` and renders as `error [CODE]: …` with its hint; no bare `Error` reaches `errorMessage()` from `src/transcribe.ts` or the transcribe functions of `src/engine.ts`; the argv actually sent is validated once, at the spawn, and the CLI's pre-UI gate validates the request's flags against the same cached describe document, so no pre-spawn failure class (`E_ENGINE_SPAWN`, `E_ENGINE_PROTOCOL`, `E_INVALID_ARG`, `E_MODEL_MISSING`) lands after the progress bar.

If the code part is false, `tests/unit/engine.test.ts` (`validateTranscribeRequest with no engine is E_ENGINE_SPAWN …`, the `E_MODEL_MISSING` cases, `Invalid transcription JSON … E_INTERNAL`) or `tests/integration/cli-contracts.test.ts` (`transcribe with no engine installed exits 1 with E_ENGINE_SPAWN …`, `… protocol-3 engine exits 1 with E_ENGINE_PROTOCOL …`) fires. If a pre-spawn failure ever lands after the bar, `tests/integration/cli-contracts.test.ts` (`… E_INVALID_ARG before any progress line`, `… E_ENGINE_PROTOCOL …` with `stderrNotContains: Transcribing`) fires; if the spawn-side validation is dropped, `tests/unit/engine.test.ts::validateTranscribeRequest refuses a flag the build lacks before any spawn` (its engine-layer half) fires.

## Rulings

- Two gates with one document: `validateTranscribeRequest` (CLI, before any progress UI) checks the engine is present, can describe itself, accepts the request's flags, and has the model files; the spawn validates the argv it actually sends. The describe document is cached by path + mtime, so the second check is free. `transcribeWithSegments` no longer re-validates: a library caller with no engine gets `E_ENGINE_SPAWN` from `getDescribe`, which names the path.
- Codes: `E_ENGINE_SPAWN` / `E_MODEL_MISSING` / `E_INTERNAL`; the `origin` discriminant and a shared `exitCodeFor` land in the say PR, where `CODE_EXIT_CODES` lives.
- Message substrings kept verbatim inside the new messages.

## Verification

- `just preflight` green on the head SHA (TS suite 1825 passed / 33 skipped, `tsc`, every `check:*`). No `rust/**` change, so the Rust gate does not run.
- Per-task reviews plus a whole-branch review aimed at the claim; findings and rulings in the PR status comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RKSL2xGHE1y3njSG8oymq
