### PR TITLE
fix(engine): an error event fails a run; kesha record exits with what its failure means

### DIFF
--- a/openspec/changes/protocol-v4/tasks.md
+++ b/openspec/changes/protocol-v4/tasks.md
@@ -28,7 +28,7 @@
 
 - [x] 5.1 Pin the beta; `src/engine/describe.ts` with cache, version gate and `validateArgv` (files created in stage 2; the `src/engine/` layout is finalised in stage 5)
 - [x] 5.2 `src/engine/events.ts` parser and `KeshaError` carrying `code`, `hint`, `exitCode`, `stderr`; delete `src/error-codes.ts`, `preflight*`, `assert*Supported`, `spawnStdioWithDebugFd` (files created in stage 2; the `src/engine/` layout is finalised in stage 5)
-- [ ] 5.3 One PR per command: transcribe, say, install, record, MCP — transcribe: #1161; say: #1162; install: this PR
+- [ ] 5.3 One PR per command: transcribe, say, install, record, MCP — transcribe: #1161; say: #1162; install: this PR; record: this PR (exit codes only — the spawn stays on protocol 3 pending #1164)
 - [ ] 5.4 `record-capability-pacts.ts` and `tests/fixtures/capabilities/*.json` record `describe`, moved here from stage 1 because they record the published Engine pin, which switches to `v1.25.0-beta.2` at 4.2
 
 ## 6. Downstream spec sweeps

--- a/openspec/changes/protocol-v4/tasks.md
+++ b/openspec/changes/protocol-v4/tasks.md
@@ -28,7 +28,7 @@
 
 - [x] 5.1 Pin the beta; `src/engine/describe.ts` with cache, version gate and `validateArgv` (files created in stage 2; the `src/engine/` layout is finalised in stage 5)
 - [x] 5.2 `src/engine/events.ts` parser and `KeshaError` carrying `code`, `hint`, `exitCode`, `stderr`; delete `src/error-codes.ts`, `preflight*`, `assert*Supported`, `spawnStdioWithDebugFd` (files created in stage 2; the `src/engine/` layout is finalised in stage 5)
-- [ ] 5.3 One PR per command: transcribe, say, install, record, MCP — transcribe: #1161; say: #1162; install: this PR; record: this PR (exit codes only — the spawn stays on protocol 3 pending #1164)
+- [ ] 5.3 One PR per command: transcribe, say, install, record, MCP — transcribe: #1161; say: #1162; install: #1165; record: this PR (exit codes only — the spawn stays on protocol 3 pending #1164)
 - [ ] 5.4 `record-capability-pacts.ts` and `tests/fixtures/capabilities/*.json` record `describe`, moved here from stage 1 because they record the published Engine pin, which switches to `v1.25.0-beta.2` at 4.2
 
 ## 6. Downstream spec sweeps

--- a/src/cli/record.ts
+++ b/src/cli/record.ts
@@ -208,12 +208,12 @@ export const recordCommand = defineCommand({
       await validateRecordRequest(resolved.target, resolved.maxSeconds);
       await recordEngine(resolved.target, resolved.maxSeconds);
     } catch (err) {
-      log.error(errorMessage(err));
       const signalExitCode = getPendingSignalExitCode();
       if (signalExitCode !== null) {
         await waitForPendingSignalCleanup();
         process.exit(signalExitCode);
       }
+      log.error(errorMessage(err));
       process.exit(err instanceof KeshaError ? exitCodeFor(err) : 1);
     }
   },

--- a/src/cli/record.ts
+++ b/src/cli/record.ts
@@ -1,5 +1,6 @@
 import { defineCommand } from "citty";
 import { errorMessage } from "../error-utils";
