### PR TITLE
test(mcp): pin that an engine failure reaches an MCP client coded

### DIFF
--- a/openspec/changes/protocol-v4/tasks.md
+++ b/openspec/changes/protocol-v4/tasks.md
@@ -28,7 +28,7 @@
 
 - [x] 5.1 Pin the beta; `src/engine/describe.ts` with cache, version gate and `validateArgv` (files created in stage 2; the `src/engine/` layout is finalised in stage 5)
 - [x] 5.2 `src/engine/events.ts` parser and `KeshaError` carrying `code`, `hint`, `exitCode`, `stderr`; delete `src/error-codes.ts`, `preflight*`, `assert*Supported`, `spawnStdioWithDebugFd` (files created in stage 2; the `src/engine/` layout is finalised in stage 5)
-- [ ] 5.3 One PR per command: transcribe, say, install, record, MCP — transcribe: #1161; say: #1162; install: #1165; record: this PR (exit codes only — the spawn stays on protocol 3 pending #1164)
+- [ ] 5.3 One PR per command: transcribe, say, install, record, MCP — transcribe: #1161; say: #1162; install: #1165; record: #1167; MCP: this PR (install and record spawns stay on protocol 3 pending #1164)
 - [ ] 5.4 `record-capability-pacts.ts` and `tests/fixtures/capabilities/*.json` record `describe`, moved here from stage 1 because they record the published Engine pin, which switches to `v1.25.0-beta.2` at 4.2
 
 ## 6. Downstream spec sweeps

--- a/tests/unit/mcp-list-voices.test.ts
+++ b/tests/unit/mcp-list-voices.test.ts
@@ -204,3 +204,43 @@ describe("list_voices() validates against describe before spawning", () => {
     });
   });
 });
+
+// A stub whose describe answers normally but whose `say --list-voices` reports a coded failure.
+function voiceListingErrorEngine(): string {
+  const dir = mkdtempSync(join(tmpdir(), "kesha-mcp-voices-error-"));
+  const path = join(dir, "kesha-engine");
+  const errorEvent = JSON.stringify({
+    kind: "error",
+    code: "E_MODEL_MISSING",
+    message: "the TTS bundle is missing",
+    hint: "run kesha install --tts",
+  });
+  writeFileSync(
+    path,
+    `#!/bin/sh\nif [ "$1" = "describe" ]; then\n  printf '%s\\n' '${describeJson({ features: ["tts"] })}'\n  exit 0\nfi\nif [ "$1" = "say" ] && [ "$2" = "--list-voices" ]; then\n  printf '%s\\n' '${errorEvent}' >&2\n  exit 1\nfi\nexit 2\n`,
+  );
+  chmodSync(path, 0o755);
+  return path;
+}
+
+describe("list_voices / list_languages surface an engine-reported failure coded", () => {
+  skipOnWin32("list_voices tool returns isError carrying the engine's code and hint", async () => {
+    await withEngineBin(voiceListingErrorEngine(), async () => {
+      const res = await call("list_voices");
+      expect(res.isError).toBe(true);
+      const text = (res.content as Array<{ text: string }>)[0]?.text;
+      expect(text).toContain("E_MODEL_MISSING");
+      expect(text).toContain("run kesha install --tts");
+    });
+  });
+
+  skipOnWin32("list_languages tool returns isError carrying the engine's code and hint", async () => {
+    await withEngineBin(voiceListingErrorEngine(), async () => {
+      const res = await call("list_languages");
+      expect(res.isError).toBe(true);
+      const text = (res.content as Array<{ text: string }>)[0]?.text;
+      expect(text).toContain("E_MODEL_MISSING");
+      expect(text).toContain("run kesha install --tts");
+    });
+  });
+});

--- a/tests/unit/mcp-list-voices.test.ts
+++ b/tests/unit/mcp-list-voices.test.ts
@@ -229,8 +229,8 @@ describe("list_voices / list_languages surface an engine-reported failure coded"
       const res = await call("list_voices");
       expect(res.isError).toBe(true);
       const text = (res.content as Array<{ text: string }>)[0]?.text;
-      expect(text).toContain("E_MODEL_MISSING");
-      expect(text).toContain("run kesha install --tts");
+      expect(text).toContain("error [E_MODEL_MISSING]:");
+      expect(text).toContain("hint: run kesha install --tts");
     });
   });
 
@@ -239,8 +239,8 @@ describe("list_voices / list_languages surface an engine-reported failure coded"
       const res = await call("list_languages");
       expect(res.isError).toBe(true);
       const text = (res.content as Array<{ text: string }>)[0]?.text;
-      expect(text).toContain("E_MODEL_MISSING");
-      expect(text).toContain("run kesha install --tts");
+      expect(text).toContain("error [E_MODEL_MISSING]:");
+      expect(text).toContain("hint: run kesha install --tts");
     });
   });
 });

--- a/tests/unit/mcp-list-voices.test.ts
+++ b/tests/unit/mcp-list-voices.test.ts
@@ -1,5 +1,5 @@
-import { describe, test, expect } from "bun:test";
-import { chmodSync, existsSync, mkdtempSync, writeFileSync } from "fs";
+import { describe, test, expect, afterAll } from "bun:test";
+import { chmodSync, existsSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
@@ -9,6 +9,18 @@ import { listVoices } from "../../src/mcp/voices";
 import { errorMessage } from "../../src/error-utils";
 import { describeJson } from "../helpers/fake-engine";
 import { KeshaError } from "../../src/engine/events";
+
+const stubDirs: string[] = [];
+
+function stubDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  stubDirs.push(dir);
+  return dir;
+}
+
+afterAll(() => {
+  for (const dir of stubDirs) rmSync(dir, { recursive: true, force: true });
+});
 
 const skipOnWin32 = process.platform === "win32" ? test.skip : test;
 
