### PR TITLE
chore(release): kesha-engine v1.25.0-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     }
   },
   "keshaEngine": {
-    "version": "1.25.0-beta.1"
+    "version": "1.25.0-beta.2"
   },
   "scripts": {
     "test": "bun test --timeout 30000",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "kesha-engine"
-version = "1.25.0-beta.1"
+version = "1.25.0-beta.2"
 dependencies = [
  "anyhow",
  "audioadapter-buffers",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesha-engine"
-version = "1.25.0-beta.1"
+version = "1.25.0-beta.2"
 edition = "2021"
 description = "Inference engine for Kesha Voice Kit: ASR + language detection"
 # Not for crates.io. The library target (`src/lib.rs`) exists only for the


### PR DESCRIPTION
Version bump only — three fields, no behaviour change. Cuts `v1.25.0-beta.2`, the carrier for the protocol-4 contract completed in #1181.

- `rust/Cargo.toml` → `1.25.0-beta.2` (via `set-cargo-version.mjs`)
- `rust/Cargo.lock` refreshed by `cargo check`
- `package.json#keshaEngine.version` → `1.25.0-beta.2`

`package.json#version` (the CLI line) stays at `1.29.1`: rule 2 needs `cli >= engine` and it already leads.

## The pin moves, and that is not optional

`check-versions` rule 1 requires `keshaEngine.version` to equal `rust/Cargo.toml#version` — a drift there means `kesha install` downloads a binary that does not match its source, which is the v1.1.0 incident. So cutting this tag necessarily advances the pin.

That is worth stating plainly because the openspec plan says the pin must not reach beta.2 before task 5.3. The constraint's teeth are on the **CLI** release, not this one: a bare engine tag publishes nothing to npm (`npm-publish.yml` skips on `engine_only`, #729), and the pin only reaches users when a `-cli` release ships it.

What it does mean on `main`: `kesha install` and `recordEngine` still inherit the engine's stdio, and beta.2 has no prose renderer, so both print raw NDJSON. Functionally unaffected — nothing parses that stream on those two paths, and the assertions in `cli-contracts` are on CLI-side prose (`Backend installed successfully`, `Installing models...`), which is unchanged. **openspec 5.3 must land before any `-cli` release carries this pin.**

## Why the branch is named `release/*`

Two lanes key off it, both deliberately: `integration-tests-full` skips (it downloads the *published* engine, whose tag does not exist yet) and `check-engine-targets` skips its 404 check. That is the documented window between this merge and the tag push, and it stays short — the tag goes up immediately after merge.

## Verification

`just ALL=1 preflight` green on the merge-base (1886 TS, 657 Rust, openspec strict 17/17, CoreML), `cargo fmt --check` clean, `ci.yml` and `rust-test.yml` green on `main` at `7b3a643f`, feature matrix checked against cargo's defaults (`tts` present in all three rows), `check-versions` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RKSL2xGHE1y3njSG8oymq