+import { exitCodeFor, KeshaError } from "../engine/events";
 import {
   isEngineInstalled,
   recordEngine,
@@ -9,6 +10,7 @@ import {
 } from "../engine";
 import { installHint } from "../install-hint";
 import { log } from "../log";
+import { getPendingSignalExitCode, waitForPendingSignalCleanup } from "../process-tree";
 
 export interface RecordArgs {
   out?: string;
@@ -207,7 +209,12 @@ export const recordCommand = defineCommand({
       await recordEngine(resolved.target, resolved.maxSeconds);
     } catch (err) {
       log.error(errorMessage(err));
-      process.exit(1);
+      const signalExitCode = getPendingSignalExitCode();
+      if (signalExitCode !== null) {
+        await waitForPendingSignalCleanup();
+        process.exit(signalExitCode);
+      }
+      process.exit(err instanceof KeshaError ? exitCodeFor(err) : 1);
     }
   },
 });

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -161,8 +161,14 @@ async function runEngine(args: string[], opts: RunEngineOptions = {}): Promise<E
   return { stdout: stdout.trim(), stderr, exitCode, error: events.error, invalid: events.invalid };
 }
 
+/** The run failed and said so: a non-zero status, or an error event whatever the status. */
+function reportedFailure(run: EngineRun): boolean {
+  return run.exitCode !== 0 || run.error !== null;
+}
+
+/** `reportedFailure` plus a line that is not a protocol event — the strict form, for paths that throw. */
 function failed(run: EngineRun): boolean {
-  return run.exitCode !== 0 || run.invalid.length > 0 || run.error !== null;
+  return reportedFailure(run) || run.invalid.length > 0;
 }
 
 let cachedDescribe: { binPath: string; mtime: number; doc: DescribeDocument } | null = null;
@@ -454,8 +460,8 @@ export async function detectAudioLanguageEngine(
 ): Promise<LangDetectResult | null> {
   if (!isEngineInstalled()) return null;
   const run = await runEngine(["detect-lang", audioPath], opts);
-  // Unlike failed(), tolerates a stray non-event line — a noisy onnxruntime warning must not blind a best-effort guess.
-  if (run.exitCode !== 0 || run.error !== null) return null;
+  // The tolerant form: a noisy onnxruntime warning must not blind a best-effort guess.
+  if (reportedFailure(run)) return null;
   return parseLangResult(run.stdout);
 }
 