@@ -73,7 +85,7 @@ describe("list_voices / list_languages guard when the engine is missing", () => 
 
 describe("list_voices guard when the engine is present but not executable", () => {
   skipOnWin32("list_voices tool returns isError with E_ENGINE_SPAWN, not a raw spawn exception", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "kesha-mcp-not-exec-"));
+    const dir = stubDir("kesha-mcp-not-exec-");
     const notExecutable = join(dir, "kesha-engine");
     writeFileSync(notExecutable, "not a binary");
     chmodSync(notExecutable, 0o644);
@@ -90,7 +102,7 @@ describe("list_voices guard when the engine is present but not executable", () =
 
 // A stub, because gating on an installed engine skipped these in every CI lane (#984).
 function voiceListingEngine(voiceIds: string[]): string {
-  const dir = mkdtempSync(join(tmpdir(), "kesha-mcp-voices-"));
+  const dir = stubDir("kesha-mcp-voices-");
   const path = join(dir, "kesha-engine");
   const args = voiceIds.map((id) => `'${id}'`).join(" ");
   writeFileSync(
@@ -105,7 +117,7 @@ const STUB_VOICES = ["en-am_michael", "en-bf_emma", "ru-vosk-m02"];
 
 // A stub that answers on stdout but writes plain prose to stderr instead of a protocol 4 event.
 function babblingVoicesEngine(): string {
-  const dir = mkdtempSync(join(tmpdir(), "kesha-mcp-voices-babble-"));
+  const dir = stubDir("kesha-mcp-voices-babble-");
   const path = join(dir, "kesha-engine");
   writeFileSync(
     path,
@@ -172,7 +184,7 @@ describe("list_languages tool", () => {
 
 describe("list_voices() validates against describe before spawning", () => {
   skipOnWin32("a stale engine that cannot describe itself is E_ENGINE_PROTOCOL pointing at kesha install", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "kesha-mcp-voices-stale-"));
+    const dir = stubDir("kesha-mcp-voices-stale-");
     const path = join(dir, "kesha-engine");
     writeFileSync(
       path,
@@ -188,7 +200,7 @@ describe("list_voices() validates against describe before spawning", () => {
   });
 
   skipOnWin32("a build without tts is E_INVALID_ARG and the engine is never asked", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "kesha-mcp-voices-notts-"));
+    const dir = stubDir("kesha-mcp-voices-notts-");
     const path = join(dir, "kesha-engine");
     const marker = join(dir, "say-was-spawned");
     writeFileSync(
@@ -207,7 +219,7 @@ describe("list_voices() validates against describe before spawning", () => {
 
 // A stub whose describe answers normally but whose `say --list-voices` reports a coded failure.
 function voiceListingErrorEngine(): string {
-  const dir = mkdtempSync(join(tmpdir(), "kesha-mcp-voices-error-"));
+  const dir = stubDir("kesha-mcp-voices-error-");
   const path = join(dir, "kesha-engine");
   const errorEvent = JSON.stringify({
     kind: "error",


### PR DESCRIPTION
## What this changes

The last of stage 2's command sweep. Every other command moved onto engine protocol v4 in its own PR; the MCP server needed no move, because no MCP path spawns the engine or gates flags on its own any more. `list_voices` and `list_languages` go through `listVoiceIds`, and the transcribe and synthesis tools go through the public library, so protocol v4 reached MCP when those landed.

What was missing is the coverage. Nothing asserted that an engine failure reaches an MCP client as the engine's own code and hint rather than bare prose, and the existing error tests do not exercise it: a missing file, a rate out of range and a missing engine all fail before the engine reports anything.

## Claim

Two tool calls, `list_voices` and `list_languages`, now fail with the engine's rendered error line and its hint in the text a client reads, and the guard holds in both directions. Replacing `errorMessage(err)` with `String(err)` in either tool's catch turns exactly that tool's case red. Neutralising the error branch of `parseEventLine` — which pushes the run onto the `E_INTERNAL` path, where the raw line is quoted verbatim — also turns both cases red. No MCP behaviour changed; the diff touches no file under `src/`.

If that is wrong, the assertions that fire are `toContain("error [E_MODEL_MISSING]:")` and `toContain("hint: run kesha install --tts")`.

The first draft of these tests asserted the bare substrings, and the branch review caught that this passes on the `E_INTERNAL` path too — where `String(err)` also contains both strings, so the mutation proof would have stopped firing with nothing to show for it. Asserting the rendered form is what closed that.

## What is not here

- **The empty voice list.** The engine prints `No voices installed. Run: kesha install --tts` to stdout, so a caller reads it as a voice id. Filed as #1168 for the engine. A CLI-side filter would be a silent fallback hiding a real engine defect.
- **openspec 5.3 stays unticked.** Every command has had its PR, but the install and record spawns still inherit stdio on protocol 3, waiting on #1164.

Refs #1164, refs #1168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RKSL2xGHE1y3njSG8oymq
