### PR TITLE
docs: state the comment rule once, where it is enforced

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,7 +220,7 @@ Engine internals, ONNX I/O shapes, G2P split, SSML, `KESHA_*` env vars: the **`t
 - **Output**: `console.log()` for results (stdout stays pipe-friendly), `console.error()` for progress/errors.
 - **Rust**: `cargo fmt` + `cargo clippy --all-targets -- -D warnings`.
 - **No inline CI scripts over 3 lines** — extract to `.github/scripts/`.
-- **Comments: default to NONE.** Delete any comment that only restates the code. Never narrate mechanics, restate a name, or add section banners. A comment is allowed only when it carries what the code cannot: non-obvious *why*, a gotcha, an issue reference, a spec citation, `// SAFETY:`, a public-API doc contract (state the contract, not the implementation), or a `TODO` with context. One line, except SAFETY blocks and doc contracts. Bias below the surrounding density — and hold agent-generated code to the same bar in review.
+- **Comments: bias below the surrounding density.** One earns its place only by carrying what the code cannot. `.claude/hooks/check-new-comments.ts` blocks an added comment that doesn't and names both the rule and the offending lines, so the list of what qualifies lives there rather than here. It judges *added* lines only: legacy blocks stay, and a plan that specifies a multi-line comment fails at implementation time rather than in review — treat that as a plan defect. Hold agent-generated code to the same bar.
 
 ## Deeper references
 


### PR DESCRIPTION
## What this changes

One line of `CLAUDE.md`. The comment rule stated a policy that `.claude/hooks/check-new-comments.ts` already states — and the hook's own message points back at `CLAUDE.md -> Code Style`, so the two referred to each other in a circle while carrying the same enumeration.

The rule now gives the principle and the enforcement point; the list of what qualifies as a legitimate comment lives in the hook, which is where an agent actually meets it, holding the offending lines.

## Why

Anthropic's [context engineering guidance for Claude 5 models](https://claude.com/blog/the-new-rules-of-context-engineering-for-claude-5-generation-models) makes two points this line was on the wrong side of: put an instruction in the mechanism that enforces it rather than repeating it across context layers, and prefer contextual guidance over a prescriptive enumeration the model can derive from its surroundings. The heading "default to NONE" also sat awkwardly against the standing instruction to match the surrounding code's comment density and idiom.

## What is kept, and what is added

Kept, because it is judgement the hook cannot express: bias *below* the surrounding density, and hold agent-generated code to the same bar in review.

Added, because it is a gotcha that was costing plans: the hook judges **added** lines only. Legacy blocks stay put, and a plan that specifies a multi-line comment does not fail review — it fails at implementation time, when the hook blocks the edit. That makes it a plan defect, and it is worth knowing before writing the plan rather than after.

## Scope

No behaviour changes. The hook is untouched, so what is enforced is exactly what was enforced before; only the duplicate prose is gone. Verified nothing else in the repo quotes the old wording.

`just preflight` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RKSL2xGHE1y3njSG8oymq