@@ -466,7 +472,7 @@ export async function detectTextLanguageEngine(
   if (text.trim().length === 0) return null;
   if (!isEngineInstalled()) return null;
   const run = await runEngine(["detect-text-lang", text], opts);
-  if (run.exitCode !== 0 || run.error !== null) {
+  if (reportedFailure(run)) {
     const warning = textLangFailureWarning(run.stderr);
     if (warning) log.warn(warning);
     return null;

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -454,7 +454,8 @@ export async function detectAudioLanguageEngine(
 ): Promise<LangDetectResult | null> {
   if (!isEngineInstalled()) return null;
   const run = await runEngine(["detect-lang", audioPath], opts);
-  if (failed(run)) return null;
+  // Unlike failed(), tolerates a stray non-event line — a noisy onnxruntime warning must not blind a best-effort guess.
+  if (run.exitCode !== 0 || run.error !== null) return null;
   return parseLangResult(run.stdout);
 }
 
@@ -465,7 +466,7 @@ export async function detectTextLanguageEngine(
   if (text.trim().length === 0) return null;
   if (!isEngineInstalled()) return null;
   const run = await runEngine(["detect-text-lang", text], opts);
-  if (failed(run)) {
+  if (run.exitCode !== 0 || run.error !== null) {
     const warning = textLangFailureWarning(run.stderr);
     if (warning) log.warn(warning);
     return null;

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -188,9 +188,9 @@ export async function getDescribe(opts: RunEngineOptions = {}): Promise<Describe
       doc = null;
     }
   }
+  // An error event names the engine-side cause even when a document parsed alongside it (#1163).
+  if (run.error) throw engineFailure("describe", run, run.exitCode);
   if (!doc) {
-    // An error event names the engine-side cause and carries the engine's own exit status; a non-event line is still the generic protocol fault, with the install hint.
-    if (run.error) throw engineFailure("describe", run, run.exitCode);
     throw new KeshaError("E_ENGINE_PROTOCOL", `kesha-engine at ${binPath} did not answer \`describe\``, {
       hint: "run `kesha install` to fetch the engine this CLI expects",
     });

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -156,12 +156,13 @@ async function runEngine(args: string[], opts: RunEngineOptions = {}): Promise<E
   }
   const stderr = events.stderr.trim();
   // #275 D4: warnings reach the user on success; on failure they travel inside the KeshaError.
-  if (exitCode === 0 && events.invalid.length === 0 && stderr.length > 0) process.stderr.write(`${stderr}\n`);
+  if (exitCode === 0 && events.invalid.length === 0 && events.error === null && stderr.length > 0)
+    process.stderr.write(`${stderr}\n`);
   return { stdout: stdout.trim(), stderr, exitCode, error: events.error, invalid: events.invalid };
 }
 
 function failed(run: EngineRun): boolean {
-  return run.exitCode !== 0 || run.invalid.length > 0;
+  return run.exitCode !== 0 || run.invalid.length > 0 || run.error !== null;
 }
 
 let cachedDescribe: { binPath: string; mtime: number; doc: DescribeDocument } | null = null;

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -453,9 +453,9 @@ export async function detectAudioLanguageEngine(
   opts: RunEngineOptions = {},
 ): Promise<LangDetectResult | null> {
   if (!isEngineInstalled()) return null;
-  const { stdout, exitCode } = await runEngine(["detect-lang", audioPath], opts);
-  if (exitCode !== 0) return null;
-  return parseLangResult(stdout);
+  const run = await runEngine(["detect-lang", audioPath], opts);
+  if (failed(run)) return null;
+  return parseLangResult(run.stdout);
 }
 
 export async function detectTextLanguageEngine(
@@ -464,13 +464,13 @@ export async function detectTextLanguageEngine(
 ): Promise<LangDetectResult | null> {
   if (text.trim().length === 0) return null;
   if (!isEngineInstalled()) return null;
-  const { stdout, stderr, exitCode } = await runEngine(["detect-text-lang", text], opts);
-  if (exitCode !== 0) {
-    const warning = textLangFailureWarning(stderr);
+  const run = await runEngine(["detect-text-lang", text], opts);
+  if (failed(run)) {
+    const warning = textLangFailureWarning(run.stderr);
     if (warning) log.warn(warning);
     return null;
   }
-  return parseLangResult(stdout);
+  return parseLangResult(run.stdout);
 }
 
 /**

--- a/tests/integration/cli-contracts.test.ts
+++ b/tests/integration/cli-contracts.test.ts
@@ -267,6 +267,28 @@ process.exit(2);
   return enginePath;
 }
 
+function createHangingRecordEngine(dir: string, enginePidPath: string): string {
+  const enginePath = join(dir, "kesha-engine-record-hang");
+  writeFileSync(
+    enginePath,
+    `#!${process.execPath}
+const args = Bun.argv.slice(2);
+if (args[0] === "describe") {
+  console.log(${JSON.stringify(describeJson({ backend: "fake", features: [] }))});
+  process.exit(0);
+}
+if (args[0] === "record") {
+  await Bun.write(${JSON.stringify(enginePidPath)}, String(process.pid));
+  await new Promise(() => {});
+}
+console.error("unexpected fake engine args: " + JSON.stringify(args));
+process.exit(2);
+`,
+  );
+  chmodSync(enginePath, 0o755);
+  return enginePath;
+}
+
 function createLifecycleEngine(
   dir: string,
   enginePidPath: string,
@@ -667,6 +689,77 @@ describe("CLI contracts", () => {
     expect(run.stderr).not.toMatch(/^\s+at /m);
     expect(existsSync(outPath)).toBe(false);
   });
+
+  test("kesha record --live against a build lacking record.live exits 2 with E_INVALID_ARG", async () => {
+    if (process.platform === "win32") return;
+    const dir = makeTempDir("kesha-cli-contract-record-flag-gate-");
+    const enginePath = join(dir, "kesha-engine");
+    writeFileSync(
+      enginePath,
+      `#!/bin/sh\nif [ "$1" = "describe" ]; then\n  printf '%s\\n' '${describeJson({ features: [] })}'\n  exit 0\nfi\nexit 2\n`,
+    );
+    chmodSync(enginePath, 0o755);
+    const run = await runCli(["record", "--live"], { env: { ...isolatedEnv(dir), KESHA_ENGINE_BIN: enginePath } });
+    expectContract(run, {
+      exitCode: 2,
+      stdoutEmpty: true,
+      stderrContains: ["error [E_INVALID_ARG]: ", "--live"],
+    });
+  });
+
+  test("kesha record against a stub that exits non-zero with no coded error line still exits 1", async () => {
+    if (process.platform === "win32") return;
+    const dir = makeTempDir("kesha-cli-contract-record-uncoded-fail-");
+    const enginePath = join(dir, "kesha-engine");
+    writeFileSync(
+      enginePath,
+      `#!/bin/sh\nif [ "$1" = "describe" ]; then\n  printf '%s\\n' '${describeJson({ features: [] })}'\n  exit 0\nfi\nexit 3\n`,
+    );
+    chmodSync(enginePath, 0o755);
+    const outPath = join(dir, "hello.wav");
+    const run = await runCli(["record", "--out", outPath], {
+      env: { ...isolatedEnv(dir), KESHA_ENGINE_BIN: enginePath },
+    });
+    expectContract(run, {
+      exitCode: 1,
+      stderrContains: ["kesha-engine record exited with code 3"],
+      stderrNotContains: ["error [E_"],
+    });
+  });
+
+  for (const [signal, exitCode] of [["SIGINT", 130], ["SIGTERM", 143]] as const) {
+    test(`${signal} mid-recording exits ${exitCode} and leaves no engine running`, async () => {
+      if (process.platform === "win32") return;
+      const dir = makeTempDir(`kesha-cli-contract-record-${signal.toLowerCase()}-exit-`);
+      const enginePidPath = join(dir, "engine.pid");
+      const enginePath = createHangingRecordEngine(dir, enginePidPath);
+      const outPath = join(dir, "hello.wav");
+
+      const proc = Bun.spawn([process.execPath, "run", "src/cli-entry.ts", "record", "--out", outPath], {
+        cwd: DEFAULT_CWD,
+        stdout: "pipe",
+        stderr: "pipe",
+        env: {
+          ...process.env,
+          NO_COLOR: "1",
+          FORCE_COLOR: "0",
+          ...isolatedEnv(dir),
+          KESHA_ENGINE_BIN: enginePath,
+        },
+      });
+      const drained = Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+      ]);
+      const enginePid = await waitForPidFile(enginePidPath);
+
+      proc.kill(signal);
+
+      const [, actualExitCode] = await Promise.all([drained, proc.exited]);
+      expect(actualExitCode).toBe(exitCode);
+      expect(await waitForPidExit(enginePid)).toBe(true);
+    });
+  }
 
   test("kesha say --list-voices without an installed engine prints the install hint, not a raw ENOENT", async () => {
     const run = await runCli(["say", "--list-voices"], { env: isolatedEnv() });

--- a/tests/integration/cli-contracts.test.ts
+++ b/tests/integration/cli-contracts.test.ts
@@ -755,8 +755,9 @@ describe("CLI contracts", () => {
 
       proc.kill(signal);
 
-      const [, actualExitCode] = await Promise.all([drained, proc.exited]);
+      const [[, stderr], actualExitCode] = await Promise.all([drained, proc.exited]);
       expect(actualExitCode).toBe(exitCode);
+      expect(stderr).toBe("");
       expect(await waitForPidExit(enginePid)).toBe(true);
     });
   }

--- a/tests/unit/engine.test.ts
+++ b/tests/unit/engine.test.ts
@@ -1029,6 +1029,28 @@ describe("the capability probe stays in step with the installed binary", () => {
     });
   });
 
+  fakeEngineTest("a describe that reports an error event fails even though its document parses (#1163 follow-up)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kesha-engine-describe-error-"));
+    const path = join(dir, "kesha-engine");
+    writeFileSync(
+      path,
+      `#!/bin/sh
+if [ "$1" = "describe" ]; then
+  printf '%s\\n' '{"kind":"error","code":"E_MODEL_MISSING","message":"the language-id model is missing"}' >&2
+  printf '%s\\n' '${describeJson({ features: ["transcribe.segments"] })}'
+  exit 0
+fi
+exit 2
+`,
+    );
+    chmodSync(path, 0o755);
+    await withEngineEnv(path, async () => {
+      const err = await failure(() => getDescribe());
+      expect(err.code).toBe("E_MODEL_MISSING");
+      expect(errorMessage(err)).toBe("error [E_MODEL_MISSING]: the language-id model is missing");
+    });
+  });
+
   // Blank text has no language to detect; spending a subprocess on it would be pure latency.
   fakeEngineTest("blank text resolves null while real text still reaches the engine", async () => {
     const path = join(mkdtempSync(join(tmpdir(), "kesha-engine-textlang-")), "kesha-engine");

--- a/tests/unit/engine.test.ts
+++ b/tests/unit/engine.test.ts
@@ -6,6 +6,7 @@ import { stubbornShell, waitForPidExit, waitForPidFile } from "../helpers/proces
 import { describeJson, envEchoEngine, saveEngineEnv, writeTranscribingEngine } from "../helpers/fake-engine";
 import { applyColorEnv } from "../../src/cli/context";
 import {
+  detectAudioLanguageEngine,
   detectTextLanguageEngine,
   getDescribe,
   getEngineBinPath,
@@ -42,6 +43,24 @@ function fakeEngine(features: string[]): string {
 }
 
 const fakeEngineTest = process.platform === "win32" ? test.skip : test;
+
+/** A stub answering one flagless lang-detect command; `body` runs before the forced `exit 0`. */
+function langDetectEngine(prefix: string, command: string, body: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  const path = join(dir, "kesha-engine");
+  writeFileSync(
+    path,
+    `#!/bin/sh
+if [ "$1" = "${command}" ]; then
+${body}
+  exit 0
+fi
+exit 2
+`,
+  );
+  chmodSync(path, 0o755);
+  return path;
+}
 
 /** Echoes the `transcribe` argv it was handed as the transcript, so a test can assert which flags were forwarded. */
 async function argEchoEngine(features: string[]): Promise<string> {
@@ -715,6 +734,18 @@ exit 2
     }
     expect(captured.join("")).not.toContain("E_MODEL_MISSING");
   });
+
+  fakeEngineTest("an error event on detect-lang is null, not a confident wrong guess (#1166)", async () => {
+    const engine = langDetectEngine(
+      "kesha-engine-detect-lang-error-",
+      "detect-lang",
+      `  printf '%s\\n' '{"kind":"error","code":"E_MODEL_MISSING","message":"the language-id model is missing"}' >&2
+  printf '%s\\n' '{"code":"xx","confidence":0.99}'`,
+    );
+    await withEngineEnv(engine, async () => {
+      expect(await detectAudioLanguageEngine("audio.wav")).toBeNull();
+    });
+  });
 });
 
 describe("text language detection degrades loudly (#770)", () => {
@@ -750,6 +781,30 @@ describe("text language detection degrades loudly (#770)", () => {
 
     const warned = captured.some((line) => line.includes("Text language detection failed"));
     expect(warned).toBe(process.platform === "darwin");
+  });
+
+  fakeEngineTest("an error event on detect-text-lang is null, not a confident wrong guess, and still warns (#1166)", async () => {
+    const engine = langDetectEngine(
+      "kesha-engine-detect-text-lang-error-",
+      "detect-text-lang",
+      `  printf '%s\\n' '{"kind":"error","code":"E_MODEL_MISSING","message":"the language-id model is missing"}' >&2
+  printf '%s\\n' '{"code":"xx","confidence":0.99}'`,
+    );
+    const savedWrite = process.stderr.write;
+    const captured: string[] = [];
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      captured.push(typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk));
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      await withEngineEnv(engine, async () => {
+        expect(await detectTextLanguageEngine("hello")).toBeNull();
+      });
+    } finally {
+      process.stderr.write = savedWrite;
+    }
+    const plain = captured.join("").replace(/\x1b\[[0-9;]*m/g, "");
+    expect(plain.includes("Text language detection failed")).toBe(process.platform === "darwin");
   });
 });
 

