### PR TITLE
test: reap temp directories in the guard bunfig already preloads

### DIFF
--- a/tests/helpers/fake-engine.ts
+++ b/tests/helpers/fake-engine.ts
@@ -2,11 +2,12 @@ import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import type { DescribeDocument, FlagSchema, TtsLanguageCapability } from "../../src/engine/describe";
+import { tempDir } from "./temp-dir";
 
 const ENGINE_ENV = ["KESHA_ENGINE_BIN", "KESHA_CACHE_DIR", "HOME", "KESHA_MODEL_MIRROR"] as const;
 
 export interface StagedEngineHome {
-  /** The temp directory standing in for `$HOME`. Remove it when the test finishes. */
+  /** The temp directory standing in for `$HOME`; the suite tears it down. */
   dir: string;
   cache: string;
   binDir: string;
@@ -18,10 +19,10 @@ export interface StagedEngineHome {
  * and `KESHA_ENGINE_BIN` at it. The bin directory exists; no engine is written, so the caller
  * decides whether it is healthy, mute or absent.
  *
- * Restore the environment with `saveEngineEnv()`'s undo, and `rmSync` the returned `dir`.
+ * Restore the environment with `saveEngineEnv()`'s undo; the directory needs no cleanup.
  */
 export function stageEngineHome(prefix: string): StagedEngineHome {
-  const dir = mkdtempSync(join(tmpdir(), prefix));
+  const dir = tempDir(prefix);
   const cache = join(dir, ".cache", "kesha");
   const binDir = join(cache, "engine", "bin");
   mkdirSync(binDir, { recursive: true });
@@ -152,7 +153,7 @@ export function writeFakeEngine(binDir: string, features: string[] | null = ["tt
 }
 
 export function writeTranscribingEngine(prefix: string, features: string[], transcribeBody: string): string {
-  const dir = mkdtempSync(join(tmpdir(), prefix));
+  const dir = tempDir(prefix);
   const path = join(dir, "kesha-engine");
   writeFileSync(
     path,
@@ -182,7 +183,7 @@ exit 2
  * path, because the interpreter is the binary and the script is its argument.
  */
 export function envEchoEngine(vars: string[]): { binPath: string; args: string[] } {
-  const dir = mkdtempSync(join(tmpdir(), "kesha-env-echo-"));
+  const dir = tempDir("kesha-env-echo-");
   const script = join(dir, "echo-env.js");
   writeFileSync(
     script,

--- a/tests/helpers/interrupted-temp-dir.fixture.ts
+++ b/tests/helpers/interrupted-temp-dir.fixture.ts
@@ -1,0 +1,15 @@
+import { test } from "bun:test";
+import { writeFileSync } from "node:fs";
+import { tempDir } from "./temp-dir";
+
+const WAIT_MS = 30_000;
+
+/** Run only as a child of `temp-dir-leak-guard.test.ts`; the parent interrupts it mid-test on purpose. */
+test(
+  "stages a temp directory and waits to be interrupted",
+  async () => {
+    writeFileSync(process.env.KESHA_TEMP_DIR_FIXTURE_OUT!, tempDir("kesha-temp-dir-interrupt-"));
+    await Bun.sleep(WAIT_MS);
+  },
+  WAIT_MS + 10_000,
+);

--- a/tests/helpers/leak-guard.ts
+++ b/tests/helpers/leak-guard.ts
@@ -8,9 +8,11 @@
  */
 import { afterAll, afterEach } from "bun:test";
 import { installInterruptReaper, reapLeakedProcesses } from "./process";
-import { reapTempDirs } from "./temp-dir";
+import { reapTempDirs, sweepStaleTempDirs } from "./temp-dir";
 
 installInterruptReaper();
+// A SIGKILLed run reaches no handler at all, so the next run is the only thing that can clean up after it (#1175).
+sweepStaleTempDirs();
 // An interrupted run reaches no `afterAll`, which is exactly when these directories used to survive (#1175).
 process.on("exit", () => reapTempDirs());
 

--- a/tests/helpers/leak-guard.ts
+++ b/tests/helpers/leak-guard.ts
@@ -1,14 +1,18 @@
 /**
- * Preloaded into every suite (`bunfig.toml`): a spawned stub has to be reaped even when the test
- * that spawned it failed, timed out or was interrupted, and a leak has to be loud rather than
- * found days later in `ps` (#1003). Temp directories are reaped the same way but quietly (#1175) —
- * the guard owning them is the point, so a suite that leaves one behind is using the helper right.
+ * Preloaded into every test process (`bunfig.toml`): a spawned stub has to be reaped even when the
+ * test that spawned it failed, timed out or was interrupted, and a leak has to be loud rather than
+ * found days later in `ps` (#1003). The hooks below are registered once for the process, so the
+ * `afterAll` runs after the last file that process loaded rather than once per suite. Temp
+ * directories are reaped the same way but quietly (#1175) — the guard owning them is the point, so
+ * a suite that leaves one behind is using the helper right.
  */
 import { afterAll, afterEach } from "bun:test";
 import { installInterruptReaper, reapLeakedProcesses } from "./process";
 import { reapTempDirs } from "./temp-dir";
 
 installInterruptReaper();
+// An interrupted run reaches no `afterAll`, which is exactly when these directories used to survive (#1175).
+process.on("exit", () => reapTempDirs());
 
 function report(scope: string, leaked: string[]): void {
   if (leaked.length === 0) return;

--- a/tests/helpers/leak-guard.ts
+++ b/tests/helpers/leak-guard.ts
@@ -1,10 +1,12 @@
 /**
  * Preloaded into every suite (`bunfig.toml`): a spawned stub has to be reaped even when the test
  * that spawned it failed, timed out or was interrupted, and a leak has to be loud rather than
- * found days later in `ps` (#1003).
+ * found days later in `ps` (#1003). Temp directories are reaped the same way but quietly (#1175) —
+ * the guard owning them is the point, so a suite that leaves one behind is using the helper right.
  */
 import { afterAll, afterEach } from "bun:test";
 import { installInterruptReaper, reapLeakedProcesses } from "./process";
+import { reapTempDirs } from "./temp-dir";
 
 installInterruptReaper();
 
@@ -17,4 +19,10 @@ function report(scope: string, leaked: string[]): void {
 
 afterEach(async () => report("this test", await reapLeakedProcesses()));
 
-afterAll(async () => report("this suite", await reapLeakedProcesses({ sweepDescendants: true })));
+afterAll(async () => {
+  try {
+    report("this suite", await reapLeakedProcesses({ sweepDescendants: true }));
+  } finally {
+    reapTempDirs();
+  }
+});

--- a/tests/helpers/leaked-temp-dir.fixture.ts
+++ b/tests/helpers/leaked-temp-dir.fixture.ts
@@ -1,0 +1,8 @@
+import { test } from "bun:test";
+import { writeFileSync } from "node:fs";
+import { tempDir } from "./temp-dir";
+
+/** Run only as a child of `temp-dir-leak-guard.test.ts`; the leak it stages is the point. */
+test("stages a temp directory and never removes it", () => {
+  writeFileSync(process.env.KESHA_TEMP_DIR_FIXTURE_OUT!, tempDir("kesha-temp-dir-fixture-"));
+});

--- a/tests/helpers/temp-dir.ts
+++ b/tests/helpers/temp-dir.ts
@@ -27,7 +27,8 @@ export function createTempDirRegistry(): TempDirRegistry {
           rmSync(dir, { recursive: true, force: true });
           removed.push(dir);
         } catch (err) {
-          // One directory the OS refuses to release must not replace the louder process report (#1175).
+          // Kept for the exit pass to retry: a refusal is often a handle closing a moment later (#1175).
+          trackedDirs.add(dir);
           console.error(`leak guard could not remove ${dir}: ${err}`);
         }
       }

--- a/tests/helpers/temp-dir.ts
+++ b/tests/helpers/temp-dir.ts
@@ -1,6 +1,13 @@
-import { mkdtempSync, readdirSync, rmSync, statSync, type Dirent } from "node:fs";
+import { mkdirSync, mkdtempSync, readdirSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+
+/** Everything the helper creates lives under here, so the sweep below cannot reach a directory it did not create (#1175). */
+function testsRoot(): string {
+  const root = join(tmpdir(), "kesha-tests");
+  mkdirSync(root, { recursive: true });
+  return root;
+}
 
 export interface TempDirRegistry {
   /** Creates a temp directory this registry will remove; removing it by hand too is safe (#1175). */
@@ -14,7 +21,7 @@ export function createTempDirRegistry(): TempDirRegistry {
   const trackedDirs = new Set<string>();
   return {
     tempDir(prefix: string): string {
-      const dir = mkdtempSync(join(tmpdir(), prefix));
+      const dir = mkdtempSync(join(testsRoot(), prefix));
       trackedDirs.add(dir);
       return dir;
     },
@@ -48,22 +55,18 @@ export const reapTempDirs = shared.reapTempDirs;
 /** Longer than any run can live: 5x the longest CI job timeout (45 min), so a concurrent run's directories are never stale (#1175). */
 const STALE_AFTER_MS = 4 * 60 * 60 * 1000;
 
-/** The six characters `mkdtempSync` appends are what tells a run's directory from `kesha-mcp`, the audio cache the MCP server keeps. */
-const SWEEPABLE = /^kesha-.+-[A-Za-z0-9]{6}$/;
-
 /** Removes directories left by a run no handler survived — SIGKILL, or a Windows exit that could not release a handle — and returns the ones that are gone (#1175). */
-export function sweepStaleTempDirs(root: string = tmpdir(), now: number = Date.now()): string[] {
-  let entries: Dirent[];
+export function sweepStaleTempDirs(root: string = testsRoot(), now: number = Date.now()): string[] {
+  let names: string[];
   try {
-    entries = readdirSync(root, { withFileTypes: true });
+    names = readdirSync(root);
   } catch {
     return [];
   }
   const cutoff = now - STALE_AFTER_MS;
   const removed: string[] = [];
-  for (const entry of entries) {
-    if (!entry.isDirectory() || !SWEEPABLE.test(entry.name)) continue;
-    const dir = join(root, entry.name);
+  for (const name of names) {
+    const dir = join(root, name);
     try {
       if (statSync(dir).mtimeMs > cutoff) continue;
       rmSync(dir, { recursive: true, force: true });

--- a/tests/helpers/temp-dir.ts
+++ b/tests/helpers/temp-dir.ts
@@ -2,19 +2,44 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-const trackedDirs = new Set<string>();
-
-/** A temp directory the preloaded guard removes when the suite ends; removing it by hand too is safe (#1175). */
-export function tempDir(prefix: string): string {
-  const dir = mkdtempSync(join(tmpdir(), prefix));
-  trackedDirs.add(dir);
-  return dir;
+export interface TempDirRegistry {
+  /** Creates a temp directory this registry will remove; removing it by hand too is safe (#1175). */
+  tempDir(prefix: string): string;
+  /** Removes every directory this registry handed out and returns the ones that are gone. */
+  reapTempDirs(): string[];
 }
 
-/** Removes every directory `tempDir()` handed out and returns them; one already gone is not an error. */
-export function reapTempDirs(): string[] {
-  const reaped = [...trackedDirs];
-  trackedDirs.clear();
-  for (const dir of reaped) rmSync(dir, { recursive: true, force: true });
-  return reaped;
+/** A registry of its own, so a test can reap without touching directories another file still holds. */
+export function createTempDirRegistry(): TempDirRegistry {
+  const trackedDirs = new Set<string>();
+  return {
+    tempDir(prefix: string): string {
+      const dir = mkdtempSync(join(tmpdir(), prefix));
+      trackedDirs.add(dir);
+      return dir;
+    },
+    reapTempDirs(): string[] {
+      const tracked = [...trackedDirs];
+      trackedDirs.clear();
+      const removed: string[] = [];
+      for (const dir of tracked) {
+        try {
+          rmSync(dir, { recursive: true, force: true });
+          removed.push(dir);
+        } catch (err) {
+          // One directory the OS refuses to release must not replace the louder process report (#1175).
+          console.error(`leak guard could not remove ${dir}: ${err}`);
+        }
+      }
+      return removed;
+    },
+  };
 }
+
+const shared = createTempDirRegistry();
+
+/** A temp directory the preloaded guard removes when the test process ends; removing it by hand too is safe (#1175). */
+export const tempDir = shared.tempDir;
+
+/** Removes every directory `tempDir()` handed out and returns the ones that are gone; one already gone is not an error. */
+export const reapTempDirs = shared.reapTempDirs;

--- a/tests/helpers/temp-dir.ts
+++ b/tests/helpers/temp-dir.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readdirSync, rmSync, statSync, type Dirent } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -44,3 +44,33 @@ export const tempDir = shared.tempDir;
 
 /** Removes every directory `tempDir()` handed out and returns the ones that are gone; one already gone is not an error. */
 export const reapTempDirs = shared.reapTempDirs;
+
+/** Longer than any run can live: 5x the longest CI job timeout (45 min), so a concurrent run's directories are never stale (#1175). */
+const STALE_AFTER_MS = 4 * 60 * 60 * 1000;
+
+/** The six characters `mkdtempSync` appends are what tells a run's directory from `kesha-mcp`, the audio cache the MCP server keeps. */
+const SWEEPABLE = /^kesha-.+-[A-Za-z0-9]{6}$/;
+
+/** Removes directories left by a run no handler survived — SIGKILL, or a Windows exit that could not release a handle — and returns the ones that are gone (#1175). */
+export function sweepStaleTempDirs(root: string = tmpdir(), now: number = Date.now()): string[] {
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(root, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const cutoff = now - STALE_AFTER_MS;
+  const removed: string[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory() || !SWEEPABLE.test(entry.name)) continue;
+    const dir = join(root, entry.name);
+    try {
+      if (statSync(dir).mtimeMs > cutoff) continue;
+      rmSync(dir, { recursive: true, force: true });
+      removed.push(dir);
+    } catch {
+      // Another run may be removing the same directory; what survives is swept next time.
+    }
+  }
+  return removed;
+}

--- a/tests/helpers/temp-dir.ts
+++ b/tests/helpers/temp-dir.ts
@@ -1,0 +1,20 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const trackedDirs = new Set<string>();
+
+/** A temp directory the preloaded guard removes when the suite ends; removing it by hand too is safe (#1175). */
+export function tempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  trackedDirs.add(dir);
+  return dir;
+}
+
+/** Removes every directory `tempDir()` handed out and returns them; one already gone is not an error. */
+export function reapTempDirs(): string[] {
+  const reaped = [...trackedDirs];
+  trackedDirs.clear();
+  for (const dir of reaped) rmSync(dir, { recursive: true, force: true });
+  return reaped;
+}

--- a/tests/helpers/wedged-temp-dir.fixture.ts
+++ b/tests/helpers/wedged-temp-dir.fixture.ts
@@ -1,0 +1,22 @@
+import { test } from "bun:test";
+import { chmodSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { stubbornShell } from "./process";
+import { tempDir } from "./temp-dir";
+
+const LEAK_TTL_S = 30;
+
+/** Run only as a child of `temp-dir-leak-guard.test.ts`; the leaked process and the unremovable directory are both the point. */
+test("leaks a process, and a directory whose removal fails", () => {
+  const dir = tempDir("kesha-temp-dir-wedged-");
+  writeFileSync(join(dir, "held"), "x");
+  writeFileSync(process.env.KESHA_TEMP_DIR_FIXTURE_OUT!, dir);
+
+  const proc = Bun.spawn(
+    ["sh", "-c", stubbornShell("TERM INT", LEAK_TTL_S), "kesha-engine-leak-guard-fixture"],
+    { stdout: "ignore", stderr: "ignore" },
+  );
+  proc.unref();
+
+  chmodSync(dir, 0o500);
+});

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -76,10 +76,13 @@ against and adds a five-minute clock. `tests/unit/process-leak-guard.test.ts` sc
 The same preload reaps temp directories, quietly — a stray directory harms nobody the way a stray
 process does, but 59,286 of them took the pre-push gate from 180s to 1154s (#1175). Create one with
 `tempDir(prefix)` from `tests/helpers/temp-dir.ts` instead of `mkdtempSync(join(tmpdir(), prefix))`;
-it returns the same path, registers it, and the guard removes it when the suite ends. Call sites
-need nothing else, and a suite that still removes its own directory keeps working unchanged.
+it returns the same path and registers it. The preload's `afterAll` is registered once for the
+test process, so the sweep happens after the last file that process loaded, not at the end of each
+suite; an interrupted run is covered by an `exit` handler instead. Call sites need nothing else,
+and a suite that still removes its own directory keeps working unchanged.
 
-`tests/unit/temp-dir-convention.test.ts` enforces that by scanning `tests/` for a direct
-`mkdtempSync` call. The suites that predate the helper are listed there by name with a reason, so
-staying on the old shape is a written-down choice rather than the default a new helper inherits —
-which is how this leak grew in the first place.
+`tests/unit/temp-dir-convention.test.ts` enforces that by scanning `tests/` for a direct call to
+`mkdtempSync` or its promise spelling, and for an import that hides either behind an alias. The
+suites that predate the helper are listed there by name with a reason, so staying on the old shape
+is a written-down choice rather than the default a new helper inherits — which is how this leak
+grew in the first place.

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -70,3 +70,16 @@ them accumulated at `PPID=1` over two days, the oldest at 45 hours, and only `ki
 `stubbornShell()` from `tests/helpers/process.ts`, which keeps the immunity the escalation is tested
 against and adds a five-minute clock. `tests/unit/process-leak-guard.test.ts` scans `tests/` and
 `rust/src/` for the unbounded shape and fails naming the file and line.
+
+## No suite may leave a temp directory behind
+
+The same preload reaps temp directories, quietly — a stray directory harms nobody the way a stray
+process does, but 59,286 of them took the pre-push gate from 180s to 1154s (#1175). Create one with
+`tempDir(prefix)` from `tests/helpers/temp-dir.ts` instead of `mkdtempSync(join(tmpdir(), prefix))`;
+it returns the same path, registers it, and the guard removes it when the suite ends. Call sites
+need nothing else, and a suite that still removes its own directory keeps working unchanged.
+
+`tests/unit/temp-dir-convention.test.ts` enforces that by scanning `tests/` for a direct
+`mkdtempSync` call. The suites that predate the helper are listed there by name with a reason, so
+staying on the old shape is a written-down choice rather than the default a new helper inherits —
+which is how this leak grew in the first place.

--- a/tests/integration/mcp-lifecycle.test.ts
+++ b/tests/integration/mcp-lifecycle.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { chmodSync, mkdtempSync, writeFileSync } from "fs";
-import { tmpdir } from "os";
+import { chmodSync, writeFileSync } from "fs";
 import { join } from "path";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { waitForPidExit, waitForPidFile } from "../helpers/process";
 import { describeJson } from "../helpers/fake-engine";
+import { tempDir } from "../helpers/temp-dir";
 
 const DEFAULT_CWD = import.meta.dir + "/../..";
 
@@ -37,7 +37,7 @@ process.exit(2);
 describe("MCP server lifecycle", () => {
   test("interrupting the server terminates a list_voices Engine spawn", async () => {
     if (process.platform === "win32") return;
-    const dir = mkdtempSync(join(tmpdir(), "kesha-mcp-lifecycle-"));
+    const dir = tempDir("kesha-mcp-lifecycle-");
     const enginePidPath = join(dir, "engine.pid");
     const enginePath = createListVoicesHangEngine(dir, enginePidPath);
 

--- a/tests/unit/check-workflows.test.ts
+++ b/tests/unit/check-workflows.test.ts
@@ -40,6 +40,7 @@ import {
   requireTestedScriptsInCodeFilter,
 } from "../../.github/scripts/check-workflows";
 import { parseRepoYaml, readRepoFile, repoPath, REPO_ROOT } from "../helpers/repo";
+import { tempDir } from "../helpers/temp-dir";
 
 const PATH = ".github/workflows/build-engine.yml";
 const CI = ".github/workflows/ci.yml";
@@ -257,14 +258,14 @@ describe("forbidFindPipedToHead", () => {
   // A dropped check wouldn't show up against the clean repo tree, only against a probe (see above).
   test("the file gate actually runs it", () => {
     const yaml = "on: push\njobs:\n  smoke:\n    runs-on: macos-14\n    steps:\n      - run: find . -name x | head -1\n";
-    const path = join(mkdtempSync(join(tmpdir(), "kesha-wf-")), "probe.yml");
+    const path = join(tempDir("kesha-wf-"), "probe.yml");
     writeFileSync(path, yaml);
     expect(checkFile(path, [], [], undefined, NO_SOURCES).filter((e) => e.includes("#1088"))).toHaveLength(1);
   });
 });
 
 describe("checkFlakeNix", () => {
-  const dir = () => mkdtempSync(join(tmpdir(), "kesha-flake-"));
+  const dir = () => tempDir("kesha-flake-");
 
   test("catches find piped to head", () => {
     const path = join(dir(), "flake.nix");
@@ -626,7 +627,7 @@ describe("manifest sources stay inside both path filters", () => {
   // The real tree cannot separate the two lists — both path filters are directory wildcards that cover
   // every models file — so the argument order checkFile forwards is only visible on distinct sets (#950 round 3).
   test("checkFile forwards each list to its own rule", () => {
-    const dir = mkdtempSync(join(tmpdir(), "kesha-wf-"));
+    const dir = tempDir("kesha-wf-");
     const ci = join(dir, "ci.yml");
     writeFileSync(ci, "on: push\njobs:\n  changes:\n    steps:\n      - with:\n          filters: |\n            code:\n              - 'a.rs'\n              - 'b.rs'\n");
     const seed = join(dir, "cache-seed.yml");
@@ -650,7 +651,7 @@ describe("manifest sources stay inside both path filters", () => {
 
   // A gate is only a gate if checkFile still calls it; the real tree cannot notice an unwired one.
   test("the file gate actually runs all three", () => {
-    const dir = mkdtempSync(join(tmpdir(), "kesha-wf-"));
+    const dir = tempDir("kesha-wf-");
     const ci = join(dir, "ci.yml");
     writeFileSync(ci, "on: push\njobs:\n  changes:\n    steps:\n      - with:\n          filters: |\n            code:\n              - 'src/**'\n");
     // Distinct fifth and sixth arguments: each rule must name the file from its OWN set, so handing
@@ -811,7 +812,7 @@ describe("requireFlakeNixInWorkflowsFilter", () => {
 
   test("the file gate actually runs it", () => {
     const yaml = "jobs:\n  changes:\n    steps:\n      - with:\n          filters: |\n            workflows:\n              - '.github/workflows/**'\n";
-    const path = join(mkdtempSync(join(tmpdir(), "kesha-wf-")), "ci.yml");
+    const path = join(tempDir("kesha-wf-"), "ci.yml");
     writeFileSync(path, yaml);
     expect(checkFile(path, [], [], undefined, NO_SOURCES).filter((e) => e.includes("#1088"))).toHaveLength(1);
   });
@@ -859,7 +860,7 @@ describe("requireBuildScriptInCoremlFilter", () => {
   test("the file gate actually runs it", () => {
     const yaml =
       "on:\n  pull_request:\njobs:\n  changes:\n    steps:\n      - with:\n          filters: |\n            coreml:\n              - 'rust/src/backend/fluidaudio.rs'\n";
-    const path = join(mkdtempSync(join(tmpdir(), "kesha-wf-")), "rust-test.yml");
+    const path = join(tempDir("kesha-wf-"), "rust-test.yml");
     writeFileSync(path, yaml);
     expect(checkFile(path, [], [], undefined, NO_SOURCES).filter((e) => e.includes("#1145"))).toHaveLength(1);
   });
@@ -1044,7 +1045,7 @@ describe("requirePipefailShell", () => {
   // dropped check because the tree it reads is already clean.
   test("the file gate actually runs it", () => {
     const yaml = "on: push\njobs:\n  smoke:\n    runs-on: ubuntu-latest\n    steps:\n      - run: a | b\n";
-    const path = join(mkdtempSync(join(tmpdir(), "kesha-wf-")), "probe.yml");
+    const path = join(tempDir("kesha-wf-"), "probe.yml");
     writeFileSync(path, yaml);
     expect(checkFile(path, [], [], undefined, NO_SOURCES).filter((e) => e.includes("#1084"))).toHaveLength(1);
   });
@@ -1092,7 +1093,7 @@ describe("requirePipefailShell", () => {
 
   test("the file gate actually runs it on a composite action", () => {
     const yaml = "name: Example\nruns:\n  using: composite\n  steps:\n    - run: a | b\n      shell: sh\n";
-    const path = join(mkdtempSync(join(tmpdir(), "kesha-wf-")), "action.yml");
+    const path = join(tempDir("kesha-wf-"), "action.yml");
     writeFileSync(path, yaml);
     expect(checkFile(path, [], [], undefined, NO_SOURCES).filter((e) => e.includes("#1089"))).toHaveLength(1);
   });
@@ -1283,7 +1284,7 @@ describe("requireJobTimeouts", () => {
   // dropped check because the tree it reads is already clean.
   test("the file gate actually runs it", () => {
     const yaml = "on: push\njobs:\n  lint:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n";
-    const path = join(mkdtempSync(join(tmpdir(), "kesha-wf-")), "probe.yml");
+    const path = join(tempDir("kesha-wf-"), "probe.yml");
     writeFileSync(path, yaml);
     expect(checkFile(path, [], [], undefined, NO_SOURCES).filter((e) => e.includes("#1105"))).toHaveLength(1);
   });
@@ -1503,7 +1504,7 @@ describe("requireConcurrencyOnPullRequestWorkflows", () => {
   test("the file gate actually runs it", () => {
     const yaml =
       "on:\n  pull_request:\njobs:\n  lint:\n    runs-on: ubuntu-latest\n    timeout-minutes: 10\n    steps:\n      - run: echo hi\n";
-    const path = join(mkdtempSync(join(tmpdir(), "kesha-wf-")), "probe.yml");
+    const path = join(tempDir("kesha-wf-"), "probe.yml");
     writeFileSync(path, yaml);
     expect(checkFile(path, [], [], undefined, NO_SOURCES).filter((e) => e.includes("#1105"))).toHaveLength(1);
   });
@@ -1565,7 +1566,7 @@ describe("requireBuildEngineSerialisesRunsPerRef", () => {
 
   test("the file gate actually runs it", () => {
     const yaml = "on:\n  push:\njobs: {}\n";
-    const path = join(mkdtempSync(join(tmpdir(), "kesha-wf-")), "build-engine.yml");
+    const path = join(tempDir("kesha-wf-"), "build-engine.yml");
     writeFileSync(path, yaml);
     expect(checkFile(path, [], [], undefined, NO_SOURCES).filter((e) => e.includes("#1108"))).toHaveLength(2);
   });
@@ -1643,7 +1644,7 @@ describe("requireReleaseVerifiesTagIsCurrent", () => {
   test("the file gate actually runs it", () => {
     const yaml =
       "on:\n  push:\njobs:\n  release:\n    steps:\n      - uses: softprops/action-gh-release@3d0d9888c\n";
-    const path = join(mkdtempSync(join(tmpdir(), "kesha-wf-")), "build-engine.yml");
+    const path = join(tempDir("kesha-wf-"), "build-engine.yml");
     writeFileSync(path, yaml);
     expect(checkFile(path, [], [], undefined, NO_SOURCES).filter((e) => e.includes("#1115"))).toHaveLength(1);
   });
@@ -1682,7 +1683,7 @@ describe("requireRustTestCancelsSupersededRuns", () => {
 
   test("the file gate actually runs it", () => {
     const yaml = "on:\n  pull_request:\nconcurrency:\n  group: ${{ github.ref }}\n  cancel-in-progress: false\njobs: {}\n";
-    const path = join(mkdtempSync(join(tmpdir(), "kesha-wf-")), "rust-test.yml");
+    const path = join(tempDir("kesha-wf-"), "rust-test.yml");
     writeFileSync(path, yaml);
     expect(checkFile(path, [], [], undefined, NO_SOURCES).filter((e) => e.includes("#1105"))).toHaveLength(1);
   });
@@ -1710,7 +1711,7 @@ describe("forbidNixBuildInCiAggregator", () => {
   // a second error containing "nix-build" and this would pass asserting nothing (#1105).
   test("the file gate actually runs it", () => {
     const yaml = "on: push\njobs:\n  nix-build:\n    if: github.event_name == 'push'\n  ci:\n    needs: [nix-build]\n";
-    const path = join(mkdtempSync(join(tmpdir(), "kesha-wf-")), "ci.yml");
+    const path = join(tempDir("kesha-wf-"), "ci.yml");
     writeFileSync(path, yaml);
     expect(checkFile(path, [], [], undefined, NO_SOURCES).filter((e) => e.includes("nix-build"))).toHaveLength(1);
   });

--- a/tests/unit/doctor.test.ts
+++ b/tests/unit/doctor.test.ts
@@ -26,6 +26,7 @@ import { engineVersion, packageName, packageVersion } from "../../src/package-in
 import { enableStats } from "../../src/stats";
 import { isDarwinArm64 } from "../../src/engine-targets";
 import { KOKORO_ANE_EN_REQUIRED, KOKORO_G2P_REQUIRED } from "../../src/kokoro-ane";
+import { tempDir } from "../helpers/temp-dir";
 
 const fakeCapabilities = describeDocument({
   backend: "fake-coreml",
@@ -910,7 +911,7 @@ describe("createSupportBundle", () => {
   });
 
   test("includes bounded diagnostic log tail only when requested", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "kesha-support-bundle-logs-test-"));
+    const dir = tempDir("kesha-support-bundle-logs-test-");
     try {
       process.env.HOME = dir;
       process.env.KESHA_LOG_DIR = join(dir, "logs");

--- a/tests/unit/engine-install.test.ts
+++ b/tests/unit/engine-install.test.ts
@@ -18,6 +18,7 @@ import { defaultEngineBinPath } from "../../src/paths";
 import { engineVersion } from "../../src/package-info";
 import { isDarwinArm64 } from "../../src/engine-targets";
 import { describeJson, isolateEngineCache } from "../helpers/fake-engine";
+import { tempDir } from "../helpers/temp-dir";
 
 /** Strips ANSI SGR sequences so captured `process.stderr.write` output can be asserted on plainly. */
 function stripAnsi(text: string): string {
@@ -25,7 +26,7 @@ function stripAnsi(text: string): string {
 }
 
 function mkTmpBinPath(): string {
-  const dir = mkdtempSync(join(tmpdir(), "kesha-install-test-"));
+  const dir = tempDir("kesha-install-test-");
   return join(dir, "kesha-engine");
 }
 

--- a/tests/unit/engine.test.ts
+++ b/tests/unit/engine.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from "bun:test";
-import { chmodSync, mkdtempSync, mkdirSync, utimesSync, writeFileSync } from "fs";
-import { homedir, tmpdir } from "os";
+import { chmodSync, mkdirSync, utimesSync, writeFileSync } from "fs";
+import { homedir } from "os";
 import { join } from "path";
 import { stubbornShell, waitForPidExit, waitForPidFile } from "../helpers/process";
 import { describeJson, envEchoEngine, saveEngineEnv, writeTranscribingEngine } from "../helpers/fake-engine";
@@ -22,6 +22,7 @@ import {
 import { KeshaError } from "../../src/engine/events";
 import { errorMessage } from "../../src/error-utils";
 import { transcribeWithSegments, validateTranscribeRequest } from "../../src/transcribe";
+import { tempDir } from "../helpers/temp-dir";
 
 /** The thrown KeshaError, so a test can assert on code and hint rather than on prose. */
 async function failure(run: () => Promise<unknown>): Promise<KeshaError> {
@@ -46,7 +47,7 @@ const fakeEngineTest = process.platform === "win32" ? test.skip : test;
 
 /** A stub answering one flagless lang-detect command; `body` runs before the forced `exit 0`. */
 function langDetectEngine(prefix: string, command: string, body: string): string {
-  const dir = mkdtempSync(join(tmpdir(), prefix));
+  const dir = tempDir(prefix);
   const path = join(dir, "kesha-engine");
   writeFileSync(
     path,
@@ -64,7 +65,7 @@ exit 2
 
 /** Echoes the `transcribe` argv it was handed as the transcript, so a test can assert which flags were forwarded. */
 async function argEchoEngine(features: string[]): Promise<string> {
-  const dir = mkdtempSync(join(tmpdir(), "kesha-engine-argecho-"));
+  const dir = tempDir("kesha-engine-argecho-");
   const path = join(dir, "kesha-engine");
   await Bun.write(
     path,
@@ -86,7 +87,7 @@ exit 2
 }
 
 function capsEngineWithVersion(protocolVersion: number): string {
-  const path = join(mkdtempSync(join(tmpdir(), "kesha-engine-proto-")), "kesha-engine");
+  const path = join(tempDir("kesha-engine-proto-"), "kesha-engine");
   writeFileSync(
     path,
     `#!/bin/sh\nif [ "$1" = "describe" ]; then\n  printf '%s\\n' '${describeJson({ features: ["transcribe"], protocolVersion })}'\n  exit 0\nfi\nexit 2\n`,
@@ -150,7 +151,7 @@ async function withEngineEnv<T>(
 
 /** #768: `--speakers` preflight requires the VAD model alongside the diarize model. */
 function cacheDirWithVadModel(): string {
-  const cache = mkdtempSync(join(tmpdir(), "kesha-cache-vad-"));
+  const cache = tempDir("kesha-cache-vad-");
   mkdirSync(join(cache, "models", "silero-vad"), { recursive: true });
   writeFileSync(join(cache, "models", "silero-vad", "silero_vad.onnx"), "");
   return cache;
@@ -255,7 +256,7 @@ describe("engine", () => {
   });
 
   fakeEngineTest("validateTranscribeRequest with no engine is E_ENGINE_SPAWN naming the install step", async () => {
-    const empty = mkdtempSync(join(tmpdir(), "kesha-engine-absent-"));
+    const empty = tempDir("kesha-engine-absent-");
     await withEngineEnv(join(empty, "kesha-engine"), async () => {
       const err = await failure(() => validateTranscribeRequest({}));
       expect(err.code).toBe("E_ENGINE_SPAWN");
@@ -267,7 +268,7 @@ describe("engine", () => {
   });
 
   fakeEngineTest("validateTranscribeRequest against an engine that cannot describe itself is E_ENGINE_PROTOCOL", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "kesha-engine-old-transcribe-"));
+    const dir = tempDir("kesha-engine-old-transcribe-");
     const old = join(dir, "kesha-engine");
     writeFileSync(old, "#!/bin/sh\necho 'error: unrecognized subcommand describe' >&2\nexit 2\n");
     chmodSync(old, 0o755);
@@ -289,7 +290,7 @@ describe("engine", () => {
   });
 
   fakeEngineTest("a library call with no engine is E_ENGINE_SPAWN from the engine layer", async () => {
-    const empty = mkdtempSync(join(tmpdir(), "kesha-engine-absent-lib-"));
+    const empty = tempDir("kesha-engine-absent-lib-");
     await withEngineEnv(join(empty, "kesha-engine"), async () => {
       const err = await failure(() => transcribeWithSegments("audio.wav"));
       expect(err.code).toBe("E_ENGINE_SPAWN");
@@ -341,7 +342,7 @@ describe("engine", () => {
   });
 
   fakeEngineTest("an engine that cannot describe itself is E_ENGINE_PROTOCOL pointing at kesha install", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "kesha-engine-old-"));
+    const dir = tempDir("kesha-engine-old-");
     const old = join(dir, "kesha-engine");
     writeFileSync(old, "#!/bin/sh\necho 'error: unrecognized subcommand describe' >&2\nexit 2\n");
     chmodSync(old, 0o755);
@@ -377,7 +378,7 @@ describe("engine", () => {
   });
 
   fakeEngineTest("preflight rejects speakers when the VAD model is missing (#768)", async () => {
-    const modelPath = mkdtempSync(join(tmpdir(), "kesha-diarize-model-"));
+    const modelPath = tempDir("kesha-diarize-model-");
     mkdirSync(join(modelPath, "Data", "com.apple.CoreML", "weights"), { recursive: true });
     await withEngineEnv(
       fakeEngine(["transcribe.segments", "transcribe.diarize"]),
@@ -389,13 +390,13 @@ describe("engine", () => {
       },
       {
         KESHA_DIARIZE_MODEL_PATH: modelPath,
-        KESHA_CACHE_DIR: mkdtempSync(join(tmpdir(), "kesha-cache-no-vad-")),
+        KESHA_CACHE_DIR: tempDir("kesha-cache-no-vad-"),
       },
     );
   });
 
   fakeEngineTest("transcribeEngineWithSegments accepts a valid diarize override and parses speakers", async () => {
-    const modelPath = mkdtempSync(join(tmpdir(), "kesha-diarize-model-"));
+    const modelPath = tempDir("kesha-diarize-model-");
     mkdirSync(join(modelPath, "Data", "com.apple.CoreML", "weights"), { recursive: true });
     await withEngineEnv(
       fakeEngine(["transcribe.segments", "transcribe.diarize"]),
@@ -478,7 +479,7 @@ describe("engine", () => {
   });
 
   fakeEngineTest("transcribeEngine surfaces E_ENGINE_SPAWN instead of a raw spawn exception", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "kesha-engine-not-exec-"));
+    const dir = tempDir("kesha-engine-not-exec-");
     const notExecutable = join(dir, "kesha-engine");
     writeFileSync(notExecutable, "not a binary");
     chmodSync(notExecutable, 0o644);
@@ -492,7 +493,7 @@ describe("engine", () => {
   });
 
   fakeEngineTest("recordEngine surfaces E_ENGINE_SPAWN instead of a raw spawn exception", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "kesha-engine-not-exec-record-"));
+    const dir = tempDir("kesha-engine-not-exec-record-");
     const notExecutable = join(dir, "kesha-engine");
     writeFileSync(notExecutable, "not a binary");
     chmodSync(notExecutable, 0o644);
@@ -509,7 +510,7 @@ describe("engine", () => {
    * error line under a transcript that arrived intact (#962).
    */
   fakeEngineTest("recordEngine accepts a live session that stopped on a signal", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "kesha-engine-record-signal-"));
+    const dir = tempDir("kesha-engine-record-signal-");
     const enginePath = join(dir, "kesha-engine");
     writeFileSync(enginePath, "#!/bin/sh\nexit ${KESHA_TEST_RECORD_EXIT:-0}\n");
     chmodSync(enginePath, 0o755);
@@ -529,7 +530,7 @@ describe("engine", () => {
 
   /** A capture-to-WAV run has no signal handler, so a signalled exit really is a lost recording. */
   fakeEngineTest("recordEngine still reports a signalled capture-to-WAV run as a failure", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "kesha-engine-record-wav-signal-"));
+    const dir = tempDir("kesha-engine-record-wav-signal-");
     const enginePath = join(dir, "kesha-engine");
     writeFileSync(enginePath, "#!/bin/sh\nexit 130\n");
     chmodSync(enginePath, 0o755);
@@ -541,7 +542,7 @@ describe("engine", () => {
   });
 
   fakeEngineTest("abort terminates the spawned engine process tree", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "kesha-engine-tree-"));
+    const dir = tempDir("kesha-engine-tree-");
     const helperPidFile = join(dir, "helper.pid");
     const enginePath = fakeLongRunningEngine(dir, helperPidFile);
     await withEngineEnv(enginePath, async () => {
@@ -565,7 +566,7 @@ describe("engine", () => {
    * wall-clock comparison to go flaky.
    */
   fakeEngineTest("progress reaches the caller while the engine is still running", async () => {
-    const ack = join(mkdtempSync(join(tmpdir(), "kesha-live-progress-")), "ack");
+    const ack = join(tempDir("kesha-live-progress-"), "ack");
     const engine = writeTranscribingEngine(
       "kesha-engine-live-progress-",
       ["transcribe.segments"],
@@ -639,7 +640,7 @@ describe("engine", () => {
   });
 
   fakeEngineTest("a describe that also writes a non-event line is E_INTERNAL, never a cached document", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "kesha-engine-babble-"));
+    const dir = tempDir("kesha-engine-babble-");
     const path = join(dir, "kesha-engine");
     writeFileSync(
       path,
@@ -663,7 +664,7 @@ exit 2
   });
 
   fakeEngineTest("a newer protocol plus a stray stderr line is still E_ENGINE_PROTOCOL", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "kesha-engine-newer-babble-"));
+    const dir = tempDir("kesha-engine-newer-babble-");
     const path = join(dir, "kesha-engine");
     writeFileSync(
       path,
@@ -868,7 +869,7 @@ describe("the engine boundary refuses to pass a malformed reply through", () => 
   }
 
   function describingEngine(payload: string, exitCode = 0): string {
-    const path = join(mkdtempSync(join(tmpdir(), "kesha-engine-describe-")), "kesha-engine");
+    const path = join(tempDir("kesha-engine-describe-"), "kesha-engine");
     writeFileSync(
       path,
       `#!/bin/sh\nif [ "$1" = "describe" ]; then\n  printf '%s\\n' '${payload}'\n  exit ${exitCode}\nfi\nexit 2\n`,
@@ -1033,7 +1034,7 @@ describe("the capability probe stays in step with the installed binary", () => {
 
   // #248: `kesha install` overwrites the binary in place, so the path alone cannot key the cache.
   fakeEngineTest("an in-place reinstall is not served from the cache", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "kesha-engine-recache-"));
+    const dir = tempDir("kesha-engine-recache-");
     await withEngineEnv(capsEngine(dir, ["transcribe.segments"]), async () => {
       expect((await getDescribe()).features).toEqual(["transcribe.segments"]);
 
@@ -1046,7 +1047,7 @@ describe("the capability probe stays in step with the installed binary", () => {
   });
 
   fakeEngineTest("a missing binary reads as no capabilities rather than throwing", async () => {
-    const missing = join(mkdtempSync(join(tmpdir(), "kesha-engine-absent-")), "kesha-engine");
+    const missing = join(tempDir("kesha-engine-absent-"), "kesha-engine");
     await withEngineEnv(missing, async () => {
       expect(await getEngineCapabilities()).toBeNull();
       expect((await failure(() => getDescribe())).code).toBe("E_ENGINE_SPAWN");
@@ -1054,7 +1055,7 @@ describe("the capability probe stays in step with the installed binary", () => {
   });
 
   fakeEngineTest("a describe that reports an error event fails even though its document parses (#1163 follow-up)", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "kesha-engine-describe-error-"));
+    const dir = tempDir("kesha-engine-describe-error-");
     const path = join(dir, "kesha-engine");
     writeFileSync(
       path,
@@ -1077,7 +1078,7 @@ exit 2
 
   // Blank text has no language to detect; spending a subprocess on it would be pure latency.
   fakeEngineTest("blank text resolves null while real text still reaches the engine", async () => {
-    const path = join(mkdtempSync(join(tmpdir(), "kesha-engine-textlang-")), "kesha-engine");
+    const path = join(tempDir("kesha-engine-textlang-"), "kesha-engine");
     writeFileSync(
       path,
       `#!/bin/sh\nif [ "$1" = "detect-text-lang" ]; then\n  printf '%s\\n' '{"code":"ru","confidence":0.9}'\n  exit 0\nfi\nexit 2\n`,

--- a/tests/unit/lib.test.ts
+++ b/tests/unit/lib.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "bun:test";
-import { chmodSync, mkdtempSync, writeFileSync } from "fs";
-import { tmpdir } from "os";
+import { chmodSync, writeFileSync } from "fs";
 import { join } from "path";
 import { transcribe } from "../../src/lib";
 import { writeTranscribingEngine } from "../helpers/fake-engine";
 import { transcribeWithSegments, validateTranscribeRequest } from "../../src/transcribe";
 import { KeshaError } from "../../src/engine/events";
+import { tempDir } from "../helpers/temp-dir";
 
 function fakeEngine(features: string[]): string {
   return writeTranscribingEngine(
@@ -80,7 +80,7 @@ describe("lib API", () => {
   it("reports the missing engine even for an invalid combo like speakers + vad:off (#768)", async () => {
     const saved = process.env.KESHA_ENGINE_BIN;
     try {
-      process.env.KESHA_ENGINE_BIN = join(mkdtempSync(join(tmpdir(), "kesha-no-engine-")), "absent");
+      process.env.KESHA_ENGINE_BIN = join(tempDir("kesha-no-engine-"), "absent");
       let err: unknown;
       try {
         await validateTranscribeRequest({ speakers: true, vad: "off" });

--- a/tests/unit/mcp-list-voices.test.ts
+++ b/tests/unit/mcp-list-voices.test.ts
@@ -1,6 +1,5 @@
-import { describe, test, expect, afterAll } from "bun:test";
-import { chmodSync, existsSync, mkdtempSync, rmSync, writeFileSync } from "fs";
-import { tmpdir } from "os";
+import { describe, test, expect } from "bun:test";
+import { chmodSync, existsSync, writeFileSync } from "fs";
 import { join } from "path";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -9,18 +8,7 @@ import { listVoices } from "../../src/mcp/voices";
 import { errorMessage } from "../../src/error-utils";
 import { describeJson } from "../helpers/fake-engine";
 import { KeshaError } from "../../src/engine/events";
-
-const stubDirs: string[] = [];
-
-function stubDir(prefix: string): string {
-  const dir = mkdtempSync(join(tmpdir(), prefix));
-  stubDirs.push(dir);
-  return dir;
-}
-
-afterAll(() => {
-  for (const dir of stubDirs) rmSync(dir, { recursive: true, force: true });
-});
+import { tempDir } from "../helpers/temp-dir";
 
 const skipOnWin32 = process.platform === "win32" ? test.skip : test;
 
@@ -85,7 +73,7 @@ describe("list_voices / list_languages guard when the engine is missing", () => 
 
 describe("list_voices guard when the engine is present but not executable", () => {
   skipOnWin32("list_voices tool returns isError with E_ENGINE_SPAWN, not a raw spawn exception", async () => {
-    const dir = stubDir("kesha-mcp-not-exec-");
+    const dir = tempDir("kesha-mcp-not-exec-");
     const notExecutable = join(dir, "kesha-engine");
     writeFileSync(notExecutable, "not a binary");
     chmodSync(notExecutable, 0o644);
@@ -102,7 +90,7 @@ describe("list_voices guard when the engine is present but not executable", () =
 
 // A stub, because gating on an installed engine skipped these in every CI lane (#984).
 function voiceListingEngine(voiceIds: string[]): string {
-  const dir = stubDir("kesha-mcp-voices-");
+  const dir = tempDir("kesha-mcp-voices-");
   const path = join(dir, "kesha-engine");
   const args = voiceIds.map((id) => `'${id}'`).join(" ");
   writeFileSync(
@@ -117,7 +105,7 @@ const STUB_VOICES = ["en-am_michael", "en-bf_emma", "ru-vosk-m02"];
 
 // A stub that answers on stdout but writes plain prose to stderr instead of a protocol 4 event.
 function babblingVoicesEngine(): string {
-  const dir = stubDir("kesha-mcp-voices-babble-");
+  const dir = tempDir("kesha-mcp-voices-babble-");
   const path = join(dir, "kesha-engine");
   writeFileSync(
     path,
@@ -184,7 +172,7 @@ describe("list_languages tool", () => {
 
 describe("list_voices() validates against describe before spawning", () => {
   skipOnWin32("a stale engine that cannot describe itself is E_ENGINE_PROTOCOL pointing at kesha install", async () => {
-    const dir = stubDir("kesha-mcp-voices-stale-");
+    const dir = tempDir("kesha-mcp-voices-stale-");
     const path = join(dir, "kesha-engine");
     writeFileSync(
       path,
@@ -200,7 +188,7 @@ describe("list_voices() validates against describe before spawning", () => {
   });
 
   skipOnWin32("a build without tts is E_INVALID_ARG and the engine is never asked", async () => {
-    const dir = stubDir("kesha-mcp-voices-notts-");
+    const dir = tempDir("kesha-mcp-voices-notts-");
     const path = join(dir, "kesha-engine");
     const marker = join(dir, "say-was-spawned");
     writeFileSync(
@@ -219,7 +207,7 @@ describe("list_voices() validates against describe before spawning", () => {
 
 // A stub whose describe answers normally but whose `say --list-voices` reports a coded failure.
 function voiceListingErrorEngine(): string {
-  const dir = stubDir("kesha-mcp-voices-error-");
+  const dir = tempDir("kesha-mcp-voices-error-");
   const path = join(dir, "kesha-engine");
   const errorEvent = JSON.stringify({
     kind: "error",

--- a/tests/unit/mcp-synthesize-voice.test.ts
+++ b/tests/unit/mcp-synthesize-voice.test.ts
@@ -1,12 +1,12 @@
 import { describe, test, expect } from "bun:test";
-import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from "fs";
-import { tmpdir } from "os";
+import { chmodSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { createKeshaMcpServer } from "../../src/mcp/server";
 import { DEFAULT_VOICE_ID, pickVoiceForLang } from "../../src/voice-routing";
 import { describeJson } from "../helpers/fake-engine";
+import { tempDir } from "../helpers/temp-dir";
 
 const skipOnWin32 = process.platform === "win32" ? test.skip : test;
 
@@ -21,7 +21,7 @@ interface SynthesizingEngine {
  * null, the Linux/Windows reality) and records the argv of the `say` it is then handed.
  */
 function synthesizingEngine(lang: { code: string; confidence: number } | null): SynthesizingEngine {
-  const dir = mkdtempSync(join(tmpdir(), "kesha-mcp-synth-"));
+  const dir = tempDir("kesha-mcp-synth-");
   const binPath = join(dir, "kesha-engine");
   const argvPath = join(dir, "say-argv");
   const detect = lang

--- a/tests/unit/release-tag-grammar.test.ts
+++ b/tests/unit/release-tag-grammar.test.ts
@@ -1,6 +1,5 @@
 import { afterAll, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmdirSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { rmdirSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { classifyReleaseTag } from "../../.github/scripts/classify-release-tag.mjs";
 import {
@@ -12,6 +11,7 @@ import {
   stableVersionRe,
 } from "../../.github/scripts/release-tags.mjs";
 import { parseRepoYaml, readRepoFile, REPO_ROOT } from "../helpers/repo";
+import { tempDir } from "../helpers/temp-dir";
 
 const WORKFLOW = ".github/workflows/build-engine.yml";
 const WORKFLOW_YAML = readRepoFile(WORKFLOW);
@@ -190,7 +190,7 @@ describe("release manifest tag check", () => {
   const LINKED = ["src", ".github", "packaging"];
 
   function fixtureRepo(version: string, engineVersion: string): string {
-    const dir = mkdtempSync(join(tmpdir(), "kesha-manifest-"));
+    const dir = tempDir("kesha-manifest-");
     for (const entry of LINKED) symlinkSync(`${REPO_ROOT}/${entry}`, join(dir, entry));
     writeFileSync(
       join(dir, "package.json"),

--- a/tests/unit/synth.test.ts
+++ b/tests/unit/synth.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, spyOn } from "bun:test";
-import { chmodSync, mkdtempSync, writeFileSync } from "fs";
-import { tmpdir } from "os";
+import { chmodSync, writeFileSync } from "fs";
 import { join } from "path";
 import { buildSayArgs, engineCrashMessage, say, SayError, type SayOptions } from "../../src/synth";
 import { validateArgv } from "../../src/engine/describe";
 import { KeshaError } from "../../src/engine/events";
 import { describeDocument, describeJson, saveEngineEnv } from "../helpers/fake-engine";
 import { errorMessage } from "../../src/error-utils";
+import { tempDir } from "../helpers/temp-dir";
 
 describe("SayOptions type contract", () => {
   const oggOpusOptions: SayOptions = {
@@ -121,7 +121,7 @@ describe("say on protocol 4", () => {
   const posixIt = process.platform === "win32" ? it.skip : it;
 
   function sayEngine(body: string): string {
-    const path = join(mkdtempSync(join(tmpdir(), "kesha-say-v4-")), "kesha-engine");
+    const path = join(tempDir("kesha-say-v4-"), "kesha-engine");
     writeFileSync(
       path,
       `#!/bin/sh\nif [ "$1" = "describe" ]; then\n  printf '%s\\n' '${describeJson({ features: ["tts"] })}'\n  exit 0\nfi\nif [ "$1" = "say" ]; then\n${body}\nfi\nexit 2\n`,

--- a/tests/unit/temp-dir-convention.test.ts
+++ b/tests/unit/temp-dir-convention.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync } from "node:fs";
+import { sep } from "node:path";
+import { readRepoFile, repoPath } from "../helpers/repo";
+
+// The temp-directory half of tests/unit/process-leak-guard.test.ts: fake-engine.ts documented a
+// contract that told every call site to rmSync its own directory, and the ones that forgot at a
+// single call site left 59,286 behind, which took the pre-push gate from 180s to 1154s (#1175).
+
+// Exempt for now: each of these removes its directories by hand. Converting them is not this change.
+const EXEMPT: Record<string, string> = {
+  "tests/helpers/temp-dir.ts": "the helper itself — the one mkdtempSync call tempDir() wraps",
+  "tests/helpers/fake-engine.ts": "converted where it leaked; isolateEngineCache() removes its directory in the undo it returns",
+  "tests/helpers/git-repo.ts": "tracks its own directories, and cleanupGitRepos() removes them",
+  "tests/integration/cli-contracts.test.ts": "removes its directories by hand; not yet converted",
+  "tests/integration/compiled-cli-assets.test.ts": "removes its directories by hand; not yet converted",
+  "tests/integration/error-codes-cli.test.ts": "removes its directories by hand; not yet converted",
+  "tests/unit/check-versions.test.ts": "removes its directories by hand; not yet converted",
+  "tests/unit/check-workflows.test.ts": "converted where it leaked; the remaining call sites remove their directories by hand",
+  "tests/unit/diagnostic-log.test.ts": "removes its directories by hand; not yet converted",
+  "tests/unit/doctor.test.ts": "converted where it leaked; the remaining call sites remove their directories by hand",
+  "tests/unit/engine-install-concurrency.test.ts": "removes its directories by hand; not yet converted",
+  "tests/unit/engine-install-decisions.test.ts": "removes its directories by hand; not yet converted",
+  "tests/unit/engine-install.test.ts": "converted where it leaked; the remaining call sites remove their directories by hand",
+  "tests/unit/engine-probe.test.ts": "removes its directories by hand; not yet converted",
+  "tests/unit/engine-repair.test.ts": "removes its directories by hand; not yet converted",
+  "tests/unit/engine-version-override.test.ts": "removes its directories by hand; not yet converted",
+  "tests/unit/fluid-asr-cache.test.ts": "removes its directories by hand; not yet converted",
+  "tests/unit/fluid-roots.test.ts": "removes its directories by hand; not yet converted",
+  "tests/unit/install-lock.test.ts": "removes its directories by hand; not yet converted",
+  "tests/unit/install-plan.test.ts": "removes its directories by hand; not yet converted",
+  "tests/unit/kokoro-ane.test.ts": "removes its directories by hand; not yet converted",
+  "tests/unit/logs-action.test.ts": "removes its directories by hand; not yet converted",
+  "tests/unit/mcp-list-voices.test.ts": "removes its directories by hand; not yet converted",
+  "tests/unit/progress-stream.test.ts": "removes its directories by hand; not yet converted",
+  "tests/unit/say-cli.test.ts": "removes its directories by hand; not yet converted",
+  "tests/unit/star.test.ts": "removes its directories by hand; not yet converted",
+  "tests/unit/stats-action.test.ts": "removes its directories by hand; not yet converted",
+  "tests/unit/stats.test.ts": "removes its directories by hand; not yet converted",
+  "tests/unit/status.test.ts": "removes its directories by hand; not yet converted",
+};
+
+const TESTS_DIR = "tests";
+
+// Assembled from the name rather than written out: the scan below reads this file too.
+const CALL_NAME = "mkdtempSync";
+const DIRECT_CALL = new RegExp(`\\b${CALL_NAME}\\s*\\(`);
+
+function directCallLines(source: string): number[] {
+  const lines: number[] = [];
+  source.split("\n").forEach((line, index) => {
+    if (DIRECT_CALL.test(line)) lines.push(index + 1);
+  });
+  return lines;
+}
+
+function testSources(): string[] {
+  return readdirSync(repoPath(TESTS_DIR), { recursive: true })
+    .map((entry) => `${TESTS_DIR}/${String(entry).split(sep).join("/")}`)
+    .filter((path) => path.endsWith(".ts"))
+    .sort();
+}
+
+const sources = testSources();
+const directCallers = sources
+  .map((path) => ({ path, lines: directCallLines(readRepoFile(path)) }))
+  .filter(({ lines }) => lines.length > 0);
+const callerPaths = directCallers.map(({ path }) => path);
+
+describe("temp directories under tests/", () => {
+  // Without this the gate below passes when the walk or the pattern stops finding anything at all.
+  test("the scan still reads the tree, and still recognises a direct call", () => {
+    expect(sources.length).toBeGreaterThan(50);
+    expect(callerPaths).toContain("tests/helpers/temp-dir.ts");
+    expect(sources).toContain("tests/unit/temp-dir-leak-guard.test.ts");
+    expect(callerPaths).not.toContain("tests/unit/temp-dir-leak-guard.test.ts");
+  });
+
+  test("no file creates one the preloaded guard cannot reap", () => {
+    const unlisted = directCallers.filter(({ path }) => EXEMPT[path] === undefined);
+    if (unlisted.length === 0) return;
+
+    const listed = unlisted.map(({ path, lines }) => `  ${path}:${lines.join(",")}`);
+    throw new Error(
+      `these files call mkdtempSync directly, so the directories they create outlive a failed, ` +
+        `timed-out or interrupted test:\n${listed.join("\n")}\n\n` +
+        `Use \`tempDir(prefix)\` from tests/helpers/temp-dir.ts, which registers the directory with ` +
+        `the guard bunfig.toml preloads; removing it by hand as well stays safe. If a file must call ` +
+        `mkdtempSync itself, add it to EXEMPT in tests/unit/temp-dir-convention.test.ts with the ` +
+        `reason. The convention is written up in tests/integration/README.md.`,
+    );
+  });
+
+  test("carries no stale exemptions", () => {
+    for (const [path, reason] of Object.entries(EXEMPT)) {
+      expect(reason.trim()).not.toBe("");
+      expect(callerPaths).toContain(path);
+    }
+  });
+});
+
+describe("directCallLines", () => {
+  test("names the line a call is on", () => {
+    expect(directCallLines(`const a = 1;\nconst dir = ${CALL_NAME}(join(tmpdir(), "p-"));\n`)).toEqual([2]);
+  });
+
+  test("leaves a file that only imports the name alone", () => {
+    expect(directCallLines(`import { ${CALL_NAME}, rmSync } from "node:fs";\nconst dir = tempDir("p-");\n`)).toEqual([]);
+  });
+});

--- a/tests/unit/temp-dir-convention.test.ts
+++ b/tests/unit/temp-dir-convention.test.ts
@@ -46,14 +46,16 @@ const CALL_NAME = "mkdtempSync";
 const ASYNC_CALL_NAME = CALL_NAME.replace("Sync", "");
 const DIRECT_CALL = new RegExp(`\\b${ASYNC_CALL_NAME}(?:Sync)?\\s*\\(`);
 // An alias renames the call, so the import is the only place the old shape is still spelled out.
-const ALIASED_IMPORT = new RegExp(`\\b(?:import|require)\\b.*\\b${ASYNC_CALL_NAME}(?:Sync)?\\s+as\\s+`);
+const ALIASED_IMPORT = new RegExp(`\\bimport\\s*\\{[^}]*\\b${ASYNC_CALL_NAME}(?:Sync)?\\s+as\\s+`, "g");
 
 function unreapableLines(source: string): number[] {
-  const lines: number[] = [];
+  const lines = new Set<number>();
   source.split("\n").forEach((line, index) => {
-    if (DIRECT_CALL.test(line) || ALIASED_IMPORT.test(line)) lines.push(index + 1);
+    if (DIRECT_CALL.test(line)) lines.add(index + 1);
   });
-  return lines;
+  // An import spans as many lines as it likes, so it is matched against the source and reported where it opens.
+  for (const match of source.matchAll(ALIASED_IMPORT)) lines.add(source.slice(0, match.index).split("\n").length);
+  return [...lines].sort((a, b) => a - b);
 }
 
 function testSources(): string[] {
@@ -116,8 +118,18 @@ describe("unreapableLines", () => {
     expect(unreapableLines(source)).toEqual([1]);
   });
 
+  test("names the import line a multiline alias hides the call behind", () => {
+    const source = `import {\n  ${CALL_NAME} as mk,\n} from "node:fs";\nconst dir = mk(join(tmpdir(), "p-"));\n`;
+    expect(unreapableLines(source)).toEqual([1]);
+  });
+
   test("leaves prose that merely names the alias alone", () => {
     expect(unreapableLines(`// prefer ${CALL_NAME} as the raw call when staging by hand\n`)).toEqual([]);
+  });
+
+  test("leaves prose that names the alias after an unrelated import alone", () => {
+    const source = `import { rmSync } from "node:fs";\n// ${CALL_NAME} as mk is the raw call\n`;
+    expect(unreapableLines(source)).toEqual([]);
   });
 
   test("leaves a file that only imports the name alone", () => {

--- a/tests/unit/temp-dir-convention.test.ts
+++ b/tests/unit/temp-dir-convention.test.ts
@@ -31,7 +31,6 @@ const EXEMPT: Record<string, string> = {
   "tests/unit/install-plan.test.ts": "removes its directories by hand; not yet converted",
   "tests/unit/kokoro-ane.test.ts": "removes its directories by hand; not yet converted",
   "tests/unit/logs-action.test.ts": "removes its directories by hand; not yet converted",
-  "tests/unit/mcp-list-voices.test.ts": "removes its directories by hand; not yet converted",
   "tests/unit/progress-stream.test.ts": "removes its directories by hand; not yet converted",
   "tests/unit/say-cli.test.ts": "removes its directories by hand; not yet converted",
   "tests/unit/star.test.ts": "removes its directories by hand; not yet converted",

--- a/tests/unit/temp-dir-convention.test.ts
+++ b/tests/unit/temp-dir-convention.test.ts
@@ -43,12 +43,15 @@ const TESTS_DIR = "tests";
 
 // Assembled from the name rather than written out: the scan below reads this file too.
 const CALL_NAME = "mkdtempSync";
-const DIRECT_CALL = new RegExp(`\\b${CALL_NAME}\\s*\\(`);
+const ASYNC_CALL_NAME = CALL_NAME.replace("Sync", "");
+const DIRECT_CALL = new RegExp(`\\b${ASYNC_CALL_NAME}(?:Sync)?\\s*\\(`);
+// An alias renames the call, so the import is the only place the old shape is still spelled out.
+const ALIASED_IMPORT = new RegExp(`\\b${ASYNC_CALL_NAME}(?:Sync)?\\s+as\\s+`);
 
-function directCallLines(source: string): number[] {
+function unreapableLines(source: string): number[] {
   const lines: number[] = [];
   source.split("\n").forEach((line, index) => {
-    if (DIRECT_CALL.test(line)) lines.push(index + 1);
+    if (DIRECT_CALL.test(line) || ALIASED_IMPORT.test(line)) lines.push(index + 1);
   });
   return lines;
 }
@@ -61,49 +64,59 @@ function testSources(): string[] {
 }
 
 const sources = testSources();
-const directCallers = sources
-  .map((path) => ({ path, lines: directCallLines(readRepoFile(path)) }))
+const offenders = sources
+  .map((path) => ({ path, lines: unreapableLines(readRepoFile(path)) }))
   .filter(({ lines }) => lines.length > 0);
-const callerPaths = directCallers.map(({ path }) => path);
+const offenderPaths = offenders.map(({ path }) => path);
 
 describe("temp directories under tests/", () => {
   // Without this the gate below passes when the walk or the pattern stops finding anything at all.
   test("the scan still reads the tree, and still recognises a direct call", () => {
     expect(sources.length).toBeGreaterThan(50);
-    expect(callerPaths).toContain("tests/helpers/temp-dir.ts");
+    expect(offenderPaths).toContain("tests/helpers/temp-dir.ts");
     expect(sources).toContain("tests/unit/temp-dir-leak-guard.test.ts");
-    expect(callerPaths).not.toContain("tests/unit/temp-dir-leak-guard.test.ts");
+    expect(offenderPaths).not.toContain("tests/unit/temp-dir-leak-guard.test.ts");
   });
 
   test("no file creates one the preloaded guard cannot reap", () => {
-    const unlisted = directCallers.filter(({ path }) => EXEMPT[path] === undefined);
+    const unlisted = offenders.filter(({ path }) => EXEMPT[path] === undefined);
     if (unlisted.length === 0) return;
 
     const listed = unlisted.map(({ path, lines }) => `  ${path}:${lines.join(",")}`);
     throw new Error(
-      `these files call mkdtempSync directly, so the directories they create outlive a failed, ` +
-        `timed-out or interrupted test:\n${listed.join("\n")}\n\n` +
+      `these files reach ${CALL_NAME} without the guard, so the directories they create outlive a ` +
+        `failed, timed-out or interrupted test:\n${listed.join("\n")}\n\n` +
         `Use \`tempDir(prefix)\` from tests/helpers/temp-dir.ts, which registers the directory with ` +
         `the guard bunfig.toml preloads; removing it by hand as well stays safe. If a file must call ` +
-        `mkdtempSync itself, add it to EXEMPT in tests/unit/temp-dir-convention.test.ts with the ` +
-        `reason. The convention is written up in tests/integration/README.md.`,
+        `it itself, under either spelling or behind an alias, add it to EXEMPT in ` +
+        `tests/unit/temp-dir-convention.test.ts with the reason. The convention is written up in ` +
+        `tests/integration/README.md.`,
     );
   });
 
   test("carries no stale exemptions", () => {
     for (const [path, reason] of Object.entries(EXEMPT)) {
       expect(reason.trim()).not.toBe("");
-      expect(callerPaths).toContain(path);
+      expect(offenderPaths).toContain(path);
     }
   });
 });
 
-describe("directCallLines", () => {
+describe("unreapableLines", () => {
   test("names the line a call is on", () => {
-    expect(directCallLines(`const a = 1;\nconst dir = ${CALL_NAME}(join(tmpdir(), "p-"));\n`)).toEqual([2]);
+    expect(unreapableLines(`const a = 1;\nconst dir = ${CALL_NAME}(join(tmpdir(), "p-"));\n`)).toEqual([2]);
+  });
+
+  test("names the line the promise spelling is called on", () => {
+    expect(unreapableLines(`const dir = await ${ASYNC_CALL_NAME}(join(tmpdir(), "p-"));\n`)).toEqual([1]);
+  });
+
+  test("names the import line an alias hides the call behind", () => {
+    const source = `import { ${CALL_NAME} as mk } from "node:fs";\nconst dir = mk(join(tmpdir(), "p-"));\n`;
+    expect(unreapableLines(source)).toEqual([1]);
   });
 
   test("leaves a file that only imports the name alone", () => {
-    expect(directCallLines(`import { ${CALL_NAME}, rmSync } from "node:fs";\nconst dir = tempDir("p-");\n`)).toEqual([]);
+    expect(unreapableLines(`import { ${CALL_NAME}, rmSync } from "node:fs";\nconst dir = tempDir("p-");\n`)).toEqual([]);
   });
 });

--- a/tests/unit/temp-dir-convention.test.ts
+++ b/tests/unit/temp-dir-convention.test.ts
@@ -46,7 +46,7 @@ const CALL_NAME = "mkdtempSync";
 const ASYNC_CALL_NAME = CALL_NAME.replace("Sync", "");
 const DIRECT_CALL = new RegExp(`\\b${ASYNC_CALL_NAME}(?:Sync)?\\s*\\(`);
 // An alias renames the call, so the import is the only place the old shape is still spelled out.
-const ALIASED_IMPORT = new RegExp(`\\b${ASYNC_CALL_NAME}(?:Sync)?\\s+as\\s+`);
+const ALIASED_IMPORT = new RegExp(`\\b(?:import|require)\\b.*\\b${ASYNC_CALL_NAME}(?:Sync)?\\s+as\\s+`);
 
 function unreapableLines(source: string): number[] {
   const lines: number[] = [];
@@ -114,6 +114,10 @@ describe("unreapableLines", () => {
   test("names the import line an alias hides the call behind", () => {
     const source = `import { ${CALL_NAME} as mk } from "node:fs";\nconst dir = mk(join(tmpdir(), "p-"));\n`;
     expect(unreapableLines(source)).toEqual([1]);
+  });
+
+  test("leaves prose that merely names the alias alone", () => {
+    expect(unreapableLines(`// prefer ${CALL_NAME} as the raw call when staging by hand\n`)).toEqual([]);
   });
 
   test("leaves a file that only imports the name alone", () => {

--- a/tests/unit/temp-dir-leak-guard.test.ts
+++ b/tests/unit/temp-dir-leak-guard.test.ts
@@ -112,6 +112,23 @@ describe("temp directory leak guard", () => {
     }
   });
 
+  wedgeable("keeps a directory it could not remove, so the exit pass gets another go", () => {
+    const registry = createTempDirRegistry();
+    const wedged = registry.tempDir("kesha-temp-dir-guard-");
+    writeFileSync(join(wedged, "held"), "x");
+    chmodSync(wedged, 0o500);
+    try {
+      expect(registry.reapTempDirs()).not.toContain(wedged);
+      chmodSync(wedged, 0o700);
+
+      expect(registry.reapTempDirs()).toContain(wedged);
+      expect(existsSync(wedged)).toBe(false);
+    } finally {
+      if (existsSync(wedged)) chmodSync(wedged, 0o700);
+      rmSync(wedged, { recursive: true, force: true });
+    }
+  });
+
   wedgeable("still reports the processes a suite leaked when a directory refuses to go", () => {
     const registry = createTempDirRegistry();
     const out = join(registry.tempDir("kesha-temp-dir-guard-"), "leaked-path");

--- a/tests/unit/temp-dir-leak-guard.test.ts
+++ b/tests/unit/temp-dir-leak-guard.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, test } from "bun:test";
-import { existsSync, readFileSync, rmSync } from "node:fs";
+import { chmodSync, existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { REPO_ROOT } from "../helpers/repo";
-import { reapTempDirs, tempDir } from "../helpers/temp-dir";
+import { createTempDirRegistry, reapTempDirs, tempDir } from "../helpers/temp-dir";
 
 const FIXTURE = "./tests/helpers/leaked-temp-dir.fixture.ts";
+const WEDGED_FIXTURE = "./tests/helpers/wedged-temp-dir.fixture.ts";
+
+/** A read-only directory is how POSIX reaches the branch Windows reaches with EPERM on an open handle; root ignores the mode. */
+const wedgeable = process.platform === "win32" || process.getuid?.() === 0 ? test.skip : test;
 
 describe("temp directory leak guard", () => {
   test("removes a directory the test never cleaned up, and names it", () => {
@@ -39,5 +43,48 @@ describe("temp directory leak guard", () => {
     const leaked = readFileSync(out, "utf8");
     expect(leaked).toContain("kesha-temp-dir-fixture-");
     expect(existsSync(leaked)).toBe(false);
+  });
+
+  wedgeable("removes the rest when one directory refuses to go, and leaves it out of the list", () => {
+    const registry = createTempDirRegistry();
+    const wedged = registry.tempDir("kesha-temp-dir-guard-");
+    writeFileSync(join(wedged, "held"), "x");
+    chmodSync(wedged, 0o500);
+    const other = registry.tempDir("kesha-temp-dir-guard-");
+
+    try {
+      const reaped = registry.reapTempDirs();
+
+      expect(reaped).toContain(other);
+      expect(reaped).not.toContain(wedged);
+      expect(existsSync(other)).toBe(false);
+    } finally {
+      chmodSync(wedged, 0o700);
+      rmSync(wedged, { recursive: true, force: true });
+    }
+  });
+
+  wedgeable("still reports the processes a suite leaked when a directory refuses to go", () => {
+    const registry = createTempDirRegistry();
+    const out = join(registry.tempDir("kesha-temp-dir-guard-"), "leaked-path");
+    let wedged = "";
+
+    try {
+      const run = Bun.spawnSync(["bun", "test", WEDGED_FIXTURE], {
+        cwd: REPO_ROOT,
+        env: { ...process.env, KESHA_TEMP_DIR_FIXTURE_OUT: out },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      wedged = readFileSync(out, "utf8");
+
+      expect(run.stderr.toString()).toContain("process(es) running");
+    } finally {
+      registry.reapTempDirs();
+      if (wedged !== "") {
+        chmodSync(wedged, 0o700);
+        rmSync(wedged, { recursive: true, force: true });
+      }
+    }
   });
 });

--- a/tests/unit/temp-dir-leak-guard.test.ts
+++ b/tests/unit/temp-dir-leak-guard.test.ts
@@ -186,8 +186,7 @@ describe("stale temp directory sweep", () => {
   test("runs at preload, so the run after a killed one is what cleans up its directories", () => {
     const registry = createTempDirRegistry();
     const out = join(registry.tempDir("kesha-temp-dir-guard-"), "leaked-path");
-    const abandoned = join(tmpdir(), `kesha-temp-dir-abandoned-${process.pid}-a1b2c3`);
-    mkdirSync(abandoned, { recursive: true });
+    const abandoned = registry.tempDir("kesha-temp-dir-abandoned-");
     utimesSync(abandoned, LONG_AGO, LONG_AGO);
 
     try {
@@ -206,21 +205,19 @@ describe("stale temp directory sweep", () => {
     }
   });
 
-  /** The temp root is shared with the MCP audio cache and with every other tool on the machine. */
-  test("leaves what no run of this suite created alone, however old", () => {
-    const registry = createTempDirRegistry();
-    const root = registry.tempDir("kesha-temp-dir-guard-");
+  /** The temp root holds the MCP audio cache and whatever else the machine put there; only the sub-root is the helper's to delete. */
+  test("cannot reach the temp root at all, whatever a directory there is called", () => {
+    const decoy = join(tmpdir(), `kesha-important-backup-${process.pid}-a1b2c3`);
+    mkdirSync(decoy, { recursive: true });
+    writeFileSync(join(decoy, "held"), "x");
+    utimesSync(decoy, LONG_AGO, LONG_AGO);
 
     try {
-      const mcpCache = stage(root, "kesha-mcp", "stale");
-      const foreign = stage(root, "some-other-tool-a1b2c3", "stale");
+      expect(sweepStaleTempDirs()).not.toContain(decoy);
 
-      expect(sweepStaleTempDirs(root)).toEqual([]);
-
-      expect(existsSync(mcpCache)).toBe(true);
-      expect(existsSync(foreign)).toBe(true);
+      expect(existsSync(decoy)).toBe(true);
     } finally {
-      registry.reapTempDirs();
+      rmSync(decoy, { recursive: true, force: true });
     }
   });
 });

--- a/tests/unit/temp-dir-leak-guard.test.ts
+++ b/tests/unit/temp-dir-leak-guard.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { REPO_ROOT } from "../helpers/repo";
+import { reapTempDirs, tempDir } from "../helpers/temp-dir";
+
+const FIXTURE = "./tests/helpers/leaked-temp-dir.fixture.ts";
+
+describe("temp directory leak guard", () => {
+  test("removes a directory the test never cleaned up, and names it", () => {
+    const dir = tempDir("kesha-temp-dir-guard-");
+    expect(existsSync(dir)).toBe(true);
+
+    const reaped = reapTempDirs();
+
+    expect(reaped).toContain(dir);
+    expect(existsSync(dir)).toBe(false);
+  });
+
+  /** Suites that already clean up by hand keep working unchanged. */
+  test("tolerates a directory the test removed itself", () => {
+    const dir = tempDir("kesha-temp-dir-guard-");
+    rmSync(dir, { recursive: true, force: true });
+
+    expect(reapTempDirs()).toContain(dir);
+  });
+
+  test("reaps a directory a whole suite left behind, without the suite asking", () => {
+    const out = join(tempDir("kesha-temp-dir-guard-"), "leaked-path");
+
+    const run = Bun.spawnSync(["bun", "test", FIXTURE], {
+      cwd: REPO_ROOT,
+      env: { ...process.env, KESHA_TEMP_DIR_FIXTURE_OUT: out },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect(run.stderr.toString()).toContain("1 pass");
+    const leaked = readFileSync(out, "utf8");
+    expect(leaked).toContain("kesha-temp-dir-fixture-");
+    expect(existsSync(leaked)).toBe(false);
+  });
+});

--- a/tests/unit/temp-dir-leak-guard.test.ts
+++ b/tests/unit/temp-dir-leak-guard.test.ts
@@ -2,20 +2,37 @@ import { describe, expect, test } from "bun:test";
 import { chmodSync, existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { REPO_ROOT } from "../helpers/repo";
-import { createTempDirRegistry, reapTempDirs, tempDir } from "../helpers/temp-dir";
+import { createTempDirRegistry } from "../helpers/temp-dir";
 
 const FIXTURE = "./tests/helpers/leaked-temp-dir.fixture.ts";
 const WEDGED_FIXTURE = "./tests/helpers/wedged-temp-dir.fixture.ts";
+const INTERRUPTED_FIXTURE = "./tests/helpers/interrupted-temp-dir.fixture.ts";
 
 /** A read-only directory is how POSIX reaches the branch Windows reaches with EPERM on an open handle; root ignores the mode. */
 const wedgeable = process.platform === "win32" || process.getuid?.() === 0 ? test.skip : test;
+const posix = process.platform === "win32" ? test.skip : test;
+
+const POLL_INTERVAL_MS = 25;
+const POLL_ATTEMPTS = 400;
+
+async function waitForPath(file: string): Promise<string> {
+  for (let i = 0; i < POLL_ATTEMPTS; i++) {
+    if (existsSync(file)) {
+      const staged = readFileSync(file, "utf8");
+      if (staged !== "") return staged;
+    }
+    await Bun.sleep(POLL_INTERVAL_MS);
+  }
+  throw new Error(`timed out waiting for the fixture to stage a directory: ${file}`);
+}
 
 describe("temp directory leak guard", () => {
   test("removes a directory the test never cleaned up, and names it", () => {
-    const dir = tempDir("kesha-temp-dir-guard-");
+    const registry = createTempDirRegistry();
+    const dir = registry.tempDir("kesha-temp-dir-guard-");
     expect(existsSync(dir)).toBe(true);
 
-    const reaped = reapTempDirs();
+    const reaped = registry.reapTempDirs();
 
     expect(reaped).toContain(dir);
     expect(existsSync(dir)).toBe(false);
@@ -23,26 +40,57 @@ describe("temp directory leak guard", () => {
 
   /** Suites that already clean up by hand keep working unchanged. */
   test("tolerates a directory the test removed itself", () => {
-    const dir = tempDir("kesha-temp-dir-guard-");
+    const registry = createTempDirRegistry();
+    const dir = registry.tempDir("kesha-temp-dir-guard-");
     rmSync(dir, { recursive: true, force: true });
 
-    expect(reapTempDirs()).toContain(dir);
+    expect(registry.reapTempDirs()).toContain(dir);
   });
 
   test("reaps a directory a whole suite left behind, without the suite asking", () => {
-    const out = join(tempDir("kesha-temp-dir-guard-"), "leaked-path");
+    const registry = createTempDirRegistry();
+    const out = join(registry.tempDir("kesha-temp-dir-guard-"), "leaked-path");
 
-    const run = Bun.spawnSync(["bun", "test", FIXTURE], {
-      cwd: REPO_ROOT,
-      env: { ...process.env, KESHA_TEMP_DIR_FIXTURE_OUT: out },
-      stdout: "pipe",
-      stderr: "pipe",
-    });
+    try {
+      const run = Bun.spawnSync(["bun", "test", FIXTURE], {
+        cwd: REPO_ROOT,
+        env: { ...process.env, KESHA_TEMP_DIR_FIXTURE_OUT: out },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
 
-    expect(run.stderr.toString()).toContain("1 pass");
-    const leaked = readFileSync(out, "utf8");
-    expect(leaked).toContain("kesha-temp-dir-fixture-");
-    expect(existsSync(leaked)).toBe(false);
+      expect(run.stderr.toString()).toContain("1 pass");
+      const leaked = readFileSync(out, "utf8");
+      expect(leaked).toContain("kesha-temp-dir-fixture-");
+      expect(existsSync(leaked)).toBe(false);
+    } finally {
+      registry.reapTempDirs();
+    }
+  });
+
+  posix("reaps what an interrupted run staged, which no afterAll ever sees", async () => {
+    const registry = createTempDirRegistry();
+    const out = join(registry.tempDir("kesha-temp-dir-guard-"), "leaked-path");
+    let staged = "";
+
+    try {
+      const run = Bun.spawn(["bun", "test", INTERRUPTED_FIXTURE], {
+        cwd: REPO_ROOT,
+        env: { ...process.env, KESHA_TEMP_DIR_FIXTURE_OUT: out },
+        stdout: "ignore",
+        stderr: "ignore",
+      });
+      staged = await waitForPath(out);
+      expect(existsSync(staged)).toBe(true);
+
+      run.kill("SIGINT");
+      await run.exited;
+
+      expect(existsSync(staged)).toBe(false);
+    } finally {
+      registry.reapTempDirs();
+      if (staged !== "") rmSync(staged, { recursive: true, force: true });
+    }
   });
 
   wedgeable("removes the rest when one directory refuses to go, and leaves it out of the list", () => {

--- a/tests/unit/temp-dir-leak-guard.test.ts
+++ b/tests/unit/temp-dir-leak-guard.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { chmodSync, existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { REPO_ROOT } from "../helpers/repo";
-import { createTempDirRegistry } from "../helpers/temp-dir";
+import { createTempDirRegistry, sweepStaleTempDirs } from "../helpers/temp-dir";
 
 const FIXTURE = "./tests/helpers/leaked-temp-dir.fixture.ts";
 const WEDGED_FIXTURE = "./tests/helpers/wedged-temp-dir.fixture.ts";
@@ -150,6 +151,76 @@ describe("temp directory leak guard", () => {
         chmodSync(wedged, 0o700);
         rmSync(wedged, { recursive: true, force: true });
       }
+    }
+  });
+});
+
+describe("stale temp directory sweep", () => {
+  const LONG_AGO = new Date(Date.now() - 5 * 60 * 60 * 1000);
+
+  function stage(root: string, name: string, age: "stale" | "fresh"): string {
+    const dir = join(root, name);
+    mkdirSync(dir);
+    writeFileSync(join(dir, "held"), "x");
+    if (age === "stale") utimesSync(dir, LONG_AGO, LONG_AGO);
+    return dir;
+  }
+
+  test("removes what a run nothing survived left behind, and leaves a live run's directory alone", () => {
+    const registry = createTempDirRegistry();
+    const root = registry.tempDir("kesha-temp-dir-guard-");
+
+    try {
+      const stale = stage(root, "kesha-temp-dir-sweep-a1b2c3", "stale");
+      const fresh = stage(root, "kesha-temp-dir-sweep-d4e5f6", "fresh");
+
+      expect(sweepStaleTempDirs(root)).toEqual([stale]);
+
+      expect(existsSync(stale)).toBe(false);
+      expect(existsSync(fresh)).toBe(true);
+    } finally {
+      registry.reapTempDirs();
+    }
+  });
+
+  test("runs at preload, so the run after a killed one is what cleans up its directories", () => {
+    const registry = createTempDirRegistry();
+    const out = join(registry.tempDir("kesha-temp-dir-guard-"), "leaked-path");
+    const abandoned = join(tmpdir(), `kesha-temp-dir-abandoned-${process.pid}-a1b2c3`);
+    mkdirSync(abandoned, { recursive: true });
+    utimesSync(abandoned, LONG_AGO, LONG_AGO);
+
+    try {
+      const run = Bun.spawnSync(["bun", "test", FIXTURE], {
+        cwd: REPO_ROOT,
+        env: { ...process.env, KESHA_TEMP_DIR_FIXTURE_OUT: out },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      expect(run.stderr.toString()).toContain("1 pass");
+      expect(existsSync(abandoned)).toBe(false);
+    } finally {
+      registry.reapTempDirs();
+      rmSync(abandoned, { recursive: true, force: true });
+    }
+  });
+
+  /** The temp root is shared with the MCP audio cache and with every other tool on the machine. */
+  test("leaves what no run of this suite created alone, however old", () => {
+    const registry = createTempDirRegistry();
+    const root = registry.tempDir("kesha-temp-dir-guard-");
+
+    try {
+      const mcpCache = stage(root, "kesha-mcp", "stale");
+      const foreign = stage(root, "some-other-tool-a1b2c3", "stale");
+
+      expect(sweepStaleTempDirs(root)).toEqual([]);
+
+      expect(existsSync(mcpCache)).toBe(true);
+      expect(existsSync(foreign)).toBe(true);
+    } finally {
+      registry.reapTempDirs();
     }
   });
 });


### PR DESCRIPTION
## What this changes

Tests stage stub engines in temp directories. `tests/helpers/fake-engine.ts` documented the contract in so many words — "`rmSync` the returned `dir`" — which put cleanup on all 155 call sites across 34 files, and every helper written from that template inherited it. Enough of them forgot that **59,286** directories accumulated in one `$TMPDIR`.

That is not a tidiness problem. It took `just preflight` from ~180 s to **1154 s**, and three consecutive runs failed three *different* sets of tests by timeout — each of which passed in isolation in about four seconds. Yesterday it cost a real verdict: PR #1176 could not get a green local gate and had to be settled by CI. A gate that cannot answer is worse than a slow one, because the next genuine failure gets waved through as "probably the machine again".

The repo had already solved this shape for a different resource. `bunfig.toml` preloads `tests/helpers/leak-guard.ts` into every suite to reap stray processes, and CLAUDE.md records the principle as **"Call sites need nothing"**. Directories now get the same treatment: `tempDir(prefix)` registers what it creates and the preloaded guard reaps the registry.

Closes #1175.

## Claim

A full run of `tests/unit/` and `tests/integration/` leaves the temp-directory count unchanged, a file that calls `mkdtempSync` directly fails a convention test unless it is listed with a reason, and nothing any test asserts was changed.

Measured, not assumed:

| | directories per run |
|---|---|
| before, `tests/unit/` alone | **+118** |
| before, both suites | **+22** |
| after, both suites | **±0** (615 → 615) |

The whole-branch reviewer reproduced it independently and also checked all depth-1 directories, not just the `kesha-*` ones: 8625 → 8625. `just preflight` on this head: 1879 pass, 0 fail, 17/17, **211 s**.

If the claim is wrong, `carries no stale exemptions` and the convention gate fire.

## What the review changed rather than confirmed

- **The quiet reaper could eat the loud one.** Reaping directories in a `finally` after the process report could throw `EPERM`/`EBUSY` — `force` swallows a missing directory, not a locked one — and that exception replaced the "left N process(es) running" error the preload exists to raise. The louder guard would have been traded for a confusing removal failure. Removal is now fault-tolerant per directory, and the test stages a genuinely unremovable directory with `chmodSync(dir, 0o500)`: a real `ENOTEMPTY` from the syscall, nothing stubbed.
- **"When the suite ends" was wrong.** A preload's `afterAll` fires once per process, after every file — established with a scratch preload, not by reading docs. The guard's own test had therefore been reaping directories belonging to files that had already run; it now owns its registry.
- **The gate missed two spellings** — `mkdtemp()` from `node:fs/promises`, and an aliased import.
- **The gate's message claimed tracked directories survive an interrupt**, which was false: the interrupt reaper killed processes only. It reaps directories now, verified with a real `SIGINT` rather than by reading the handler.

## Scope, deliberately

- **My original file list was wrong and the measurement caught it.** I selected leaking files as "calls `mkdtempSync` and never calls `rmSync`" — a per-file test. Three files clean up at one call site and leak at another, so they passed the filter while leaking 22 directories per run. The convention test therefore detects the call itself, never that heuristic.
- **The 29-file exemption list is a ratchet, not a blessing.** New call sites are blocked; each future conversion deletes a line. Converting the remaining 113 sites is churn that does not belong beside a fix, and gets its own ticket.
- **A file-local duplicate is deleted.** `tests/unit/mcp-list-voices.test.ts` carried its own `stubDir` and sweep, written in #1169 before the shared helper existed. It is the canonical helper now.

## Known gaps

The process guard's own error still says "this suite" though the hook is per process. Left alone here: it predates this branch and other tests assert on that text, so changing it would edit assertions in a branch whose claim is that none changed. It goes in the follow-up ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RKSL2xGHE1y3njSG8oymq