--- a/tests/unit/engine.test.ts
+++ b/tests/unit/engine.test.ts
@@ -678,6 +678,43 @@ exit 2
     });
     expect(seen).toEqual(["proto=4"]);
   });
+
+  fakeEngineTest("an error event fails the run even when the engine exits 0 (#1163)", async () => {
+    const engine = writeTranscribingEngine(
+      "kesha-engine-error-exit-0-",
+      ["transcribe"],
+      `  printf '%s\\n' '{"kind":"error","code":"E_MODEL_MISSING","message":"the ASR model is missing"}' >&2
+  printf '%s\\n' 'this looks like a transcript but must not be returned'`,
+    );
+    await withEngineEnv(engine, async () => {
+      const err = await failure(() => transcribeEngine("audio.wav"));
+      expect(err.code).toBe("E_MODEL_MISSING");
+      expect(errorMessage(err)).toBe("error [E_MODEL_MISSING]: the ASR model is missing");
+    });
+  });
+
+  fakeEngineTest("a run that fails on the error event alone is not also echoed to stderr as a warning (#1163)", async () => {
+    const engine = writeTranscribingEngine(
+      "kesha-engine-error-no-echo-",
+      ["transcribe"],
+      `  printf '%s\\n' '{"kind":"error","code":"E_MODEL_MISSING","message":"the ASR model is missing"}' >&2
+  printf '%s\\n' 'this looks like a transcript but must not be returned'`,
+    );
+    const savedWrite = process.stderr.write;
+    const captured: string[] = [];
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      captured.push(typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk));
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      await withEngineEnv(engine, async () => {
+        await failure(() => transcribeEngine("audio.wav"));
+      });
+    } finally {
+      process.stderr.write = savedWrite;
+    }
+    expect(captured.join("")).not.toContain("E_MODEL_MISSING");
+  });
 });
 
 describe("text language detection degrades loudly (#770)", () => {

--- a/tests/unit/engine.test.ts
+++ b/tests/unit/engine.test.ts
@@ -746,6 +746,18 @@ exit 2
       expect(await detectAudioLanguageEngine("audio.wav")).toBeNull();
     });
   });
+
+  fakeEngineTest("a stray non-event line on detect-lang does not blind language detection (#1166 follow-up)", async () => {
+    const engine = langDetectEngine(
+      "kesha-engine-detect-lang-noisy-",
+      "detect-lang",
+      `  echo 'onnxruntime: some warning' >&2
+  printf '%s\\n' '{"code":"ru","confidence":0.87}'`,
+    );
+    await withEngineEnv(engine, async () => {
+      expect(await detectAudioLanguageEngine("audio.wav")).toEqual({ code: "ru", confidence: 0.87 });
+    });
+  });
 });
 
 describe("text language detection degrades loudly (#770)", () => {
@@ -805,6 +817,18 @@ describe("text language detection degrades loudly (#770)", () => {
     }
     const plain = captured.join("").replace(/\x1b\[[0-9;]*m/g, "");
     expect(plain.includes("Text language detection failed")).toBe(process.platform === "darwin");
+  });
+
+  fakeEngineTest("a stray non-event line on detect-text-lang does not blind language detection (#1166 follow-up)", async () => {
+    const engine = langDetectEngine(
+      "kesha-engine-detect-text-lang-noisy-",
+      "detect-text-lang",
+      `  echo 'onnxruntime: some warning' >&2
+  printf '%s\\n' '{"code":"ru","confidence":0.87}'`,
+    );
+    await withEngineEnv(engine, async () => {
+      expect(await detectTextLanguageEngine("hello")).toEqual({ code: "ru", confidence: 0.87 });
+    });
   });
 });
 


### PR DESCRIPTION
Stage 2, PR 5 of the v2 contract-first refactor: the shared failure predicate stops trusting the exit status alone, and `kesha record` exits with the status its failure means.

## Summary

- `failed()` in `src/engine.ts` now fails a run that reported an error event, whatever its exit status. `say()` and `listVoiceIds()` already worked that way; this was the last place that disagreed. Closes #1163.
- The success-path stderr echo is gated on the same condition. Without that, the engine's own coded line was written raw and then printed again by the thrown error.
- `detectAudioLanguageEngine` and `detectTextLanguageEngine` use the same predicate, so an engine reporting an error can no longer hand back a confident wrong language. Both keep their contract of returning nothing rather than throwing, and the text path still emits its failure warning. Closes #1166.
- `kesha record` stops collapsing every failure onto exit 1: an argv the installed engine refuses exits 2, an interrupt wins with 130 or 143, and a failure the CLI cannot code stays on 1.

## Claim

An engine that reports a well-formed error event fails the run on every path through `runEngine`, and language detection returns nothing rather than a guess in that case. `kesha record` exits with what its failure means. No command that used to succeed now fails.

The assertions that fire if that is false live in `tests/unit/engine.test.ts` and in the `record` cases of `tests/integration/cli-contracts.test.ts`.

## What this PR deliberately does not do

`record` keeps inherited stderr on protocol 3, alongside the model install. The engine's live "Listening… Ns" ticker paints only under protocol 3 on a terminal, so piping it for event parsing would leave a recording session showing nothing at all. That is the same trap that reverted the model install in #1165, and both wait on **#1164**, where the design question is now recorded: downloads count bytes, recordings count seconds, and the event shape should be settled once rather than twice.

## Rulings

1. **An uncoded record failure keeps exit 1.** The shared rule maps a non-coded error to 4, which `docs/errors.md` reserves for an internal fault. With inherited stderr the engine has already printed its own coded line, so the CLI reports the operational status it has always reported rather than inventing a worse one.
2. **The language-detection repair landed here rather than in a follow-up.** The review first suggested an issue, but this branch's own echo gate had removed the last visible signal on that path. Shipping a diagnosability regression and deferring the fix is not a trade worth making, so #1166 closes with this PR.
3. **The two detection functions do not start throwing,** and they tolerate noise the throwing paths refuse. A stray non-event line on stderr, the shape an ONNX runtime warning takes, must not blind a best-effort guess; a reported error still yields nothing. Callers, including voice auto-routing, are written against that nothing meaning "unknown".
4. **An interrupt now prints nothing before it exits.** The failure message moved below the signal check, matching the install command. The cost is that a genuine failure coinciding with an interrupt is silent, which is the same trade that command already makes.

## Verification

- `just preflight` green: 1858 tests pass, 0 fail; tsc, recipes, workflows, versions, specs, engine targets and the release manifest all pass. The Rust and CoreML gates skip on a diff with no `rust/` changes.
- Every new guard was proved by reverting the line it guards. Before the fix, a stub that reported an error event and exited 0 returned a language with 0.99 confidence and printed nothing.
- The interrupt case drives a real signal at a hanging stub and reuses the transcribe path's existing helpers, so a stray process fails the run and names itself.

Follows #1165 (stage 2, PR 4). Refs `openspec/changes/protocol-v4` task 5.3 (record), refs #1164. Closes #1163, closes #1166.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RKSL2xGHE1y3njSG8oymq
